### PR TITLE
test: add Firecracker logger producer audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,8 +127,12 @@ dependencies = [
 name = "bangbang-firecracker-capability-audit"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
+ "quote",
  "serde",
  "serde_json",
+ "sha2",
+ "syn",
  "yaml_serde",
 ]
 

--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -20,6 +20,12 @@ For commands and test-layer selection, see the
 - [`capabilities.json`](capabilities.json) is human-owned. It assigns exactly
   one disposition to every generated identity and adds reviewed semantic
   records for cross-leaf behavior.
+- [`logger-producer-manifest.json`](logger-producer-manifest.json) is
+  machine-owned. It records every pinned public logger invocation identity,
+  syntax/source context, input Git blob, and value-redacted fingerprint.
+- [`logger-producer-audit.json`](logger-producer-audit.json) is human-owned. It
+  maps every logger invocation explicitly to one closed semantic class and its
+  reviewed delivery, limiter, disposition, owner, and evidence policy.
 - Contract Markdown files are human-owned evidence ledgers. They define a
   selected capability family, its exact supported or excluded boundary, and
   the implementation and validation evidence for its dispositions.
@@ -58,6 +64,7 @@ reviewed delta.
 | [Snapshot editor state](snapshot-editor-contract.md) | Native-state version/vCPU/VM inspection, finite reviewed-register editing, no-clobber publication, signed Full/Diff product restore, and the exact twelve-row closure |
 | [Snapshot Wave 6](snapshot-wave6-contract.md) | Exact 70-row load, artifact, version, device, tool, time/identity, portability, and downstream-owner certification |
 | [Observability, tools, and specification](observability-tools-specification-contract.md) | Exact Wave 7 ownership, core API certification, x86 CPUID/MSR platform exclusions, and retained downstream handoffs |
+| [Logger producers](logger-contract.md) | Exact 468-invocation source closure, closed semantic classes, safe fields, delivery/limiter policy, and #1807/#1808/#1809 ownership |
 
 ## Dispositions
 
@@ -107,5 +114,6 @@ full evidence and Challenge gate.
 Validate the checked inventory, compare or regenerate candidates, and run the
 normal repository checks using
 [Testing Guide](../../../docs/testing.md#firecracker-capability-inventory).
-Review candidate identity changes before updating `source-manifest.json`;
-never use regeneration to alter `capabilities.json`.
+Review candidate identity changes before updating either machine-owned
+manifest. Never use regeneration to alter `capabilities.json` or
+`logger-producer-audit.json`.

--- a/compat/firecracker/v1.16.0/logger-contract.md
+++ b/compat/firecracker/v1.16.0/logger-contract.md
@@ -1,0 +1,228 @@
+# Firecracker v1.16.0 logger producer contract
+
+This contract is the human policy and source-closure ledger for issue
+[#1786](https://github.com/seven332/bangbang/issues/1786). It is pinned to
+Firecracker v1.16.0 commit
+`d83d72b710361a10294480131377b1b00b163af8` and Bangbang's macOS arm64/HVF
+target.
+
+The contract does not copy Firecracker log messages. It maps every upstream
+logger invocation to one closed Bangbang semantic class so later producer work
+can retain observable outcomes without retaining dynamic source arguments.
+
+## Authority and ownership
+
+Three checked files have distinct owners:
+
+- [`logger-producer-manifest.json`](logger-producer-manifest.json) is
+  machine-owned. It records source identities, syntax/source context, Git blob
+  inputs, and normalized SHA-256 fingerprints.
+- [`logger-producer-audit.json`](logger-producer-audit.json) is human-owned. It
+  defines semantic classes and contains one explicit mapping for every source
+  identity.
+- this Markdown file is human-owned. It explains policy and repeats only
+  mechanically checked class-level closure facts.
+
+Regeneration creates only an explicit machine-manifest candidate. It never
+generates, carries forward, or rewrites semantic classes, dispositions,
+rationales, owners, or evidence.
+
+## Exact pinned source population
+
+The extractor parses all 362 tracked `src/**/*.rs` files. The checked result is
+468 invocations in 81 matching files:
+
+| Source fact | Exact count |
+| --- | ---: |
+| Ordinary calls | 429 |
+| Explicit unrestricted calls | 39 |
+| `error!` | 180 |
+| `warn!` | 138 |
+| `info!` | 54 |
+| `debug!` | 47 |
+| `trace!` | 10 |
+| `error_unrestricted!` | 22 |
+| `warn_unrestricted!` | 7 |
+| `info_unrestricted!` | 10 |
+| Production context | 446 |
+| Test-only context | 0 |
+| Example context | 22 |
+| Direct AST invocation | 466 |
+| Nonlogger macro-template invocation | 2 |
+
+The two macro-template producers are the block async-engine helper and signal
+handler generator. They are real public logger calls in expansion templates
+and are counted once at their source coordinates. Firecracker's logger wrapper
+definitions contain hidden `__log_*` calls and are not public invocation rows.
+
+An identity is
+`logger-invocation:<source-path>:<one-based-line>:<one-based-column>`. Its
+fingerprint is SHA-256 over normalized Rust macro tokens. Neither the normalized
+tokens nor the raw message/arguments appear in the checked data or mismatch
+diagnostics.
+
+## Semantic class rules
+
+Every source identity maps to exactly one class. A class may group multiple
+source calls only when subsystem, observable outcome, target fields, delivery,
+module/origin behavior, limiter policy, disposition, and delivery owner agree.
+There are no path selectors and no `other`, `unknown`, or catch-all class.
+
+The 31 classes contain 5 implemented classes, 19 planned classes, and 7 exact
+not-applicable classes. Across source mappings this is 9 implemented, 397
+planned, and 62 not-applicable invocations.
+
+`planned` is an explicit intermediate delivery state. The three owners are:
+
+- #1807: logger defaults/configuration, API receipt/result, and startup;
+- #1808: host lifecycle, API/VMM worker, snapshot, signal, and observability
+  outcomes; and
+- #1809: backend, vCPU, transport, and device outcomes.
+
+Delivery validation accepts those named planned classes. Final validation
+rejects every planned class.
+
+`logger.api.result` is planned because general closed result/rejection coverage
+is not complete. Its metadata nevertheless records the already compiled
+`InstanceStart` and `FlushMetrics` events and their exact #1785 evidence. This
+does not promote the broader class; it prevents existing compiled behavior from
+being lost while #1807 completes the shared source boundary.
+
+## Closed class ledger
+
+`Mappings` is the exact number of source identities assigned to the class.
+Owners apply only to planned work.
+
+| Class | Disposition | Owner/reason | Mappings |
+| --- | --- | --- | ---: |
+| `logger.api-control.outcome` | `planned` | #1807 | 7 |
+| `logger.api-worker.outcome` | `planned` | #1808 | 5 |
+| `logger.api.request` | `implemented` | parsed method/template receipt | 1 |
+| `logger.api.result` | `planned` | #1807; existing minimal actions retained | 5 |
+| `logger.backend.outcome` | `planned` | #1809 | 26 |
+| `logger.balloon.outcome` | `planned` | #1809 | 28 |
+| `logger.block.outcome` | `planned` | #1809 | 34 |
+| `logger.boot.time` | `implemented` | bounded boot timing | 1 |
+| `logger.entropy.outcome` | `planned` | #1809 | 16 |
+| `logger.lifecycle.outcome` | `planned` | #1808 | 24 |
+| `logger.limiter.recovery` | `implemented` | bounded suppressed count | 1 |
+| `logger.memory-hotplug.outcome` | `planned` | #1809 | 22 |
+| `logger.network.outcome` | `planned` | #1809 | 26 |
+| `logger.nonapp.example` | `not-applicable` | `example-only` | 22 |
+| `logger.nonapp.fuzzing` | `not-applicable` | `developer-instrumentation` | 1 |
+| `logger.nonapp.gdb` | `not-applicable` | `developer-instrumentation` | 19 |
+| `logger.nonapp.linux-hardening` | `not-applicable` | `linux-kvm-only` | 2 |
+| `logger.nonapp.tool` | `not-applicable` | `separate-tool-owner` | 1 |
+| `logger.nonapp.tracing` | `not-applicable` | `tracing-owned` | 2 |
+| `logger.nonapp.x86` | `not-applicable` | `x86-only` | 15 |
+| `logger.observability.outcome` | `planned` | #1808 | 4 |
+| `logger.pmem.outcome` | `planned` | #1809 | 18 |
+| `logger.process-signal.outcome` | `planned` | #1808 | 5 |
+| `logger.process-startup.outcome` | `planned` | #1807 | 5 |
+| `logger.process.exit` | `implemented` | fixed terminal category | 3 |
+| `logger.process.panic` | `implemented` | fixed emergency record | 3 |
+| `logger.serial.outcome` | `planned` | #1809 | 12 |
+| `logger.snapshot.outcome` | `planned` | #1808 | 18 |
+| `logger.time-identity.outcome` | `planned` | #1809 | 16 |
+| `logger.transport.outcome` | `planned` | #1809 | 74 |
+| `logger.vsock.outcome` | `planned` | #1809 | 52 |
+
+The outcome classes are semantic, not raw-line mirrors. Their fixed
+`device-kind`, `operation`, and `outcome` values distinguish the public result;
+the closed outcome selects level. Adding a new operation/outcome requires
+deliberate class metadata and compiled-event review, never inheritance from a
+source-path selector.
+
+## Allowed fields and redaction
+
+The complete allowed field vocabulary is:
+
+- parsed HTTP method and fixed route template;
+- fixed action;
+- fixed operation, outcome, device kind, or process category;
+- bounded wall/CPU microseconds for the boot timer; and
+- bounded rate-limit recovery count.
+
+No class admits a request or response body, fault/panic/raw error text, dynamic
+URI or selector, host path, grant reference, descriptor or queue index,
+credential, guest byte, packet, address/offset, register/vCPU value, socket,
+per-device identity, instance/session identifier, or other cross-session value.
+Unsafe source arguments are discarded before a `LoggerEvent` exists; they are
+never sanitized after formatting.
+
+Module values are a closed set of fixed Bangbang module identities. Origin is
+either the configured normalized source origin, the prepared panic origin, or
+not applicable. Dynamic Firecracker module paths are not copied.
+
+## Delivery and limiter policy
+
+Applicable classes use one of four delivery policies:
+
+- `unrestricted-host`: one fixed operator/process outcome submitted without a
+  lexical limiter;
+- `bounded-host`: ordinary host delivery with a bounded receipt whose result is
+  discarded by the functional operation;
+- `nonblocking-async`: worker/callback delivery with no wait or sink access;
+- `nonblocking-guest`: guest/vCPU/device delivery with filter and limiter before
+  one nonblocking queue attempt.
+
+A guest-capable class applies the guest-safe policy to every mapped producer,
+including a host-only member of the same semantic class. This is deliberately
+conservative: it cannot grant a producer a blocking or unrestricted path.
+
+Every guest-capable class is rate-limited under its own fixed class identity.
+The sole exception is `logger.limiter.recovery`, which must be unrestricted to
+report a prior admitted recovery without recursively limiting itself. Queue,
+receipt, write, flush, and replacement loss never changes the request, VM,
+guest, worker, or process result and increments the exact existing loss counter
+once.
+
+## Default output and configuration projection
+
+Pinned Firecracker writes to process stdout when no logger path is configured.
+The challenged #1786 Plan selects that platform-feasible behavior, mediated by
+Bangbang's existing bounded worker. It remains planned under #1807 in this
+audit-only change: the current executable is not silently changed by this
+contract.
+
+A later explicit direct path or contained write-only sink replaces stdout
+through the existing failure-atomic worker transaction. A path-free update
+retains the active target. Producers never write synchronously to stdout or any
+other sink.
+
+`FullVmConfiguration.logger` remains omitted. The pinned Firecracker ordinary
+configuration conversion also returns `logger: None`, and exporting Bangbang's
+process-local path, module, grant, delivery, or limiter state would leak host
+authority and create a misleading round trip. #1807 owns the final API/schema
+evidence for this optional-field decision.
+
+## Update and verification workflow
+
+Ordinary validation uses only checked files:
+
+```text
+cargo run -p bangbang-firecracker-capability-audit --locked -- validate
+```
+
+Exact upstream comparison requires a clean checkout at the pinned commit:
+
+```text
+cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker
+```
+
+Create a machine-only candidate with:
+
+```text
+cargo run -p bangbang-firecracker-capability-audit --locked -- \
+  regenerate-logger-producers --firecracker ../firecracker \
+  --output codex-work/tmp/logger-producer-manifest.candidate.json
+```
+
+The command refuses existing destinations and lexical or canonical aliases of
+all checked JSON files. Review identity, syntax, context, input, count, and
+fingerprint changes before deliberately updating the checked manifest. Resolve
+every missing/stale human mapping separately.
+
+This audit slice does not change `capabilities.json`: all eleven #1786 records
+remain `audit-required` until their owning behavior and aggregate evidence are
+complete.

--- a/compat/firecracker/v1.16.0/logger-producer-audit.json
+++ b/compat/firecracker/v1.16.0/logger-producer-audit.json
@@ -1,0 +1,2651 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "version": "1.16.0",
+    "commit": "d83d72b710361a10294480131377b1b00b163af8",
+    "target": "aarch64-macos-hvf"
+  },
+  "classes": [
+    {
+      "id": "logger.api-control.outcome",
+      "subsystem": "api",
+      "summary": "Fixed redacted API server transport and recognized result.",
+      "guest_triggerable": false,
+      "delivery": "bounded-host",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::api_server",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic API server transport and recognized result; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1807"
+    },
+    {
+      "id": "logger.api-worker.outcome",
+      "subsystem": "api",
+      "summary": "Fixed redacted API/VMM worker lifecycle.",
+      "guest_triggerable": false,
+      "delivery": "nonblocking-async",
+      "level": "outcome-derived",
+      "module": "bangbang::worker",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic API/VMM worker lifecycle; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1808"
+    },
+    {
+      "id": "logger.api.request",
+      "subsystem": "api",
+      "summary": "Parsed API method and fixed route-template receipt without body or selector values.",
+      "guest_triggerable": false,
+      "delivery": "unrestricted-host",
+      "level": "info",
+      "module": "bangbang_runtime::api_server",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "method",
+        "route"
+      ],
+      "disposition": "implemented",
+      "rationale": "The pinned receipt producer maps to Bangbang's closed method and route-template event; dynamic descriptions are replaced before record construction.",
+      "compiled_events": [
+        "api-request"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parsed request logger dispatch"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed logger producers and delivery policy"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed logger event encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "API request logger tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "method, route, body, selector, and redaction logger evidence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "API request encoding, filtering, and delivery tests"
+        }
+      ]
+    },
+    {
+      "id": "logger.api.result",
+      "subsystem": "api",
+      "summary": "Recognized API result category, including the already implemented minimal successful actions.",
+      "guest_triggerable": false,
+      "delivery": "bounded-host",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::api_server",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "action",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "Firecracker shares these producer sites across many responses; Bangbang already emits fixed InstanceStart and FlushMetrics success actions, while closed general success/rejection/result coverage remains owned by #1807.",
+      "delivery_issue": "#1807",
+      "compiled_events": [
+        "instance-start",
+        "flush-metrics"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "successful InstanceStart and FlushMetrics action logging"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed logger producers and delivery policy"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed logger event encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "successful action logger tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "successful action process logger evidence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "fixed action encoding and delivery tests"
+        }
+      ]
+    },
+    {
+      "id": "logger.backend.outcome",
+      "subsystem": "cpu-and-machine",
+      "summary": "Fixed redacted backend, memory, interrupt, or vCPU outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_hvf::backend",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.backend.outcome",
+      "allowed_fields": [
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic backend, memory, interrupt, or vCPU outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.balloon.outcome",
+      "subsystem": "memory-devices",
+      "summary": "Fixed redacted balloon device outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.balloon.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic balloon device outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.block.outcome",
+      "subsystem": "storage",
+      "summary": "Fixed redacted block device outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.block.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic block device outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.boot.time",
+      "subsystem": "vm-lifecycle",
+      "summary": "Guest boot wall and process CPU timing admitted through one bounded atomic call site.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "info",
+      "module": "bangbang_runtime::boot_timer",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.boot-time",
+      "allowed_fields": [
+        "cpu-time-us",
+        "wall-time-us"
+      ],
+      "disposition": "implemented",
+      "rationale": "The pinned boot-timer producer maps to Bangbang's fixed numeric boot event without guest bytes, addresses, or device identity.",
+      "compiled_events": [
+        "boot-time"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/boot_timer.rs",
+          "anchor": "boot timer logger admission"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed logger producers and delivery policy"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed logger event encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed guest boot-timer logger evidence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/boot_timer.rs",
+          "anchor": "boot timer MMIO and logger tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "boot timing limiter, filtering, and recovery tests"
+        }
+      ]
+    },
+    {
+      "id": "logger.entropy.outcome",
+      "subsystem": "remaining-devices",
+      "summary": "Fixed redacted entropy device outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.entropy.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic entropy device outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.lifecycle.outcome",
+      "subsystem": "vm-lifecycle",
+      "summary": "Fixed redacted VM lifecycle and control outcome.",
+      "guest_triggerable": false,
+      "delivery": "bounded-host",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::lifecycle",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic VM lifecycle and control outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1808"
+    },
+    {
+      "id": "logger.limiter.recovery",
+      "subsystem": "observability",
+      "summary": "Fixed rate-limit recovery summary containing only a bounded suppressed count.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "warn",
+      "module": "bangbang_runtime::boot_timer",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "suppressed-count"
+      ],
+      "disposition": "implemented",
+      "rationale": "The recovery record is emitted only after an admitted bounded producer call and cannot recurse through its own limiter.",
+      "compiled_events": [
+        "rate-limit-recovery"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed logger producers and delivery policy"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed logger event encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "rate-limit denial and recovery tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/rate_limiter.rs",
+          "anchor": "atomic limiter identity and suppression tests"
+        }
+      ]
+    },
+    {
+      "id": "logger.memory-hotplug.outcome",
+      "subsystem": "memory-devices",
+      "summary": "Fixed redacted virtio-mem outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.memory-hotplug.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic virtio-mem outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.network.outcome",
+      "subsystem": "network-and-mmds",
+      "summary": "Fixed redacted network or MMDS outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.network.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic network or MMDS outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.nonapp.example",
+      "subsystem": "developer-tooling",
+      "summary": "Log-instrument example-binary output.",
+      "guest_triggerable": false,
+      "delivery": "not-applicable",
+      "level": "not-applicable",
+      "module": "not-applicable",
+      "origin": "not-applicable",
+      "limiter": "not-applicable",
+      "allowed_fields": [],
+      "disposition": "not-applicable",
+      "non_applicable_reason": "example-only",
+      "rationale": "These calls exist only in upstream example programs and are not Firecracker VMM process producers."
+    },
+    {
+      "id": "logger.nonapp.fuzzing",
+      "subsystem": "developer-tooling",
+      "summary": "Fuzzing-build warning.",
+      "guest_triggerable": false,
+      "delivery": "not-applicable",
+      "level": "not-applicable",
+      "module": "not-applicable",
+      "origin": "not-applicable",
+      "limiter": "not-applicable",
+      "allowed_fields": [],
+      "disposition": "not-applicable",
+      "non_applicable_reason": "developer-instrumentation",
+      "rationale": "The producer exists only in an explicitly insecure developer fuzzing build and is not a production VMM outcome."
+    },
+    {
+      "id": "logger.nonapp.gdb",
+      "subsystem": "developer-tooling",
+      "summary": "Optional GDB remote-debugging protocol diagnostics.",
+      "guest_triggerable": false,
+      "delivery": "not-applicable",
+      "level": "not-applicable",
+      "module": "not-applicable",
+      "origin": "not-applicable",
+      "limiter": "not-applicable",
+      "allowed_fields": [],
+      "disposition": "not-applicable",
+      "non_applicable_reason": "developer-instrumentation",
+      "rationale": "These calls serve Firecracker's optional developer GDB server rather than the production VMM logger contract selected for Bangbang."
+    },
+    {
+      "id": "logger.nonapp.linux-hardening",
+      "subsystem": "process",
+      "summary": "Linux prctl speculation-mitigation failure.",
+      "guest_triggerable": false,
+      "delivery": "not-applicable",
+      "level": "not-applicable",
+      "module": "not-applicable",
+      "origin": "not-applicable",
+      "limiter": "not-applicable",
+      "allowed_fields": [],
+      "disposition": "not-applicable",
+      "non_applicable_reason": "linux-kvm-only",
+      "rationale": "The producer reports a Linux prctl mechanism that has no identity-preserving macOS/HVF operation; Bangbang documents its platform security boundary separately."
+    },
+    {
+      "id": "logger.nonapp.tool",
+      "subsystem": "developer-tooling",
+      "summary": "CPU-template helper command warning.",
+      "guest_triggerable": false,
+      "delivery": "not-applicable",
+      "level": "not-applicable",
+      "module": "not-applicable",
+      "origin": "not-applicable",
+      "limiter": "not-applicable",
+      "allowed_fields": [],
+      "disposition": "not-applicable",
+      "non_applicable_reason": "separate-tool-owner",
+      "rationale": "This producer belongs to the separately delivered CPU-template-helper command rather than the Bangbang VMM process logger."
+    },
+    {
+      "id": "logger.nonapp.tracing",
+      "subsystem": "observability",
+      "summary": "Developer tracing span entry and exit output.",
+      "guest_triggerable": false,
+      "delivery": "not-applicable",
+      "level": "not-applicable",
+      "module": "not-applicable",
+      "origin": "not-applicable",
+      "limiter": "not-applicable",
+      "allowed_fields": [],
+      "disposition": "not-applicable",
+      "non_applicable_reason": "tracing-owned",
+      "rationale": "The log-instrument crate implements developer tracing owned by #1791, not the Firecracker VMM logger compatibility surface."
+    },
+    {
+      "id": "logger.nonapp.x86",
+      "subsystem": "cpu-and-machine",
+      "summary": "X86 KVM, CPUID, xstate, interrupt, or debug-register producer.",
+      "guest_triggerable": false,
+      "delivery": "not-applicable",
+      "level": "not-applicable",
+      "module": "not-applicable",
+      "origin": "not-applicable",
+      "limiter": "not-applicable",
+      "allowed_fields": [],
+      "disposition": "not-applicable",
+      "non_applicable_reason": "x86-only",
+      "rationale": "The containing code is compiled only for Firecracker's x86_64 backend and has no identity-preserving macOS arm64/HVF execution path."
+    },
+    {
+      "id": "logger.observability.outcome",
+      "subsystem": "observability",
+      "summary": "Fixed redacted logger or metrics worker outcome.",
+      "guest_triggerable": false,
+      "delivery": "nonblocking-async",
+      "level": "outcome-derived",
+      "module": "bangbang::worker",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic logger or metrics worker outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1808"
+    },
+    {
+      "id": "logger.pmem.outcome",
+      "subsystem": "storage",
+      "summary": "Fixed redacted pmem device outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.pmem.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic pmem device outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.process-signal.outcome",
+      "subsystem": "process",
+      "summary": "Fixed redacted host signal and shutdown convergence.",
+      "guest_triggerable": false,
+      "delivery": "nonblocking-async",
+      "level": "outcome-derived",
+      "module": "bangbang::worker",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic host signal and shutdown convergence; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1808"
+    },
+    {
+      "id": "logger.process-startup.outcome",
+      "subsystem": "process",
+      "summary": "Fixed redacted process startup and readiness.",
+      "guest_triggerable": false,
+      "delivery": "bounded-host",
+      "level": "outcome-derived",
+      "module": "bangbang::process",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic process startup and readiness; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1807"
+    },
+    {
+      "id": "logger.process.exit",
+      "subsystem": "process",
+      "summary": "One fixed process-exit category emitted during terminal convergence.",
+      "guest_triggerable": false,
+      "delivery": "unrestricted-host",
+      "level": "category-derived",
+      "module": "bangbang::process",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "category"
+      ],
+      "disposition": "implemented",
+      "rationale": "Firecracker's success, error-detail, and exit-code lines converge to one value-free Bangbang category; error payload and numeric exit-code text are not retained.",
+      "compiled_events": [
+        "process-exit"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "terminal observability convergence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed logger producers and delivery policy"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed logger event encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "terminal observability unit tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "success, configuration, failure, cancellation, and panic terminal evidence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "process category encoding and delivery tests"
+        }
+      ]
+    },
+    {
+      "id": "logger.process.panic",
+      "subsystem": "process",
+      "summary": "One pre-encoded fixed process-panic event with emergency admission.",
+      "guest_triggerable": false,
+      "delivery": "unrestricted-host",
+      "level": "error",
+      "module": "bangbang::panic",
+      "origin": "prepared-emergency",
+      "limiter": "unrestricted",
+      "allowed_fields": [],
+      "disposition": "implemented",
+      "rationale": "Firecracker's panic payload and secondary cleanup/metrics errors collapse into one fixed record so panic data and nested failure text never reach the sink.",
+      "compiled_events": [
+        "process-panic"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/panic_bridge.rs",
+          "anchor": "fixed panic bridge publication and admission"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed logger producers and delivery policy"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed logger event encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "panic and terminal observability tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/panic_bridge.rs",
+          "anchor": "panic bridge concurrency and fallback tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "panic redaction and terminal-order evidence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "emergency logger delivery and loss tests"
+        }
+      ]
+    },
+    {
+      "id": "logger.serial.outcome",
+      "subsystem": "remaining-devices",
+      "summary": "Fixed redacted serial device outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.serial.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic serial device outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.snapshot.outcome",
+      "subsystem": "snapshot",
+      "summary": "Fixed redacted snapshot create, load, or restore outcome.",
+      "guest_triggerable": false,
+      "delivery": "bounded-host",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::snapshot",
+      "origin": "configurable",
+      "limiter": "unrestricted",
+      "allowed_fields": [
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic snapshot create, load, or restore outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1808"
+    },
+    {
+      "id": "logger.time-identity.outcome",
+      "subsystem": "remaining-devices",
+      "summary": "Fixed redacted time, identity, or legacy platform-device outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.time-identity.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic time, identity, or legacy platform-device outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.transport.outcome",
+      "subsystem": "device-transport",
+      "summary": "Fixed redacted device transport, PCI, queue, or notification outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.transport.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic device transport, PCI, queue, or notification outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    },
+    {
+      "id": "logger.vsock.outcome",
+      "subsystem": "vsock",
+      "summary": "Fixed redacted vsock transport or connection outcome.",
+      "guest_triggerable": true,
+      "delivery": "nonblocking-guest",
+      "level": "outcome-derived",
+      "module": "bangbang_runtime::device",
+      "origin": "configurable",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.vsock.outcome",
+      "allowed_fields": [
+        "device-kind",
+        "operation",
+        "outcome"
+      ],
+      "disposition": "planned",
+      "rationale": "All mapped upstream calls report the same semantic vsock transport or connection outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "delivery_issue": "#1809"
+    }
+  ],
+  "mappings": [
+    {
+      "invocation_id": "logger-invocation:src/cpu-template-helper/src/template/dump/aarch64.rs:20:17",
+      "class_id": "logger.nonapp.tool"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/mod.rs:102:21",
+      "class_id": "logger.api-control.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/mod.rs:112:21",
+      "class_id": "logger.api-control.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/mod.rs:116:17",
+      "class_id": "logger.api-control.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/mod.rs:135:21",
+      "class_id": "logger.api-control.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/mod.rs:141:17",
+      "class_id": "logger.api-control.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/mod.rs:183:13",
+      "class_id": "logger.api-control.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/mod.rs:85:9",
+      "class_id": "logger.api-control.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/mod.rs:97:21",
+      "class_id": "logger.api-worker.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:169:9",
+      "class_id": "logger.api.result"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:176:9",
+      "class_id": "logger.api.result"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:192:21",
+      "class_id": "logger.api.result"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:218:25",
+      "class_id": "logger.api.result"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:225:25",
+      "class_id": "logger.api.result"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:76:9",
+      "class_id": "logger.api.request"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server_adapter.rs:130:21",
+      "class_id": "logger.api-worker.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server_adapter.rs:137:13",
+      "class_id": "logger.api-worker.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server_adapter.rs:143:13",
+      "class_id": "logger.api-worker.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/api_server_adapter.rs:189:5",
+      "class_id": "logger.api-worker.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:110:9",
+      "class_id": "logger.process.exit"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:113:9",
+      "class_id": "logger.process.exit"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:116:9",
+      "class_id": "logger.process.exit"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:139:9",
+      "class_id": "logger.process.panic"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:141:13",
+      "class_id": "logger.process.panic"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:151:13",
+      "class_id": "logger.process.panic"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:333:5",
+      "class_id": "logger.process-startup.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:336:5",
+      "class_id": "logger.nonapp.fuzzing"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:351:17",
+      "class_id": "logger.process-startup.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:541:9",
+      "class_id": "logger.nonapp.linux-hardening"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:546:13",
+      "class_id": "logger.nonapp.linux-hardening"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/main.rs:608:5",
+      "class_id": "logger.process-startup.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/metrics.rs:47:13",
+      "class_id": "logger.observability.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/metrics.rs:65:13",
+      "class_id": "logger.observability.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/metrics.rs:77:13",
+      "class_id": "logger.observability.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/firecracker/src/metrics.rs:83:13",
+      "class_id": "logger.observability.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/five.rs:13:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/five.rs:15:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/five.rs:25:17",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/five.rs:26:17",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/four.rs:11:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/four.rs:13:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/four.rs:22:17",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/one.rs:10:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/one.rs:11:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/one.rs:12:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/one.rs:17:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/six.rs:10:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/six.rs:11:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/six.rs:12:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/six.rs:17:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/six.rs:26:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/three.rs:10:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/three.rs:11:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/three.rs:20:13",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/two.rs:10:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/two.rs:11:5",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/examples/two.rs:20:13",
+      "class_id": "logger.nonapp.example"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/src/lib.rs:37:9",
+      "class_id": "logger.nonapp.tracing"
+    },
+    {
+      "invocation_id": "logger-invocation:src/log-instrument/src/lib.rs:54:9",
+      "class_id": "logger.nonapp.tracing"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/acpi/mod.rs:181:32",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/acpi/mod.rs:183:9",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/acpi/mod.rs:70:32",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/acpi/mod.rs:72:9",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/aarch64/cache_info.rs:307:21",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/aarch64/mod.rs:180:9",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/aarch64/mod.rs:195:9",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/aarch64/mod.rs:208:17",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/aarch64/mod.rs:70:9",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/aarch64/vcpu.rs:504:9",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/mod.rs:70:13",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/mod.rs:120:9",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/mod.rs:458:5",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/mptable.rs:131:5",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:283:13",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:405:21",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:432:29",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:588:13",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:728:25",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:738:25",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:746:17",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/xstate.rs:120:13",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/arch/x86_64/xstate.rs:79:13",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/builder.rs:304:9",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/builder.rs:354:9",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/builder.rs:386:5",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/builder.rs:388:5",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/builder.rs:390:5",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/builder.rs:392:5",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/builder.rs:449:5",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/builder.rs:553:5",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs:382:25",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs:48:33",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/device_manager/mmio.rs:85:5",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/device_manager/mod.rs:135:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/device_manager/mod.rs:141:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/device_manager/mod.rs:375:9",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/device_manager/mod.rs:619:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/device_manager/pci_mngr.rs:151:9",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/device_manager/pci_mngr.rs:325:25",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/device_manager/pci_mngr.rs:95:9",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/acpi/vmclock.rs:151:9",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/acpi/vmgenid.rs:110:9",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/acpi/vmgenid.rs:116:9",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/acpi/vmgenid.rs:61:9",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/i8042.rs:152:13",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/i8042.rs:236:21",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/i8042.rs:263:21",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/i8042.rs:325:21",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/rtc_pl031.rs:114:13",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/rtc_pl031.rs:38:9",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/rtc_pl031.rs:44:9",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/rtc_pl031.rs:99:13",
+      "class_id": "logger.time-identity.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:120:25",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:202:13",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:208:17",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:305:27",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:312:13",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:320:21",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:341:21",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:353:25",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:361:25",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:384:17",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:387:17",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:427:17",
+      "class_id": "logger.serial.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/mod.rs:34:5",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/pci/pci_segment.rs:131:9",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/pci/pci_segment.rs:153:9",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/pseudo/boot_timer.rs:31:13",
+      "class_id": "logger.boot.time"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:239:17",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:406:25",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:457:21",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:498:17",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:510:17",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:573:25",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:586:21",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:591:21",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:598:21",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:640:21",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:711:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:935:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:947:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:985:17",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:109:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:138:21",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:142:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:27:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:34:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:42:17",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:49:17",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:60:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:70:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:83:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:89:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:97:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/mod.rs:121:5",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/balloon/util.rs:39:13",
+      "class_id": "logger.balloon.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/device.rs:336:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:19:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:25:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:32:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:45:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:56:17",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:59:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:72:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:148:17",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:275:17",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:363:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:417:25",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:438:29",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:460:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:480:21",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:501:29",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:525:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:567:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:628:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:641:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:684:21",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:82:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:23:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:30:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:39:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:49:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:55:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:63:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:78:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:91:22",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:94:13",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/request.rs:116:17",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/request.rs:124:17",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/request.rs:136:17",
+      "class_id": "logger.block.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:137:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:149:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:158:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:197:9",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:200:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:278:9",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:356:17",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:390:17",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:417:17",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:439:17",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:453:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:476:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:482:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:550:21",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:581:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:588:9",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:644:17",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:652:9",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:665:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:691:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:22:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:32:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:38:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:50:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:73:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:78:13",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:87:17",
+      "class_id": "logger.memory-hotplug.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:1029:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:1045:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:498:21",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:503:17",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:560:17",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:566:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:609:17",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:698:29",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:709:21",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:759:17",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:888:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:925:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:949:17",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:966:17",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:108:21",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:113:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:26:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:33:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:40:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:47:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:54:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:64:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:70:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:78:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:92:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:386:21",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:392:17",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:404:21",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:463:21",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:482:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:493:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:501:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:507:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:562:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:593:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:21:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:28:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:38:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:44:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:56:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:75:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:80:13",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:89:17",
+      "class_id": "logger.pmem.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/queue.rs:567:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:152:21",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:161:25",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:168:25",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:174:21",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:186:21",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:200:17",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:210:13",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:228:17",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:22:13",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:29:13",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:39:13",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:45:13",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:57:13",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:80:13",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:85:13",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:94:17",
+      "class_id": "logger.entropy.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:137:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:146:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:225:25",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:230:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:285:25",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:293:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:325:29",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:348:25",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:359:21",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:363:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:473:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:115:18",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:128:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:138:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:195:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:202:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:231:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:249:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:296:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:359:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:390:21",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:415:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:91:18",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:565:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:592:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:836:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:851:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:896:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:910:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:941:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:952:21",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:982:21",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:252:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:262:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:308:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:319:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:391:17",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:460:17",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:468:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:189:33",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:206:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:213:17",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:236:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:239:25",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:252:17",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:274:35",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:277:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:352:17",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:363:9",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:418:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:432:17",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:104:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:116:29",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:147:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:154:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:161:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:168:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:178:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:184:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:192:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:216:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:223:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:52:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:58:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:72:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:78:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:98:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:183:17",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:205:9",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:221:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:301:17",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:344:9",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:368:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:389:25",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:415:29",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:421:17",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:493:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:583:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:672:25",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:676:25",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:706:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:722:29",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:741:21",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:787:13",
+      "class_id": "logger.vsock.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/arch/x86.rs:129:9",
+      "class_id": "logger.nonapp.x86"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:135:17",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:138:17",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:141:17",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:143:39",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:147:17",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:149:17",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:151:17",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:67:21",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:84:25",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:88:21",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/mod.rs:57:5",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/target.rs:209:13",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/target.rs:282:13",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/target.rs:311:13",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/target.rs:324:13",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/target.rs:428:17",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/target.rs:443:21",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/target.rs:468:17",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/gdb/target.rs:483:21",
+      "class_id": "logger.nonapp.gdb"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/lib.rs:690:9",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/lib.rs:765:13",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/lib.rs:770:13",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/lib.rs:775:13",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/lib.rs:781:13",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/lib.rs:821:21",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/lib.rs:831:21",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/logger/mod.rs:44:13",
+      "class_id": "logger.process-startup.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/logger/mod.rs:47:13",
+      "class_id": "logger.process-startup.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/logger/rate_limited.rs:175:21",
+      "class_id": "logger.limiter.recovery"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/mmds/token.rs:211:13",
+      "class_id": "logger.network.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/configuration.rs:283:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/configuration.rs:293:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/configuration.rs:305:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/configuration.rs:329:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:175:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:185:25",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:189:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:191:21",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:233:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:246:25",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:264:25",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:272:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:286:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:303:28",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:317:28",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:320:20",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:346:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:379:13",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:390:25",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:401:25",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:409:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:417:9",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:458:22",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/pci/msix.rs:459:23",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:228:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:229:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:231:17",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:235:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:236:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:239:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:240:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:243:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:244:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:264:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:265:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:267:17",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:271:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:272:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:275:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:276:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:279:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/persist.rs:280:13",
+      "class_id": "logger.snapshot.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/rate_limiter/mod.rs:199:17",
+      "class_id": "logger.transport.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/resources.rs:218:13",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/rpc_interface.rs:390:13",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/rpc_interface.rs:457:17",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/rpc_interface.rs:651:13",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/rpc_interface.rs:680:9",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/rpc_interface.rs:877:9",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/rpc_interface.rs:890:9",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/rpc_interface.rs:940:17",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/rpc_interface.rs:950:17",
+      "class_id": "logger.lifecycle.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/signal_handler.rs:144:9",
+      "class_id": "logger.process-signal.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/signal_handler.rs:150:5",
+      "class_id": "logger.process-signal.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/signal_handler.rs:25:9",
+      "class_id": "logger.process-signal.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/signal_handler.rs:45:13",
+      "class_id": "logger.process-signal.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/signal_handler.rs:70:5",
+      "class_id": "logger.process-signal.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/interrupts.rs:184:21",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/memory.rs:429:21",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/memory.rs:447:21",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:302:21",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:368:13",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:388:13",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:426:25",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:436:25",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:447:17",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:459:17",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:467:21",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:475:21",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:496:17",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:504:17",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vm.rs:167:21",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vm.rs:250:13",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vm.rs:253:13",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vm.rs:397:17",
+      "class_id": "logger.backend.outcome"
+    },
+    {
+      "invocation_id": "logger-invocation:src/vmm/src/vstate/vm.rs:701:9",
+      "class_id": "logger.backend.outcome"
+    }
+  ]
+}

--- a/compat/firecracker/v1.16.0/logger-producer-manifest.json
+++ b/compat/firecracker/v1.16.0/logger-producer-manifest.json
@@ -1,0 +1,5117 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "version": "1.16.0",
+    "commit": "d83d72b710361a10294480131377b1b00b163af8",
+    "target": "aarch64-macos-hvf"
+  },
+  "generator_version": 1,
+  "inputs": [
+    {
+      "path": "src/cpu-template-helper/src/template/dump/aarch64.rs",
+      "git_blob": "3456298f5212b306c2b983dcedb8d7073d0dba48",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/firecracker/src/api_server/mod.rs",
+      "git_blob": "ecc6a7217c94475385dd2038d9e3787c10633167",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/firecracker/src/api_server/parsed_request.rs",
+      "git_blob": "2946b19706718653d9a0728c32571e39f7ce40d5",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/firecracker/src/api_server_adapter.rs",
+      "git_blob": "cd6a444c675ef3a9ef493b018189d4c8e9b03402",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/firecracker/src/main.rs",
+      "git_blob": "39c989c87f622472e104a66ac864440c1c9b7b7a",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/firecracker/src/metrics.rs",
+      "git_blob": "7914dece48f434a4de105995ae837f89d9f226e3",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/log-instrument/examples/five.rs",
+      "git_blob": "07aa0951935249fbe5bf8dde8aaafaec2143bd31",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/log-instrument/examples/four.rs",
+      "git_blob": "803cb6d8e9f5cc0a6dd99013c925db70279ea6e0",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/log-instrument/examples/one.rs",
+      "git_blob": "57836a0330d5130c43bd4bb036c4542d86a5a84c",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/log-instrument/examples/six.rs",
+      "git_blob": "443b36adea3eab0eb884850aa13d9e905169f084",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/log-instrument/examples/three.rs",
+      "git_blob": "13f8e0049cee90197843508f67c25f9f2518d3da",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/log-instrument/examples/two.rs",
+      "git_blob": "3c13ae9e78281df23ad50e4db9b2e6991d3c7de4",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/log-instrument/src/lib.rs",
+      "git_blob": "3939dc6df769f854d406d9a8e502d886815d7934",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/acpi/mod.rs",
+      "git_blob": "1dce12246781087e07c4619e86130c9ed05f4f1e",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/arch/aarch64/cache_info.rs",
+      "git_blob": "4c934626f1b548a848341c1690f7e10369699431",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/arch/aarch64/mod.rs",
+      "git_blob": "007ef1bf4bdf91027650d3545642609b535a501f",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/arch/aarch64/vcpu.rs",
+      "git_blob": "989aa78a2fb5140baedd416e8d5f894141eac1a3",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/arch/mod.rs",
+      "git_blob": "a35c61d311757c1bab2bd804c8f0a15159157a6e",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/arch/x86_64/mod.rs",
+      "git_blob": "cf7efe66dbc83d4243effd3403a6d3a210f04742",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/arch/x86_64/mptable.rs",
+      "git_blob": "6b6bde062df9c47fb75fe02dc06d63d201568b9b",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/arch/x86_64/vcpu.rs",
+      "git_blob": "98563aab2e357a0873e543acae4427f866dac6e3",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/arch/x86_64/xstate.rs",
+      "git_blob": "836c77b96bcd3e30c595c97f6a4841a5ab070825",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/builder.rs",
+      "git_blob": "45dd3865155541b9bdfbe459289d5909481fd3e6",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs",
+      "git_blob": "7accc3ecd714c7ca7c7f7dad8fbdea213a6a8d58",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs",
+      "git_blob": "1e790f1a9517ac450254de312a6a131923b7176c",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/device_manager/mmio.rs",
+      "git_blob": "e84784a3d5ff0919900f5443f1281816894c2e60",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/device_manager/mod.rs",
+      "git_blob": "202c457b6487989c8cf656600da7c3e5f76059f6",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/device_manager/pci_mngr.rs",
+      "git_blob": "8a625037c4d815991a7ed99eb4423e99f962c089",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/acpi/vmclock.rs",
+      "git_blob": "dbd42add87ebb5cac5d754e482dea5c7846782b9",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/acpi/vmgenid.rs",
+      "git_blob": "443faadde897bc711f863a3165daa95c65c7c6b5",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/legacy/i8042.rs",
+      "git_blob": "2f1b6b95c1d553ff4f56fb3aea48a03d38a22255",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/legacy/rtc_pl031.rs",
+      "git_blob": "96b1134eb1c6d39128cdcc037582cb775d2f3a5d",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "git_blob": "e38480179de107a3d6c27066fd9e93b8c3b2b043",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/mod.rs",
+      "git_blob": "7bff1948d0a5394540463965a20faf532fd56c6e",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/pci/pci_segment.rs",
+      "git_blob": "1761b8c22611d67ec9f1c62bb607d8aa0edbcb37",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/pseudo/boot_timer.rs",
+      "git_blob": "81f9abb34f3d3298f17182ba099ae86a9f1bbad1",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "git_blob": "1e962e828d77481115ef2cbfadfcd20845a322fb",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "git_blob": "a89cfe8477d9680cef80d94a727c6e49fec49b13",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/balloon/mod.rs",
+      "git_blob": "96005a36a8a9f3d1267029f9c1f5123b0e8fa529",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/balloon/util.rs",
+      "git_blob": "1d00891783e98f33224f1dc3e84d5fdf39d003f1",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/device.rs",
+      "git_blob": "7df600722ab95ea85360712e5737b54f870f1fc5",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs",
+      "git_blob": "4f143995630a148787349969e2992906ff32516b",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "git_blob": "ec7ec468505f5f9291d37d337a95cb9421cb8c6f",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "git_blob": "9f02862f81494073f5733cc0b8a37a767ed36e80",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/block/virtio/request.rs",
+      "git_blob": "feaa811e221e6f603b77f59084c0a0253019c3a5",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/device.rs",
+      "git_blob": "1cb591d7a3a6cdbe24071eb2c4b8b4f6ecaff078",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "git_blob": "c6c0ea443e42876d528b40e55398732d0397e66b",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/mem/event_handler.rs",
+      "git_blob": "ae81ef12a64f78c3a48dd8089f1f72372bcc9b7a",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "git_blob": "22b223b383b460cc5ba6edc4ea4c3a0a5eb2ddab",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "git_blob": "9d8c09a45f228d64c05d515dc05ef285af6197bb",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "git_blob": "4d4da40a8e97a2a4c3291e51fcdd375e0a47f273",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/pmem/event_handler.rs",
+      "git_blob": "2324c509a6950ebdc82789132c6dac795f306bed",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/queue.rs",
+      "git_blob": "b4ff6514ed3018c11decd7ddf46ea1d41d322e7a",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/rng/device.rs",
+      "git_blob": "a6fee70262880a9b9ee6301c98757f3e2282f5a9",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/rng/event_handler.rs",
+      "git_blob": "dffda5d88451d9271520c18c93619925f787f32b",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "git_blob": "9c519604a9683720ee04dc3cb60cc709310ce36c",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "git_blob": "09d11a79f2068c295865a9c72d9e80b681c00c93",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "git_blob": "40e8c2fc1390c01e0157cbbc99824eedc0ad4e4a",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/vsock/csm/connection.rs",
+      "git_blob": "eee415ef65f5e69ab099c44e1626cf6805b6ab53",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "git_blob": "16ee25a5a0af9976c44cdb1da2fd78b79b8c4d13",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "git_blob": "a680fda338ef025e15ea48f3716127530ae50527",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "git_blob": "e2c28033ec73b785f8c7220d079cc0039fa76a2c",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/gdb/arch/x86.rs",
+      "git_blob": "f8df58bedef307d49450ca3afeccbc858de76324",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "git_blob": "13d1f438a47824eedb90715a7af2ccdae25dcb8b",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/gdb/mod.rs",
+      "git_blob": "4656093ed77241021a0336c0a94876c1c83fc71a",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/gdb/target.rs",
+      "git_blob": "442d06c1c133510646ae66afc3a0cddf5b820b02",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/lib.rs",
+      "git_blob": "98884fdb7fc4c5fa6fc0961206fe5ea0f1d3e114",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/logger/mod.rs",
+      "git_blob": "df71f408db809edae5ee1d58c822386d2e37fb5c",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/logger/rate_limited.rs",
+      "git_blob": "e840e501c9cebd1ed6659bcc543b5561adb7238b",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/mmds/token.rs",
+      "git_blob": "f397c7a48557e911f472506b3d7e1b7269ad7c5d",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/pci/configuration.rs",
+      "git_blob": "b838262a0a4553b12a4956dca90debe4e5cdf55f",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/pci/msix.rs",
+      "git_blob": "0d7c3e75fe146772580cbdec531f1d4bb887c9fe",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/persist.rs",
+      "git_blob": "feb53c0e19e63aa11fcf863be1367596cf4f4fa0",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/rate_limiter/mod.rs",
+      "git_blob": "58a63194a1c2195fa20e376d360da1f199e95be6",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/resources.rs",
+      "git_blob": "64254170e7650c75ec4f71c39da122992ba4c2db",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/rpc_interface.rs",
+      "git_blob": "7693b305f650268e40ce5a54219138f081a0c240",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/signal_handler.rs",
+      "git_blob": "772d724d2fdc78524af52a837aaa3b112185ea09",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/vstate/interrupts.rs",
+      "git_blob": "1b8e40bf72a2faeb5d1db1353a9c04ce6a7ef466",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/vstate/memory.rs",
+      "git_blob": "7bff6ad070df2b5dd80fe4b941a1dcd7f451e6fb",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "git_blob": "4b99ac386b3b296a5da82a638e0441790aed33a3",
+      "extractor": "rust-logger-macro-v1"
+    },
+    {
+      "path": "src/vmm/src/vstate/vm.rs",
+      "git_blob": "4ba4bdc9c827e5d4c8ed60cf8bf796ace8b3ff1e",
+      "extractor": "rust-logger-macro-v1"
+    }
+  ],
+  "counts": {
+    "scanned_rust_files": 362,
+    "matching_input_files": 81,
+    "ordinary": 429,
+    "unrestricted": 39,
+    "error": 180,
+    "warn": 138,
+    "info": 54,
+    "debug": 47,
+    "trace": 10,
+    "error_unrestricted": 22,
+    "warn_unrestricted": 7,
+    "info_unrestricted": 10,
+    "production": 446,
+    "test": 0,
+    "example": 22,
+    "direct": 466,
+    "macro_template": 2
+  },
+  "invocations": [
+    {
+      "id": "logger-invocation:src/cpu-template-helper/src/template/dump/aarch64.rs:20:17",
+      "path": "src/cpu-template-helper/src/template/dump/aarch64.rs",
+      "line": 20,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:bd0177b927f0e7542190658af0f58e4161214341539036f080b7eb6ffdcc328e"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/mod.rs:102:21",
+      "path": "src/firecracker/src/api_server/mod.rs",
+      "line": 102,
+      "column": 21,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:efdc2f50dfb399876a08e5c57363f30930129592767b782f11ca92bc4df18dcc"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/mod.rs:112:21",
+      "path": "src/firecracker/src/api_server/mod.rs",
+      "line": 112,
+      "column": 21,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:46005169bddccedbeb7b9df168c656c8609f13eb580ba244070ff0fd4fbe791c"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/mod.rs:116:17",
+      "path": "src/firecracker/src/api_server/mod.rs",
+      "line": 116,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c529c5afa589334d7b61c710af3e8b659638236e20de09b6fb57ebd9f12a20a4"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/mod.rs:135:21",
+      "path": "src/firecracker/src/api_server/mod.rs",
+      "line": 135,
+      "column": 21,
+      "macro_name": "warn_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5a18f84545ac5fd54ca16b68d277bd50c2ec1313e84047663561e7f6f9b46507"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/mod.rs:141:17",
+      "path": "src/firecracker/src/api_server/mod.rs",
+      "line": 141,
+      "column": 17,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:94122f3c538872c279d98bb78a17ed5a6dacb4c6a252e34d0114c14ff7f97fb5"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/mod.rs:183:13",
+      "path": "src/firecracker/src/api_server/mod.rs",
+      "line": 183,
+      "column": 13,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8e6ae572becf4d8c26a7580b8d93d2af16c3d5d5dd245fc6e680aae0ac37649d"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/mod.rs:85:9",
+      "path": "src/firecracker/src/api_server/mod.rs",
+      "line": 85,
+      "column": 9,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0463d0125fa0c1a33f36f81b5851d92099bfac6c560f619aebc609b94317cc83"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/mod.rs:97:21",
+      "path": "src/firecracker/src/api_server/mod.rs",
+      "line": 97,
+      "column": 21,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:590e792e9d950fc4f7124174cdc235767b1bb1062e55f3106e2728a4d6021bd7"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:169:9",
+      "path": "src/firecracker/src/api_server/parsed_request.rs",
+      "line": 169,
+      "column": 9,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a19ba04e2e866588f6529385498e96709862a8462b3aa473a7853945a8865611"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:176:9",
+      "path": "src/firecracker/src/api_server/parsed_request.rs",
+      "line": 176,
+      "column": 9,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a19ba04e2e866588f6529385498e96709862a8462b3aa473a7853945a8865611"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:192:21",
+      "path": "src/firecracker/src/api_server/parsed_request.rs",
+      "line": 192,
+      "column": 21,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:41501ae031ad9ad39e11348344d096ffd98b8117134791af3a18a1e0e6c6017c"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:218:25",
+      "path": "src/firecracker/src/api_server/parsed_request.rs",
+      "line": 218,
+      "column": 25,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:b9c0c42e82fd203e1ef16d9f0ea3011ace8dd1f9a8e298fd11abfc0c9c39ed8f"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:225:25",
+      "path": "src/firecracker/src/api_server/parsed_request.rs",
+      "line": 225,
+      "column": 25,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cea92526ccdf22bd5828c4ae801cab56c8b0508b21f736f683314770319b519f"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server/parsed_request.rs:76:9",
+      "path": "src/firecracker/src/api_server/parsed_request.rs",
+      "line": 76,
+      "column": 9,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c5060c7c13576cf237d8b06168a7f7fa9c83855f63a5e85df49d950cee8db985"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server_adapter.rs:130:21",
+      "path": "src/firecracker/src/api_server_adapter.rs",
+      "line": 130,
+      "column": 21,
+      "macro_name": "warn_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a68267648f6ea9ca9916e9ed3f9fc2fe930363e3aa91622b044c314ae706eb08"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server_adapter.rs:137:13",
+      "path": "src/firecracker/src/api_server_adapter.rs",
+      "line": 137,
+      "column": 13,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a1bd47f04428438839c20e2b6f82e5d62cb858c8da43166ded0962a4a30f7e0d"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server_adapter.rs:143:13",
+      "path": "src/firecracker/src/api_server_adapter.rs",
+      "line": 143,
+      "column": 13,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:742ea6e2b3874a7993ce0cb4e929fb293740e1f7780ebd3b940f0b48545bdfce"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/api_server_adapter.rs:189:5",
+      "path": "src/firecracker/src/api_server_adapter.rs",
+      "line": 189,
+      "column": 5,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4c7c2f4f84766926792373731b32f2b7ebcb688408507f732114e82a014e0713"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:110:9",
+      "path": "src/firecracker/src/main.rs",
+      "line": 110,
+      "column": 9,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2863c6368cf2c0edb327406daf110deed200ad9086b586b6ff12e7ebc3fe15ef"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:113:9",
+      "path": "src/firecracker/src/main.rs",
+      "line": 113,
+      "column": 9,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8f687ffeb6649e942d34e46c248376fdc376ec950a2e3ac3397a297d3fea0f94"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:116:9",
+      "path": "src/firecracker/src/main.rs",
+      "line": 116,
+      "column": 9,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2a1c6371cf6736fd6febf5585b45d8f41ef336895a28fecf1bd78021e77839f3"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:139:9",
+      "path": "src/firecracker/src/main.rs",
+      "line": 139,
+      "column": 9,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:18b2c3010adb391a005ee91a9e49d062fb3f7852e57afcaa9a059514811e086b"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:141:13",
+      "path": "src/firecracker/src/main.rs",
+      "line": 141,
+      "column": 13,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2ee174b8bcc4d4b51860a89e3744d5f41b7f93d60c8e68fd5dadf93e588a0b65"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:151:13",
+      "path": "src/firecracker/src/main.rs",
+      "line": 151,
+      "column": 13,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:260aba0a8e4a1fe12c923dd68b8efe1d5d6c3be5832d7fb9836cb0ef7f431706"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:333:5",
+      "path": "src/firecracker/src/main.rs",
+      "line": 333,
+      "column": 5,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a1bef615002d9a832acf556dc7ef00a36dab380220056f3d14ec677945cf1b48"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:336:5",
+      "path": "src/firecracker/src/main.rs",
+      "line": 336,
+      "column": 5,
+      "macro_name": "warn_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a1ea55faf4ca04a16d323ff2d612c43a8572bfdcb23539226ceab86a8cb93c5b"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:351:17",
+      "path": "src/firecracker/src/main.rs",
+      "line": 351,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8b8398aa287a31fe4852e39d1d52abd73d940dcefd01ae4849bb76190effd778"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:541:9",
+      "path": "src/firecracker/src/main.rs",
+      "line": 541,
+      "column": 9,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3a3ac8ae494b2f075ff547a46178bbbd0f2ac938f0dec0cb80117f7a587d59ec"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:546:13",
+      "path": "src/firecracker/src/main.rs",
+      "line": 546,
+      "column": 13,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d85a9e8421dcf37e3444f03d675358b18768d605a2a365344806a7924ed76f55"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/main.rs:608:5",
+      "path": "src/firecracker/src/main.rs",
+      "line": 608,
+      "column": 5,
+      "macro_name": "info_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9451e314cf071963e3219e13ebea7133db0fbc06c4b523c089298592e2f85c25"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/metrics.rs:47:13",
+      "path": "src/firecracker/src/metrics.rs",
+      "line": 47,
+      "column": 13,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:96f534dd0dd35b91f1626230e092abb3a7b0878223459a85b72ace5a7ae34a34"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/metrics.rs:65:13",
+      "path": "src/firecracker/src/metrics.rs",
+      "line": 65,
+      "column": 13,
+      "macro_name": "warn_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d59f5c76c36f6d8b98d95affc0fa4b97c1a46b82a26b57ad01d89ff956b42d6e"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/metrics.rs:77:13",
+      "path": "src/firecracker/src/metrics.rs",
+      "line": 77,
+      "column": 13,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:326e1eaabf2fe7d020656e9b262ea54f25d775358260dd8030df5a0d525ba388"
+    },
+    {
+      "id": "logger-invocation:src/firecracker/src/metrics.rs:83:13",
+      "path": "src/firecracker/src/metrics.rs",
+      "line": 83,
+      "column": 13,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8213d21e290526f445fdbcb9e37f1a6c04bec5116798dcce71b37703a959a367"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/five.rs:13:5",
+      "path": "src/log-instrument/examples/five.rs",
+      "line": 13,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:66707bc12e9125c141b9c18baf3a6f53f2d6a2be29996a6e444d6dc314cb9654"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/five.rs:15:5",
+      "path": "src/log-instrument/examples/five.rs",
+      "line": 15,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:66707bc12e9125c141b9c18baf3a6f53f2d6a2be29996a6e444d6dc314cb9654"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/five.rs:25:17",
+      "path": "src/log-instrument/examples/five.rs",
+      "line": 25,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:6796d722fd35faa9d14b028184d66d69b8cc581781e9f0b63db3846f389f7470"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/five.rs:26:17",
+      "path": "src/log-instrument/examples/five.rs",
+      "line": 26,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:828ba34fca714600b99d081a68fa3f2108d30914837926ce7a133ec087eb8aee"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/four.rs:11:5",
+      "path": "src/log-instrument/examples/four.rs",
+      "line": 11,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:66707bc12e9125c141b9c18baf3a6f53f2d6a2be29996a6e444d6dc314cb9654"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/four.rs:13:5",
+      "path": "src/log-instrument/examples/four.rs",
+      "line": 13,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:66707bc12e9125c141b9c18baf3a6f53f2d6a2be29996a6e444d6dc314cb9654"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/four.rs:22:17",
+      "path": "src/log-instrument/examples/four.rs",
+      "line": 22,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:6796d722fd35faa9d14b028184d66d69b8cc581781e9f0b63db3846f389f7470"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/one.rs:10:5",
+      "path": "src/log-instrument/examples/one.rs",
+      "line": 10,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:da81106049a2e179a1ac1dc4aa3e9e30c0ed19f52f7fbafb83a047ff85de16c9"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/one.rs:11:5",
+      "path": "src/log-instrument/examples/one.rs",
+      "line": 11,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:da272edcdc91b15501a07b0409ba852ed9aac46c6616d02eea72706a0c81a1ec"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/one.rs:12:5",
+      "path": "src/log-instrument/examples/one.rs",
+      "line": 12,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:d1afc836c684dd7ac0ee931481c978ccee65ca093d50dfcfabfbd18ad4236045"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/one.rs:17:5",
+      "path": "src/log-instrument/examples/one.rs",
+      "line": 17,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:918561356dac0005c9462d5ac9c2e10865780df1277549eca0054a430e2aa29c"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/six.rs:10:5",
+      "path": "src/log-instrument/examples/six.rs",
+      "line": 10,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:da81106049a2e179a1ac1dc4aa3e9e30c0ed19f52f7fbafb83a047ff85de16c9"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/six.rs:11:5",
+      "path": "src/log-instrument/examples/six.rs",
+      "line": 11,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:da272edcdc91b15501a07b0409ba852ed9aac46c6616d02eea72706a0c81a1ec"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/six.rs:12:5",
+      "path": "src/log-instrument/examples/six.rs",
+      "line": 12,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:d1afc836c684dd7ac0ee931481c978ccee65ca093d50dfcfabfbd18ad4236045"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/six.rs:17:5",
+      "path": "src/log-instrument/examples/six.rs",
+      "line": 17,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:918561356dac0005c9462d5ac9c2e10865780df1277549eca0054a430e2aa29c"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/six.rs:26:5",
+      "path": "src/log-instrument/examples/six.rs",
+      "line": 26,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:900e1f2912754cb36dec158fca0add4330960ee2e7e9ba39b221d31f3ee808a4"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/three.rs:10:5",
+      "path": "src/log-instrument/examples/three.rs",
+      "line": 10,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:53cc57a731aec1f6df8edace3cb853c04f6422b7166ca7ed6a58c834e846629c"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/three.rs:11:5",
+      "path": "src/log-instrument/examples/three.rs",
+      "line": 11,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:027968dcef836c1be2825024a131e89afce2c1e86d2f3ef15b782148a2e51e79"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/three.rs:20:13",
+      "path": "src/log-instrument/examples/three.rs",
+      "line": 20,
+      "column": 13,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:6796d722fd35faa9d14b028184d66d69b8cc581781e9f0b63db3846f389f7470"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/two.rs:10:5",
+      "path": "src/log-instrument/examples/two.rs",
+      "line": 10,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:9ca20ec7f16d2ca625df027a1d8459b1f846b5734f224012e8bd777a47b333fa"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/two.rs:11:5",
+      "path": "src/log-instrument/examples/two.rs",
+      "line": 11,
+      "column": 5,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:fcb582e6b7dd93f07d2d5520bb7045e4f596f3a333895e273b5d31a5ff5c8d2a"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/examples/two.rs:20:13",
+      "path": "src/log-instrument/examples/two.rs",
+      "line": 20,
+      "column": 13,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "example",
+      "fingerprint": "sha256:6796d722fd35faa9d14b028184d66d69b8cc581781e9f0b63db3846f389f7470"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/src/lib.rs:37:9",
+      "path": "src/log-instrument/src/lib.rs",
+      "line": 37,
+      "column": 9,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:88a289651aa3ca77a81341f1c48b4c6ee4ad41fd1cf34d628341713d2c87b951"
+    },
+    {
+      "id": "logger-invocation:src/log-instrument/src/lib.rs:54:9",
+      "path": "src/log-instrument/src/lib.rs",
+      "line": 54,
+      "column": 9,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6e9367de9582c1ab2433cb56705ec1ac8b6bb4d0d19d527b82355f85a6edbcb1"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/acpi/mod.rs:181:32",
+      "path": "src/vmm/src/acpi/mod.rs",
+      "line": 181,
+      "column": 32,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:bda88c9bea15a17befbd3dc30f3d8275aa983f04ed9a4ffaf4ddd4e84073b407"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/acpi/mod.rs:183:9",
+      "path": "src/vmm/src/acpi/mod.rs",
+      "line": 183,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:bee844270c94ce2f35f37a96f16c066176c6b28e7f64df914c427a571db86fe9"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/acpi/mod.rs:70:32",
+      "path": "src/vmm/src/acpi/mod.rs",
+      "line": 70,
+      "column": 32,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a4a7e76d9aaac99e1eb3a8495803bf395890dd51bfe4a22182270321b7831b09"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/acpi/mod.rs:72:9",
+      "path": "src/vmm/src/acpi/mod.rs",
+      "line": 72,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e13bab07d7d43db60b5817fde9bf2c37dfa50e40de08ba005825318c4ba0cb0e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/aarch64/cache_info.rs:307:21",
+      "path": "src/vmm/src/arch/aarch64/cache_info.rs",
+      "line": 307,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:55290b859b13df3ecc1b44c4cf9227c46946fc6b6ed808656e0c4b812d9707be"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/aarch64/mod.rs:180:9",
+      "path": "src/vmm/src/arch/aarch64/mod.rs",
+      "line": 180,
+      "column": 9,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:69aad1df4cf1aeafd48d151839a06fe282f99965fc806bca16dd0cae0d4b0b2c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/aarch64/mod.rs:195:9",
+      "path": "src/vmm/src/arch/aarch64/mod.rs",
+      "line": 195,
+      "column": 9,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:147303e2343960457dcc1720da9d7c8737d85ee54ca93be27146bb5c654ca412"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/aarch64/mod.rs:208:17",
+      "path": "src/vmm/src/arch/aarch64/mod.rs",
+      "line": 208,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:90ab72f44ddc2819f8a3ab12187c823ec5c9cf7dfd9ffd34a4f01139a5a84910"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/aarch64/mod.rs:70:9",
+      "path": "src/vmm/src/arch/aarch64/mod.rs",
+      "line": 70,
+      "column": 9,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cc045c418a94852053bc4df1ba08ed4bc2978fac2a458d425bd2e8b1a3b26506"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/aarch64/vcpu.rs:504:9",
+      "path": "src/vmm/src/arch/aarch64/vcpu.rs",
+      "line": 504,
+      "column": 9,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:14df607128278f141c6936560280d57a2b40f1690aa2d12581e79cf87402e2ee"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/mod.rs:70:13",
+      "path": "src/vmm/src/arch/mod.rs",
+      "line": 70,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0cfd5cd5d68e19191d00164cae67a0e0db536e0e4e92353d9e1fda54d5010347"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/mod.rs:120:9",
+      "path": "src/vmm/src/arch/x86_64/mod.rs",
+      "line": 120,
+      "column": 9,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cc045c418a94852053bc4df1ba08ed4bc2978fac2a458d425bd2e8b1a3b26506"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/mod.rs:458:5",
+      "path": "src/vmm/src/arch/x86_64/mod.rs",
+      "line": 458,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7055e4b087f1fde0bbff3ed7a39763862c4d491a0a0ce178f2869723624b2a00"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/mptable.rs:131:5",
+      "path": "src/vmm/src/arch/x86_64/mptable.rs",
+      "line": 131,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6121ed0d4ae94d6631ace050522bf97e5f25f57aa021877f94940241e554a597"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:283:13",
+      "path": "src/vmm/src/arch/x86_64/vcpu.rs",
+      "line": 283,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:aef4feb5c76df939879fbd37655e6125e48e164101df389726117b04af97003b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:405:21",
+      "path": "src/vmm/src/arch/x86_64/vcpu.rs",
+      "line": 405,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:52f9edb34266e9e06d7f391dc221cdad48711c813adb1d455a0d94a572a2fecb"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:432:29",
+      "path": "src/vmm/src/arch/x86_64/vcpu.rs",
+      "line": 432,
+      "column": 29,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:88762a289a595ef670b1d952ed38d23dd9678d64ac9e93ca493a53f0722ccd29"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:588:13",
+      "path": "src/vmm/src/arch/x86_64/vcpu.rs",
+      "line": 588,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cf1c9f731865f0f02d082f939b72bf00003ab038f61d84ba51826236eb4a9296"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:728:25",
+      "path": "src/vmm/src/arch/x86_64/vcpu.rs",
+      "line": 728,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:46ccb8a82817766b1b2e4ad01481c6e53ad689849e9517617ef9d297acf35f28"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:738:25",
+      "path": "src/vmm/src/arch/x86_64/vcpu.rs",
+      "line": 738,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7383f73b99abcca7efef6bcfe54e949110bfa5373733e448201269fcdcc84a40"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/vcpu.rs:746:17",
+      "path": "src/vmm/src/arch/x86_64/vcpu.rs",
+      "line": 746,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d451db0981d47bb914085b79fa96692d6204e523acd09dec401c5f858e8ca256"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/xstate.rs:120:13",
+      "path": "src/vmm/src/arch/x86_64/xstate.rs",
+      "line": 120,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:003ca18206765416e8d6d397ddb89b490c2d337556e7f6e32a810bf591f12fff"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/arch/x86_64/xstate.rs:79:13",
+      "path": "src/vmm/src/arch/x86_64/xstate.rs",
+      "line": 79,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ebaa1b2272c95103a344d6ae4b06eb3308247af3615c538cb8825e9530b04576"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/builder.rs:304:9",
+      "path": "src/vmm/src/builder.rs",
+      "line": 304,
+      "column": 9,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:92a31fd370ae004a4e876421e12d06215c491b326994ad0082095c2f4a8193b4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/builder.rs:354:9",
+      "path": "src/vmm/src/builder.rs",
+      "line": 354,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c95384fa1c5bd9ecef6e279edb7c0c6bdd8621b9e2d1865f9698936bb967e2a0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/builder.rs:386:5",
+      "path": "src/vmm/src/builder.rs",
+      "line": 386,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c4bb438b8ac15da96983b298d3381868d940c3edaf05b59094a9a0b9567e5898"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/builder.rs:388:5",
+      "path": "src/vmm/src/builder.rs",
+      "line": 388,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f730ff3c36914e0dee43af934b8f1b7058dba9e56e003b2e59f913bc400a3e50"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/builder.rs:390:5",
+      "path": "src/vmm/src/builder.rs",
+      "line": 390,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f8bcc6e4e66376cdded96c78c50abf8fe59084c27bf6c18194abe4487454895e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/builder.rs:392:5",
+      "path": "src/vmm/src/builder.rs",
+      "line": 392,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4b8ba93121abd7e30a33dcf08b5d4ee7c2112db765de524b79f1c0b654db8eae"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/builder.rs:449:5",
+      "path": "src/vmm/src/builder.rs",
+      "line": 449,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e2968a55827f958119551cffacddac981eaa13e6705ab461468dd6c034044679"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/builder.rs:553:5",
+      "path": "src/vmm/src/builder.rs",
+      "line": 553,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6acaa9db94f0e91ca51ecea2eec95e3aa3ab5b2c5a978c1c9e2ea3fe595cae1a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs:382:25",
+      "path": "src/vmm/src/cpu_config/x86_64/cpuid/normalize.rs",
+      "line": 382,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:eda573a1fbe2a7e525e071e4ec8d3d0d6bb3afad1ecc9a76fca89f6247eb9f99"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs:48:33",
+      "path": "src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs",
+      "line": 48,
+      "column": 33,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:004d5527822f888fbcba66a9c63d7caa4f386750e70c39e3f08afdf900ebe711"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/device_manager/mmio.rs:85:5",
+      "path": "src/vmm/src/device_manager/mmio.rs",
+      "line": 85,
+      "column": 5,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:df1e04446050965c80737d1ccae89fb291ad6ff388dd592dc6e94a4ba109db84"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/device_manager/mod.rs:135:13",
+      "path": "src/vmm/src/device_manager/mod.rs",
+      "line": 135,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ce0cdecf60f5714e84a779d3f919248e1d68004d8c278d609086ceedf00d5d6a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/device_manager/mod.rs:141:13",
+      "path": "src/vmm/src/device_manager/mod.rs",
+      "line": 141,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:eac95b763f1b82ad5cfb5c5bf6213d1257904a5d674b0244a9d880e96d0a2bc7"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/device_manager/mod.rs:375:9",
+      "path": "src/vmm/src/device_manager/mod.rs",
+      "line": 375,
+      "column": 9,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:73240e64f238225780cfb85105892f3c8b680bd7baacd1d30647f2c5d0c04676"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/device_manager/mod.rs:619:13",
+      "path": "src/vmm/src/device_manager/mod.rs",
+      "line": 619,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4925d6971b882c161ed26c0d39c58009a8d297fe2dbf339e11b66dfd95836042"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/device_manager/pci_mngr.rs:151:9",
+      "path": "src/vmm/src/device_manager/pci_mngr.rs",
+      "line": 151,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e269ede522569122579533fded85fe006a4a9e8be575768b5a252383db5ebe87"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/device_manager/pci_mngr.rs:325:25",
+      "path": "src/vmm/src/device_manager/pci_mngr.rs",
+      "line": 325,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9a22b49e8e628af0adc6fe58f987b3eba777405b573579a119157546896f4aa6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/device_manager/pci_mngr.rs:95:9",
+      "path": "src/vmm/src/device_manager/pci_mngr.rs",
+      "line": 95,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:bbe29c9564285059e2b41be8c75f24a420a4c4be5b34fecb7b413e4fe66aa47a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/acpi/vmclock.rs:151:9",
+      "path": "src/vmm/src/devices/acpi/vmclock.rs",
+      "line": 151,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:55d798d975e63d4fcbe1a1aa38529be64e9090a1a47c4624482f80e717483b1a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/acpi/vmgenid.rs:110:9",
+      "path": "src/vmm/src/devices/acpi/vmgenid.rs",
+      "line": 110,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:97dca02a1ecd40467e6f3c198aa7a5f66585bb2c1d8c106419f929b241a3914f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/acpi/vmgenid.rs:116:9",
+      "path": "src/vmm/src/devices/acpi/vmgenid.rs",
+      "line": 116,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7f74eb4cdee20dbe0474833e7e3c65e2c65ff956eff10fc4c9ed9910081bef9e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/acpi/vmgenid.rs:61:9",
+      "path": "src/vmm/src/devices/acpi/vmgenid.rs",
+      "line": 61,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9daa946970f77e42aedafda4eb500ff108576ecd0d4c717818c6425903ae7caf"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/i8042.rs:152:13",
+      "path": "src/vmm/src/devices/legacy/i8042.rs",
+      "line": 152,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5b3e9c07bfa0f0674270f725da83eee3f72592eb77cec2539db679a639762fbc"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/i8042.rs:236:21",
+      "path": "src/vmm/src/devices/legacy/i8042.rs",
+      "line": 236,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4e88da8cc3c96f87212b0d08c7d1edd366aad12c76274e8d502613eb747121af"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/i8042.rs:263:21",
+      "path": "src/vmm/src/devices/legacy/i8042.rs",
+      "line": 263,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:aeb3061b5d2530a3b443f666f967e60c179596406bbc3a8884b9f933d7538864"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/i8042.rs:325:21",
+      "path": "src/vmm/src/devices/legacy/i8042.rs",
+      "line": 325,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4e88da8cc3c96f87212b0d08c7d1edd366aad12c76274e8d502613eb747121af"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/rtc_pl031.rs:114:13",
+      "path": "src/vmm/src/devices/legacy/rtc_pl031.rs",
+      "line": 114,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1dd9044b859b66efab8f8cde881e292904892c805332b1afed934de15c85fa52"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/rtc_pl031.rs:38:9",
+      "path": "src/vmm/src/devices/legacy/rtc_pl031.rs",
+      "line": 38,
+      "column": 9,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1e7a60b09eb269807c3d39100d38baf9e3dcefb74f77acab5120abab04bdf18d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/rtc_pl031.rs:44:9",
+      "path": "src/vmm/src/devices/legacy/rtc_pl031.rs",
+      "line": 44,
+      "column": 9,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cb50fedbc0c0f038371d23030b920275ab75166c0e1d2f99b18810e4f90d244b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/rtc_pl031.rs:99:13",
+      "path": "src/vmm/src/devices/legacy/rtc_pl031.rs",
+      "line": 99,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f100e67ecf00ed502a42b0c7856f7efbe47f274a34d14081ad07deb2298a9b21"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:120:25",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 120,
+      "column": 25,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:92096eb50df2374dd5f63a37a3ac36928c6067fb82a3d841545459e1f3d3a8bf"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:202:13",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 202,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4a47f09c8305d62365f8c4a8cc5e9354755389057915fb93cc24debfa2bc6bba"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:208:17",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 208,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:70234e8c3f74efeceeab935330f1b38d1999b4e5e74ef7a0ff6aca96174ece05"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:305:27",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 305,
+      "column": 27,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0bf2a456f921f22455ef19947a33455186afd683b509af2970b50fddbb94eb6f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:312:13",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 312,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4a47f09c8305d62365f8c4a8cc5e9354755389057915fb93cc24debfa2bc6bba"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:320:21",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 320,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:b03705d070b763a42987120bdc3d9ea6a5d413bd9e061faf68ea0ac5a4619335"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:341:21",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 341,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5540edc3198558d1f6384efca7cb54535ef06d7566ea0f0d8d759b708bf3ae3c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:353:25",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 353,
+      "column": 25,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2e1bbf74ef9c599ff8e4232f2c55b1e94008ee3430c88cce1e7807ca4d3a6bab"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:361:25",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 361,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5540edc3198558d1f6384efca7cb54535ef06d7566ea0f0d8d759b708bf3ae3c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:384:17",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 384,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:628e50fc2731cccb87202d6fd680225b7d0231c0dcf84fc40bffff2870b6c23a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:387:17",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 387,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:69215730aafb394dd88be8d0e7714ff9d292a128a3f2d708cf599df0be52be64"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/legacy/serial.rs:427:17",
+      "path": "src/vmm/src/devices/legacy/serial.rs",
+      "line": 427,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ad3a41b4ecb4161df97eba2fad614509af5f1012aad0e84c10424da3e6684820"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/mod.rs:34:5",
+      "path": "src/vmm/src/devices/mod.rs",
+      "line": 34,
+      "column": 5,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:da3bdb7e383d9cc58637bfd4fde5b2666c264b7b1158b82ea3c7c926812cb2a6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/pci/pci_segment.rs:131:9",
+      "path": "src/vmm/src/devices/pci/pci_segment.rs",
+      "line": 131,
+      "column": 9,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1934a80a3fae5a210b2b798fd538c951d523c965423e087c142cd17a4e8d56bd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/pci/pci_segment.rs:153:9",
+      "path": "src/vmm/src/devices/pci/pci_segment.rs",
+      "line": 153,
+      "column": 9,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c375f659f033248ca67c123989909fe54860fa79c3a4c694a7b84637ec3fb242"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/pseudo/boot_timer.rs:31:13",
+      "path": "src/vmm/src/devices/pseudo/boot_timer.rs",
+      "line": 31,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3afb5c3c3fcd38874a6f796fc0f40c16390f717c43aa081a6519a54b6babf570"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:239:17",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 239,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2dee9ac974d5ddd6681cddaded16fc4d54752efd024501b4f2d834d2a8079df3"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:406:25",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 406,
+      "column": 25,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f9ee05c8604d4f0b0e62adbde2ebd48efd23fbeb697f160b7c9154bafc276d7a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:457:21",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 457,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8b675237911764aa1216277e4497759c76ed014e6a617085d317dde89c5ceda9"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:498:17",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 498,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1c6e49a4173241c1b469b4884aec79a1291b5c57d31b6f4084e6b39203eef4b2"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:510:17",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 510,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1944f212a4f0a663435f26cb02e176e09fadfdc65bc97f2c8520296a353248aa"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:573:25",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 573,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:628ee3af511977b30b19a8e08819c68cb166b5712f110b3f7f778a0ead812b82"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:586:21",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 586,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1acb2e41dfd7d50b92a108b05eb9e43257a4b6cca8e861622c1fd3c283686d0b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:591:21",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 591,
+      "column": 21,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cfcddd41a6d1b304db23f63788467c24062c00d7eee2ebfb532215fdb56f9f23"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:598:21",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 598,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:875a4485c7238931d882942c578dc7529dc5129f018544b0f92f8d1aca925185"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:640:21",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 640,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:66aed05520bc8e6c1610d101fd527136486f5888bc51941c364295330cfb96f6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:711:13",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 711,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c0b5360f694217d38a64c73bedc11170f9bbb027573cff43019c8eaeb501fd3d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:935:13",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 935,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ecaa3654de91bd5887ad2e13e9b54b42105b1ea78d46889337114f7cc84d01b0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:947:13",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 947,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fb3e06b163a50af6324285f395bee2b6c629b3e1848767a21c0550b8df6d08b9"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/device.rs:985:17",
+      "path": "src/vmm/src/devices/virtio/balloon/device.rs",
+      "line": 985,
+      "column": 17,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:35bbd72a084bee8d354c863b9d68b09b9b6109222b792dc29e675ad42f2568a3"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:109:13",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 109,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f0c943edeca79067c7d33bf36e9e33411fddb0885ee9cacfeea751f16aa44d54"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:138:21",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 138,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2313f418b4662051556ce6a1472a320dd6d731ef64a4d763c846cfddb80bae92"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:142:13",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 142,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9ef4bb4433a6e7906a8813721f5e6d97d05fa0c01d229b8e00e38ee6a669d0e5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:27:13",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 27,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fadbbd3873b904cb672b044e78962d26449a38496bddf84cae9d45742b26b167"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:34:13",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 34,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5210cf6102a923cf54368f0fe22dda7569f5404b3ba16a4d3634f04d49ae734f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:42:17",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 42,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8b86d97b2c4c663543ef3d5706bd3121f4c136010f76a17a3ac55785ecfdc5cd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:49:17",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 49,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0872ccc59080d9c68a7102f991364f2c6d183409ff3133ede8b0a9a75a23c0d7"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:60:13",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 60,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:617656a99e23d734fa361063b76dbf2d369a733099c400b9f771a9b418f8e61d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:70:13",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 70,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:db021f6e4cac00944c74ae1c0707668723e7aaba011af78e2fdd99e338002295"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:83:13",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 83,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fb6727cbf72d9a49a1f105aa78425f205ea86e8b77839101d9bd4afcf80a9f4d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:89:13",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 89,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a08d2d0dcc30745604b516041b9aa079421ec71a0ad208d6ed5fd84c82769c6c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/event_handler.rs:97:13",
+      "path": "src/vmm/src/devices/virtio/balloon/event_handler.rs",
+      "line": 97,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:39e030d758589ff924b9292b1672a678971e61ec59cf7401d9e75242b4875d54"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/mod.rs:121:5",
+      "path": "src/vmm/src/devices/virtio/balloon/mod.rs",
+      "line": 121,
+      "column": 5,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:da3bdb7e383d9cc58637bfd4fde5b2666c264b7b1158b82ea3c7c926812cb2a6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/balloon/util.rs:39:13",
+      "path": "src/vmm/src/devices/virtio/balloon/util.rs",
+      "line": 39,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:aaa54f7eaf5853f5581e1c6eca102d843edfffc95d38f372efbb1d293caaa134"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/device.rs:336:13",
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/device.rs",
+      "line": 336,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ecaa3654de91bd5887ad2e13e9b54b42105b1ea78d46889337114f7cc84d01b0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:19:13",
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs",
+      "line": 19,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fb6727cbf72d9a49a1f105aa78425f205ea86e8b77839101d9bd4afcf80a9f4d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:25:13",
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs",
+      "line": 25,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3cfccbc985eb7e76fb2cdb55ff963e4ff4d8a5e3be8afb95e9674a7bdcc4e108"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:32:13",
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs",
+      "line": 32,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:39e030d758589ff924b9292b1672a678971e61ec59cf7401d9e75242b4875d54"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:45:13",
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs",
+      "line": 45,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f0c943edeca79067c7d33bf36e9e33411fddb0885ee9cacfeea751f16aa44d54"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:56:17",
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs",
+      "line": 56,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ed7b53897d8217612c433aad847b074064a2121786600ac454cb6f7f7c016563"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:59:13",
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs",
+      "line": 59,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5887f6ab860fcce4e51dc261fe90662e9d349916a3c50e557310e6316a0ededa"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs:72:13",
+      "path": "src/vmm/src/devices/virtio/block/vhost_user/event_handler.rs",
+      "line": 72,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4081cab8087989c959256915ecfda06fe27cfef1cdf9da8c0ed30271975ea717"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:148:17",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 148,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0c068283c221ce2ce9e5d3906d40a4a5d652609e182de51d83290b820ff25439"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:275:17",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 275,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "macro-template",
+      "source_context": "production",
+      "fingerprint": "sha256:7c5bed2f3228062fa1ac822331479055bca42ef2f370a5301721ee815b55aa8c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:363:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 363,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0f0682b02f8765298b14237fc6e1d0d3c861db76c348249a7d782f453b333cef"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:417:25",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 417,
+      "column": 25,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:b1574ec9c4c776d7e4a6608eb92a7acc6ab449b09de11dbddd8b82c3fe4eb2a3"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:438:29",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 438,
+      "column": 29,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:83686cc8762464920482bb3f2a2cb1daa28dad906e87120abece184e9722e9ca"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:460:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 460,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6ecb32b896dd734fb3c3e733d350a9dfb09d312abdaff5d6461a5c819ece8c79"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:480:21",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 480,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:49f3bd8ddfe46f965a88e261cea844d65f9a046af1e40ef80861fc5eaed0b367"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:501:29",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 501,
+      "column": 29,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:28613decbf8b4adf1af56a5e91f2953d16d0a2a0ba0d6f117723d7b87265d714"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:525:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 525,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:59addf0b96ff81dd4df2a8533540ad6d9f64f702c3b6b779c403a9ced5279183"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:567:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 567,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6a54b0d71677fbcf1ba5a243252f29c1e7f8a3d552faa7ceeaacad79616880bf"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:628:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 628,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ecaa3654de91bd5887ad2e13e9b54b42105b1ea78d46889337114f7cc84d01b0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:641:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 641,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fb3e06b163a50af6324285f395bee2b6c629b3e1848767a21c0550b8df6d08b9"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:684:21",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 684,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:52399d3c47bb5f207f08b087994fcca78bf21cbb0e72d17b557d2b296f059cc8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/device.rs:82:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/device.rs",
+      "line": 82,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cb55e78babb37b4b9be7d204d95da04e4053011cf9afb95108537048a1288da1"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:23:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "line": 23,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:246fba342f062d564d51e765ef739d25e0dcb73d37fdbab7c529bbdf136b4fdc"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:30:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "line": 30,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:312df1e0603e03e5d4c8112bf211f5d1ae1d020392e6f258a712533211fb66ec"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:39:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "line": 39,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fa0b753e3d3645dc57c7e5cb55838f41119069cf1edde2d38d2d32e147436b74"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:49:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "line": 49,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fb6727cbf72d9a49a1f105aa78425f205ea86e8b77839101d9bd4afcf80a9f4d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:55:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "line": 55,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3cfccbc985eb7e76fb2cdb55ff963e4ff4d8a5e3be8afb95e9674a7bdcc4e108"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:63:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "line": 63,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:39e030d758589ff924b9292b1672a678971e61ec59cf7401d9e75242b4875d54"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:78:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "line": 78,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:345df4e8106b9956dab8238b8cb7805208b6f191bbdc6a98c514c4930cf7b389"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:91:22",
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "line": 91,
+      "column": 22,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2d2758adefb4f1621074c7d4cd87863e9f3e1e1d1fa1609ec86d6f28abefdc7e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/event_handler.rs:94:13",
+      "path": "src/vmm/src/devices/virtio/block/virtio/event_handler.rs",
+      "line": 94,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:30515bc25a28981df67bba100915c802c656b469e36ad34ef8fe17d0cffd0abb"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/request.rs:116:17",
+      "path": "src/vmm/src/devices/virtio/block/virtio/request.rs",
+      "line": 116,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2d4719147936e1a06b2f2b3438b88f2108389369c2bb4e5949130d8cabdc527b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/request.rs:124:17",
+      "path": "src/vmm/src/devices/virtio/block/virtio/request.rs",
+      "line": 124,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:569f36b23a0453f129e22b81663f2f835b14197b9a6158dfd97236685a6c1af1"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/block/virtio/request.rs:136:17",
+      "path": "src/vmm/src/devices/virtio/block/virtio/request.rs",
+      "line": 136,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c61616158f278233f4e7c6465e2a94ec9caf9efc0d768e7226c954a76f8e6c41"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:137:17",
+      "path": "src/vmm/src/devices/virtio/device.rs",
+      "line": 137,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a0287b76ad3c4d898bf5373eea6ae405bc6dc0a4a5a2d1f0e9ba590f352607e5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:149:17",
+      "path": "src/vmm/src/devices/virtio/device.rs",
+      "line": 149,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:eebb807e94fbbc803b03eaa492a25d6c64e3e082228cdbb184f8f79dc8bda71b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:158:13",
+      "path": "src/vmm/src/devices/virtio/device.rs",
+      "line": 158,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:615892f7256079a5aa19516c0d47f4de1b4e8046266d6c238d48aed4ecdebbca"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:197:9",
+      "path": "src/vmm/src/devices/virtio/device.rs",
+      "line": 197,
+      "column": 9,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1ae35738ecc68ed8fc0b77b34b856a1ce8db8290ffa40976bec1c5b9b69d727d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/device.rs:200:17",
+      "path": "src/vmm/src/devices/virtio/device.rs",
+      "line": 200,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:b6f503283e0f764ca253de56adfb7be233bf654181af7950a2343f0102f73c95"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:278:9",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 278,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:070be605993b27e3893b4c3ce359adb85e649a9e642b5a3fd9c0bec3dff65cf1"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:356:17",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 356,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f3121341a067fad5859ffe21bbb06b7816b79f6b596150abf0fb86b542f10fcc"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:390:17",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 390,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a90f00f72544b682bac2a777eac2895c109f0aa6c4da09edb3b8109c4ab29428"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:417:17",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 417,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:50d3b21d548cfda30c44047e045d4120fb0e3c3151ac14206d303e4f39b7c78e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:439:17",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 439,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:145b889c34adba2016efb2aa0ca63335be02d60f145d4b9f483e3f6676a56ff3"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:453:13",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 453,
+      "column": 13,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:953403d654de20475eaa925289e5bd6430451004761e36455441985498d530f4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:476:13",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 476,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:aca73f998ca8e9bfb366de10b6df871f85bf041af70ca2dae74e29125c2e2caf"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:482:13",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 482,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0669aaef6a308be42a410ea864ded63f6f62bc2d0cc43ac7af22135b7b30aa36"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:550:21",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 550,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2eb106d95090462dac23873a5fece15b6d0ebafa8c85d12c3be729f420839be1"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:581:13",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 581,
+      "column": 13,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:62425afa6a831d55dab29733bd8e3ded9f6523bad781f78a3fc7123767e41097"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:588:9",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 588,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:281fbbbcbeb8760226f4ddb1a15e5b5b9ae7323c75fbbbce4780affcce0409ab"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:644:17",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 644,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:654beb38939187031763fe1711459d74d552d9ffc9389fceb7919374b1540ecd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:652:9",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 652,
+      "column": 9,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f09628aa4b7443fd4d7d47ab3b00e7d7e0ff3207466116c00973b98993d64e4b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:665:13",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 665,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:650504fe7ec936e94816e68163be1a710b9d5d1776492b6f851e1ff69e978787"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/device.rs:691:13",
+      "path": "src/vmm/src/devices/virtio/mem/device.rs",
+      "line": 691,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:bb7b4406dcf3de69b2d2124e14feae4be9b20eafeeac8f97fe9249fd3d18ff61"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:22:13",
+      "path": "src/vmm/src/devices/virtio/mem/event_handler.rs",
+      "line": 22,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e247cadfe60e6a2a964d731fc229d4a588899cbac25e47191d201a1d2cdd2139"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:32:13",
+      "path": "src/vmm/src/devices/virtio/mem/event_handler.rs",
+      "line": 32,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:16d5901f6d29163e68daa372727da2e646847c14ad40f194adb965b62f3dbf16"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:38:13",
+      "path": "src/vmm/src/devices/virtio/mem/event_handler.rs",
+      "line": 38,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:22692059252743c6da6a0cd41a333dc2832b85cd47de2818a21bd93c2c2e0c9f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:50:13",
+      "path": "src/vmm/src/devices/virtio/mem/event_handler.rs",
+      "line": 50,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:77e676eb61e72bb180e2e7dc883461abd6b816b9851244f371e48f52a99b5621"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:73:13",
+      "path": "src/vmm/src/devices/virtio/mem/event_handler.rs",
+      "line": 73,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4a4b1fc9a6d4634a79214687198007cad5885f9e75531d70a37af1a5249d1fbc"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:78:13",
+      "path": "src/vmm/src/devices/virtio/mem/event_handler.rs",
+      "line": 78,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:dc2e84f180302ebaba73f9542c50266990b9820842dfb32406145e113e6302f4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/mem/event_handler.rs:87:17",
+      "path": "src/vmm/src/devices/virtio/mem/event_handler.rs",
+      "line": 87,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:70db8655907c5a9c3615972cb10b7d2f0364df69d80b75b2695996bce04467cd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:1029:13",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 1029,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ecaa3654de91bd5887ad2e13e9b54b42105b1ea78d46889337114f7cc84d01b0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:1045:13",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 1045,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fb3e06b163a50af6324285f395bee2b6c629b3e1848767a21c0550b8df6d08b9"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:498:21",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 498,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3c38242c71e7e67e402e6db7d0312de9561d1910cadfbe46778db0c2b4349b63"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:503:17",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 503,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6cd5c729784557d0199420920fddb4aca21ed8542b0ca4b43d63a171b31dcd96"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:560:17",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 560,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:48340b19ca1e03c12356db15040c2d70e53e83e80e2e6da7597af12181a66fb4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:566:13",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 566,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6c61e5971acb76d5738eb58af0cb4184377aee52564f7da6860cd92ca6520f99"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:609:17",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 609,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6614ab1c453f6f0104022d5272a273d04a07a3be390f9a13ca284c5d06198768"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:698:29",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 698,
+      "column": 29,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c35c6ddd4d6b8366181b44b2250ebe5eeab32c91a78788e91055f7c599e45c80"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:709:21",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 709,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:538fd62aba50d2f3861e34310a0870a6e1d24632d31f8dd51b19cf6b53ac83eb"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:759:17",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 759,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cadcefc83f4c992ef5c5d0b65e4d9b7b53a3b50aeba315be4e5f260b82198887"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:888:13",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 888,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:85c94644d8bd18aefe9cda95a206bfde4774aa5bdf53ea6910212384b727063a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:925:13",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 925,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:b32a780540c36ea2a155452fc541e4dd589443e64c152e306addc3b5cd02ec08"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:949:17",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 949,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:b2f62df8cf63fc1ec3034d9653fa1ebc96a99bd343e70a41418edd0c3e4baf62"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/device.rs:966:17",
+      "path": "src/vmm/src/devices/virtio/net/device.rs",
+      "line": 966,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:00576e85afb214e3a493d1d488dac45f3af89a95f28a56ab40d794c920826c8e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:108:21",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 108,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3a92e40ebefb8fce9512d008f3331187e1e9647643a5d4219a4a6c0068d545af"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:113:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 113,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0deac52e91846f1a28fe562bb1239cdd5ed0df2c71e057a4c2a067963fef7051"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:26:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 26,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5ed6402ec867a4975768d228290922a6abc1a7db08bd443ffcddc95fa765a9b7"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:33:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 33,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:746ac12e9a550989f9ce1bb16fee0775a4b368723aab9c9a0c4988cf4b1be3d4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:40:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 40,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5ed6402ec867a4975768d228290922a6abc1a7db08bd443ffcddc95fa765a9b7"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:47:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 47,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:746ac12e9a550989f9ce1bb16fee0775a4b368723aab9c9a0c4988cf4b1be3d4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:54:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 54,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:11e022264a4e7b26611550f075762d4afe1a78d99a0b51fadec6e480f90255ba"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:64:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 64,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fb6727cbf72d9a49a1f105aa78425f205ea86e8b77839101d9bd4afcf80a9f4d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:70:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 70,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a3124fca727c4194fc1aa28b07432f524f7f38c3df155be7b8ac3ab94cddbfa5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:78:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 78,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:39e030d758589ff924b9292b1672a678971e61ec59cf7401d9e75242b4875d54"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/net/event_handler.rs:92:13",
+      "path": "src/vmm/src/devices/virtio/net/event_handler.rs",
+      "line": 92,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f0c943edeca79067c7d33bf36e9e33411fddb0885ee9cacfeea751f16aa44d54"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:386:21",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 386,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:678d7bf0f86365074c9a49d1e34910bc407f0feee8d4c2d5a8eaf17adcefaffe"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:392:17",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 392,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:678d7bf0f86365074c9a49d1e34910bc407f0feee8d4c2d5a8eaf17adcefaffe"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:404:21",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 404,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:678d7bf0f86365074c9a49d1e34910bc407f0feee8d4c2d5a8eaf17adcefaffe"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:463:21",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 463,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6c3e06d68548aa82b0c46c2243c594abbfee7cca135ec724361c937a5337434a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:482:13",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 482,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:64667d7f70e50852268c27f6cd8db8a05cce8fa3c1e6de8f34250dbd6f383979"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:493:13",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 493,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:b92a7ed163b8d00d0b0b5fca9713b945da78e3eac3d214be12b1f48f8945c896"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:501:13",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 501,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d88fbb880e5005b2e509311916702f9075e4e499b43aaa4e4b4e8517dc196e05"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:507:13",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 507,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:b92a7ed163b8d00d0b0b5fca9713b945da78e3eac3d214be12b1f48f8945c896"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:562:13",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 562,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ecaa3654de91bd5887ad2e13e9b54b42105b1ea78d46889337114f7cc84d01b0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/device.rs:593:13",
+      "path": "src/vmm/src/devices/virtio/pmem/device.rs",
+      "line": 593,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:651503be4c26b3337aafdf6df9955011079254d2e8ecc2e2459712977b9acf3c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:21:13",
+      "path": "src/vmm/src/devices/virtio/pmem/event_handler.rs",
+      "line": 21,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2f972600123dec11f12c794debd9372b9f487ae3d58aac34f87f8ed5d839c591"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:28:13",
+      "path": "src/vmm/src/devices/virtio/pmem/event_handler.rs",
+      "line": 28,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ea03e89b86cb3a00a984933c78dafc2994d0f6745117711f29d9f2a451203799"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:38:13",
+      "path": "src/vmm/src/devices/virtio/pmem/event_handler.rs",
+      "line": 38,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4b051c726fcf67dc41aaa97090bcc883972cdff3f2e4291f11c65b26f45130c4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:44:13",
+      "path": "src/vmm/src/devices/virtio/pmem/event_handler.rs",
+      "line": 44,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d7c4edea59b9646fd860fcc78c742d054f739e213e357fbf05146e83631bfe6d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:56:13",
+      "path": "src/vmm/src/devices/virtio/pmem/event_handler.rs",
+      "line": 56,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6c4665460c615de98576da226733be3feca0522dd0c20c9312332436943869a0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:75:13",
+      "path": "src/vmm/src/devices/virtio/pmem/event_handler.rs",
+      "line": 75,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:653f562159f2ae70fe0f82b69dae56f287fb4fea6742e2574833e7607b690e24"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:80:13",
+      "path": "src/vmm/src/devices/virtio/pmem/event_handler.rs",
+      "line": 80,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ecc255f0b11389a5fb3f8beab6867ca4cb8d4b03066174bf2c4b09543ace5453"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/pmem/event_handler.rs:89:17",
+      "path": "src/vmm/src/devices/virtio/pmem/event_handler.rs",
+      "line": 89,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5ecdf9706e45f50cade4d833d192037ba237c2c65d8a245bc1ad820fe2f72204"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/queue.rs:567:13",
+      "path": "src/vmm/src/devices/virtio/queue.rs",
+      "line": 567,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0bbee47b0e10fc0751284fa6efbba8afb1eb35c6f090bee605ce8a6b0be4eab0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:152:21",
+      "path": "src/vmm/src/devices/virtio/rng/device.rs",
+      "line": 152,
+      "column": 21,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:01470b7b57274889c2a3fd9e4732418b6ccb0b6c171bac04166e746c39e4fd2c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:161:25",
+      "path": "src/vmm/src/devices/virtio/rng/device.rs",
+      "line": 161,
+      "column": 25,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ebf0d91955344928427f569bc932a3033c98115d933166b8a71ce6348b635baf"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:168:25",
+      "path": "src/vmm/src/devices/virtio/rng/device.rs",
+      "line": 168,
+      "column": 25,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:875febd62f361e36ff33e9337fb60211edcf0ba2a03d4313d393356913e9d7fa"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:174:21",
+      "path": "src/vmm/src/devices/virtio/rng/device.rs",
+      "line": 174,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:24df24c32588b8c4e7d2b9f4bccd0c0aff4f37e8ae926a2d5cae0ed1ea75d535"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:186:21",
+      "path": "src/vmm/src/devices/virtio/rng/device.rs",
+      "line": 186,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e3813b06e875d87e9f16f4d8e00261d067398a43208623da0f16b97ca26b6116"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:200:17",
+      "path": "src/vmm/src/devices/virtio/rng/device.rs",
+      "line": 200,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a24d8bf06596ff386a9474110b9f7df9e7eec1102180c1c6775ef51d37e0e256"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:210:13",
+      "path": "src/vmm/src/devices/virtio/rng/device.rs",
+      "line": 210,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1dd4ae5b896f9811d067945e21abf461733e2555ac33cd5c18548fde6c6825b5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/device.rs:228:17",
+      "path": "src/vmm/src/devices/virtio/rng/device.rs",
+      "line": 228,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f2251ba8c6ee9a72f2d991411ac749319dd5695aff7c635bc3c59b6e9f33bf31"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:22:13",
+      "path": "src/vmm/src/devices/virtio/rng/event_handler.rs",
+      "line": 22,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:19a84e69fcc8b0d3f901a61598e9634396c2849ff718c75d9ef2e763da6d1487"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:29:13",
+      "path": "src/vmm/src/devices/virtio/rng/event_handler.rs",
+      "line": 29,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:649e9a8f141ee2042a57eb31fc60a516929f3d023a6ab125adfde51251d4bc22"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:39:13",
+      "path": "src/vmm/src/devices/virtio/rng/event_handler.rs",
+      "line": 39,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:aaf78b6cf7f97d99886316ca894402ea53144d172df07b82fa5037e034ac8f97"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:45:13",
+      "path": "src/vmm/src/devices/virtio/rng/event_handler.rs",
+      "line": 45,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:56b4c21cf0b586344024b9cae5539fc5169bd615eb100c8c8b8e18f26cdc7d28"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:57:13",
+      "path": "src/vmm/src/devices/virtio/rng/event_handler.rs",
+      "line": 57,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:54fd669d5261ab301a4f825944fcf17bd4ec3bc622f8dc0e2769df970ce698ae"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:80:13",
+      "path": "src/vmm/src/devices/virtio/rng/event_handler.rs",
+      "line": 80,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:153f74bc1952e6b92fc7355f31c7920265fbbfbc4b08472926bc0cd6c84d36bf"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:85:13",
+      "path": "src/vmm/src/devices/virtio/rng/event_handler.rs",
+      "line": 85,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4d2fc786f065cf8f18564eb2b302b698cab3c0216306fabd873f5e2dae2739ed"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/rng/event_handler.rs:94:17",
+      "path": "src/vmm/src/devices/virtio/rng/event_handler.rs",
+      "line": 94,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cb9c1e9eb0e71bc830376d6146a1362425e39b25a77dce4c160b5158426d6e0f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:137:13",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 137,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:36f285ba76496178cd70ee1397249bedb9bd46b3ade70b70a65afdc40a81801e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:146:13",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 146,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:acb3fb2cbf612c583f3b17a29d3313c28a79172afe229e958e66733efa518e69"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:225:25",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 225,
+      "column": 25,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5c7c3752306313d930173b752d23f6201abf02c25b75a112ffc967d93595fc24"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:230:13",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 230,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:760137752ab839046103936455a41ae28a9ce6a2292d0f1a7e7e971a8124563a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:285:25",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 285,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:492bdeeb75fe38045998cce5c613edb807f982845ec25f7a9ea7a13acb3d2905"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:293:17",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 293,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c790ee96409c4732485efb82bfe431e2251f020e2df4feaa8ecd3f87f9df8e0c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:325:29",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 325,
+      "column": 29,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8d3c50c0c6575de5e3102f48b9493fab793a541a4842faf95e01324cfb2b1f67"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:348:25",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 348,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:12bab3dac49fd72333112698d7285836bda989fd3b21aa62452164bbb6db0bc6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:359:21",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 359,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8c2d730e665f32b5cff5e77905430ed69c9ec830f64bd3cabd06030db727b4c8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:363:17",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 363,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5027349d0b8535b760c2f49a52f9dbe8304b0a3c23d11126aace6a31715684a4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/mmio.rs:473:13",
+      "path": "src/vmm/src/devices/virtio/transport/mmio.rs",
+      "line": 473,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:08e3b71d3765864aaa344fa281fc27e2bf1a899b9c8a759cb9e2cf57aaf026fe"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:115:18",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 115,
+      "column": 18,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1ed5bffa320e3f04d5f721bc5bacf5303daf909afb3553dde1069242a9ecb200"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:128:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 128,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f33fd81e4f3398e9731116ec4d7ace2b131c06475434b848c92312760efddeb6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:138:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 138,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:64675520fbd7f107542b0b6e6ff6be3c26a8d927326e66dd817b9929c4cd2b0e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:195:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 195,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9a33898c5c120177cb06e22afb0e9cc9006ebd0d5eb1190b62f21b98cf3a4c49"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:202:13",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 202,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ec80fe8cd3eb837d149dd6bd21d7264b08bb3944e25bbec3f893fda987ff8fcd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:231:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 231,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e0e57764d0413fa84083d7260c1bf61f8fccb6807cfc76852d59e82a8e021448"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:249:13",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 249,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d32e295b35e328c9def5c878bf6da8f839910e247b535edcc7f12a1d0d1a0677"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:296:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 296,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c2293d6c540ea12a18f697c51c216c1a36a86e937e2cfc5441086e58d1a9632f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:359:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 359,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0474c830dc9b15980903214cee2d1fc8863d87471aad8344f7f29b567b121c2a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:390:21",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 390,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0e5acbdc7ff1b2721c3e86601e84aedfa89fdedc093cbce7c201c4443e59d5ac"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:415:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 415,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:81710f941da45be638c2d1a08345b5baf3fe7c79b2b80bcb943398b04a4141c3"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/common_config.rs:91:18",
+      "path": "src/vmm/src/devices/virtio/transport/pci/common_config.rs",
+      "line": 91,
+      "column": 18,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1d225fedc1a0cb126acf8924ce04482bb697d212f2fa1d9f339e576b5506c9be"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:565:13",
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "line": 565,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5c59e8893f3a47c331d11b0fec092c373f57cdaa04f925f60cf0a90cbc1d5087"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:592:13",
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "line": 592,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1a40a7ddd518fb8c957797b0771fdb716c4a2675a1066122917ede65a3bdb99c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:836:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "line": 836,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8cb666bbffdc7bc6138eed3fa2d5cd43fa89b133db18659d244f44f1f5879198"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:851:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "line": 851,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d10f3bb27e452eff0b1e8626b9c7832da7987f06aeddb394b13abaa184037977"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:896:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "line": 896,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7bda7ca1cd6052bf2e6cec81d55c64a435d918269c290a908e02d3df12a01b79"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:910:17",
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "line": 910,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d3cd01550e66f188e78589bd07c88aaa56481513e8dfd03e07522899dbd9c5df"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:941:13",
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "line": 941,
+      "column": 13,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:26c641a5c18dace909c000f36d258b69bdffb01b21e4a8bfa5ef53fe64f0a649"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:952:21",
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "line": 952,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:dbaa68c180a9350de909f1a4ef95aae769c918c80151115c978b9c5b70c6c27e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/transport/pci/device.rs:982:21",
+      "path": "src/vmm/src/devices/virtio/transport/pci/device.rs",
+      "line": 982,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6a7d71429c915122aefb8e6ee4a7ddc8a0e49518cea038854daf3ab2435b60b5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:252:21",
+      "path": "src/vmm/src/devices/virtio/vsock/csm/connection.rs",
+      "line": 252,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e016f2d1f28f908a5588328b9cea06ea4a09364976165b391545dd1403e03bc1"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:262:21",
+      "path": "src/vmm/src/devices/virtio/vsock/csm/connection.rs",
+      "line": 262,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:679c8f1a24bd93cfda06113e739c1e5aea9543b3e5db2f16e514942d34ee6ca1"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:308:21",
+      "path": "src/vmm/src/devices/virtio/vsock/csm/connection.rs",
+      "line": 308,
+      "column": 21,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d4a67012b531c4a4245300679429f2b216b2ccbc91b2720fd357e9782db20d62"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:319:21",
+      "path": "src/vmm/src/devices/virtio/vsock/csm/connection.rs",
+      "line": 319,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:bcdbfd10ee063f231640f4c2787f470b6d030773d493f60c46fc3d2777331f23"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:391:17",
+      "path": "src/vmm/src/devices/virtio/vsock/csm/connection.rs",
+      "line": 391,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e3766c7d9c43d6e2b288c059cb86f7a3b4b9347ef53b8b7835137a4e7f1b05e2"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:460:17",
+      "path": "src/vmm/src/devices/virtio/vsock/csm/connection.rs",
+      "line": 460,
+      "column": 17,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:55b1f4ca600956483f9e889983a4bd090ec8295956698caa1204d2f791110295"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/csm/connection.rs:468:21",
+      "path": "src/vmm/src/devices/virtio/vsock/csm/connection.rs",
+      "line": 468,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3256d0db018ce2029deb122d3f7b783c9c53b7af20bbbdfc8be1a63e0e374a4d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:189:33",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 189,
+      "column": 33,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:266f7d4de967ea065a3c9d82b2e9c81db71d901f03ff69f1777295b3ec97b96e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:206:21",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 206,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fe5e558dfb7410d17d5948dda97a112e46796c0c531f9a660388b1efa1189123"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:213:17",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 213,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:955a7fb314bdab6066d07046cd310c80413ebd1286b8f8802411cc1abbdfd807"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:236:21",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 236,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9d58a404adc46eca0ea147feb6ef20d5899f826ea9be560d6a4cfe8a1e3be4c5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:239:25",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 239,
+      "column": 25,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:955a7fb314bdab6066d07046cd310c80413ebd1286b8f8802411cc1abbdfd807"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:252:17",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 252,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:955a7fb314bdab6066d07046cd310c80413ebd1286b8f8802411cc1abbdfd807"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:274:35",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 274,
+      "column": 35,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:37f470266f70fda83eaf7acdf0c8036fc04896fae6f882652d7331cc0ba37b5f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:277:13",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 277,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d18defb56044b883393271baa5d5c7ecec72f67c64518650df404f3b1797b9c8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:352:17",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 352,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6f371b6ba6539667b126a7055bb91f8fea9315ca770d201e04722d74888d02b4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:363:9",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 363,
+      "column": 9,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:858e7830c9de948e6c82d7e2db533b15e97d1dafaaa204004541dba66cf8b1ac"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:418:13",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 418,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:383471643474724b226873fc6ccf827923c12d45200c8d0067f52a7220407091"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/device.rs:432:17",
+      "path": "src/vmm/src/devices/virtio/vsock/device.rs",
+      "line": 432,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f69bb5f417c3c2f40ba854115ac36722dc59f72966249d3f8a9e7f30e83c978b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:104:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 104,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5d8be579532e14e22acd0a5232c84e850ad9d0c903e2709b8d772378edd60db5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:116:29",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 116,
+      "column": 29,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5e643ceb476d14b5da06f984a7d8f3011fc45fa7837126230f6cf0023edd5f86"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:147:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 147,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5ed6402ec867a4975768d228290922a6abc1a7db08bd443ffcddc95fa765a9b7"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:154:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 154,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:746ac12e9a550989f9ce1bb16fee0775a4b368723aab9c9a0c4988cf4b1be3d4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:161:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 161,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:091146563696bc6a7082bb3779b816e6f78f1b369b2cd9b7e7856ce0e691de22"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:168:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 168,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2c58065639a13a822b6716ab49148276acbe13cc2043e8faee565b9ad25d0b74"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:178:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 178,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fb6727cbf72d9a49a1f105aa78425f205ea86e8b77839101d9bd4afcf80a9f4d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:184:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 184,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a3124fca727c4194fc1aa28b07432f524f7f38c3df155be7b8ac3ab94cddbfa5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:192:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 192,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:39e030d758589ff924b9292b1672a678971e61ec59cf7401d9e75242b4875d54"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:216:21",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 216,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2c900a21156a897a0342f500ab5f1b2622e60647da0cccecf46ad79544f385ab"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:223:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 223,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7c348abe157dacc628acd337fc13d4a93c1c51b2d18ab33b588f11ee24a394a1"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:52:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 52,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7bc7ff58670eab73ef17c11893693251932c9c3ab5ac39551056decf41a0f61e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:58:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 58,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:89c9bf12f9a01be02e8107c51613cf06cbf0591c2570b2429b9af8ef793aeccd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:72:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 72,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4480e3e9e5278b6573c48af15f7b81c5785320a85ca5d82a3a519be420619301"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:78:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 78,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c38d8f939341b694b7bb7381bdddf6e87059861ae436bdff19f26dc2ca5dec0c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/event_handler.rs:98:13",
+      "path": "src/vmm/src/devices/virtio/vsock/event_handler.rs",
+      "line": 98,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d952d73f2519b26125bc5b4c2b76d1022fa07cf31f134e4b4027dd3ee25ff5d2"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:183:17",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 183,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:810907857b021791b99e34726f227d469884cd2bc19c2cba513161f7133ec4e2"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:205:9",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 205,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2e865e765482ef191977708c27456d6d58576ce157758cce4f06347facb12bed"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:221:13",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 221,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7ed605376caff86066f65fc92ce5df803a57261df219b2d7326a53dbdad776f5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:301:17",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 301,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d574b8b99bec929ab2cc3853d7fc327dd93778657f4a916b1a1623bdbcdbee14"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:344:9",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 344,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7efa1c3985d66c0c3409c5086b309dbffaf8f63bc5cbe097dd9d6b4ee053f34b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:368:21",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 368,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:bc2a58e30012a5464e5e8c5b826a7267f095f144dddee72e4d1be1dfefc6cd42"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:389:25",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 389,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:547988e17d8e96fdfa07dc78758cc988acc50be48709bf61303be7438663c0a2"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:415:29",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 415,
+      "column": 29,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d5739036c79031054ba8f3db8f122dd563ad441328c1e4e4c90aef5e68ce04e8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:421:17",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 421,
+      "column": 17,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:61c0a70b2a19ba7b31b3a55d99a086433d15d1929517efa318dce9a53bc28495"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:493:13",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 493,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ef35680d597002d2e2b95c853af2f97c844f1279eb5b77be83c31b5400247f9f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:583:21",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 583,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:985c0fbbdfcfd9b1700b02d8b3b8848eea7ebd4024105f4773c921ff9094adfe"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:672:25",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 672,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e0b4610c3202e3e1d497dc96a1437fc7febe5e966c8143fa0e901f7e6b74f98e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:676:25",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 676,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:db3c0b19e4a1b1cec9c3e629485b7529944dcedc8db6c69420e962f16fd94c03"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:706:21",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 706,
+      "column": 21,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:360c8427c1b2c8ce259a20d88c739fa4fb58e0cad8391249cf11db5d33f0fbe8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:722:29",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 722,
+      "column": 29,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9e04bee1a279963fcaa9b1e3ca259fb29c90460630c2d38b15c891a1ab61bf7b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:741:21",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 741,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9e04bee1a279963fcaa9b1e3ca259fb29c90460630c2d38b15c891a1ab61bf7b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/devices/virtio/vsock/unix/muxer.rs:787:13",
+      "path": "src/vmm/src/devices/virtio/vsock/unix/muxer.rs",
+      "line": 787,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ca7a6e8837ec7432fbb3742cfa1e01d7d8a1ca187ba100a8c9e3c56fba30a496"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/arch/x86.rs:129:9",
+      "path": "src/vmm/src/gdb/arch/x86.rs",
+      "line": 129,
+      "column": 9,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:929d824ec1ce7fdda5cbc07bf9cbed255b4e3cdab9c13015e52db15f22e30e2e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:135:17",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 135,
+      "column": 17,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:827ebc04f6e2ffe0fbdebcc632d32f3bf0e0bf914f2334d6c266dee62ee17d80"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:138:17",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 138,
+      "column": 17,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1edc5226f3924d0d8ef345b6d43ea0cb902112579df8ec55d4074a97e6609126"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:141:17",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 141,
+      "column": 17,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2710dc6cab5fddbfbab6a43a5df5736fc1a4b3428e1af767b94b43a6fe4c8ba0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:143:39",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 143,
+      "column": 39,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:009e37fe71837e4655e6911c3e99d26532c8f702bea5c7884ecc6b0a9a275db2"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:147:17",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 147,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1b7132230da8c3176a4c1ec0aae182fbdc226e974ff7b0d9bde06cae1d8b0599"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:149:17",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 149,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d68b6ef08d92f45a38e61b7cab3d9b97dfaa9ed1bcffeac975a0d8f2e8dfb35e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:151:17",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 151,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cc9c8855e3166a1914d39a8f2e2fcbf365a85916f9f4a95d5cbd9575ac64b67b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:67:21",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 67,
+      "column": 21,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:5dac8d5e619520f65e00294901170b6d4c6912b7a75ba23cb4376759169d3d47"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:84:25",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 84,
+      "column": 25,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:293ee95c93e73462163f4fab1504658a3be9cdb91f6cf94a55a27968711fda17"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/event_loop.rs:88:21",
+      "path": "src/vmm/src/gdb/event_loop.rs",
+      "line": 88,
+      "column": 21,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e789aa2bce849807253f4e39be565fc404acfc28e76134dd088fb64dd930a1c5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/mod.rs:57:5",
+      "path": "src/vmm/src/gdb/mod.rs",
+      "line": 57,
+      "column": 5,
+      "macro_name": "trace",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fcc34737082eb222a25476aef4cb054a07d187b2944cca572601542a13f1ba9f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/target.rs:209:13",
+      "path": "src/vmm/src/gdb/target.rs",
+      "line": 209,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c92c4562e295967df1af1d5a176340b861a8b6450ef1ea37cf8a0e3539cd8237"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/target.rs:282:13",
+      "path": "src/vmm/src/gdb/target.rs",
+      "line": 282,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4dd5bca827028ea80fdbf59f90e7fcfb32e7df00800206c7637bb6c23c57d16f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/target.rs:311:13",
+      "path": "src/vmm/src/gdb/target.rs",
+      "line": 311,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:6ec702e7b25e27a9349fd87985cce1546d4670d8bc89d6121a85d491991ee279"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/target.rs:324:13",
+      "path": "src/vmm/src/gdb/target.rs",
+      "line": 324,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fd2ca0f934391d4bb49e274120ee171c4abbe71daabf4df2edbf95112c1271d4"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/target.rs:428:17",
+      "path": "src/vmm/src/gdb/target.rs",
+      "line": 428,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d141bbc5373a95fc79df71e65fbfeac652384a8e6d03cbb54584908fe4f1691f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/target.rs:443:21",
+      "path": "src/vmm/src/gdb/target.rs",
+      "line": 443,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:60d0ef00138691d12a5bf7ba0c2a46df9c474a96600727786ab5b7c82d17f8c7"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/target.rs:468:17",
+      "path": "src/vmm/src/gdb/target.rs",
+      "line": 468,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d141bbc5373a95fc79df71e65fbfeac652384a8e6d03cbb54584908fe4f1691f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/gdb/target.rs:483:21",
+      "path": "src/vmm/src/gdb/target.rs",
+      "line": 483,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:976038bcd7b6479a6ca4a87d186c75c1e7c549857d915626c0e50879844a91b7"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/lib.rs:690:9",
+      "path": "src/vmm/src/lib.rs",
+      "line": 690,
+      "column": 9,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4529fb3ef603031e3c208e7053cc285ce8014dd59b3cac6c10f9055a3ca47628"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/lib.rs:765:13",
+      "path": "src/vmm/src/lib.rs",
+      "line": 765,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:514c3244aa51411225f5fda339cfccf7940388763dbe863e33f3bc3d266214be"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/lib.rs:770:13",
+      "path": "src/vmm/src/lib.rs",
+      "line": 770,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a5d3a923b5da4e04e6ed1c2dc6b7862ee34e483baa9069808a01f9b3de39f1dc"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/lib.rs:775:13",
+      "path": "src/vmm/src/lib.rs",
+      "line": 775,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4832b683bbc9d2170fcddc7a5a1559fdcab41fa0651e48ca494269ff9fb62908"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/lib.rs:781:13",
+      "path": "src/vmm/src/lib.rs",
+      "line": 781,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4a5d651639ff7c1725147311387065975d96c31e74b69a10499d404cd40634ec"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/lib.rs:821:21",
+      "path": "src/vmm/src/lib.rs",
+      "line": 821,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:950dca6db97235bd6f9e8dec7795c6bed5bbbf1dfcbead9a33a96e5e709bcf24"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/lib.rs:831:21",
+      "path": "src/vmm/src/lib.rs",
+      "line": 831,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:97e0aa2d1e4b0a67484deb6281db55fdbbc560dded54ab99d338c5ae69e7dae9"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/logger/mod.rs:44:13",
+      "path": "src/vmm/src/logger/mod.rs",
+      "line": 44,
+      "column": 13,
+      "macro_name": "warn_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a90f816affef974edbc89dd231bb4dae7bb792b7eac75dbd096b3764f06648d8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/logger/mod.rs:47:13",
+      "path": "src/vmm/src/logger/mod.rs",
+      "line": 47,
+      "column": 13,
+      "macro_name": "warn_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0985179602d56d65c742c5ff973a9fbf5653f0995a09e4144c469178baea1288"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/logger/rate_limited.rs:175:21",
+      "path": "src/vmm/src/logger/rate_limited.rs",
+      "line": 175,
+      "column": 21,
+      "macro_name": "warn_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:70d168afd8bd2f81237a8681ff8f92d644401fd1cded0cf1561818ef0b70e81f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/mmds/token.rs:211:13",
+      "path": "src/vmm/src/mmds/token.rs",
+      "line": 211,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a425e4a75c1dc50e6e4fb52bfe8a715fd9a65dc4a9283c6a9efcafb28cd00098"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/configuration.rs:283:13",
+      "path": "src/vmm/src/pci/configuration.rs",
+      "line": 283,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:38540781996fc3591038a2f1cfb6fef449cb3bb6684b1d261efea5288149391c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/configuration.rs:293:17",
+      "path": "src/vmm/src/pci/configuration.rs",
+      "line": 293,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cadbcabaa8f6d323f1a4be4c03ec71d001c1d8ad715cae0853f6689f9c79948c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/configuration.rs:305:13",
+      "path": "src/vmm/src/pci/configuration.rs",
+      "line": 305,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cadbcabaa8f6d323f1a4be4c03ec71d001c1d8ad715cae0853f6689f9c79948c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/configuration.rs:329:13",
+      "path": "src/vmm/src/pci/configuration.rs",
+      "line": 329,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cadbcabaa8f6d323f1a4be4c03ec71d001c1d8ad715cae0853f6689f9c79948c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:175:17",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 175,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a64c3eb444951c7ba4f9c16067308dc32b59de416f42026f8d75056a03601c54"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:185:25",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 185,
+      "column": 25,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7f72fb8225bea2a65bea494ee588724c8149154900225017abab652fc51219e6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:189:17",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 189,
+      "column": 17,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:cc135a0a8af3031fab287288afd16a311fd7b52b78051aeda5b04edc39acfa70"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:191:21",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 191,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:179eb90a96869cbe58340d0dbb84a2f620360ffb5363e7c268ca1c2dd0add63e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:233:13",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 233,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:447bbb88561b42d29af05e927085e524fd1b638a31ba82deec4194ca824a36c6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:246:25",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 246,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:faac1a6d6027d15944afb214ba0559f4e9be12eb041d9711d0012b0ba3f3247d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:264:25",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 264,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:faac1a6d6027d15944afb214ba0559f4e9be12eb041d9711d0012b0ba3f3247d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:272:17",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 272,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:24417f0e9a9b09e10e9f1fc91ea54cfed0ccf9b062b784dff130083318b67cb0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:286:13",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 286,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:49d24171112508ead0a43a106cfcfe270fd0c54c4666824c659746e8a2074fb2"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:303:28",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 303,
+      "column": 28,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e258e941ea3daa861e6a8cf0600998b12b9189092d9d5ee868fc1da15899adbd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:317:28",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 317,
+      "column": 28,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:e258e941ea3daa861e6a8cf0600998b12b9189092d9d5ee868fc1da15899adbd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:320:20",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 320,
+      "column": 20,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:91b79bbbaec7150bec8e36796d4ce185155e313de4bf743e5e1ebc45191b4ef8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:346:17",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 346,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:7f72fb8225bea2a65bea494ee588724c8149154900225017abab652fc51219e6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:379:13",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 379,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3977d188a8f83ab3c91f9d46cd6f3f8d8673db659ec11f7725b93a888ad35a7d"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:390:25",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 390,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:887847c1c41ff5f1aedda2b4d9f4b248fe68e776f207b048fbfe6260f2b45279"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:401:25",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 401,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:887847c1c41ff5f1aedda2b4d9f4b248fe68e776f207b048fbfe6260f2b45279"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:409:17",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 409,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:24417f0e9a9b09e10e9f1fc91ea54cfed0ccf9b062b784dff130083318b67cb0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:417:9",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 417,
+      "column": 9,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:08c584d0e445e2ba28c6e6afb90e31e01c14bb6e78b665f9a935e5a935355121"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:458:22",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 458,
+      "column": 22,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a131894c7b117b22970475d747db6ba62ac6798db08ec1667305cdee420cae82"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/pci/msix.rs:459:23",
+      "path": "src/vmm/src/pci/msix.rs",
+      "line": 459,
+      "column": 23,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ea8c94f26a84c20a7c6882a2ffa38916269e68f0b329d41b3ebad179547b9814"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:228:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 228,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:893c7c74a305b3e6590a684b4ad6c90f747044e7c1bd69a1714cbde7ae5a503e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:229:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 229,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:aeb9334e1baf772568569a02fe2b4215dd992130ae85f21bbc9be76f09883b1c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:231:17",
+      "path": "src/vmm/src/persist.rs",
+      "line": 231,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:90b92014572b0cf343bf69b5cbcd27d9adc2abc45894c7031210a14fce0c8bb9"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:235:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 235,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:893c7c74a305b3e6590a684b4ad6c90f747044e7c1bd69a1714cbde7ae5a503e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:236:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 236,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fc12596144b489880ed1b0e455db6776327f8ecbbcbe8d311d0a4bb732ce73a6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:239:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 239,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8176593b0e42c45a5df25a51f210120702d593a5ace9dea5311704ca0c914ca0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:240:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 240,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:aeb9334e1baf772568569a02fe2b4215dd992130ae85f21bbc9be76f09883b1c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:243:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 243,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:8176593b0e42c45a5df25a51f210120702d593a5ace9dea5311704ca0c914ca0"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:244:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 244,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:fc12596144b489880ed1b0e455db6776327f8ecbbcbe8d311d0a4bb732ce73a6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:264:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 264,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:30a440f388e5c03d71d01187d051fc2c68c044b8ae3b9a54d7aed8b95c539712"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:265:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 265,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:da685946fe992dd91a599a88087b5767698d7b2ce999bdbb427e71f96b2b1ae8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:267:17",
+      "path": "src/vmm/src/persist.rs",
+      "line": 267,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:24ae3eb26c917becb28f5f023194035f2f7052d4e7dd1481fd8d6ce4674224a5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:271:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 271,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:30a440f388e5c03d71d01187d051fc2c68c044b8ae3b9a54d7aed8b95c539712"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:272:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 272,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2a3030d651d31ca0c23a4814a1ee2d13df36faedaf5261a97ee164a503f2dcab"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:275:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 275,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:370acc5f2aeef6c1767d2ea6153c39760b4ea9da3845023b852cc28302ba00ee"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:276:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 276,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:da685946fe992dd91a599a88087b5767698d7b2ce999bdbb427e71f96b2b1ae8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:279:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 279,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:370acc5f2aeef6c1767d2ea6153c39760b4ea9da3845023b852cc28302ba00ee"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/persist.rs:280:13",
+      "path": "src/vmm/src/persist.rs",
+      "line": 280,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2a3030d651d31ca0c23a4814a1ee2d13df36faedaf5261a97ee164a503f2dcab"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/rate_limiter/mod.rs:199:17",
+      "path": "src/vmm/src/rate_limiter/mod.rs",
+      "line": 199,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:855376208ed75d3439facc91cdf587e9fb6618a5f02910c0b90eca408aea5b2e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/resources.rs:218:13",
+      "path": "src/vmm/src/resources.rs",
+      "line": 218,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1b4cfd932bbf44fc9422542dd8511f40bff8e92b49af1d2343f61ba99c6502a5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/rpc_interface.rs:390:13",
+      "path": "src/vmm/src/rpc_interface.rs",
+      "line": 390,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1b4cfd932bbf44fc9422542dd8511f40bff8e92b49af1d2343f61ba99c6502a5"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/rpc_interface.rs:457:17",
+      "path": "src/vmm/src/rpc_interface.rs",
+      "line": 457,
+      "column": 17,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:b6af5031b55d7847c8e02a252332e3b6e7f77ce6b235f5ba0f0425b47ae9f2f3"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/rpc_interface.rs:651:13",
+      "path": "src/vmm/src/rpc_interface.rs",
+      "line": 651,
+      "column": 13,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:51ba9f308828769d1bd1e5db175b299435bcff796c33b5e9e200ae62a360c4fd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/rpc_interface.rs:680:9",
+      "path": "src/vmm/src/rpc_interface.rs",
+      "line": 680,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:1d521f50fff7feeacb493a7071ab0c873096479d087adb3cd96e945c10359fa6"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/rpc_interface.rs:877:9",
+      "path": "src/vmm/src/rpc_interface.rs",
+      "line": 877,
+      "column": 9,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:bed4aaf8b1268a4f5d3f676cd9dfb4f12a86c36f14c28d36317478b08e330228"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/rpc_interface.rs:890:9",
+      "path": "src/vmm/src/rpc_interface.rs",
+      "line": 890,
+      "column": 9,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0fa07d6b2fab727e3b6409195e81c3c01945c9a6a2a48e5ca6c9146848d29f07"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/rpc_interface.rs:940:17",
+      "path": "src/vmm/src/rpc_interface.rs",
+      "line": 940,
+      "column": 17,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9916117db3c73e59d8382a6b0a988179d3301742a9d8f80535036f0283bc0e45"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/rpc_interface.rs:950:17",
+      "path": "src/vmm/src/rpc_interface.rs",
+      "line": 950,
+      "column": 17,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:4d04d804f0e0acbec1a502a7698f4184932b953a980b9fcaec7cdb97cdae6080"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/signal_handler.rs:144:9",
+      "path": "src/vmm/src/signal_handler.rs",
+      "line": 144,
+      "column": 9,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:018f6dc04574e4f5edecbf46f14756ca31b664c950bce0ffd542ea88da840022"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/signal_handler.rs:150:5",
+      "path": "src/vmm/src/signal_handler.rs",
+      "line": 150,
+      "column": 5,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:f64365dbbc6ffaaee633ff551e67ad5e8f3445549869e16a9aff0f0e5d36699a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/signal_handler.rs:25:9",
+      "path": "src/vmm/src/signal_handler.rs",
+      "line": 25,
+      "column": 9,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2d4c54e89a6e738629ffd0d64896d31ba8e328f979b0f5cce3b3a433b16224af"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/signal_handler.rs:45:13",
+      "path": "src/vmm/src/signal_handler.rs",
+      "line": 45,
+      "column": 13,
+      "macro_name": "error_unrestricted",
+      "syntax": "macro-template",
+      "source_context": "production",
+      "fingerprint": "sha256:a36ddfd9a632b54f8cefd16b8775c0b8fac50e1e0c50b88eca7d20bb8b2ae562"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/signal_handler.rs:70:5",
+      "path": "src/vmm/src/signal_handler.rs",
+      "line": 70,
+      "column": 5,
+      "macro_name": "error_unrestricted",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:aa5d3c8d0cf0be8633945b6d7c35ce454d897e9c66e382692aa6e17558d35f40"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/interrupts.rs:184:21",
+      "path": "src/vmm/src/vstate/interrupts.rs",
+      "line": 184,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a0ddb32a5e680fe38e8876b238b4a741d88cfa56623d20f89d2329fe75afb05e"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/memory.rs:429:21",
+      "path": "src/vmm/src/vstate/memory.rs",
+      "line": 429,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:2cc6919fb0f2b12a70446ec3b1f5bd1dd32a17666017bddc647f50c1abf5877b"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/memory.rs:447:21",
+      "path": "src/vmm/src/vstate/memory.rs",
+      "line": 447,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:53781238b2faeb7705512f4190164f4449eb8ce4696822c8e331f0f32dfcaa95"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:302:21",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 302,
+      "column": 21,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0be0652ed92d08aa80004d8c512c38816a63134ccaf85cd98fe31f7bc67ee12f"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:368:13",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 368,
+      "column": 13,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a9e5692d463de739da1670aa96073b3942d18dfbbb45980e123f9d1af5ecd5fc"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:388:13",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 388,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d6f935686c2ef581a3e698cf48839d193936a94d88648c5e6d5bef86dca8e13a"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:426:25",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 426,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3d435a04cc1f4cf6cf9ebbeaf75a024e36b1f8488c90fbfef2dd19d3017387bd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:436:25",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 436,
+      "column": 25,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:3d435a04cc1f4cf6cf9ebbeaf75a024e36b1f8488c90fbfef2dd19d3017387bd"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:447:17",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 447,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:a8b85b2fba7690018e40d230153dde64ce5cfc9eb994b7bd83c219920ea3481c"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:459:17",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 459,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:c6b73229075e8e56e4a34f999c1b4970cffbaf4e5f66e2834f6a06a702b8d121"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:467:21",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 467,
+      "column": 21,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:ee4bbabe8505dc93986bda0f52870f641bf52db0705942c4e0eff1a49532aaa8"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:475:21",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 475,
+      "column": 21,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0a2ea996885651573964a3fc665321628174bc71c86405b4a3c53f6b30212057"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:496:17",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 496,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:33f7995871909a45135f0fcbd343b7c3b2edae20beb9e2255735fb2e8bde0a47"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vcpu.rs:504:17",
+      "path": "src/vmm/src/vstate/vcpu.rs",
+      "line": 504,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:d3df90935775cf9460133f47756edc019ee6f3c97380cf953167447567b52418"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vm.rs:167:21",
+      "path": "src/vmm/src/vstate/vm.rs",
+      "line": 167,
+      "column": 21,
+      "macro_name": "info",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:0af20a950f890a2779ba4b985122d1360a324079fca2b5d0a4ad942091e37b93"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vm.rs:250:13",
+      "path": "src/vmm/src/vstate/vm.rs",
+      "line": 250,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:9047eca7d5e2100ce572adec3c3166afa1d0df81919fc1e8c30e3d35db2da216"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vm.rs:253:13",
+      "path": "src/vmm/src/vstate/vm.rs",
+      "line": 253,
+      "column": 13,
+      "macro_name": "warn",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:388bddced83e99963f0721866273f552371ec2a45012fe4ac8d076178e090c91"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vm.rs:397:17",
+      "path": "src/vmm/src/vstate/vm.rs",
+      "line": 397,
+      "column": 17,
+      "macro_name": "error",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:541c3625bbb770d7afc922f86bc79771de738a9c6dcba560096afad9a868f1ee"
+    },
+    {
+      "id": "logger-invocation:src/vmm/src/vstate/vm.rs:701:9",
+      "path": "src/vmm/src/vstate/vm.rs",
+      "line": 701,
+      "column": 9,
+      "macro_name": "debug",
+      "syntax": "direct",
+      "source_context": "production",
+      "fingerprint": "sha256:aa2a8fb0bf27d1210f4426b575a3bf0fcdba36aca5ec82ea68f6895dde6c66c1"
+    }
+  ]
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1395,9 +1395,10 @@ cargo test -p bangbang-firecracker-capability-audit --all-targets --locked
 cargo run -p bangbang-firecracker-capability-audit --locked -- validate
 ```
 
-The workspace suite also validates both checked JSON files. Ordinary validation
-uses only the pinned checked-in inventory and does not discover or require a
-sibling Firecracker checkout.
+The workspace suite also validates all four checked JSON files: the general
+source manifest and capability overlay plus the logger producer manifest and
+human audit. Ordinary validation uses only the pinned checked-in inventory and
+does not discover or require a sibling Firecracker checkout.
 
 ### Evidence Responsibilities
 
@@ -1507,6 +1508,27 @@ Review exact identity changes before updating `source-manifest.json`. Never
 use regeneration to alter `capabilities.json`; missing and stale overlays
 must be resolved deliberately.
 
+The checked logger producer audit uses the same authority split. The pinned
+machine manifest contains exactly 429 ordinary and 39 unrestricted public
+logger calls across 81 matching files: 446 production, zero test-only, 22
+example, 466 direct, and two nonlogger macro-template invocations. Compare both
+machine manifests with the command above, or create a logger-only candidate:
+
+```sh
+cargo run -p bangbang-firecracker-capability-audit --locked -- \
+  regenerate-logger-producers \
+  --firecracker /path/to/firecracker \
+  --output codex-work/tmp/logger-producer-manifest.candidate.json
+```
+
+The destination must not exist and cannot alias any checked JSON artifact.
+Review every identity, syntax/source context, input, count, and fingerprint
+change before deliberately updating `logger-producer-manifest.json`. The
+command never creates, carries forward, or rewrites semantic classes in
+`logger-producer-audit.json`; missing or stale mappings require human review.
+The class policy and safe-field boundary are documented in the
+[logger producer contract](../compat/firecracker/v1.16.0/logger-contract.md).
+
 The final parent gate is:
 
 ```sh
@@ -1514,9 +1536,9 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- validate --final
 ```
 
 Final mode fails while any `audit-required` or
-`missing-platform-feasible` record remains. An inventory-only change does not
-promote a capability without record-specific implementation and validation
-evidence.
+`missing-platform-feasible` capability record or any planned logger class
+remains. An inventory-only change does not promote a capability without
+record-specific implementation and validation evidence.
 
 ## Running Tests
 

--- a/tools/firecracker-capability-audit/Cargo.toml
+++ b/tools/firecracker-capability-audit/Cargo.toml
@@ -6,8 +6,12 @@ repository.workspace = true
 publish = false
 
 [dependencies]
+proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
+quote = "1.0.46"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.140"
+sha2 = "0.11.0"
+syn = { version = "2.0.118", features = ["full", "visit"] }
 yaml_serde = "0.10.4"
 
 [lints]

--- a/tools/firecracker-capability-audit/src/lib.rs
+++ b/tools/firecracker-capability-audit/src/lib.rs
@@ -1,9 +1,21 @@
 //! Firecracker capability inventory parsing, validation, and source comparison.
 
+mod logger_model;
+mod logger_upstream;
+mod logger_validate;
 mod model;
 mod upstream;
 mod validate;
 
+pub use logger_model::{
+    LoggerClassDisposition, LoggerCompiledEvent, LoggerDeliveryPolicy, LoggerField,
+    LoggerInvocation, LoggerInvocationSyntax, LoggerLevelPolicy, LoggerLimiterPolicy, LoggerMacro,
+    LoggerModulePolicy, LoggerNonApplicableReason, LoggerOriginPolicy, LoggerProducerAudit,
+    LoggerProducerClass, LoggerProducerCounts, LoggerProducerManifest, LoggerProducerMapping,
+    LoggerSourceContext, LoggerSubsystem,
+};
+pub use logger_upstream::derive_logger_producer_manifest;
+pub use logger_validate::validate_logger_producers;
 pub use model::{
     AuditMode, Baseline, Capability, CapabilityInventory, Counts, Disposition, Input,
     PlatformExclusion, Reference, SourceItem, SourceManifest,
@@ -24,10 +36,20 @@ pub const FIRECRACKER_TARGET: &str = "aarch64-macos-hvf";
 pub const SCHEMA_VERSION: u32 = 1;
 /// Current generated source-manifest format.
 pub const GENERATOR_VERSION: u32 = 1;
+/// Current checked-in logger producer schema.
+pub const LOGGER_PRODUCER_SCHEMA_VERSION: u32 = 1;
+/// Current generated logger producer format.
+pub const LOGGER_PRODUCER_GENERATOR_VERSION: u32 = 1;
 /// Repository-relative generated source manifest path.
 pub const SOURCE_MANIFEST_PATH: &str = "compat/firecracker/v1.16.0/source-manifest.json";
 /// Repository-relative human capability overlay path.
 pub const CAPABILITY_INVENTORY_PATH: &str = "compat/firecracker/v1.16.0/capabilities.json";
+/// Repository-relative generated logger producer manifest path.
+pub const LOGGER_PRODUCER_MANIFEST_PATH: &str =
+    "compat/firecracker/v1.16.0/logger-producer-manifest.json";
+/// Repository-relative human logger producer audit path.
+pub const LOGGER_PRODUCER_AUDIT_PATH: &str =
+    "compat/firecracker/v1.16.0/logger-producer-audit.json";
 
 /// Error produced while reading, parsing, or deriving an inventory.
 #[derive(Debug)]
@@ -65,10 +87,53 @@ pub fn read_capability_inventory(path: &Path) -> Result<CapabilityInventory, Aud
         .map_err(|error| AuditError::new(format!("failed to parse capability inventory: {error}")))
 }
 
+/// Read and parse a checked-in logger producer manifest.
+pub fn read_logger_producer_manifest(path: &Path) -> Result<LoggerProducerManifest, AuditError> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        AuditError::new(format!("failed to read logger producer manifest: {error}"))
+    })?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        AuditError::new(format!("failed to parse logger producer manifest: {error}"))
+    })
+}
+
+/// Read and parse a checked-in logger producer audit overlay.
+pub fn read_logger_producer_audit(path: &Path) -> Result<LoggerProducerAudit, AuditError> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        AuditError::new(format!("failed to read logger producer audit: {error}"))
+    })?;
+    serde_json::from_slice(&bytes)
+        .map_err(|error| AuditError::new(format!("failed to parse logger producer audit: {error}")))
+}
+
 /// Serialize a generated source manifest using canonical pretty JSON.
 pub fn source_manifest_json(manifest: &SourceManifest) -> Result<Vec<u8>, AuditError> {
     let mut bytes = serde_json::to_vec_pretty(manifest).map_err(|error| {
         AuditError::new(format!("failed to serialize source manifest: {error}"))
+    })?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+/// Serialize a generated logger producer manifest using canonical pretty JSON.
+pub fn logger_producer_manifest_json(
+    manifest: &LoggerProducerManifest,
+) -> Result<Vec<u8>, AuditError> {
+    let mut bytes = serde_json::to_vec_pretty(manifest).map_err(|error| {
+        AuditError::new(format!(
+            "failed to serialize logger producer manifest: {error}"
+        ))
+    })?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+/// Serialize a human logger producer audit using canonical pretty JSON.
+pub fn logger_producer_audit_json(audit: &LoggerProducerAudit) -> Result<Vec<u8>, AuditError> {
+    let mut bytes = serde_json::to_vec_pretty(audit).map_err(|error| {
+        AuditError::new(format!(
+            "failed to serialize logger producer audit: {error}"
+        ))
     })?;
     bytes.push(b'\n');
     Ok(bytes)

--- a/tools/firecracker-capability-audit/src/logger_model.rs
+++ b/tools/firecracker-capability-audit/src/logger_model.rs
@@ -1,0 +1,363 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Baseline, Input, Reference};
+
+/// Cardinalities for the pinned logger producer source population.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoggerProducerCounts {
+    pub scanned_rust_files: usize,
+    pub matching_input_files: usize,
+    pub ordinary: usize,
+    pub unrestricted: usize,
+    pub error: usize,
+    pub warn: usize,
+    pub info: usize,
+    pub debug: usize,
+    pub trace: usize,
+    pub error_unrestricted: usize,
+    pub warn_unrestricted: usize,
+    pub info_unrestricted: usize,
+    pub production: usize,
+    pub test: usize,
+    pub example: usize,
+    pub direct: usize,
+    pub macro_template: usize,
+}
+
+/// Exact Firecracker logger macro invoked by a producer site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum LoggerMacro {
+    #[serde(rename = "error")]
+    Error,
+    #[serde(rename = "warn")]
+    Warn,
+    #[serde(rename = "info")]
+    Info,
+    #[serde(rename = "debug")]
+    Debug,
+    #[serde(rename = "trace")]
+    Trace,
+    #[serde(rename = "error_unrestricted")]
+    ErrorUnrestricted,
+    #[serde(rename = "warn_unrestricted")]
+    WarnUnrestricted,
+    #[serde(rename = "info_unrestricted")]
+    InfoUnrestricted,
+}
+
+impl LoggerMacro {
+    pub(crate) const fn from_name(name: &str) -> Option<Self> {
+        match name.as_bytes() {
+            b"error" => Some(Self::Error),
+            b"warn" => Some(Self::Warn),
+            b"info" => Some(Self::Info),
+            b"debug" => Some(Self::Debug),
+            b"trace" => Some(Self::Trace),
+            b"error_unrestricted" => Some(Self::ErrorUnrestricted),
+            b"warn_unrestricted" => Some(Self::WarnUnrestricted),
+            b"info_unrestricted" => Some(Self::InfoUnrestricted),
+            _ => None,
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+            Self::ErrorUnrestricted => "error_unrestricted",
+            Self::WarnUnrestricted => "warn_unrestricted",
+            Self::InfoUnrestricted => "info_unrestricted",
+        }
+    }
+
+    pub const fn is_unrestricted(self) -> bool {
+        matches!(
+            self,
+            Self::ErrorUnrestricted | Self::WarnUnrestricted | Self::InfoUnrestricted
+        )
+    }
+}
+
+/// Compile context of a pinned logger invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerSourceContext {
+    Production,
+    Test,
+    Example,
+}
+
+/// Rust syntax location in which a pinned invocation is expressed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerInvocationSyntax {
+    Direct,
+    MacroTemplate,
+}
+
+/// One value-redacted invocation identity derived from pinned Rust syntax.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoggerInvocation {
+    pub id: String,
+    pub path: String,
+    pub line: usize,
+    pub column: usize,
+    pub macro_name: LoggerMacro,
+    pub syntax: LoggerInvocationSyntax,
+    pub source_context: LoggerSourceContext,
+    pub fingerprint: String,
+}
+
+/// Machine-owned logger producer manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoggerProducerManifest {
+    pub schema_version: u32,
+    pub baseline: Baseline,
+    pub generator_version: u32,
+    pub inputs: Vec<Input>,
+    pub counts: LoggerProducerCounts,
+    pub invocations: Vec<LoggerInvocation>,
+}
+
+/// Closed subsystem owning a semantic logger producer class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerSubsystem {
+    Api,
+    Process,
+    VmLifecycle,
+    Snapshot,
+    CpuAndMachine,
+    DeviceTransport,
+    Storage,
+    NetworkAndMmds,
+    Vsock,
+    MemoryDevices,
+    RemainingDevices,
+    Observability,
+    DeveloperTooling,
+}
+
+/// Delivery contract for a semantic logger class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerDeliveryPolicy {
+    UnrestrictedHost,
+    BoundedHost,
+    NonblockingAsync,
+    NonblockingGuest,
+    NotApplicable,
+}
+
+/// Fixed level for a semantic logger class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerLevelPolicy {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+    CategoryDerived,
+    OutcomeDerived,
+    NotApplicable,
+}
+
+/// Fixed module identity for a semantic logger class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum LoggerModulePolicy {
+    #[serde(rename = "bangbang::process")]
+    Process,
+    #[serde(rename = "bangbang::panic")]
+    Panic,
+    #[serde(rename = "bangbang::worker")]
+    Worker,
+    #[serde(rename = "bangbang_runtime::api_server")]
+    ApiServer,
+    #[serde(rename = "bangbang_runtime::vmm_action")]
+    VmmAction,
+    #[serde(rename = "bangbang_runtime::boot_timer")]
+    BootTimer,
+    #[serde(rename = "bangbang_runtime::lifecycle")]
+    Lifecycle,
+    #[serde(rename = "bangbang_runtime::snapshot")]
+    Snapshot,
+    #[serde(rename = "bangbang_runtime::device")]
+    Device,
+    #[serde(rename = "bangbang_hvf::backend")]
+    Backend,
+    #[serde(rename = "bangbang_hvf::vcpu")]
+    Vcpu,
+    #[serde(rename = "not-applicable")]
+    NotApplicable,
+}
+
+/// Origin-prefix behavior for a semantic logger class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerOriginPolicy {
+    Configurable,
+    PreparedEmergency,
+    NotApplicable,
+}
+
+/// Limiter behavior for a semantic logger class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerLimiterPolicy {
+    Unrestricted,
+    RateLimited,
+    NotApplicable,
+}
+
+/// Closed safe field vocabulary admitted by a semantic logger class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerField {
+    Action,
+    Category,
+    CpuTimeUs,
+    DeviceKind,
+    Method,
+    Operation,
+    Outcome,
+    Route,
+    SuppressedCount,
+    WallTimeUs,
+}
+
+/// Delivery state of a semantic logger class in the current repository.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerClassDisposition {
+    Implemented,
+    Planned,
+    NotApplicable,
+}
+
+/// Exact reason that an upstream invocation is not a Bangbang producer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerNonApplicableReason {
+    TestOnly,
+    ExampleOnly,
+    DeveloperInstrumentation,
+    DuplicatePropagation,
+    TracingOwned,
+    LinuxKvmOnly,
+    X86Only,
+    UpstreamInternalMechanism,
+    SeparateToolOwner,
+}
+
+/// Existing compiled event shape synchronized by the audit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoggerCompiledEvent {
+    ApiRequest,
+    InstanceStart,
+    FlushMetrics,
+    BootTime,
+    RateLimitRecovery,
+    ProcessPanic,
+    ProcessExit,
+}
+
+/// Human-owned policy and evidence for one coherent semantic producer class.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoggerProducerClass {
+    pub id: String,
+    pub subsystem: LoggerSubsystem,
+    pub summary: String,
+    pub guest_triggerable: bool,
+    pub delivery: LoggerDeliveryPolicy,
+    pub level: LoggerLevelPolicy,
+    pub module: LoggerModulePolicy,
+    pub origin: LoggerOriginPolicy,
+    pub limiter: LoggerLimiterPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limiter_identity: Option<String>,
+    pub allowed_fields: Vec<LoggerField>,
+    pub disposition: LoggerClassDisposition,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub non_applicable_reason: Option<LoggerNonApplicableReason>,
+    pub rationale: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery_issue: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub compiled_events: Vec<LoggerCompiledEvent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub implementation: Vec<Reference>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validation: Vec<Reference>,
+}
+
+/// Explicit source-to-class mapping for one pinned invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoggerProducerMapping {
+    pub invocation_id: String,
+    pub class_id: String,
+}
+
+/// Human-owned logger producer classification overlay.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoggerProducerAudit {
+    pub schema_version: u32,
+    pub baseline: Baseline,
+    pub classes: Vec<LoggerProducerClass>,
+    pub mappings: Vec<LoggerProducerMapping>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logger_macro_names_are_exact() {
+        assert_eq!(LoggerMacro::from_name("error"), Some(LoggerMacro::Error));
+        assert_eq!(
+            LoggerMacro::from_name("error_unrestricted"),
+            Some(LoggerMacro::ErrorUnrestricted)
+        );
+        assert_eq!(LoggerMacro::from_name("compile_error"), None);
+        assert_eq!(LoggerMacro::from_name("__log_error"), None);
+    }
+
+    #[test]
+    fn rejects_unknown_logger_class_fields() {
+        let json = r#"{
+            "id":"logger.api-request",
+            "subsystem":"api",
+            "summary":"request",
+            "guest_triggerable":false,
+            "delivery":"unrestricted-host",
+            "level":"info",
+            "module":"bangbang_runtime::api_server",
+            "origin":"configurable",
+            "limiter":"unrestricted",
+            "allowed_fields":[],
+            "disposition":"planned",
+            "rationale":"planned",
+            "typo":true
+        }"#;
+        let error = serde_json::from_str::<LoggerProducerClass>(json)
+            .expect_err("unknown class fields must fail");
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_out_of_vocabulary_logger_policy() {
+        let error = serde_json::from_str::<LoggerClassDisposition>(r#""other""#)
+            .expect_err("out-of-vocabulary disposition must fail");
+        assert!(error.to_string().contains("unknown variant"));
+    }
+}

--- a/tools/firecracker-capability-audit/src/logger_upstream.rs
+++ b/tools/firecracker-capability-audit/src/logger_upstream.rs
@@ -1,0 +1,650 @@
+use std::path::Path;
+
+use proc_macro2::{TokenStream, TokenTree};
+use quote::ToTokens;
+use sha2::{Digest, Sha256};
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::visit::Visit;
+use syn::{Attribute, Expr, ForeignItem, ImplItem, Item, Meta, Stmt, Token, TraitItem};
+
+use crate::upstream::{ensure_regular_input, git_output, read_input};
+use crate::{
+    AuditError, Baseline, FIRECRACKER_COMMIT, FIRECRACKER_TARGET, FIRECRACKER_VERSION, Input,
+    LOGGER_PRODUCER_GENERATOR_VERSION, LOGGER_PRODUCER_SCHEMA_VERSION, LoggerInvocation,
+    LoggerInvocationSyntax, LoggerMacro, LoggerProducerCounts, LoggerProducerManifest,
+    LoggerSourceContext, ensure_pinned_checkout,
+};
+
+const LOGGER_EXTRACTOR: &str = "rust-logger-macro-v1";
+
+/// Derive the machine-owned logger producer manifest from pinned Rust syntax.
+pub fn derive_logger_producer_manifest(path: &Path) -> Result<LoggerProducerManifest, AuditError> {
+    let checkout = ensure_pinned_checkout(path)?;
+    let rust_paths = tracked_rust_paths(&checkout)?;
+    let mut invocations = Vec::new();
+    let mut inputs = Vec::new();
+
+    for input_path in &rust_paths {
+        let source = read_input(&checkout, input_path)?;
+        let mut file_invocations = extract_logger_invocations(input_path, &source)?;
+        if file_invocations.is_empty() {
+            continue;
+        }
+        let object = format!("HEAD:{input_path}");
+        inputs.push(Input {
+            path: input_path.clone(),
+            git_blob: git_output(&checkout, &["rev-parse", &object])?,
+            extractor: LOGGER_EXTRACTOR.to_string(),
+        });
+        invocations.append(&mut file_invocations);
+    }
+
+    invocations.sort_by(|left, right| left.id.cmp(&right.id));
+    let counts = logger_counts(rust_paths.len(), inputs.len(), &invocations);
+    Ok(LoggerProducerManifest {
+        schema_version: LOGGER_PRODUCER_SCHEMA_VERSION,
+        baseline: Baseline {
+            version: FIRECRACKER_VERSION.to_string(),
+            commit: FIRECRACKER_COMMIT.to_string(),
+            target: FIRECRACKER_TARGET.to_string(),
+        },
+        generator_version: LOGGER_PRODUCER_GENERATOR_VERSION,
+        inputs,
+        counts,
+        invocations,
+    })
+}
+
+fn tracked_rust_paths(checkout: &Path) -> Result<Vec<String>, AuditError> {
+    let paths = git_output(
+        checkout,
+        &["ls-tree", "-r", "--name-only", "HEAD", "--", "src"],
+    )?;
+    let rust_paths = paths
+        .lines()
+        .filter(|path| path.starts_with("src/") && path.ends_with(".rs"))
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    for path in &rust_paths {
+        ensure_regular_input(checkout, path)?;
+    }
+    Ok(rust_paths)
+}
+
+fn extract_logger_invocations(
+    path: &str,
+    source: &str,
+) -> Result<Vec<LoggerInvocation>, AuditError> {
+    let syntax = syn::parse_file(source)
+        .map_err(|_| AuditError::new(format!("failed to parse Rust logger input: {path}")))?;
+    let mut visitor = LoggerVisitor::new(path);
+    visitor.visit_file(&syntax);
+    visitor.invocations.sort_by(|left, right| {
+        (left.line, left.column, left.macro_name).cmp(&(right.line, right.column, right.macro_name))
+    });
+    for pair in visitor.invocations.windows(2) {
+        let [left, right] = pair else {
+            continue;
+        };
+        if left.id == right.id {
+            return Err(AuditError::new(format!(
+                "duplicate logger invocation source identity: {}",
+                left.id
+            )));
+        }
+    }
+    Ok(visitor.invocations)
+}
+
+struct LoggerVisitor<'a> {
+    path: &'a str,
+    base_context: LoggerSourceContext,
+    test_only: bool,
+    invocations: Vec<LoggerInvocation>,
+}
+
+impl<'a> LoggerVisitor<'a> {
+    fn new(path: &'a str) -> Self {
+        Self {
+            path,
+            base_context: path_source_context(path),
+            test_only: false,
+            invocations: Vec::new(),
+        }
+    }
+
+    fn push_attrs(&mut self, attrs: &[Attribute]) -> bool {
+        let previous = self.test_only;
+        self.test_only |= attrs_require_test(attrs);
+        previous
+    }
+
+    fn restore_test_context(&mut self, previous: bool) {
+        self.test_only = previous;
+    }
+
+    fn source_context(&self) -> LoggerSourceContext {
+        if self.test_only {
+            LoggerSourceContext::Test
+        } else {
+            self.base_context
+        }
+    }
+
+    fn record_invocation(
+        &mut self,
+        macro_name: LoggerMacro,
+        syntax: LoggerInvocationSyntax,
+        span: proc_macro2::Span,
+        normalized: &str,
+    ) {
+        let start = span.start();
+        let line = start.line;
+        let column = start.column + 1;
+        self.invocations.push(LoggerInvocation {
+            id: format!("logger-invocation:{}:{line}:{column}", self.path),
+            path: self.path.to_string(),
+            line,
+            column,
+            macro_name,
+            syntax,
+            source_context: self.source_context(),
+            fingerprint: sha256_fingerprint(normalized.as_bytes()),
+        });
+    }
+}
+
+impl<'ast> Visit<'ast> for LoggerVisitor<'_> {
+    fn visit_file(&mut self, node: &'ast syn::File) {
+        let previous = self.push_attrs(&node.attrs);
+        syn::visit::visit_file(self, node);
+        self.restore_test_context(previous);
+    }
+
+    fn visit_item(&mut self, node: &'ast Item) {
+        let previous = self.push_attrs(item_attrs(node));
+        syn::visit::visit_item(self, node);
+        self.restore_test_context(previous);
+    }
+
+    fn visit_impl_item(&mut self, node: &'ast ImplItem) {
+        let previous = self.push_attrs(impl_item_attrs(node));
+        syn::visit::visit_impl_item(self, node);
+        self.restore_test_context(previous);
+    }
+
+    fn visit_trait_item(&mut self, node: &'ast TraitItem) {
+        let previous = self.push_attrs(trait_item_attrs(node));
+        syn::visit::visit_trait_item(self, node);
+        self.restore_test_context(previous);
+    }
+
+    fn visit_foreign_item(&mut self, node: &'ast ForeignItem) {
+        let previous = self.push_attrs(foreign_item_attrs(node));
+        syn::visit::visit_foreign_item(self, node);
+        self.restore_test_context(previous);
+    }
+
+    fn visit_expr(&mut self, node: &'ast Expr) {
+        let previous = self.push_attrs(expr_attrs(node));
+        syn::visit::visit_expr(self, node);
+        self.restore_test_context(previous);
+    }
+
+    fn visit_stmt(&mut self, node: &'ast Stmt) {
+        let previous = self.push_attrs(stmt_attrs(node));
+        syn::visit::visit_stmt(self, node);
+        self.restore_test_context(previous);
+    }
+
+    fn visit_arm(&mut self, node: &'ast syn::Arm) {
+        let previous = self.push_attrs(&node.attrs);
+        syn::visit::visit_arm(self, node);
+        self.restore_test_context(previous);
+    }
+
+    fn visit_macro(&mut self, node: &'ast syn::Macro) {
+        for invocation in logger_invocations_in_tokens(&node.tokens) {
+            self.record_invocation(
+                invocation.macro_name,
+                LoggerInvocationSyntax::MacroTemplate,
+                invocation.span,
+                &invocation.normalized,
+            );
+        }
+
+        let Some(macro_name) = node
+            .path
+            .segments
+            .last()
+            .and_then(|segment| LoggerMacro::from_name(&segment.ident.to_string()))
+        else {
+            return;
+        };
+        let normalized = node.to_token_stream().to_string();
+        self.record_invocation(
+            macro_name,
+            LoggerInvocationSyntax::Direct,
+            node.path.span(),
+            &normalized,
+        );
+    }
+}
+
+fn sha256_fingerprint(bytes: &[u8]) -> String {
+    let hex_digit = |nibble: u8| {
+        char::from(if nibble < 10 {
+            b'0' + nibble
+        } else {
+            b'a' + (nibble - 10)
+        })
+    };
+    let digest = Sha256::digest(bytes);
+    let mut fingerprint = String::with_capacity(71);
+    fingerprint.push_str("sha256:");
+    for byte in digest {
+        fingerprint.push(hex_digit(byte >> 4));
+        fingerprint.push(hex_digit(byte & 0x0f));
+    }
+    fingerprint
+}
+
+fn path_source_context(path: &str) -> LoggerSourceContext {
+    let components = path.split('/').collect::<Vec<_>>();
+    if components.contains(&"tests") {
+        LoggerSourceContext::Test
+    } else if components.contains(&"examples") {
+        LoggerSourceContext::Example
+    } else {
+        LoggerSourceContext::Production
+    }
+}
+
+fn attrs_require_test(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attribute| {
+        if attribute.path().is_ident("test") {
+            return true;
+        }
+        if !attribute.path().is_ident("cfg") {
+            return false;
+        }
+        attribute
+            .parse_args::<Meta>()
+            .is_ok_and(|predicate| meta_requires_test(&predicate))
+    })
+}
+
+fn meta_requires_test(meta: &Meta) -> bool {
+    match meta {
+        Meta::Path(path) => path.is_ident("test"),
+        Meta::List(list) if list.path.is_ident("all") => {
+            parse_meta_list(&list.tokens).is_some_and(|items| items.iter().any(meta_requires_test))
+        }
+        Meta::List(list) if list.path.is_ident("any") => parse_meta_list(&list.tokens)
+            .is_some_and(|items| !items.is_empty() && items.iter().all(meta_requires_test)),
+        Meta::List(_) | Meta::NameValue(_) => false,
+    }
+}
+
+fn parse_meta_list(tokens: &TokenStream) -> Option<Punctuated<Meta, Token![,]>> {
+    Punctuated::<Meta, Token![,]>::parse_terminated
+        .parse2(tokens.clone())
+        .ok()
+}
+
+struct TokenInvocation {
+    macro_name: LoggerMacro,
+    span: proc_macro2::Span,
+    normalized: String,
+}
+
+fn logger_invocations_in_tokens(tokens: &TokenStream) -> Vec<TokenInvocation> {
+    let mut invocations = Vec::new();
+    collect_logger_invocations_in_tokens(tokens, &mut invocations);
+    invocations
+}
+
+fn collect_logger_invocations_in_tokens(
+    tokens: &TokenStream,
+    invocations: &mut Vec<TokenInvocation>,
+) {
+    let trees = tokens.clone().into_iter().collect::<Vec<_>>();
+    for (index, tree) in trees.iter().enumerate() {
+        if let TokenTree::Group(group) = tree {
+            collect_logger_invocations_in_tokens(&group.stream(), invocations);
+        }
+        let Some(TokenTree::Punct(punctuation)) = trees.get(index) else {
+            continue;
+        };
+        if punctuation.as_char() != '!'
+            || trees
+                .get(index + 1)
+                .is_none_or(|tree| !matches!(tree, TokenTree::Group(_)))
+        {
+            continue;
+        }
+        let Some(TokenTree::Ident(identifier)) =
+            index.checked_sub(1).and_then(|index| trees.get(index))
+        else {
+            continue;
+        };
+        let Some(macro_name) = LoggerMacro::from_name(&identifier.to_string()) else {
+            continue;
+        };
+        let start = qualified_path_start(&trees, index - 1);
+        let Some(invocation_tokens) = trees.get(start..=index + 1) else {
+            continue;
+        };
+        let normalized = invocation_tokens
+            .iter()
+            .cloned()
+            .collect::<TokenStream>()
+            .to_string();
+        invocations.push(TokenInvocation {
+            macro_name,
+            span: identifier.span(),
+            normalized,
+        });
+    }
+}
+
+fn qualified_path_start(trees: &[TokenTree], final_ident: usize) -> usize {
+    let mut start = final_ident;
+    while start >= 3
+        && matches!(trees.get(start - 1), Some(TokenTree::Punct(punctuation)) if punctuation.as_char() == ':')
+        && matches!(trees.get(start - 2), Some(TokenTree::Punct(punctuation)) if punctuation.as_char() == ':')
+        && matches!(trees.get(start - 3), Some(TokenTree::Ident(_)))
+    {
+        start -= 3;
+    }
+    if start >= 2
+        && matches!(trees.get(start - 1), Some(TokenTree::Punct(punctuation)) if punctuation.as_char() == ':')
+        && matches!(trees.get(start - 2), Some(TokenTree::Punct(punctuation)) if punctuation.as_char() == ':')
+    {
+        start -= 2;
+    }
+    start
+}
+
+fn logger_counts(
+    scanned_rust_files: usize,
+    matching_input_files: usize,
+    invocations: &[LoggerInvocation],
+) -> LoggerProducerCounts {
+    let macro_count = |name| {
+        invocations
+            .iter()
+            .filter(|invocation| invocation.macro_name == name)
+            .count()
+    };
+    let context_count = |context| {
+        invocations
+            .iter()
+            .filter(|invocation| invocation.source_context == context)
+            .count()
+    };
+    LoggerProducerCounts {
+        scanned_rust_files,
+        matching_input_files,
+        ordinary: invocations
+            .iter()
+            .filter(|invocation| !invocation.macro_name.is_unrestricted())
+            .count(),
+        unrestricted: invocations
+            .iter()
+            .filter(|invocation| invocation.macro_name.is_unrestricted())
+            .count(),
+        error: macro_count(LoggerMacro::Error),
+        warn: macro_count(LoggerMacro::Warn),
+        info: macro_count(LoggerMacro::Info),
+        debug: macro_count(LoggerMacro::Debug),
+        trace: macro_count(LoggerMacro::Trace),
+        error_unrestricted: macro_count(LoggerMacro::ErrorUnrestricted),
+        warn_unrestricted: macro_count(LoggerMacro::WarnUnrestricted),
+        info_unrestricted: macro_count(LoggerMacro::InfoUnrestricted),
+        production: context_count(LoggerSourceContext::Production),
+        test: context_count(LoggerSourceContext::Test),
+        example: context_count(LoggerSourceContext::Example),
+        direct: invocations
+            .iter()
+            .filter(|invocation| invocation.syntax == LoggerInvocationSyntax::Direct)
+            .count(),
+        macro_template: invocations
+            .iter()
+            .filter(|invocation| invocation.syntax == LoggerInvocationSyntax::MacroTemplate)
+            .count(),
+    }
+}
+
+fn item_attrs(item: &Item) -> &[Attribute] {
+    match item {
+        Item::Const(item) => &item.attrs,
+        Item::Enum(item) => &item.attrs,
+        Item::ExternCrate(item) => &item.attrs,
+        Item::Fn(item) => &item.attrs,
+        Item::ForeignMod(item) => &item.attrs,
+        Item::Impl(item) => &item.attrs,
+        Item::Macro(item) => &item.attrs,
+        Item::Mod(item) => &item.attrs,
+        Item::Static(item) => &item.attrs,
+        Item::Struct(item) => &item.attrs,
+        Item::Trait(item) => &item.attrs,
+        Item::TraitAlias(item) => &item.attrs,
+        Item::Type(item) => &item.attrs,
+        Item::Union(item) => &item.attrs,
+        Item::Use(item) => &item.attrs,
+        Item::Verbatim(_) | _ => &[],
+    }
+}
+
+fn impl_item_attrs(item: &ImplItem) -> &[Attribute] {
+    match item {
+        ImplItem::Const(item) => &item.attrs,
+        ImplItem::Fn(item) => &item.attrs,
+        ImplItem::Type(item) => &item.attrs,
+        ImplItem::Macro(item) => &item.attrs,
+        ImplItem::Verbatim(_) | _ => &[],
+    }
+}
+
+fn trait_item_attrs(item: &TraitItem) -> &[Attribute] {
+    match item {
+        TraitItem::Const(item) => &item.attrs,
+        TraitItem::Fn(item) => &item.attrs,
+        TraitItem::Type(item) => &item.attrs,
+        TraitItem::Macro(item) => &item.attrs,
+        TraitItem::Verbatim(_) | _ => &[],
+    }
+}
+
+fn foreign_item_attrs(item: &ForeignItem) -> &[Attribute] {
+    match item {
+        ForeignItem::Fn(item) => &item.attrs,
+        ForeignItem::Static(item) => &item.attrs,
+        ForeignItem::Type(item) => &item.attrs,
+        ForeignItem::Macro(item) => &item.attrs,
+        ForeignItem::Verbatim(_) | _ => &[],
+    }
+}
+
+fn stmt_attrs(statement: &Stmt) -> &[Attribute] {
+    match statement {
+        Stmt::Local(local) => &local.attrs,
+        Stmt::Macro(statement) => &statement.attrs,
+        Stmt::Item(_) | Stmt::Expr(_, _) => &[],
+    }
+}
+
+fn expr_attrs(expression: &Expr) -> &[Attribute] {
+    match expression {
+        Expr::Array(expression) => &expression.attrs,
+        Expr::Assign(expression) => &expression.attrs,
+        Expr::Async(expression) => &expression.attrs,
+        Expr::Await(expression) => &expression.attrs,
+        Expr::Binary(expression) => &expression.attrs,
+        Expr::Block(expression) => &expression.attrs,
+        Expr::Break(expression) => &expression.attrs,
+        Expr::Call(expression) => &expression.attrs,
+        Expr::Cast(expression) => &expression.attrs,
+        Expr::Closure(expression) => &expression.attrs,
+        Expr::Const(expression) => &expression.attrs,
+        Expr::Continue(expression) => &expression.attrs,
+        Expr::Field(expression) => &expression.attrs,
+        Expr::ForLoop(expression) => &expression.attrs,
+        Expr::Group(expression) => &expression.attrs,
+        Expr::If(expression) => &expression.attrs,
+        Expr::Index(expression) => &expression.attrs,
+        Expr::Infer(expression) => &expression.attrs,
+        Expr::Let(expression) => &expression.attrs,
+        Expr::Lit(expression) => &expression.attrs,
+        Expr::Loop(expression) => &expression.attrs,
+        Expr::Macro(expression) => &expression.attrs,
+        Expr::Match(expression) => &expression.attrs,
+        Expr::MethodCall(expression) => &expression.attrs,
+        Expr::Paren(expression) => &expression.attrs,
+        Expr::Path(expression) => &expression.attrs,
+        Expr::Range(expression) => &expression.attrs,
+        Expr::RawAddr(expression) => &expression.attrs,
+        Expr::Reference(expression) => &expression.attrs,
+        Expr::Repeat(expression) => &expression.attrs,
+        Expr::Return(expression) => &expression.attrs,
+        Expr::Struct(expression) => &expression.attrs,
+        Expr::Try(expression) => &expression.attrs,
+        Expr::TryBlock(expression) => &expression.attrs,
+        Expr::Tuple(expression) => &expression.attrs,
+        Expr::Unary(expression) => &expression.attrs,
+        Expr::Unsafe(expression) => &expression.attrs,
+        Expr::While(expression) => &expression.attrs,
+        Expr::Yield(expression) => &expression.attrs,
+        Expr::Verbatim(_) | _ => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract(path: &str, source: &str) -> Vec<LoggerInvocation> {
+        extract_logger_invocations(path, source).expect("fixture must extract")
+    }
+
+    #[test]
+    fn extracts_exact_qualified_and_multiline_invocations() {
+        let invocations = extract(
+            "src/vmm/src/sample.rs",
+            r#"
+fn run() {
+    error!("one");
+    crate::logger::warn_unrestricted!(
+        "two"
+    );
+    log::trace!("three");
+    compile_error!("not a logger call");
+    __log_error!("not public");
+}
+"#,
+        );
+        assert_eq!(invocations.len(), 3);
+        assert_eq!(invocations[0].macro_name, LoggerMacro::Error);
+        assert_eq!(invocations[1].macro_name, LoggerMacro::WarnUnrestricted);
+        assert_eq!(invocations[2].macro_name, LoggerMacro::Trace);
+        assert!(
+            invocations
+                .iter()
+                .all(|invocation| invocation.syntax == LoggerInvocationSyntax::Direct)
+        );
+        assert!(
+            invocations
+                .iter()
+                .all(|invocation| invocation.source_context == LoggerSourceContext::Production)
+        );
+    }
+
+    #[test]
+    fn ignores_logger_wrapper_definitions() {
+        let invocations = extract(
+            "src/vmm/src/logger.rs",
+            r#"
+macro_rules! error {
+    ($($arg:tt)+) => { $crate::logger::__log_error!($($arg)+) };
+}
+"#,
+        );
+        assert!(invocations.is_empty());
+    }
+
+    #[test]
+    fn extracts_target_invocations_in_nonlogger_macro_templates() {
+        let source = r#"fn run() { outer!(error!("secret-value")); }"#;
+        let invocations = extract_logger_invocations("src/vmm/src/sample.rs", source)
+            .expect("macro-template producer must extract");
+        assert_eq!(invocations.len(), 1);
+        assert_eq!(invocations[0].macro_name, LoggerMacro::Error);
+        assert_eq!(invocations[0].syntax, LoggerInvocationSyntax::MacroTemplate);
+        assert!(!invocations[0].fingerprint.contains("secret-value"));
+    }
+
+    #[test]
+    fn keeps_direct_and_nested_sites_distinct_and_ignores_text() {
+        let invocations = extract(
+            "src/vmm/src/sample.rs",
+            r#"
+fn run() {
+    error!("same");
+    outer!(error!("same"));
+    let _text = "warn!(\"not syntax\")";
+    // info!("not syntax");
+}
+"#,
+        );
+        assert_eq!(invocations.len(), 2);
+        assert_eq!(invocations[0].syntax, LoggerInvocationSyntax::Direct);
+        assert_eq!(invocations[1].syntax, LoggerInvocationSyntax::MacroTemplate);
+        assert_ne!(invocations[0].id, invocations[1].id);
+        assert_eq!(invocations[0].fingerprint, invocations[1].fingerprint);
+    }
+
+    #[test]
+    fn derives_test_and_example_contexts_from_syntax_and_paths() {
+        let invocations = extract(
+            "src/vmm/src/sample.rs",
+            r#"
+#[cfg(test)]
+mod tests {
+    fn test_call() { warn!("test"); }
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn production_possible() { info!("production"); }
+
+#[cfg(all(target_arch = "aarch64", test))]
+fn test_required() { debug!("test"); }
+"#,
+        );
+        assert_eq!(invocations[0].source_context, LoggerSourceContext::Test);
+        assert_eq!(
+            invocations[1].source_context,
+            LoggerSourceContext::Production
+        );
+        assert_eq!(invocations[2].source_context, LoggerSourceContext::Test);
+
+        let examples = extract(
+            "src/log-instrument/examples/one.rs",
+            "fn main() { info!(\"example\"); }",
+        );
+        assert_eq!(examples[0].source_context, LoggerSourceContext::Example);
+    }
+
+    #[test]
+    fn fingerprints_normalize_formatting_and_change_with_tokens() {
+        let compact = extract("src/vmm/src/sample.rs", "fn f(){error!(\"one\");}");
+        let spaced = extract("src/vmm/src/sample.rs", "fn f() { error! ( \"one\" ) ; }");
+        let changed = extract("src/vmm/src/sample.rs", "fn f(){error!(\"two\");}");
+        assert_eq!(compact[0].fingerprint, spaced[0].fingerprint);
+        assert_ne!(compact[0].fingerprint, changed[0].fingerprint);
+        assert!(compact[0].fingerprint.starts_with("sha256:"));
+        assert_eq!(compact[0].fingerprint.len(), 71);
+    }
+}

--- a/tools/firecracker-capability-audit/src/logger_validate.rs
+++ b/tools/firecracker-capability-audit/src/logger_validate.rs
@@ -324,10 +324,16 @@ fn validate_expected_counts(counts: &LoggerProducerCounts, errors: &mut Vec<Stri
             ));
         }
     }
-    if counts.production + counts.test + counts.example != counts.ordinary + counts.unrestricted {
+    let invocation_total = counts.ordinary.checked_add(counts.unrestricted);
+    let context_total = counts
+        .production
+        .checked_add(counts.test)
+        .and_then(|total| total.checked_add(counts.example));
+    if context_total.is_none() || context_total != invocation_total {
         errors.push("logger source-context counts must cover every invocation".to_string());
     }
-    if counts.direct + counts.macro_template != counts.ordinary + counts.unrestricted {
+    let syntax_total = counts.direct.checked_add(counts.macro_template);
+    if syntax_total.is_none() || syntax_total != invocation_total {
         errors.push("logger syntax-kind counts must cover every invocation".to_string());
     }
 }

--- a/tools/firecracker-capability-audit/src/logger_validate.rs
+++ b/tools/firecracker-capability-audit/src/logger_validate.rs
@@ -1,14 +1,14 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Component, Path};
-use std::process::Command;
+use std::path::{Component, Path, PathBuf};
 
+use crate::validate::{tracked_repository_files, validate_reference};
 use crate::{
     AuditMode, Baseline, FIRECRACKER_COMMIT, FIRECRACKER_TARGET, FIRECRACKER_VERSION,
     LOGGER_PRODUCER_GENERATOR_VERSION, LOGGER_PRODUCER_SCHEMA_VERSION, LoggerClassDisposition,
     LoggerCompiledEvent, LoggerDeliveryPolicy, LoggerInvocation, LoggerInvocationSyntax,
     LoggerLevelPolicy, LoggerLimiterPolicy, LoggerModulePolicy, LoggerNonApplicableReason,
     LoggerOriginPolicy, LoggerProducerAudit, LoggerProducerClass, LoggerProducerCounts,
-    LoggerProducerManifest, LoggerSourceContext, Reference, ValidationErrors,
+    LoggerProducerManifest, LoggerSourceContext, ValidationErrors,
 };
 
 const EXPECTED_SCANNED_RUST_FILES: usize = 362;
@@ -339,6 +339,7 @@ fn validate_audit(
     mode: AuditMode,
     errors: &mut Vec<String>,
 ) {
+    let tracked_files = tracked_repository_files(repository_root, errors);
     check_sorted_unique(
         audit.classes.iter().map(|class| class.id.as_str()),
         "logger class id",
@@ -350,7 +351,7 @@ fn validate_audit(
         .map(|class| (class.id.as_str(), class))
         .collect::<BTreeMap<_, _>>();
     for class in &audit.classes {
-        validate_class(class, repository_root, mode, errors);
+        validate_class(class, repository_root, &tracked_files, mode, errors);
     }
 
     check_sorted_unique(
@@ -424,6 +425,7 @@ fn validate_audit(
 fn validate_class(
     class: &LoggerProducerClass,
     repository_root: &Path,
+    tracked_files: &BTreeSet<PathBuf>,
     mode: AuditMode,
     errors: &mut Vec<String>,
 ) {
@@ -471,7 +473,13 @@ fn validate_class(
         errors,
     );
     for reference in class.implementation.iter().chain(&class.validation) {
-        validate_reference(reference, repository_root, &class.id, errors);
+        validate_reference(
+            reference,
+            repository_root,
+            tracked_files,
+            &format!("logger class {} evidence", class.id),
+            errors,
+        );
     }
     if (class.compiled_events.is_empty()
         && (!class.implementation.is_empty() || !class.validation.is_empty()))
@@ -678,61 +686,6 @@ fn validate_compiled_event_set(classes: &[LoggerProducerClass], errors: &mut Vec
             errors.push(format!(
                 "logger compiled event must have its exact class: {event:?} -> {owners:?}, expected {expected_class}"
             ));
-        }
-    }
-}
-
-fn validate_reference(
-    reference: &Reference,
-    repository_root: &Path,
-    class_id: &str,
-    errors: &mut Vec<String>,
-) {
-    match reference {
-        Reference::Local { path, anchor } => {
-            if !is_safe_relative_path(Path::new(path)) {
-                errors.push(format!(
-                    "logger class local reference must be repository-relative: {class_id} -> {path}"
-                ));
-                return;
-            }
-            if anchor
-                .as_deref()
-                .is_some_and(|anchor| anchor.trim().is_empty())
-            {
-                errors.push(format!(
-                    "logger class local reference anchor must not be empty: {class_id} -> {path}"
-                ));
-            }
-            let full_path = repository_root.join(path);
-            let Ok(metadata) = std::fs::symlink_metadata(&full_path) else {
-                errors.push(format!(
-                    "logger class local reference does not exist: {class_id} -> {path}"
-                ));
-                return;
-            };
-            if metadata.file_type().is_symlink() || !metadata.is_file() {
-                errors.push(format!(
-                    "logger class local reference must be a regular non-symlink file: {class_id} -> {path}"
-                ));
-            }
-            let status = Command::new("git")
-                .arg("-C")
-                .arg(repository_root)
-                .args(["ls-files", "--error-unmatch", "--", path])
-                .output();
-            if !status.is_ok_and(|output| output.status.success()) {
-                errors.push(format!(
-                    "logger class local reference must be tracked: {class_id} -> {path}"
-                ));
-            }
-        }
-        Reference::Github { url } | Reference::Authoritative { url } => {
-            if !url.starts_with("https://") {
-                errors.push(format!(
-                    "logger class external reference must use HTTPS: {class_id}"
-                ));
-            }
         }
     }
 }

--- a/tools/firecracker-capability-audit/src/logger_validate.rs
+++ b/tools/firecracker-capability-audit/src/logger_validate.rs
@@ -1,0 +1,814 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path};
+use std::process::Command;
+
+use crate::{
+    AuditMode, Baseline, FIRECRACKER_COMMIT, FIRECRACKER_TARGET, FIRECRACKER_VERSION,
+    LOGGER_PRODUCER_GENERATOR_VERSION, LOGGER_PRODUCER_SCHEMA_VERSION, LoggerClassDisposition,
+    LoggerCompiledEvent, LoggerDeliveryPolicy, LoggerInvocation, LoggerInvocationSyntax,
+    LoggerLevelPolicy, LoggerLimiterPolicy, LoggerModulePolicy, LoggerNonApplicableReason,
+    LoggerOriginPolicy, LoggerProducerAudit, LoggerProducerClass, LoggerProducerCounts,
+    LoggerProducerManifest, LoggerSourceContext, Reference, ValidationErrors,
+};
+
+const EXPECTED_SCANNED_RUST_FILES: usize = 362;
+const EXPECTED_MATCHING_INPUT_FILES: usize = 81;
+const EXPECTED_ORDINARY: usize = 429;
+const EXPECTED_UNRESTRICTED: usize = 39;
+const EXPECTED_ERROR: usize = 180;
+const EXPECTED_WARN: usize = 138;
+const EXPECTED_INFO: usize = 54;
+const EXPECTED_DEBUG: usize = 47;
+const EXPECTED_TRACE: usize = 10;
+const EXPECTED_ERROR_UNRESTRICTED: usize = 22;
+const EXPECTED_WARN_UNRESTRICTED: usize = 7;
+const EXPECTED_INFO_UNRESTRICTED: usize = 10;
+const EXPECTED_PRODUCTION: usize = 446;
+const EXPECTED_TEST: usize = 0;
+const EXPECTED_EXAMPLE: usize = 22;
+const EXPECTED_DIRECT: usize = 466;
+const EXPECTED_MACRO_TEMPLATE: usize = 2;
+const LOGGER_EXTRACTOR: &str = "rust-logger-macro-v1";
+const PLANNED_ISSUES: [&str; 3] = ["#1807", "#1808", "#1809"];
+
+/// Validate the checked logger source manifest and human classification overlay.
+pub fn validate_logger_producers(
+    manifest: &LoggerProducerManifest,
+    audit: &LoggerProducerAudit,
+    repository_root: &Path,
+    mode: AuditMode,
+) -> Result<(), ValidationErrors> {
+    let mut errors = Vec::new();
+    validate_baselines(manifest, audit, &mut errors);
+    validate_manifest(manifest, &mut errors);
+    validate_audit(manifest, audit, repository_root, mode, &mut errors);
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(ValidationErrors::from_messages(errors))
+    }
+}
+
+fn validate_baselines(
+    manifest: &LoggerProducerManifest,
+    audit: &LoggerProducerAudit,
+    errors: &mut Vec<String>,
+) {
+    if manifest.schema_version != LOGGER_PRODUCER_SCHEMA_VERSION {
+        errors.push(format!(
+            "logger producer manifest schema_version must be {LOGGER_PRODUCER_SCHEMA_VERSION}, found {}",
+            manifest.schema_version
+        ));
+    }
+    if audit.schema_version != LOGGER_PRODUCER_SCHEMA_VERSION {
+        errors.push(format!(
+            "logger producer audit schema_version must be {LOGGER_PRODUCER_SCHEMA_VERSION}, found {}",
+            audit.schema_version
+        ));
+    }
+    if manifest.generator_version != LOGGER_PRODUCER_GENERATOR_VERSION {
+        errors.push(format!(
+            "logger producer generator_version must be {LOGGER_PRODUCER_GENERATOR_VERSION}, found {}",
+            manifest.generator_version
+        ));
+    }
+    if manifest.baseline != audit.baseline {
+        errors.push("logger producer manifest and audit baselines differ".to_string());
+    }
+    validate_expected_baseline("logger producer manifest", &manifest.baseline, errors);
+    validate_expected_baseline("logger producer audit", &audit.baseline, errors);
+}
+
+fn validate_expected_baseline(label: &str, baseline: &Baseline, errors: &mut Vec<String>) {
+    if baseline.version != FIRECRACKER_VERSION {
+        errors.push(format!(
+            "{label} version must be {FIRECRACKER_VERSION}, found {}",
+            baseline.version
+        ));
+    }
+    if baseline.commit != FIRECRACKER_COMMIT {
+        errors.push(format!(
+            "{label} commit must be {FIRECRACKER_COMMIT}, found {}",
+            baseline.commit
+        ));
+    }
+    if baseline.target != FIRECRACKER_TARGET {
+        errors.push(format!(
+            "{label} target must be {FIRECRACKER_TARGET}, found {}",
+            baseline.target
+        ));
+    }
+}
+
+fn validate_manifest(manifest: &LoggerProducerManifest, errors: &mut Vec<String>) {
+    check_sorted_unique(
+        manifest.inputs.iter().map(|input| input.path.as_str()),
+        "logger input path",
+        errors,
+    );
+    let input_paths = manifest
+        .inputs
+        .iter()
+        .map(|input| input.path.as_str())
+        .collect::<BTreeSet<_>>();
+    for input in &manifest.inputs {
+        if !is_safe_relative_path(Path::new(&input.path))
+            || !input.path.starts_with("src/")
+            || !input.path.ends_with(".rs")
+        {
+            errors.push(format!(
+                "logger input path must be a safe src Rust path: {}",
+                input.path
+            ));
+        }
+        if input.git_blob.len() < 40 || !input.git_blob.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
+            errors.push(format!(
+                "logger input git_blob is not a Git object id: {}",
+                input.path
+            ));
+        }
+        if input.extractor != LOGGER_EXTRACTOR {
+            errors.push(format!(
+                "logger input extractor must be {LOGGER_EXTRACTOR}: {} -> {}",
+                input.path, input.extractor
+            ));
+        }
+    }
+
+    check_sorted_unique(
+        manifest
+            .invocations
+            .iter()
+            .map(|invocation| invocation.id.as_str()),
+        "logger invocation id",
+        errors,
+    );
+    let mut invoked_paths = BTreeSet::new();
+    for invocation in &manifest.invocations {
+        validate_invocation(invocation, &input_paths, errors);
+        invoked_paths.insert(invocation.path.as_str());
+    }
+    for path in input_paths.difference(&invoked_paths) {
+        errors.push(format!("logger input contains no invocation: {path}"));
+    }
+
+    let actual_counts = computed_counts(
+        manifest.counts.scanned_rust_files,
+        manifest.inputs.len(),
+        &manifest.invocations,
+    );
+    if actual_counts != manifest.counts {
+        errors.push(format!(
+            "declared logger producer counts do not match entries: declared {:?}, actual {:?}",
+            manifest.counts, actual_counts
+        ));
+    }
+    validate_expected_counts(&manifest.counts, errors);
+}
+
+fn validate_invocation(
+    invocation: &LoggerInvocation,
+    input_paths: &BTreeSet<&str>,
+    errors: &mut Vec<String>,
+) {
+    if !input_paths.contains(invocation.path.as_str()) {
+        errors.push(format!(
+            "logger invocation references undeclared input: {}",
+            invocation.id
+        ));
+    }
+    if invocation.line == 0 || invocation.column == 0 {
+        errors.push(format!(
+            "logger invocation coordinates must be one-based: {}",
+            invocation.id
+        ));
+    }
+    let canonical_id = format!(
+        "logger-invocation:{}:{}:{}",
+        invocation.path, invocation.line, invocation.column
+    );
+    if invocation.id != canonical_id {
+        errors.push(format!(
+            "logger invocation id is not canonical: {}",
+            invocation.id
+        ));
+    }
+    let Some(digest) = invocation.fingerprint.strip_prefix("sha256:") else {
+        errors.push(format!(
+            "logger invocation fingerprint must use sha256: {}",
+            invocation.id
+        ));
+        return;
+    };
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        errors.push(format!(
+            "logger invocation fingerprint is not lowercase SHA-256: {}",
+            invocation.id
+        ));
+    }
+}
+
+fn computed_counts(
+    scanned_rust_files: usize,
+    matching_input_files: usize,
+    invocations: &[LoggerInvocation],
+) -> LoggerProducerCounts {
+    let macro_count = |name| {
+        invocations
+            .iter()
+            .filter(|invocation| invocation.macro_name == name)
+            .count()
+    };
+    let context_count = |context| {
+        invocations
+            .iter()
+            .filter(|invocation| invocation.source_context == context)
+            .count()
+    };
+    use crate::LoggerMacro;
+    LoggerProducerCounts {
+        scanned_rust_files,
+        matching_input_files,
+        ordinary: invocations
+            .iter()
+            .filter(|invocation| !invocation.macro_name.is_unrestricted())
+            .count(),
+        unrestricted: invocations
+            .iter()
+            .filter(|invocation| invocation.macro_name.is_unrestricted())
+            .count(),
+        error: macro_count(LoggerMacro::Error),
+        warn: macro_count(LoggerMacro::Warn),
+        info: macro_count(LoggerMacro::Info),
+        debug: macro_count(LoggerMacro::Debug),
+        trace: macro_count(LoggerMacro::Trace),
+        error_unrestricted: macro_count(LoggerMacro::ErrorUnrestricted),
+        warn_unrestricted: macro_count(LoggerMacro::WarnUnrestricted),
+        info_unrestricted: macro_count(LoggerMacro::InfoUnrestricted),
+        production: context_count(LoggerSourceContext::Production),
+        test: context_count(LoggerSourceContext::Test),
+        example: context_count(LoggerSourceContext::Example),
+        direct: invocations
+            .iter()
+            .filter(|invocation| invocation.syntax == LoggerInvocationSyntax::Direct)
+            .count(),
+        macro_template: invocations
+            .iter()
+            .filter(|invocation| invocation.syntax == LoggerInvocationSyntax::MacroTemplate)
+            .count(),
+    }
+}
+
+fn validate_expected_counts(counts: &LoggerProducerCounts, errors: &mut Vec<String>) {
+    let expected = [
+        (
+            "scanned Rust files",
+            EXPECTED_SCANNED_RUST_FILES,
+            counts.scanned_rust_files,
+        ),
+        (
+            "matching input files",
+            EXPECTED_MATCHING_INPUT_FILES,
+            counts.matching_input_files,
+        ),
+        ("ordinary invocations", EXPECTED_ORDINARY, counts.ordinary),
+        (
+            "unrestricted invocations",
+            EXPECTED_UNRESTRICTED,
+            counts.unrestricted,
+        ),
+        ("error invocations", EXPECTED_ERROR, counts.error),
+        ("warn invocations", EXPECTED_WARN, counts.warn),
+        ("info invocations", EXPECTED_INFO, counts.info),
+        ("debug invocations", EXPECTED_DEBUG, counts.debug),
+        ("trace invocations", EXPECTED_TRACE, counts.trace),
+        (
+            "error_unrestricted invocations",
+            EXPECTED_ERROR_UNRESTRICTED,
+            counts.error_unrestricted,
+        ),
+        (
+            "warn_unrestricted invocations",
+            EXPECTED_WARN_UNRESTRICTED,
+            counts.warn_unrestricted,
+        ),
+        (
+            "info_unrestricted invocations",
+            EXPECTED_INFO_UNRESTRICTED,
+            counts.info_unrestricted,
+        ),
+        (
+            "production invocations",
+            EXPECTED_PRODUCTION,
+            counts.production,
+        ),
+        ("test invocations", EXPECTED_TEST, counts.test),
+        ("example invocations", EXPECTED_EXAMPLE, counts.example),
+        ("direct invocations", EXPECTED_DIRECT, counts.direct),
+        (
+            "macro-template invocations",
+            EXPECTED_MACRO_TEMPLATE,
+            counts.macro_template,
+        ),
+    ];
+    for (label, expected, actual) in expected {
+        if actual != expected {
+            errors.push(format!(
+                "logger producer {label} must be {expected}, found {actual}"
+            ));
+        }
+    }
+    if counts.production + counts.test + counts.example != counts.ordinary + counts.unrestricted {
+        errors.push("logger source-context counts must cover every invocation".to_string());
+    }
+    if counts.direct + counts.macro_template != counts.ordinary + counts.unrestricted {
+        errors.push("logger syntax-kind counts must cover every invocation".to_string());
+    }
+}
+
+fn validate_audit(
+    manifest: &LoggerProducerManifest,
+    audit: &LoggerProducerAudit,
+    repository_root: &Path,
+    mode: AuditMode,
+    errors: &mut Vec<String>,
+) {
+    check_sorted_unique(
+        audit.classes.iter().map(|class| class.id.as_str()),
+        "logger class id",
+        errors,
+    );
+    let classes = audit
+        .classes
+        .iter()
+        .map(|class| (class.id.as_str(), class))
+        .collect::<BTreeMap<_, _>>();
+    for class in &audit.classes {
+        validate_class(class, repository_root, mode, errors);
+    }
+
+    check_sorted_unique(
+        audit
+            .mappings
+            .iter()
+            .map(|mapping| mapping.invocation_id.as_str()),
+        "logger mapping invocation id",
+        errors,
+    );
+    let invocation_ids = manifest
+        .invocations
+        .iter()
+        .map(|invocation| invocation.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mapping_ids = audit
+        .mappings
+        .iter()
+        .map(|mapping| mapping.invocation_id.as_str())
+        .collect::<BTreeSet<_>>();
+    for missing in invocation_ids.difference(&mapping_ids) {
+        errors.push(format!("logger invocation has no audit mapping: {missing}"));
+    }
+    for stale in mapping_ids.difference(&invocation_ids) {
+        errors.push(format!("logger audit mapping is stale: {stale}"));
+    }
+
+    let invocations = manifest
+        .invocations
+        .iter()
+        .map(|invocation| (invocation.id.as_str(), invocation))
+        .collect::<BTreeMap<_, _>>();
+    let mut referenced_classes = BTreeSet::new();
+    for mapping in &audit.mappings {
+        let Some(class) = classes.get(mapping.class_id.as_str()) else {
+            errors.push(format!(
+                "logger mapping references unknown class: {} -> {}",
+                mapping.invocation_id, mapping.class_id
+            ));
+            continue;
+        };
+        referenced_classes.insert(class.id.as_str());
+        if let Some(invocation) = invocations.get(mapping.invocation_id.as_str()) {
+            validate_context_mapping(invocation, class, errors);
+        }
+    }
+    for class_id in classes.keys() {
+        if !referenced_classes.contains(class_id) {
+            errors.push(format!(
+                "logger class has no invocation mapping: {class_id}"
+            ));
+        }
+    }
+
+    validate_compiled_event_set(&audit.classes, errors);
+    let planned_owners = audit
+        .classes
+        .iter()
+        .filter(|class| class.disposition == LoggerClassDisposition::Planned)
+        .filter_map(|class| class.delivery_issue.as_deref())
+        .collect::<BTreeSet<_>>();
+    for issue in PLANNED_ISSUES {
+        if !planned_owners.contains(issue) {
+            errors.push(format!(
+                "logger audit has no planned class owned by {issue}"
+            ));
+        }
+    }
+}
+
+fn validate_class(
+    class: &LoggerProducerClass,
+    repository_root: &Path,
+    mode: AuditMode,
+    errors: &mut Vec<String>,
+) {
+    if !is_logger_class_id(&class.id) {
+        errors.push(format!("logger class id is not canonical: {}", class.id));
+    }
+    let lower_id = class.id.to_ascii_lowercase();
+    let has_catch_all_term = lower_id.split('.').any(|segment| {
+        segment == "catch-all"
+            || segment
+                .split('-')
+                .any(|part| matches!(part, "other" | "unknown" | "catchall"))
+    });
+    if has_catch_all_term {
+        errors.push(format!(
+            "logger class id uses a catch-all term: {}",
+            class.id
+        ));
+    }
+    if class.summary.trim().is_empty() || class.rationale.trim().is_empty() {
+        errors.push(format!(
+            "logger class summary and rationale must not be empty: {}",
+            class.id
+        ));
+    }
+    check_sorted_unique(
+        class.allowed_fields.iter().copied(),
+        &format!("logger class allowed field for {}", class.id),
+        errors,
+    );
+    check_sorted_unique(
+        class.compiled_events.iter().copied(),
+        &format!("logger class compiled event for {}", class.id),
+        errors,
+    );
+    validate_limiter(class, errors);
+    check_sorted_unique(
+        class.implementation.iter(),
+        &format!("logger class implementation reference for {}", class.id),
+        errors,
+    );
+    check_sorted_unique(
+        class.validation.iter(),
+        &format!("logger class validation reference for {}", class.id),
+        errors,
+    );
+    for reference in class.implementation.iter().chain(&class.validation) {
+        validate_reference(reference, repository_root, &class.id, errors);
+    }
+    if (class.compiled_events.is_empty()
+        && (!class.implementation.is_empty() || !class.validation.is_empty()))
+        || (!class.compiled_events.is_empty()
+            && (class.implementation.is_empty() || class.validation.is_empty()))
+    {
+        errors.push(format!(
+            "logger compiled-event metadata and exact evidence must appear together: {}",
+            class.id
+        ));
+    }
+
+    match class.disposition {
+        LoggerClassDisposition::Implemented => {
+            if class.non_applicable_reason.is_some() || class.delivery_issue.is_some() {
+                errors.push(format!(
+                    "implemented logger class must not retain a reason or delivery issue: {}",
+                    class.id
+                ));
+            }
+            if class.compiled_events.is_empty()
+                || class.implementation.is_empty()
+                || class.validation.is_empty()
+            {
+                errors.push(format!(
+                    "implemented logger class requires compiled event and exact evidence: {}",
+                    class.id
+                ));
+            }
+            validate_applicable_policy(class, errors);
+        }
+        LoggerClassDisposition::Planned => {
+            if mode == AuditMode::Final {
+                errors.push(format!(
+                    "final logger validation forbids planned class: {}",
+                    class.id
+                ));
+            }
+            if class.non_applicable_reason.is_some() {
+                errors.push(format!(
+                    "planned logger class must not claim a non-applicable reason: {}",
+                    class.id
+                ));
+            }
+            if !class
+                .delivery_issue
+                .as_deref()
+                .is_some_and(|issue| PLANNED_ISSUES.contains(&issue))
+            {
+                errors.push(format!(
+                    "planned logger class must be owned by #1807, #1808, or #1809: {}",
+                    class.id
+                ));
+            }
+            validate_applicable_policy(class, errors);
+        }
+        LoggerClassDisposition::NotApplicable => {
+            if class.non_applicable_reason.is_none()
+                || class.delivery_issue.is_some()
+                || !class.compiled_events.is_empty()
+                || !class.implementation.is_empty()
+                || !class.validation.is_empty()
+            {
+                errors.push(format!(
+                    "not-applicable logger class requires one reason and no owner/event/evidence: {}",
+                    class.id
+                ));
+            }
+            if class.guest_triggerable
+                || class.delivery != LoggerDeliveryPolicy::NotApplicable
+                || class.level != LoggerLevelPolicy::NotApplicable
+                || class.module != LoggerModulePolicy::NotApplicable
+                || class.origin != LoggerOriginPolicy::NotApplicable
+                || class.limiter != LoggerLimiterPolicy::NotApplicable
+                || class.limiter_identity.is_some()
+                || !class.allowed_fields.is_empty()
+            {
+                errors.push(format!(
+                    "not-applicable logger class must use only not-applicable policy: {}",
+                    class.id
+                ));
+            }
+        }
+    }
+}
+
+fn validate_applicable_policy(class: &LoggerProducerClass, errors: &mut Vec<String>) {
+    if class.delivery == LoggerDeliveryPolicy::NotApplicable
+        || class.level == LoggerLevelPolicy::NotApplicable
+        || class.module == LoggerModulePolicy::NotApplicable
+        || class.origin == LoggerOriginPolicy::NotApplicable
+        || class.limiter == LoggerLimiterPolicy::NotApplicable
+    {
+        errors.push(format!(
+            "applicable logger class must define complete delivery policy: {}",
+            class.id
+        ));
+    }
+    let is_recovery = class.compiled_events == [LoggerCompiledEvent::RateLimitRecovery];
+    if class.guest_triggerable && class.limiter != LoggerLimiterPolicy::RateLimited && !is_recovery
+    {
+        errors.push(format!(
+            "guest-triggerable logger class must be rate limited: {}",
+            class.id
+        ));
+    }
+}
+
+fn validate_limiter(class: &LoggerProducerClass, errors: &mut Vec<String>) {
+    match class.limiter {
+        LoggerLimiterPolicy::RateLimited => {
+            if !class
+                .limiter_identity
+                .as_deref()
+                .is_some_and(is_limiter_identity)
+            {
+                errors.push(format!(
+                    "rate-limited logger class requires canonical limiter identity: {}",
+                    class.id
+                ));
+            }
+        }
+        LoggerLimiterPolicy::Unrestricted | LoggerLimiterPolicy::NotApplicable => {
+            if class.limiter_identity.is_some() {
+                errors.push(format!(
+                    "unrestricted or inapplicable logger class must not name a limiter: {}",
+                    class.id
+                ));
+            }
+        }
+    }
+}
+
+fn validate_context_mapping(
+    invocation: &LoggerInvocation,
+    class: &LoggerProducerClass,
+    errors: &mut Vec<String>,
+) {
+    match invocation.source_context {
+        LoggerSourceContext::Test => {
+            if class.disposition != LoggerClassDisposition::NotApplicable
+                || class.non_applicable_reason != Some(LoggerNonApplicableReason::TestOnly)
+            {
+                errors.push(format!(
+                    "test logger invocation must map to test-only class: {}",
+                    invocation.id
+                ));
+            }
+        }
+        LoggerSourceContext::Example => {
+            if class.disposition != LoggerClassDisposition::NotApplicable
+                || class.non_applicable_reason != Some(LoggerNonApplicableReason::ExampleOnly)
+            {
+                errors.push(format!(
+                    "example logger invocation must map to example-only class: {}",
+                    invocation.id
+                ));
+            }
+        }
+        LoggerSourceContext::Production => {
+            if matches!(
+                class.non_applicable_reason,
+                Some(LoggerNonApplicableReason::TestOnly | LoggerNonApplicableReason::ExampleOnly)
+            ) {
+                errors.push(format!(
+                    "production logger invocation cannot map to test/example class: {}",
+                    invocation.id
+                ));
+            }
+        }
+    }
+}
+
+fn validate_compiled_event_set(classes: &[LoggerProducerClass], errors: &mut Vec<String>) {
+    let expected = BTreeMap::from([
+        (LoggerCompiledEvent::ApiRequest, "logger.api.request"),
+        (LoggerCompiledEvent::InstanceStart, "logger.api.result"),
+        (LoggerCompiledEvent::FlushMetrics, "logger.api.result"),
+        (LoggerCompiledEvent::BootTime, "logger.boot.time"),
+        (
+            LoggerCompiledEvent::RateLimitRecovery,
+            "logger.limiter.recovery",
+        ),
+        (LoggerCompiledEvent::ProcessPanic, "logger.process.panic"),
+        (LoggerCompiledEvent::ProcessExit, "logger.process.exit"),
+    ]);
+    let actual = classes
+        .iter()
+        .flat_map(|class| class.compiled_events.iter().copied())
+        .collect::<BTreeSet<_>>();
+    let expected_events = expected.keys().copied().collect::<BTreeSet<_>>();
+    if actual != expected_events {
+        errors.push(format!(
+            "logger compiled event set differs: expected {expected_events:?}, found {actual:?}"
+        ));
+    }
+    for (event, expected_class) in expected {
+        let owners = classes
+            .iter()
+            .filter(|class| class.compiled_events.contains(&event))
+            .map(|class| class.id.as_str())
+            .collect::<Vec<_>>();
+        if owners != [expected_class] {
+            errors.push(format!(
+                "logger compiled event must have its exact class: {event:?} -> {owners:?}, expected {expected_class}"
+            ));
+        }
+    }
+}
+
+fn validate_reference(
+    reference: &Reference,
+    repository_root: &Path,
+    class_id: &str,
+    errors: &mut Vec<String>,
+) {
+    match reference {
+        Reference::Local { path, anchor } => {
+            if !is_safe_relative_path(Path::new(path)) {
+                errors.push(format!(
+                    "logger class local reference must be repository-relative: {class_id} -> {path}"
+                ));
+                return;
+            }
+            if anchor
+                .as_deref()
+                .is_some_and(|anchor| anchor.trim().is_empty())
+            {
+                errors.push(format!(
+                    "logger class local reference anchor must not be empty: {class_id} -> {path}"
+                ));
+            }
+            let full_path = repository_root.join(path);
+            let Ok(metadata) = std::fs::symlink_metadata(&full_path) else {
+                errors.push(format!(
+                    "logger class local reference does not exist: {class_id} -> {path}"
+                ));
+                return;
+            };
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                errors.push(format!(
+                    "logger class local reference must be a regular non-symlink file: {class_id} -> {path}"
+                ));
+            }
+            let status = Command::new("git")
+                .arg("-C")
+                .arg(repository_root)
+                .args(["ls-files", "--error-unmatch", "--", path])
+                .output();
+            if !status.is_ok_and(|output| output.status.success()) {
+                errors.push(format!(
+                    "logger class local reference must be tracked: {class_id} -> {path}"
+                ));
+            }
+        }
+        Reference::Github { url } | Reference::Authoritative { url } => {
+            if !url.starts_with("https://") {
+                errors.push(format!(
+                    "logger class external reference must use HTTPS: {class_id}"
+                ));
+            }
+        }
+    }
+}
+
+fn is_safe_relative_path(path: &Path) -> bool {
+    !path.as_os_str().is_empty()
+        && !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn is_logger_class_id(value: &str) -> bool {
+    value
+        .strip_prefix("logger.")
+        .is_some_and(|suffix| !suffix.is_empty() && suffix.split('.').all(is_slug))
+}
+
+fn is_limiter_identity(value: &str) -> bool {
+    value
+        .strip_prefix("logger-rate.")
+        .is_some_and(|suffix| !suffix.is_empty() && suffix.split('.').all(is_slug))
+}
+
+fn is_slug(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        && value
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        && value
+            .as_bytes()
+            .last()
+            .is_some_and(u8::is_ascii_alphanumeric)
+}
+
+fn check_sorted_unique<I, T>(values: I, label: &str, errors: &mut Vec<String>)
+where
+    I: IntoIterator<Item = T>,
+    T: Ord + std::fmt::Debug,
+{
+    let values = values.into_iter().collect::<Vec<_>>();
+    for pair in values.windows(2) {
+        let [left, right] = pair else {
+            continue;
+        };
+        if left >= right {
+            errors.push(format!(
+                "{label} entries must be sorted and unique: {:?} then {:?}",
+                left, right
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_and_limiter_ids_are_closed_slugs() {
+        assert!(is_logger_class_id("logger.api.request"));
+        assert!(is_limiter_identity("logger-rate.device.queue"));
+        assert!(!is_logger_class_id("logger.api.other_value"));
+        assert!(!is_limiter_identity("device.queue"));
+    }
+
+    #[test]
+    fn safe_paths_reject_parent_and_absolute_components() {
+        assert!(is_safe_relative_path(Path::new(
+            "crates/runtime/src/logger.rs"
+        )));
+        assert!(!is_safe_relative_path(Path::new("../logger.rs")));
+        assert!(!is_safe_relative_path(Path::new("/tmp/logger.rs")));
+    }
+}

--- a/tools/firecracker-capability-audit/src/logger_validate.rs
+++ b/tools/firecracker-capability-audit/src/logger_validate.rs
@@ -122,7 +122,11 @@ fn validate_manifest(manifest: &LoggerProducerManifest, errors: &mut Vec<String>
                 input.path
             ));
         }
-        if input.git_blob.len() < 40 || !input.git_blob.bytes().all(|byte| byte.is_ascii_hexdigit())
+        if input.git_blob.len() != 40
+            || !input
+                .git_blob
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
         {
             errors.push(format!(
                 "logger input git_blob is not a Git object id: {}",
@@ -585,10 +589,22 @@ fn validate_applicable_policy(class: &LoggerProducerClass, errors: &mut Vec<Stri
         ));
     }
     let is_recovery = class.compiled_events == [LoggerCompiledEvent::RateLimitRecovery];
+    if class.guest_triggerable != (class.delivery == LoggerDeliveryPolicy::NonblockingGuest) {
+        errors.push(format!(
+            "logger guest triggerability requires exact nonblocking-guest delivery: {}",
+            class.id
+        ));
+    }
     if class.guest_triggerable && class.limiter != LoggerLimiterPolicy::RateLimited && !is_recovery
     {
         errors.push(format!(
             "guest-triggerable logger class must be rate limited: {}",
+            class.id
+        ));
+    }
+    if is_recovery && class.limiter != LoggerLimiterPolicy::Unrestricted {
+        errors.push(format!(
+            "logger limiter recovery must be unrestricted: {}",
             class.id
         ));
     }

--- a/tools/firecracker-capability-audit/src/main.rs
+++ b/tools/firecracker-capability-audit/src/main.rs
@@ -5,8 +5,11 @@ use std::path::{Component, Path, PathBuf};
 use std::process::{Command, ExitCode};
 
 use bangbang_firecracker_capability_audit::{
-    AuditError, AuditMode, CAPABILITY_INVENTORY_PATH, SOURCE_MANIFEST_PATH, derive_source_manifest,
-    read_capability_inventory, read_source_manifest, source_manifest_json, validate,
+    AuditError, AuditMode, CAPABILITY_INVENTORY_PATH, LOGGER_PRODUCER_AUDIT_PATH,
+    LOGGER_PRODUCER_MANIFEST_PATH, SOURCE_MANIFEST_PATH, derive_logger_producer_manifest,
+    derive_source_manifest, logger_producer_manifest_json, read_capability_inventory,
+    read_logger_producer_audit, read_logger_producer_manifest, read_source_manifest,
+    source_manifest_json, validate, validate_logger_producers,
 };
 
 fn main() -> ExitCode {
@@ -31,6 +34,7 @@ fn run(args: Vec<String>) -> Result<String, AuditError> {
         "validate" => run_validate(command_args),
         "compare" => run_compare(command_args),
         "regenerate" => run_regenerate(command_args),
+        "regenerate-logger-producers" => run_regenerate_logger_producers(command_args),
         "help" | "--help" | "-h" => Ok(usage().to_string()),
         _ => Err(AuditError::new(format!(
             "unknown command: {command}\n{}",
@@ -54,12 +58,17 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
     let inventory = read_capability_inventory(&root.join(CAPABILITY_INVENTORY_PATH))?;
     validate(&manifest, &inventory, &root, mode)
         .map_err(|errors| AuditError::new(format!("inventory validation errors:\n{errors}")))?;
+    let logger_manifest = read_logger_producer_manifest(&root.join(LOGGER_PRODUCER_MANIFEST_PATH))?;
+    let logger_audit = read_logger_producer_audit(&root.join(LOGGER_PRODUCER_AUDIT_PATH))?;
+    validate_logger_producers(&logger_manifest, &logger_audit, &root, mode).map_err(|errors| {
+        AuditError::new(format!("logger producer validation errors:\n{errors}"))
+    })?;
     let mode_name = match mode {
         AuditMode::Delivery => "delivery",
         AuditMode::Final => "final",
     };
     Ok(format!(
-        "Firecracker capability inventory is valid in {mode_name} mode"
+        "Firecracker capability inventory and logger producer audit are valid in {mode_name} mode"
     ))
 }
 
@@ -68,17 +77,41 @@ fn run_compare(args: &[String]) -> Result<String, AuditError> {
     let root = repository_root()?;
     let checked_in = read_source_manifest(&root.join(SOURCE_MANIFEST_PATH))?;
     let derived = derive_source_manifest(Path::new(&firecracker))?;
+    let checked_logger = read_logger_producer_manifest(&root.join(LOGGER_PRODUCER_MANIFEST_PATH))?;
+    let derived_logger = derive_logger_producer_manifest(Path::new(&firecracker))?;
+    let mut differences = Vec::new();
     if checked_in != derived {
         let checked_json = String::from_utf8(source_manifest_json(&checked_in)?)
             .map_err(|_| AuditError::new("checked source manifest JSON is not valid UTF-8"))?;
         let derived_json = String::from_utf8(source_manifest_json(&derived)?)
             .map_err(|_| AuditError::new("derived source manifest JSON is not valid UTF-8"))?;
-        return Err(AuditError::new(format!(
+        differences.push(format!(
             "derived source manifest differs from {SOURCE_MANIFEST_PATH}; run regenerate to an explicit candidate path\n{}",
             canonical_line_diff(&checked_json, &derived_json)
-        )));
+        ));
     }
-    Ok("checked-in source manifest matches the pinned Firecracker checkout".to_string())
+    if checked_logger != derived_logger {
+        let checked_json = String::from_utf8(logger_producer_manifest_json(&checked_logger)?)
+            .map_err(|_| {
+                AuditError::new("checked logger producer manifest JSON is not valid UTF-8")
+            })?;
+        let derived_json = String::from_utf8(logger_producer_manifest_json(&derived_logger)?)
+            .map_err(|_| {
+                AuditError::new("derived logger producer manifest JSON is not valid UTF-8")
+            })?;
+        differences.push(format!(
+            "derived logger producer manifest differs from {LOGGER_PRODUCER_MANIFEST_PATH}; run regenerate-logger-producers to an explicit candidate path\n{}",
+            canonical_line_diff(&checked_json, &derived_json)
+        ));
+    }
+    if differences.is_empty() {
+        Ok(
+            "checked-in source and logger producer manifests match the pinned Firecracker checkout"
+                .to_string(),
+        )
+    } else {
+        Err(AuditError::new(differences.join("\n")))
+    }
 }
 
 fn canonical_line_diff(checked: &str, derived: &str) -> String {
@@ -125,13 +158,48 @@ fn run_regenerate(args: &[String]) -> Result<String, AuditError> {
     ))
 }
 
+fn run_regenerate_logger_producers(args: &[String]) -> Result<String, AuditError> {
+    let options = required_options(args, &["--firecracker", "--output"])?;
+    let firecracker = options
+        .get("--firecracker")
+        .ok_or_else(|| AuditError::new("--firecracker is required"))?;
+    let output = options
+        .get("--output")
+        .ok_or_else(|| AuditError::new("--output is required"))?;
+    let root = repository_root()?;
+    let output_path = candidate_output_path(&root, Path::new(output))?;
+    let derived = derive_logger_producer_manifest(Path::new(firecracker))?;
+    let bytes = logger_producer_manifest_json(&derived)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&output_path)
+        .map_err(|error| AuditError::new(format!("failed to create candidate output: {error}")))?;
+    file.write_all(&bytes)
+        .and_then(|()| file.sync_all())
+        .map_err(|error| AuditError::new(format!("failed to write candidate output: {error}")))?;
+    Ok(format!(
+        "generated logger producer manifest candidate: {}",
+        output_path.display()
+    ))
+}
+
 fn candidate_output_path(root: &Path, output: &Path) -> Result<PathBuf, AuditError> {
     let output_path = absolute_from(root, output);
     let source_path = root.join(SOURCE_MANIFEST_PATH);
     let inventory_path = root.join(CAPABILITY_INVENTORY_PATH);
+    let logger_manifest_path = root.join(LOGGER_PRODUCER_MANIFEST_PATH);
+    let logger_audit_path = root.join(LOGGER_PRODUCER_AUDIT_PATH);
     let normalized_output = normalize_lexically(&output_path);
-    if normalized_output == normalize_lexically(&source_path)
-        || normalized_output == normalize_lexically(&inventory_path)
+    let checked_paths = [
+        &source_path,
+        &inventory_path,
+        &logger_manifest_path,
+        &logger_audit_path,
+    ];
+    if checked_paths
+        .iter()
+        .any(|path| normalized_output == normalize_lexically(path))
     {
         return Err(AuditError::new(
             "regenerate requires a separate candidate output and never overwrites checked-in inventory files",
@@ -155,7 +223,7 @@ fn candidate_output_path(root: &Path, output: &Path) -> Result<PathBuf, AuditErr
         .canonicalize()
         .map_err(|_| AuditError::new("candidate output parent directory is not accessible"))?;
     let effective_output = canonical_parent.join(file_name);
-    for checked_path in [&source_path, &inventory_path] {
+    for checked_path in checked_paths {
         if checked_path
             .canonicalize()
             .is_ok_and(|canonical| canonical == effective_output)
@@ -249,7 +317,7 @@ fn absolute_from(root: &Path, path: &Path) -> PathBuf {
 }
 
 fn usage() -> &'static str {
-    "Usage:\n  bangbang-firecracker-capability-audit validate [--final]\n  bangbang-firecracker-capability-audit compare --firecracker PATH\n  bangbang-firecracker-capability-audit regenerate --firecracker PATH --output PATH"
+    "Usage:\n  bangbang-firecracker-capability-audit validate [--final]\n  bangbang-firecracker-capability-audit compare --firecracker PATH\n  bangbang-firecracker-capability-audit regenerate --firecracker PATH --output PATH\n  bangbang-firecracker-capability-audit regenerate-logger-producers --firecracker PATH --output PATH"
 }
 
 #[cfg(test)]
@@ -295,9 +363,14 @@ mod tests {
     }
 
     #[test]
-    fn regenerate_refuses_both_checked_inventory_files() {
+    fn regeneration_refuses_all_checked_inventory_files() {
         let root = Path::new("/repository");
-        for path in [SOURCE_MANIFEST_PATH, CAPABILITY_INVENTORY_PATH] {
+        for path in [
+            SOURCE_MANIFEST_PATH,
+            CAPABILITY_INVENTORY_PATH,
+            LOGGER_PRODUCER_MANIFEST_PATH,
+            LOGGER_PRODUCER_AUDIT_PATH,
+        ] {
             let error = candidate_output_path(root, Path::new(path))
                 .expect_err("checked inventory path should be refused");
             assert!(error.to_string().contains("never overwrites"));
@@ -305,11 +378,13 @@ mod tests {
     }
 
     #[test]
-    fn regenerate_refuses_lexical_aliases_of_checked_inventory_files() {
+    fn regeneration_refuses_lexical_aliases_of_checked_inventory_files() {
         let root = Path::new("/repository");
         for path in [
             "compat/firecracker/../firecracker/v1.16.0/source-manifest.json",
             "compat/firecracker/v1.16.0/./capabilities.json",
+            "compat/firecracker/v1.16.0/./logger-producer-manifest.json",
+            "compat/firecracker/v1.16.0/../v1.16.0/logger-producer-audit.json",
         ] {
             let error = candidate_output_path(root, Path::new(path))
                 .expect_err("checked inventory alias should be refused");

--- a/tools/firecracker-capability-audit/src/main.rs
+++ b/tools/firecracker-capability-audit/src/main.rs
@@ -56,13 +56,18 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
     let root = repository_root()?;
     let manifest = read_source_manifest(&root.join(SOURCE_MANIFEST_PATH))?;
     let inventory = read_capability_inventory(&root.join(CAPABILITY_INVENTORY_PATH))?;
-    validate(&manifest, &inventory, &root, mode)
-        .map_err(|errors| AuditError::new(format!("inventory validation errors:\n{errors}")))?;
     let logger_manifest = read_logger_producer_manifest(&root.join(LOGGER_PRODUCER_MANIFEST_PATH))?;
     let logger_audit = read_logger_producer_audit(&root.join(LOGGER_PRODUCER_AUDIT_PATH))?;
-    validate_logger_producers(&logger_manifest, &logger_audit, &root, mode).map_err(|errors| {
-        AuditError::new(format!("logger producer validation errors:\n{errors}"))
-    })?;
+    let mut failures = Vec::new();
+    if let Err(errors) = validate(&manifest, &inventory, &root, mode) {
+        failures.push(format!("inventory validation errors:\n{errors}"));
+    }
+    if let Err(errors) = validate_logger_producers(&logger_manifest, &logger_audit, &root, mode) {
+        failures.push(format!("logger producer validation errors:\n{errors}"));
+    }
+    if !failures.is_empty() {
+        return Err(AuditError::new(failures.join("\n")));
+    }
     let mode_name = match mode {
         AuditMode::Delivery => "delivery",
         AuditMode::Final => "final",
@@ -390,5 +395,13 @@ mod tests {
                 .expect_err("checked inventory alias should be refused");
             assert!(error.to_string().contains("never overwrites"));
         }
+    }
+
+    #[test]
+    fn regeneration_refuses_an_existing_destination() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let error = candidate_output_path(root, Path::new("Cargo.toml"))
+            .expect_err("an existing candidate destination must be refused");
+        assert!(error.to_string().contains("already exists"));
     }
 }

--- a/tools/firecracker-capability-audit/src/upstream.rs
+++ b/tools/firecracker-capability-audit/src/upstream.rs
@@ -715,7 +715,7 @@ fn ensure_checkout_at(path: &Path, expected_commit: &str) -> Result<PathBuf, Aud
     Ok(canonical)
 }
 
-fn git_output(checkout: &Path, args: &[&str]) -> Result<String, AuditError> {
+pub(crate) fn git_output(checkout: &Path, args: &[&str]) -> Result<String, AuditError> {
     let output = Command::new("git")
         .arg("-C")
         .arg(checkout)
@@ -732,7 +732,7 @@ fn git_output(checkout: &Path, args: &[&str]) -> Result<String, AuditError> {
         .map_err(|_| AuditError::new("Git returned non-UTF-8 output"))
 }
 
-fn ensure_regular_input(checkout: &Path, relative: &str) -> Result<PathBuf, AuditError> {
+pub(crate) fn ensure_regular_input(checkout: &Path, relative: &str) -> Result<PathBuf, AuditError> {
     let joined = checkout.join(relative);
     let metadata = std::fs::symlink_metadata(&joined)
         .map_err(|_| AuditError::new(format!("pinned input is missing: {relative}")))?;
@@ -752,7 +752,7 @@ fn ensure_regular_input(checkout: &Path, relative: &str) -> Result<PathBuf, Audi
     Ok(canonical)
 }
 
-fn read_input(checkout: &Path, relative: &str) -> Result<String, AuditError> {
+pub(crate) fn read_input(checkout: &Path, relative: &str) -> Result<String, AuditError> {
     let path = ensure_regular_input(checkout, relative)?;
     std::fs::read_to_string(path)
         .map_err(|error| AuditError::new(format!("failed to read {relative}: {error}")))

--- a/tools/firecracker-capability-audit/src/validate.rs
+++ b/tools/firecracker-capability-audit/src/validate.rs
@@ -41,6 +41,12 @@ const EXTRACTORS: &[&str] = &[
 pub struct ValidationErrors(Vec<String>);
 
 impl ValidationErrors {
+    pub(crate) fn from_messages(mut messages: Vec<String>) -> Self {
+        messages.sort();
+        messages.dedup();
+        Self(messages)
+    }
+
     /// Individual validation failures in deterministic order.
     pub fn messages(&self) -> &[String] {
         &self.0

--- a/tools/firecracker-capability-audit/src/validate.rs
+++ b/tools/firecracker-capability-audit/src/validate.rs
@@ -619,7 +619,7 @@ fn validate_exclusion(
     }
 }
 
-fn validate_reference(
+pub(crate) fn validate_reference(
     reference: &Reference,
     repository_root: &Path,
     tracked_files: &BTreeSet<PathBuf>,
@@ -704,6 +704,13 @@ fn tracked_files_for_inventory(
     if !inventory_has_local_references(inventory) {
         return BTreeSet::new();
     }
+    tracked_repository_files(repository_root, errors)
+}
+
+pub(crate) fn tracked_repository_files(
+    repository_root: &Path,
+    errors: &mut Vec<String>,
+) -> BTreeSet<PathBuf> {
     let output = match Command::new("git")
         .arg("-C")
         .arg(repository_root)

--- a/tools/firecracker-capability-audit/tests/checked_inventory.rs
+++ b/tools/firecracker-capability-audit/tests/checked_inventory.rs
@@ -3,10 +3,11 @@ use std::path::PathBuf;
 
 use bangbang_firecracker_capability_audit::{
     AuditMode, CAPABILITY_INVENTORY_PATH, Disposition, LOGGER_PRODUCER_AUDIT_PATH,
-    LOGGER_PRODUCER_MANIFEST_PATH, LoggerClassDisposition, LoggerCompiledEvent, Reference,
-    SOURCE_MANIFEST_PATH, logger_producer_audit_json, logger_producer_manifest_json,
-    read_capability_inventory, read_logger_producer_audit, read_logger_producer_manifest,
-    read_source_manifest, source_manifest_json, validate, validate_logger_producers,
+    LOGGER_PRODUCER_MANIFEST_PATH, LoggerClassDisposition, LoggerCompiledEvent,
+    LoggerDeliveryPolicy, Reference, SOURCE_MANIFEST_PATH, logger_producer_audit_json,
+    logger_producer_manifest_json, read_capability_inventory, read_logger_producer_audit,
+    read_logger_producer_manifest, read_source_manifest, source_manifest_json, validate,
+    validate_logger_producers,
 };
 
 #[test]
@@ -491,6 +492,18 @@ fn logger_audit_mutations_fail_closed() {
     .to_string();
     assert!(error.contains("logger source-context counts must cover every invocation"));
 
+    let mut malformed_blob = manifest.clone();
+    malformed_blob.inputs[0].git_blob = "A".repeat(40);
+    let error = validate_logger_producers(
+        &malformed_blob,
+        &audit,
+        &repository_root,
+        AuditMode::Delivery,
+    )
+    .expect_err("noncanonical Git blob ID must fail")
+    .to_string();
+    assert!(error.contains("logger input git_blob is not a Git object id"));
+
     let mut catch_all = audit.clone();
     let class = catch_all
         .classes
@@ -520,6 +533,23 @@ fn logger_audit_mutations_fail_closed() {
     .expect_err("not-applicable policy mismatch must fail")
     .to_string();
     assert!(error.contains("must use only not-applicable policy"));
+
+    let mut blocking_guest = audit.clone();
+    let class = blocking_guest
+        .classes
+        .iter_mut()
+        .find(|class| class.id == "logger.block.outcome")
+        .expect("block class must exist");
+    class.delivery = LoggerDeliveryPolicy::BoundedHost;
+    let error = validate_logger_producers(
+        &manifest,
+        &blocking_guest,
+        &repository_root,
+        AuditMode::Delivery,
+    )
+    .expect_err("guest-triggerable blocking delivery must fail")
+    .to_string();
+    assert!(error.contains("requires exact nonblocking-guest delivery"));
 
     let mut evidence_mismatch = audit.clone();
     let class = evidence_mismatch

--- a/tools/firecracker-capability-audit/tests/checked_inventory.rs
+++ b/tools/firecracker-capability-audit/tests/checked_inventory.rs
@@ -479,6 +479,18 @@ fn logger_audit_mutations_fail_closed() {
     .to_string();
     assert!(error.contains("fingerprint is not lowercase SHA-256"));
 
+    let mut overflowing_counts = manifest.clone();
+    overflowing_counts.counts.production = usize::MAX;
+    let error = validate_logger_producers(
+        &overflowing_counts,
+        &audit,
+        &repository_root,
+        AuditMode::Delivery,
+    )
+    .expect_err("overflowing declared counts must fail without panicking")
+    .to_string();
+    assert!(error.contains("logger source-context counts must cover every invocation"));
+
     let mut catch_all = audit.clone();
     let class = catch_all
         .classes

--- a/tools/firecracker-capability-audit/tests/checked_inventory.rs
+++ b/tools/firecracker-capability-audit/tests/checked_inventory.rs
@@ -2,8 +2,11 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use bangbang_firecracker_capability_audit::{
-    AuditMode, CAPABILITY_INVENTORY_PATH, Disposition, Reference, SOURCE_MANIFEST_PATH,
-    read_capability_inventory, read_source_manifest, source_manifest_json, validate,
+    AuditMode, CAPABILITY_INVENTORY_PATH, Disposition, LOGGER_PRODUCER_AUDIT_PATH,
+    LOGGER_PRODUCER_MANIFEST_PATH, LoggerClassDisposition, LoggerCompiledEvent, Reference,
+    SOURCE_MANIFEST_PATH, logger_producer_audit_json, logger_producer_manifest_json,
+    read_capability_inventory, read_logger_producer_audit, read_logger_producer_manifest,
+    read_source_manifest, source_manifest_json, validate, validate_logger_producers,
 };
 
 #[test]
@@ -43,6 +46,538 @@ fn checked_source_manifest_is_canonical_and_deterministic() {
         first, checked_bytes,
         "checked source manifest must use canonical serialization"
     );
+}
+
+#[test]
+fn checked_logger_artifacts_are_canonical_and_valid_for_delivery() {
+    let repository_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|tools| tools.parent())
+        .expect("tool package must be nested under the repository tools directory")
+        .to_path_buf();
+    let manifest_path = repository_root.join(LOGGER_PRODUCER_MANIFEST_PATH);
+    let audit_path = repository_root.join(LOGGER_PRODUCER_AUDIT_PATH);
+    let manifest = read_logger_producer_manifest(&manifest_path)
+        .expect("checked logger producer manifest must parse");
+    let audit =
+        read_logger_producer_audit(&audit_path).expect("checked logger producer audit must parse");
+
+    validate_logger_producers(&manifest, &audit, &repository_root, AuditMode::Delivery)
+        .expect("checked logger artifacts must satisfy delivery-time invariants");
+
+    let first_manifest =
+        logger_producer_manifest_json(&manifest).expect("logger producer manifest must serialize");
+    let second_manifest = logger_producer_manifest_json(&manifest)
+        .expect("logger producer manifest must serialize again");
+    assert_eq!(first_manifest, second_manifest);
+    assert_eq!(
+        first_manifest,
+        std::fs::read(manifest_path).expect("checked logger producer manifest must be readable")
+    );
+
+    let first_audit =
+        logger_producer_audit_json(&audit).expect("logger producer audit must serialize");
+    let second_audit =
+        logger_producer_audit_json(&audit).expect("logger producer audit must serialize again");
+    assert_eq!(first_audit, second_audit);
+    assert_eq!(
+        first_audit,
+        std::fs::read(audit_path).expect("checked logger producer audit must be readable")
+    );
+}
+
+#[test]
+fn checked_logger_producer_audit_is_complete_and_stable() {
+    const CONTRACT_PATH: &str = "compat/firecracker/v1.16.0/logger-contract.md";
+    const EXPECTED_CLASSES: [(&str, LoggerClassDisposition, usize); 31] = [
+        (
+            "logger.api-control.outcome",
+            LoggerClassDisposition::Planned,
+            7,
+        ),
+        (
+            "logger.api-worker.outcome",
+            LoggerClassDisposition::Planned,
+            5,
+        ),
+        ("logger.api.request", LoggerClassDisposition::Implemented, 1),
+        ("logger.api.result", LoggerClassDisposition::Planned, 5),
+        (
+            "logger.backend.outcome",
+            LoggerClassDisposition::Planned,
+            26,
+        ),
+        (
+            "logger.balloon.outcome",
+            LoggerClassDisposition::Planned,
+            28,
+        ),
+        ("logger.block.outcome", LoggerClassDisposition::Planned, 34),
+        ("logger.boot.time", LoggerClassDisposition::Implemented, 1),
+        (
+            "logger.entropy.outcome",
+            LoggerClassDisposition::Planned,
+            16,
+        ),
+        (
+            "logger.lifecycle.outcome",
+            LoggerClassDisposition::Planned,
+            24,
+        ),
+        (
+            "logger.limiter.recovery",
+            LoggerClassDisposition::Implemented,
+            1,
+        ),
+        (
+            "logger.memory-hotplug.outcome",
+            LoggerClassDisposition::Planned,
+            22,
+        ),
+        (
+            "logger.network.outcome",
+            LoggerClassDisposition::Planned,
+            26,
+        ),
+        (
+            "logger.nonapp.example",
+            LoggerClassDisposition::NotApplicable,
+            22,
+        ),
+        (
+            "logger.nonapp.fuzzing",
+            LoggerClassDisposition::NotApplicable,
+            1,
+        ),
+        (
+            "logger.nonapp.gdb",
+            LoggerClassDisposition::NotApplicable,
+            19,
+        ),
+        (
+            "logger.nonapp.linux-hardening",
+            LoggerClassDisposition::NotApplicable,
+            2,
+        ),
+        (
+            "logger.nonapp.tool",
+            LoggerClassDisposition::NotApplicable,
+            1,
+        ),
+        (
+            "logger.nonapp.tracing",
+            LoggerClassDisposition::NotApplicable,
+            2,
+        ),
+        (
+            "logger.nonapp.x86",
+            LoggerClassDisposition::NotApplicable,
+            15,
+        ),
+        (
+            "logger.observability.outcome",
+            LoggerClassDisposition::Planned,
+            4,
+        ),
+        ("logger.pmem.outcome", LoggerClassDisposition::Planned, 18),
+        (
+            "logger.process-signal.outcome",
+            LoggerClassDisposition::Planned,
+            5,
+        ),
+        (
+            "logger.process-startup.outcome",
+            LoggerClassDisposition::Planned,
+            5,
+        ),
+        (
+            "logger.process.exit",
+            LoggerClassDisposition::Implemented,
+            3,
+        ),
+        (
+            "logger.process.panic",
+            LoggerClassDisposition::Implemented,
+            3,
+        ),
+        ("logger.serial.outcome", LoggerClassDisposition::Planned, 12),
+        (
+            "logger.snapshot.outcome",
+            LoggerClassDisposition::Planned,
+            18,
+        ),
+        (
+            "logger.time-identity.outcome",
+            LoggerClassDisposition::Planned,
+            16,
+        ),
+        (
+            "logger.transport.outcome",
+            LoggerClassDisposition::Planned,
+            74,
+        ),
+        ("logger.vsock.outcome", LoggerClassDisposition::Planned, 52),
+    ];
+    const LOGGER_CAPABILITIES: [&str; 11] = [
+        "api-operation:PUT /logger",
+        "api-path:/logger",
+        "api-property:FullVmConfiguration.logger",
+        "api-property:Logger.level",
+        "api-property:Logger.log_path",
+        "api-property:Logger.module",
+        "api-property:Logger.show_level",
+        "api-property:Logger.show_log_origin",
+        "api-schema:Logger",
+        "corpus:logger",
+        "semantic.observability:logger-delivery-filtering-loss-and-redaction",
+    ];
+
+    let repository_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|tools| tools.parent())
+        .expect("tool package must be nested under the repository tools directory")
+        .to_path_buf();
+    let manifest =
+        read_logger_producer_manifest(&repository_root.join(LOGGER_PRODUCER_MANIFEST_PATH))
+            .expect("checked logger producer manifest must parse");
+    let audit = read_logger_producer_audit(&repository_root.join(LOGGER_PRODUCER_AUDIT_PATH))
+        .expect("checked logger producer audit must parse");
+    let inventory = read_capability_inventory(&repository_root.join(CAPABILITY_INVENTORY_PATH))
+        .expect("checked capability inventory must parse");
+
+    assert_eq!(manifest.invocations.len(), 468);
+    assert_eq!(manifest.inputs.len(), 81);
+    assert_eq!(manifest.counts.scanned_rust_files, 362);
+    assert_eq!(manifest.counts.ordinary, 429);
+    assert_eq!(manifest.counts.unrestricted, 39);
+    assert_eq!(manifest.counts.production, 446);
+    assert_eq!(manifest.counts.test, 0);
+    assert_eq!(manifest.counts.example, 22);
+    assert_eq!(manifest.counts.direct, 466);
+    assert_eq!(manifest.counts.macro_template, 2);
+    assert_eq!(audit.classes.len(), 31);
+    assert_eq!(audit.mappings.len(), 468);
+
+    let classes = audit
+        .classes
+        .iter()
+        .map(|class| (class.id.as_str(), class))
+        .collect::<BTreeMap<_, _>>();
+    let mapping_counts =
+        audit
+            .mappings
+            .iter()
+            .fold(BTreeMap::<&str, usize>::new(), |mut counts, mapping| {
+                *counts.entry(mapping.class_id.as_str()).or_default() += 1;
+                counts
+            });
+    let contract = std::fs::read_to_string(repository_root.join(CONTRACT_PATH))
+        .expect("logger producer contract must be readable");
+    let contract_rows = contract
+        .lines()
+        .filter(|line| line.starts_with("| `logger."))
+        .collect::<Vec<_>>();
+    assert_eq!(contract_rows.len(), EXPECTED_CLASSES.len());
+
+    for (id, disposition, expected_mappings) in EXPECTED_CLASSES {
+        let class = classes
+            .get(id)
+            .unwrap_or_else(|| panic!("logger class must exist: {id}"));
+        assert_eq!(class.disposition, disposition, "disposition drifted: {id}");
+        assert_eq!(mapping_counts.get(id), Some(&expected_mappings));
+        let disposition = match disposition {
+            LoggerClassDisposition::Implemented => "implemented",
+            LoggerClassDisposition::Planned => "planned",
+            LoggerClassDisposition::NotApplicable => "not-applicable",
+        };
+        let prefix = format!("| `{id}` | `{disposition}` |");
+        let row = contract_rows
+            .iter()
+            .find(|row| row.starts_with(&prefix))
+            .unwrap_or_else(|| panic!("contract class row must exist: {id}"));
+        assert!(
+            row.ends_with(&format!("| {expected_mappings} |")),
+            "contract mapping count drifted: {id}"
+        );
+    }
+
+    assert_eq!(
+        audit
+            .classes
+            .iter()
+            .filter(|class| class.disposition == LoggerClassDisposition::Implemented)
+            .count(),
+        5
+    );
+    assert_eq!(
+        audit
+            .classes
+            .iter()
+            .filter(|class| class.disposition == LoggerClassDisposition::Planned)
+            .count(),
+        19
+    );
+    assert_eq!(
+        audit
+            .classes
+            .iter()
+            .filter(|class| class.disposition == LoggerClassDisposition::NotApplicable)
+            .count(),
+        7
+    );
+    let mapped_dispositions = audit
+        .mappings
+        .iter()
+        .map(|mapping| {
+            classes
+                .get(mapping.class_id.as_str())
+                .expect("mapped class must exist")
+                .disposition
+        })
+        .fold(BTreeMap::new(), |mut counts, disposition| {
+            *counts.entry(disposition).or_insert(0_usize) += 1;
+            counts
+        });
+    assert_eq!(
+        mapped_dispositions,
+        BTreeMap::from([
+            (LoggerClassDisposition::Implemented, 9),
+            (LoggerClassDisposition::Planned, 397),
+            (LoggerClassDisposition::NotApplicable, 62),
+        ])
+    );
+    let planned_owners = audit
+        .classes
+        .iter()
+        .filter(|class| class.disposition == LoggerClassDisposition::Planned)
+        .fold(BTreeMap::new(), |mut counts, class| {
+            let issue = class
+                .delivery_issue
+                .as_deref()
+                .expect("planned class must name its owner");
+            *counts.entry(issue).or_insert(0_usize) += 1;
+            counts
+        });
+    assert_eq!(
+        planned_owners,
+        BTreeMap::from([("#1807", 3), ("#1808", 5), ("#1809", 11)])
+    );
+
+    let compiled_events = audit
+        .classes
+        .iter()
+        .flat_map(|class| class.compiled_events.iter().copied())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        compiled_events,
+        BTreeSet::from([
+            LoggerCompiledEvent::ApiRequest,
+            LoggerCompiledEvent::InstanceStart,
+            LoggerCompiledEvent::FlushMetrics,
+            LoggerCompiledEvent::BootTime,
+            LoggerCompiledEvent::RateLimitRecovery,
+            LoggerCompiledEvent::ProcessPanic,
+            LoggerCompiledEvent::ProcessExit,
+        ])
+    );
+    let planned_with_compiled_events = audit
+        .classes
+        .iter()
+        .filter(|class| {
+            class.disposition == LoggerClassDisposition::Planned
+                && !class.compiled_events.is_empty()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(planned_with_compiled_events.len(), 1);
+    assert_eq!(planned_with_compiled_events[0].id, "logger.api.result");
+    assert_eq!(
+        planned_with_compiled_events[0].compiled_events,
+        [
+            LoggerCompiledEvent::InstanceStart,
+            LoggerCompiledEvent::FlushMetrics,
+        ]
+    );
+    assert!(!planned_with_compiled_events[0].implementation.is_empty());
+    assert!(!planned_with_compiled_events[0].validation.is_empty());
+
+    let capabilities = inventory
+        .capabilities
+        .iter()
+        .map(|capability| (capability.id.as_str(), capability))
+        .collect::<BTreeMap<_, _>>();
+    for id in LOGGER_CAPABILITIES {
+        assert_eq!(
+            capabilities
+                .get(id)
+                .unwrap_or_else(|| panic!("logger capability must exist: {id}"))
+                .disposition,
+            Disposition::AuditRequired,
+            "audit-only slice must not promote logger capability: {id}"
+        );
+    }
+}
+
+#[test]
+fn logger_audit_mutations_fail_closed() {
+    let repository_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|tools| tools.parent())
+        .expect("tool package must be nested under the repository tools directory")
+        .to_path_buf();
+    let manifest =
+        read_logger_producer_manifest(&repository_root.join(LOGGER_PRODUCER_MANIFEST_PATH))
+            .expect("checked logger producer manifest must parse");
+    let audit = read_logger_producer_audit(&repository_root.join(LOGGER_PRODUCER_AUDIT_PATH))
+        .expect("checked logger producer audit must parse");
+
+    let final_error =
+        validate_logger_producers(&manifest, &audit, &repository_root, AuditMode::Final)
+            .expect_err("final mode must reject planned classes")
+            .to_string();
+    assert!(final_error.contains("final logger validation forbids planned class"));
+
+    let mut missing = audit.clone();
+    missing.mappings.pop();
+    let error =
+        validate_logger_producers(&manifest, &missing, &repository_root, AuditMode::Delivery)
+            .expect_err("missing mapping must fail")
+            .to_string();
+    assert!(error.contains("logger invocation has no audit mapping"));
+
+    let mut duplicate = audit.clone();
+    duplicate.mappings.push(
+        duplicate
+            .mappings
+            .last()
+            .expect("mapping must exist")
+            .clone(),
+    );
+    let error =
+        validate_logger_producers(&manifest, &duplicate, &repository_root, AuditMode::Delivery)
+            .expect_err("duplicate mapping must fail")
+            .to_string();
+    assert!(error.contains("logger mapping invocation id entries must be sorted and unique"));
+
+    let mut stale = audit.clone();
+    let mut stale_mapping = stale.mappings.last().expect("mapping must exist").clone();
+    stale_mapping.invocation_id = "logger-invocation:zzz/stale.rs:1:1".to_string();
+    stale.mappings.push(stale_mapping);
+    let error = validate_logger_producers(&manifest, &stale, &repository_root, AuditMode::Delivery)
+        .expect_err("stale mapping must fail")
+        .to_string();
+    assert!(error.contains("logger audit mapping is stale"));
+
+    let mut malformed_manifest = manifest.clone();
+    malformed_manifest.invocations[0].fingerprint = "sha256:NOT-A-DIGEST".to_string();
+    let error = validate_logger_producers(
+        &malformed_manifest,
+        &audit,
+        &repository_root,
+        AuditMode::Delivery,
+    )
+    .expect_err("malformed fingerprint must fail")
+    .to_string();
+    assert!(error.contains("fingerprint is not lowercase SHA-256"));
+
+    let mut catch_all = audit.clone();
+    let class = catch_all
+        .classes
+        .iter_mut()
+        .find(|class| class.id == "logger.api-control.outcome")
+        .expect("planned class must exist");
+    class.id = "logger.api.catch-all".to_string();
+    let error =
+        validate_logger_producers(&manifest, &catch_all, &repository_root, AuditMode::Delivery)
+            .expect_err("catch-all class must fail")
+            .to_string();
+    assert!(error.contains("logger class id uses a catch-all term"));
+
+    let mut mismatched_not_applicable = audit.clone();
+    let class = mismatched_not_applicable
+        .classes
+        .iter_mut()
+        .find(|class| class.id == "logger.nonapp.example")
+        .expect("example class must exist");
+    class.guest_triggerable = true;
+    let error = validate_logger_producers(
+        &manifest,
+        &mismatched_not_applicable,
+        &repository_root,
+        AuditMode::Delivery,
+    )
+    .expect_err("not-applicable policy mismatch must fail")
+    .to_string();
+    assert!(error.contains("must use only not-applicable policy"));
+
+    let mut evidence_mismatch = audit.clone();
+    let class = evidence_mismatch
+        .classes
+        .iter_mut()
+        .find(|class| class.id == "logger.api.result")
+        .expect("API result class must exist");
+    class.validation.clear();
+    let error = validate_logger_producers(
+        &manifest,
+        &evidence_mismatch,
+        &repository_root,
+        AuditMode::Delivery,
+    )
+    .expect_err("compiled event without complete evidence must fail")
+    .to_string();
+    assert!(error.contains("compiled-event metadata and exact evidence must appear together"));
+
+    let mut wrong_compiled_owner = audit.clone();
+    let boot_class = wrong_compiled_owner
+        .classes
+        .iter()
+        .find(|class| class.id == "logger.boot.time")
+        .expect("boot class must exist")
+        .clone();
+    let class = wrong_compiled_owner
+        .classes
+        .iter_mut()
+        .find(|class| class.id == "logger.boot.time")
+        .expect("boot class must exist");
+    class.compiled_events.clear();
+    class.implementation.clear();
+    class.validation.clear();
+    let class = wrong_compiled_owner
+        .classes
+        .iter_mut()
+        .find(|class| class.id == "logger.api-control.outcome")
+        .expect("API control class must exist");
+    class.compiled_events = vec![LoggerCompiledEvent::BootTime];
+    class.implementation = boot_class.implementation;
+    class.validation = boot_class.validation;
+    let error = validate_logger_producers(
+        &manifest,
+        &wrong_compiled_owner,
+        &repository_root,
+        AuditMode::Delivery,
+    )
+    .expect_err("compiled event on the wrong class must fail")
+    .to_string();
+    assert!(error.contains("logger compiled event must have its exact class"));
+
+    let mut unresolved_evidence = audit;
+    let class = unresolved_evidence
+        .classes
+        .iter_mut()
+        .find(|class| class.id == "logger.api.request")
+        .expect("API request class must exist");
+    class.implementation[0] = Reference::Local {
+        path: "crates/runtime/src/missing-logger-evidence.rs".to_string(),
+        anchor: None,
+    };
+    let error = validate_logger_producers(
+        &manifest,
+        &unresolved_evidence,
+        &repository_root,
+        AuditMode::Delivery,
+    )
+    .expect_err("unresolved local evidence must fail")
+    .to_string();
+    assert!(error.contains("logger class local reference does not exist"));
 }
 
 fn local_reference_paths(references: &[Reference]) -> Option<BTreeSet<&str>> {

--- a/tools/firecracker-capability-audit/tests/checked_inventory.rs
+++ b/tools/firecracker-capability-audit/tests/checked_inventory.rs
@@ -577,7 +577,7 @@ fn logger_audit_mutations_fail_closed() {
     )
     .expect_err("unresolved local evidence must fail")
     .to_string();
-    assert!(error.contains("logger class local reference does not exist"));
+    assert!(error.contains("local reference path does not exist"));
 }
 
 fn local_reference_paths(references: &[Reference]) -> Option<BTreeSet<&str>> {


### PR DESCRIPTION
## Summary

- add a syntax-aware, value-redacted Firecracker v1.16.0 logger producer extractor and checked machine manifest for all 429 ordinary plus 39 unrestricted invocations
- add a human-owned 31-class audit with one explicit mapping per invocation, exact existing event evidence, planned ownership, and delivery/final-mode validation
- document the field/redaction/delivery/limiter contract and add create-new regeneration, exact sibling comparison, canonical closure tests, and fail-closed mutation tests

## Scope exclusions

- no runtime, API, HVF, launcher, or logger sink behavior changes
- no `capabilities.json` disposition changes; all eleven #1786 logger records remain `audit-required`
- no automatic generation or carry-forward of human semantic classifications

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p bangbang-firecracker-capability-audit --all-targets --all-features --locked`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo check -p bangbang-snapshot-tools --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf --quiet`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`

Closes #1806

Parent: #1786  
Delivery root: #1348
