### PR TITLE
feat: log host lifecycle and worker outcomes

### DIFF
--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -64,7 +64,7 @@ reviewed delta.
 | [Snapshot editor state](snapshot-editor-contract.md) | Native-state version/vCPU/VM inspection, finite reviewed-register editing, no-clobber publication, signed Full/Diff product restore, and the exact twelve-row closure |
 | [Snapshot Wave 6](snapshot-wave6-contract.md) | Exact 70-row load, artifact, version, device, tool, time/identity, portability, and downstream-owner certification |
 | [Observability, tools, and specification](observability-tools-specification-contract.md) | Exact Wave 7 ownership, core API certification, x86 CPUID/MSR platform exclusions, and retained downstream handoffs |
-| [Logger producers](logger-contract.md) | Exact 468-invocation source closure, implemented configuration/API/startup classes, safe fields, bounded default-stdout admission/forwarding policy, and remaining #1808/#1809 ownership |
+| [Logger producers](logger-contract.md) | Exact 468-invocation source closure, 13 implemented configuration/API/host-lifecycle/worker/snapshot classes, safe fields, bounded default-stdout admission/forwarding policy, and remaining #1809 ownership |
 
 ## Dispositions
 

--- a/compat/firecracker/v1.16.0/logger-contract.md
+++ b/compat/firecracker/v1.16.0/logger-contract.md
@@ -68,15 +68,12 @@ source calls only when subsystem, observable outcome, target fields, delivery,
 module/origin behavior, limiter policy, disposition, and delivery owner agree.
 There are no path selectors and no `other`, `unknown`, or catch-all class.
 
-The 31 classes contain 8 implemented classes, 16 planned classes, and 7 exact
-not-applicable classes. Across source mappings this is 26 implemented, 380
+The 31 classes contain 13 implemented classes, 11 planned classes, and 7 exact
+not-applicable classes. Across source mappings this is 82 implemented, 324
 planned, and 62 not-applicable invocations.
 
-`planned` is an explicit intermediate delivery state. The two remaining owners
-are:
+`planned` is an explicit intermediate delivery state. The remaining owner is:
 
-- #1808: host lifecycle, API/VMM worker, snapshot, signal, and observability
-  outcomes; and
 - #1809: backend, vCPU, transport, and device outcomes.
 
 Delivery validation accepts those named planned classes. Final validation
@@ -90,6 +87,12 @@ one control record and no result. Process startup has one fixed `running`
 outcome after the no-API owner is ready or the API socket is bound and before
 readiness is announced.
 
+Issue #1808 closes the host lifecycle and live-device controls, API/VMM worker
+status, snapshot create/load results, metrics-worker failures, host signals,
+guest power convergence, cancellation, and orderly/abnormal shutdown. These
+records use typed fixed vocabularies, discard payloads before encoding, and
+preserve the functional result when logger delivery fails.
+
 ## Closed class ledger
 
 `Mappings` is the exact number of source identities assigned to the class.
@@ -98,7 +101,7 @@ Owners apply only to planned work.
 | Class | Disposition | Owner/reason | Mappings |
 | --- | --- | --- | ---: |
 | `logger.api-control.outcome` | `implemented` | fixed server/connection/request outcomes | 7 |
-| `logger.api-worker.outcome` | `planned` | #1808 | 5 |
+| `logger.api-worker.outcome` | `implemented` | fixed worker lifecycle | 5 |
 | `logger.api.request` | `implemented` | parsed method/template receipt | 1 |
 | `logger.api.result` | `implemented` | closed HTTP result plus retained actions | 5 |
 | `logger.backend.outcome` | `planned` | #1809 | 26 |
@@ -106,7 +109,7 @@ Owners apply only to planned work.
 | `logger.block.outcome` | `planned` | #1809 | 34 |
 | `logger.boot.time` | `implemented` | bounded boot timing | 1 |
 | `logger.entropy.outcome` | `planned` | #1809 | 16 |
-| `logger.lifecycle.outcome` | `planned` | #1808 | 24 |
+| `logger.lifecycle.outcome` | `implemented` | fixed VM and live-device lifecycle | 24 |
 | `logger.limiter.recovery` | `implemented` | bounded suppressed count | 1 |
 | `logger.memory-hotplug.outcome` | `planned` | #1809 | 22 |
 | `logger.network.outcome` | `planned` | #1809 | 26 |
@@ -117,14 +120,14 @@ Owners apply only to planned work.
 | `logger.nonapp.tool` | `not-applicable` | `separate-tool-owner` | 1 |
 | `logger.nonapp.tracing` | `not-applicable` | `tracing-owned` | 2 |
 | `logger.nonapp.x86` | `not-applicable` | `x86-only` | 15 |
-| `logger.observability.outcome` | `planned` | #1808 | 4 |
+| `logger.observability.outcome` | `implemented` | rate-limited metrics-worker failure | 4 |
 | `logger.pmem.outcome` | `planned` | #1809 | 18 |
-| `logger.process-signal.outcome` | `planned` | #1808 | 5 |
+| `logger.process-signal.outcome` | `implemented` | fixed signal and shutdown convergence | 5 |
 | `logger.process-startup.outcome` | `implemented` | fixed normal startup outcome | 5 |
 | `logger.process.exit` | `implemented` | fixed terminal category | 3 |
 | `logger.process.panic` | `implemented` | fixed emergency record | 3 |
 | `logger.serial.outcome` | `planned` | #1809 | 12 |
-| `logger.snapshot.outcome` | `planned` | #1808 | 18 |
+| `logger.snapshot.outcome` | `implemented` | fixed create/load result | 18 |
 | `logger.time-identity.outcome` | `planned` | #1809 | 16 |
 | `logger.transport.outcome` | `planned` | #1809 | 74 |
 | `logger.vsock.outcome` | `planned` | #1809 | 52 |
@@ -135,19 +138,32 @@ the closed outcome selects level. Adding a new operation/outcome requires
 deliberate class metadata and compiled-event review, never inheritance from a
 source-path selector.
 
-The newly closed records have exact fixed shapes:
+The implemented host-owned records have exact fixed shapes:
 
 - API control: `operation=<server|connection|request|request-parse>
   outcome=<closed-outcome>`;
 - parsed dispatch result: `action=request
-  outcome=<ok|no-content|bad-request|payload-too-large>`; and
-- normal startup: `operation=process-startup outcome=running`.
+  outcome=<ok|no-content|bad-request|payload-too-large>`;
+- normal startup: `operation=process-startup outcome=running`;
+- VM lifecycle: `operation=<backend-startup|vm-start|vm-pause|vm-resume|vm-stop>
+  outcome=<closed-outcome>`;
+- live device control: `device-kind=<block|network|pmem>
+  operation=<device-attach|device-update|device-detach>
+  outcome=<succeeded|rejected|failed>`;
+- snapshots: `operation=<snapshot-create|snapshot-load>
+  outcome=<succeeded|rejected|failed|cancelled>`;
+- worker and observability status:
+  `operation=<boot-worker|metrics-worker> outcome=<closed-outcome>`; and
+- process convergence:
+  `operation=<host-signal|cancellation|guest-power|shutdown>
+  outcome=<closed-outcome>`.
 
-Control/result levels are selected from the closed outcome: normal operation is
-`Info`, server stop is `Debug`, deprecation is `Warn`, and connection, parse,
-or error response outcomes are `Error`. These records use fixed modules and do
-not carry a URI, request/response body, fault text, status integer, path, or
-selector.
+Levels are selected from the closed outcome: normal operation is `Info`,
+unchanged VM state and an orderly stopped worker are `Debug`, snapshot
+cancellation and deprecation are `Warn`, and rejection, failure, or abnormal shutdown are
+`Error`. These records use fixed modules and do not carry a URI,
+request/response body, fault text, status integer, path, selector, device ID,
+MAC address, or guest value.
 
 ## Allowed fields and redaction
 
@@ -186,9 +202,11 @@ A guest-capable class applies the guest-safe policy to every mapped producer,
 including a host-only member of the same semantic class. This is deliberately
 conservative: it cannot grant a producer a blocking or unrestricted path.
 
-Every guest-capable class is rate-limited under its own fixed class identity.
-The sole exception is `logger.limiter.recovery`, which must be unrestricted to
-report a prior admitted recovery without recursively limiting itself. Queue,
+Every guest-capable class is rate-limited under its own fixed class identity,
+and the repeating asynchronous metrics-worker class independently uses
+`logger-rate.observability-worker`. The sole exception is
+`logger.limiter.recovery`, which must be unrestricted to report a prior
+admitted recovery without recursively limiting itself. Queue,
 receipt, write, flush, and replacement loss never changes the request, VM,
 guest, worker, or process result and increments the exact existing loss counter
 once. That exact boundary ends at the writer configured in the logger worker.
@@ -270,5 +288,5 @@ Issue #1807 promotes the nine concrete `/logger` operation, path, schema,
 property, and full-configuration records in `capabilities.json`. The two
 aggregate `corpus:logger` and
 `semantic.observability:logger-delivery-filtering-loss-and-redaction` records
-remain `audit-required` until #1808, #1809, and final certification close every
-planned producer class.
+remain `audit-required` until #1809 and final certification close every planned
+producer class and verify the aggregate claim.

--- a/compat/firecracker/v1.16.0/logger-producer-audit.json
+++ b/compat/firecracker/v1.16.0/logger-producer-audit.json
@@ -74,9 +74,45 @@
         "operation",
         "outcome"
       ],
-      "disposition": "planned",
+      "disposition": "implemented",
       "rationale": "All mapped upstream calls report the same semantic API/VMM worker lifecycle; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
-      "delivery_issue": "#1808"
+      "compiled_events": [
+        "api-worker"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "boot worker observation and shutdown convergence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed asynchronous API worker producer and delivery"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed API worker outcome encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "worker outcome, redaction, and terminal-order tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "process worker lifecycle evidence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "asynchronous worker delivery and loss tests"
+        }
+      ]
     },
     {
       "id": "logger.api.request",
@@ -338,12 +374,54 @@
       "origin": "configurable",
       "limiter": "unrestricted",
       "allowed_fields": [
+        "device-kind",
         "operation",
         "outcome"
       ],
-      "disposition": "planned",
+      "disposition": "implemented",
       "rationale": "All mapped upstream calls report the same semantic VM lifecycle and control outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
-      "delivery_issue": "#1808"
+      "compiled_events": [
+        "lifecycle"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "backend, VM, and live device lifecycle convergence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed bounded lifecycle producer and delivery"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed lifecycle outcome encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "API lifecycle ordering and redaction tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "VM state, backend, live device, and shutdown outcome tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "process lifecycle and shutdown evidence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "bounded lifecycle delivery and filtering tests"
+        }
+      ]
     },
     {
       "id": "logger.limiter.recovery",
@@ -536,20 +614,57 @@
     {
       "id": "logger.observability.outcome",
       "subsystem": "observability",
-      "summary": "Fixed redacted logger or metrics worker outcome.",
+      "summary": "Fixed redacted metrics worker outcome.",
       "guest_triggerable": false,
       "delivery": "nonblocking-async",
       "level": "outcome-derived",
       "module": "bangbang::worker",
       "origin": "configurable",
-      "limiter": "unrestricted",
+      "limiter": "rate-limited",
+      "limiter_identity": "logger-rate.observability-worker",
       "allowed_fields": [
         "operation",
         "outcome"
       ],
-      "disposition": "planned",
-      "rationale": "All mapped upstream calls report the same semantic logger or metrics worker outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
-      "delivery_issue": "#1808"
+      "disposition": "implemented",
+      "rationale": "All mapped upstream calls report the same semantic metrics worker outcome; the closed outcome selects level while Bangbang rate-limits repeated failures independently and discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
+      "compiled_events": [
+        "observability"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "automatic metrics worker failure convergence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed rate-limited observability worker producer"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed observability outcome encoding"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/rate_limiter.rs",
+          "anchor": "independent observability worker limiter identity"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "periodic metrics failure and redaction tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "observability limiter independence and asynchronous loss tests"
+        }
+      ]
     },
     {
       "id": "logger.pmem.outcome",
@@ -585,9 +700,55 @@
         "operation",
         "outcome"
       ],
-      "disposition": "planned",
+      "disposition": "implemented",
       "rationale": "All mapped upstream calls report the same semantic host signal and shutdown convergence; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
-      "delivery_issue": "#1808"
+      "compiled_events": [
+        "process-signal"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "API shutdown wakeup observation"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "no-API shutdown wakeup observation"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "signal, guest power, cancellation, and shutdown convergence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed asynchronous process signal producer"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed process signal outcome encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "terminal convergence and failure-preservation tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "guest power, signal, cancellation, and shutdown ordering tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "signal and terminal-order process evidence"
+        }
+      ]
     },
     {
       "id": "logger.process-startup.outcome",
@@ -796,9 +957,45 @@
         "operation",
         "outcome"
       ],
-      "disposition": "planned",
+      "disposition": "implemented",
       "rationale": "All mapped upstream calls report the same semantic snapshot create, load, or restore outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
-      "delivery_issue": "#1808"
+      "compiled_events": [
+        "snapshot"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "public snapshot create and load outcome convergence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "typed bounded snapshot producer and delivery"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed snapshot outcome encoding"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "snapshot API outcome and latency tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "snapshot success, rejection, failure, cancellation, and redaction tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "bounded snapshot delivery and filtering tests"
+        }
+      ]
     },
     {
       "id": "logger.time-identity.outcome",

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -273,6 +273,7 @@ impl ApiServer {
                 ApiServerWaitResult::TimedOut => {}
             }
             if drain_shutdown_wakeup(shutdown_wakeup)? {
+                vmm.record_shutdown_wakeup();
                 return Ok(());
             }
             vmm.drain_process_exit_wakeup()
@@ -6485,7 +6486,12 @@ mod tests {
         assert_api_request_log_with_origin(lines.next(), "Put", "/boot-source");
         assert_api_result_log_with_origin(lines.next(), "no-content");
         assert_api_request_log_with_origin(lines.next(), "Put", "/actions");
+        assert_lifecycle_log_with_origin(
+            lines.next(),
+            "operation=backend-startup outcome=succeeded",
+        );
         assert_action_log_with_origin(lines.next(), "InstanceStart");
+        assert_lifecycle_log_with_origin(lines.next(), "operation=vm-start outcome=succeeded");
         assert_api_result_log_with_origin(lines.next(), "no-content");
         assert_api_request_log_with_origin(lines.next(), "Put", "/actions");
         assert_action_log_with_origin(lines.next(), "FlushMetrics");
@@ -6682,6 +6688,27 @@ mod tests {
         );
     }
 
+    fn assert_lifecycle_log_with_origin(line: Option<&str>, event: &str) {
+        let line = line.expect("logger output should include lifecycle line");
+        assert!(line.starts_with("level=Info origin="));
+        let suffix = format!(" {event}");
+        assert!(line.ends_with(&suffix));
+
+        let origin = line
+            .strip_prefix("level=Info origin=")
+            .expect("logger output should include origin prefix")
+            .strip_suffix(&suffix)
+            .expect("logger output should include lifecycle suffix");
+        let (file, line_number) = origin
+            .rsplit_once(':')
+            .expect("logger origin should include file and line");
+        assert!(file.ends_with("vmm.rs"), "unexpected origin file: {file}");
+        assert!(
+            line_number.parse::<u32>().is_ok(),
+            "unexpected origin line: {line_number}"
+        );
+    }
+
     fn assert_api_result_log_with_origin(line: Option<&str>, outcome: &str) {
         let line = line.expect("logger output should include API result line");
         assert!(line.starts_with("level=Info origin="));
@@ -6759,7 +6786,10 @@ mod tests {
                 "The API server received a Put request on \"/boot-source\".\n",
                 "action=request outcome=no-content\n",
                 "The API server received a Put request on \"/actions\".\n",
+                "operation=backend-startup outcome=succeeded\n",
                 "action=InstanceStart\n",
+                "operation=boot-worker outcome=running\n",
+                "operation=vm-start outcome=succeeded\n",
                 "action=request outcome=no-content\n",
             )
         );
@@ -13078,7 +13108,7 @@ mod tests {
         .expect("boot source should configure");
         vmm.handle_action(VmmAction::InstanceStart)
             .expect("instance should start");
-        process_exit_trigger.trigger(ProcessSessionExitStatus::GuestRequestedStop);
+        process_exit_trigger.trigger(ProcessSessionExitStatus::GuestPoweroff);
 
         assert_eq!(server.run_until(&mut vmm, &mut shutdown_reader), Ok(()));
         drop(server);

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -5610,7 +5610,17 @@ mod tests {
         ));
         let _explicit_attempt = metrics_fifo.drain_available();
 
-        let output = fs::read_to_string(&logger_path).expect("logger output should be readable");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let output = loop {
+            let output =
+                fs::read_to_string(&logger_path).expect("logger output should be readable");
+            if output.contains("operation=metrics-worker outcome=failed\n")
+                || Instant::now() >= deadline
+            {
+                break output;
+            }
+            std::thread::yield_now();
+        };
         assert_eq!(
             output
                 .matches("operation=metrics-worker outcome=failed\n")

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -609,6 +609,7 @@ fn wait_for_no_api_shutdown_with_periodic_schedulers(
             ProcessWaitResult::TimedOut => {}
         }
         if shutdown_signal.drain_wakeup()? {
+            vmm.record_shutdown_wakeup();
             return Ok(());
         }
         vmm.drain_process_exit_wakeup()
@@ -3154,7 +3155,7 @@ mod tests {
         fn handle_periodic_metrics_flush(&mut self) {
             self.inner.handle_periodic_metrics_flush();
             self.process_exit_trigger
-                .trigger(ProcessSessionExitStatus::GuestRequestedStop);
+                .trigger(ProcessSessionExitStatus::GuestPoweroff);
         }
 
         fn balloon_statistics_update_interval(&self) -> Option<Duration> {
@@ -3164,7 +3165,7 @@ mod tests {
         fn handle_periodic_balloon_statistics_update(&mut self) -> Result<bool, VmmActionError> {
             let result = self.inner.handle_periodic_balloon_statistics_update();
             self.process_exit_trigger
-                .trigger(ProcessSessionExitStatus::GuestRequestedStop);
+                .trigger(ProcessSessionExitStatus::GuestPoweroff);
             result
         }
 
@@ -5142,7 +5143,13 @@ mod tests {
         );
         assert_eq!(
             fs::read_to_string(&logger_path).expect("logger output should be readable"),
-            "level=Info action=InstanceStart\nlevel=Info action=FlushMetrics\n"
+            concat!(
+                "level=Info operation=backend-startup outcome=succeeded\n",
+                "level=Info action=InstanceStart\n",
+                "level=Info operation=boot-worker outcome=running\n",
+                "level=Info operation=vm-start outcome=succeeded\n",
+                "level=Info action=FlushMetrics\n",
+            )
         );
 
         fs::remove_file(config_path).expect("fixture config should clean up");
@@ -5355,7 +5362,16 @@ mod tests {
         vmm.handle_action(VmmAction::InstanceStart)
             .expect("instance should start");
         vmm.handle_initial_metrics_flush();
-        assert_eq!(logger_fifo.drain_available(), b"action=InstanceStart\n");
+        assert_eq!(
+            logger_fifo.drain_available(),
+            concat!(
+                "operation=backend-startup outcome=succeeded\n",
+                "action=InstanceStart\n",
+                "operation=boot-worker outcome=running\n",
+                "operation=vm-start outcome=succeeded\n",
+            )
+            .as_bytes()
+        );
         logger_fifo.fill_to_capacity();
 
         let result = Err(ProcessError::ApiServer(ApiServerError::Accept(
@@ -5375,7 +5391,7 @@ mod tests {
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
             concat!(
                 "{\"vmm\":{\"metrics_flush_count\":1}}\n",
-                "{\"logger\":{\"missed_log_count\":1},\"vmm\":{\"metrics_flush_count\":1}}\n",
+                "{\"logger\":{\"missed_log_count\":3},\"vmm\":{\"metrics_flush_count\":1}}\n",
             )
         );
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -5407,7 +5423,7 @@ mod tests {
         vmm.handle_initial_metrics_flush();
         let mut shutdown_signal = test_shutdown_signal();
 
-        process_exit_trigger.trigger(ProcessSessionExitStatus::GuestRequestedStop);
+        process_exit_trigger.trigger(ProcessSessionExitStatus::GuestPoweroff);
 
         let result = super::wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm);
         assert_eq!(
@@ -5517,6 +5533,7 @@ mod tests {
     #[test]
     fn no_api_periodic_metrics_failure_reschedules_and_retries_delta() {
         let mut metrics_fifo = MetricsFifo::create("periodic-retry");
+        let logger_path = unique_logger_path("periodic-retry");
         let signal_metrics = SharedSignalMetrics::default();
         let mut vmm = ProcessVmm::with_starter(
             "demo-1",
@@ -5529,6 +5546,10 @@ mod tests {
             metrics_fifo.path(),
         )))
         .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new().with_log_path(&logger_path),
+        ))
+        .expect("logger should configure");
         vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
             "/tmp/vmlinux",
         )))
@@ -5588,6 +5609,16 @@ mod tests {
             VmmActionError::MetricsFlush(MetricsFlushError::Write(ErrorKind::WouldBlock))
         ));
         let _explicit_attempt = metrics_fifo.drain_available();
+
+        let output = fs::read_to_string(&logger_path).expect("logger output should be readable");
+        assert_eq!(
+            output
+                .matches("operation=metrics-worker outcome=failed\n")
+                .count(),
+            1
+        );
+        assert!(!output.contains("WouldBlock"));
+        fs::remove_file(logger_path).expect("logger fixture should clean up");
     }
 
     #[test]
@@ -6867,7 +6898,13 @@ mod tests {
 
         assert_eq!(
             fs::read_to_string(&path).expect("logger output should be readable"),
-            "level=Info action=InstanceStart\nlevel=Info action=FlushMetrics\n"
+            concat!(
+                "level=Info operation=backend-startup outcome=succeeded\n",
+                "level=Info action=InstanceStart\n",
+                "level=Info operation=boot-worker outcome=running\n",
+                "level=Info operation=vm-start outcome=succeeded\n",
+                "level=Info action=FlushMetrics\n",
+            )
         );
 
         fs::remove_file(path).expect("fixture should clean up");
@@ -6907,7 +6944,12 @@ mod tests {
             .expect("flush metrics should succeed");
         assert_eq!(
             fs::read_to_string(&matching_path).expect("matching logger output should be readable"),
-            "action=InstanceStart\naction=FlushMetrics\n"
+            concat!(
+                "operation=backend-startup outcome=succeeded\n",
+                "action=InstanceStart\n",
+                "operation=vm-start outcome=succeeded\n",
+                "action=FlushMetrics\n",
+            )
         );
 
         let filtered_path = unique_logger_path("module-filter-miss");

--- a/crates/bangbang/src/snapshot_restore_resources.rs
+++ b/crates/bangbang/src/snapshot_restore_resources.rs
@@ -264,6 +264,10 @@ impl SnapshotRestoreResourceError {
     pub(crate) const fn cleanup_failed(&self) -> bool {
         self.cleanup_failed
     }
+
+    pub(crate) const fn is_cancelled(&self) -> bool {
+        matches!(&self.kind, SnapshotRestoreResourceErrorKind::Cancelled) && !self.cleanup_failed
+    }
 }
 
 impl fmt::Debug for SnapshotRestoreResourceError {
@@ -4924,6 +4928,17 @@ impl SnapshotV2StorageRestoreBundleError {
             Self::Bundle { .. } => SnapshotRestoreResourceDisposition::Terminal,
         }
     }
+
+    pub(crate) const fn is_cancelled(&self) -> bool {
+        match self {
+            Self::Resources(source) => source.is_cancelled(),
+            Self::Bundle {
+                source,
+                completion_abort: None,
+            } => source.is_cancelled() && !source.cleanup_failed(),
+            Self::Plan(_) | Self::Bundle { .. } => false,
+        }
+    }
 }
 
 impl fmt::Debug for SnapshotV2StorageRestoreBundleError {
@@ -4997,6 +5012,10 @@ impl SnapshotV2MultiBlockRestoreBundleError {
             } => SnapshotRestoreResourceDisposition::Retryable,
             Self::Bundle { .. } => SnapshotRestoreResourceDisposition::Terminal,
         }
+    }
+
+    pub(crate) const fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Resources(source) if source.is_cancelled())
     }
 }
 
@@ -7044,6 +7063,7 @@ mod tests {
             SnapshotRestoreResourceDisposition::Retryable
         );
         assert!(!error.cleanup_failed);
+        assert!(error.is_cancelled());
         fixture.assert_authorities_available(true);
     }
 
@@ -7073,6 +7093,7 @@ mod tests {
             SnapshotRestoreResourceDisposition::Terminal
         );
         assert!(error.cleanup_failed);
+        assert!(!error.is_cancelled());
         assert_coherent_root_claim_restored(&fixture);
         let directory = fixture
             .directories()
@@ -7113,6 +7134,7 @@ mod tests {
             SnapshotRestoreResourceDisposition::Terminal
         );
         assert!(error.cleanup_failed);
+        assert!(!error.is_cancelled());
         assert_coherent_root_claim_restored(&fixture);
         let directory = fixture
             .directories()
@@ -10159,6 +10181,7 @@ mod tests {
             !error.cleanup_failed,
             "ordinary cleanup success must remain distinct from retry safety"
         );
+        assert!(error.is_cancelled());
     }
 
     #[test]
@@ -10280,6 +10303,7 @@ mod tests {
             SnapshotRestoreResourceDisposition::Retryable
         );
         assert!(!error.cleanup_failed);
+        assert!(error.is_cancelled());
 
         let root = TempRoot::new("cancel-after-prepare", b"root");
         let authority = root_file_grant_authority_for_test(root.path());
@@ -10304,6 +10328,7 @@ mod tests {
             SnapshotRestoreResourceDisposition::Retryable
         );
         assert!(!error.cleanup_failed);
+        assert!(error.is_cancelled());
         assert_root_claim_restored(&authority);
 
         let poisoned_root = TempRoot::new("cancel-cleanup-failure", b"root");
@@ -10329,6 +10354,7 @@ mod tests {
             SnapshotRestoreResourceDisposition::Terminal
         );
         assert!(error.cleanup_failed);
+        assert!(!error.is_cancelled());
     }
 
     #[test]

--- a/crates/bangbang/src/snapshot_serial_restore.rs
+++ b/crates/bangbang/src/snapshot_serial_restore.rs
@@ -473,6 +473,10 @@ impl SnapshotV2SerialStorageAdoptionError {
             SnapshotRestoreResourceDisposition::Terminal
         )
     }
+
+    pub(crate) const fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Bundle(source) if source.is_cancelled() && !source.cleanup_failed())
+    }
 }
 
 impl fmt::Debug for SnapshotV2SerialStorageAdoptionError {
@@ -989,6 +993,20 @@ impl SnapshotV2SerialRestoreBundleError {
             Self::Stdio { .. } | Self::Cancelled { .. } => {
                 SnapshotRestoreResourceDisposition::Terminal
             }
+        }
+    }
+
+    pub(crate) const fn is_cancelled(&self) -> bool {
+        match self {
+            Self::Resources(source) => source.is_cancelled(),
+            Self::Cancelled {
+                owners_cleanup: None,
+                completion_abort: None,
+            } => true,
+            Self::Stdio { .. }
+            | Self::SerialConfig { .. }
+            | Self::InvalidResourceSet { .. }
+            | Self::Cancelled { .. } => false,
         }
     }
 }
@@ -1887,6 +1905,7 @@ mod tests {
             error.disposition(),
             SnapshotRestoreResourceDisposition::Retryable
         );
+        assert!(!error.is_cancelled());
 
         let resources = batch(None, &state);
         let (input_reader, _input_writer) = pipe_files();
@@ -1912,6 +1931,7 @@ mod tests {
             error.disposition(),
             SnapshotRestoreResourceDisposition::Retryable
         );
+        assert!(error.is_cancelled());
         assert_eq!(
             status_flags(input_reader.as_raw_fd()) & (libc::O_ACCMODE | libc::O_NONBLOCK),
             original_input_flags & (libc::O_ACCMODE | libc::O_NONBLOCK)

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -3057,6 +3057,7 @@ fn native_v2_error_after_process_root_completion_abort(
 pub(crate) struct NativeV2MultiBlockDestinationLoadError {
     transport: SnapshotV2DeviceTransportKind,
     terminal: bool,
+    cancelled: bool,
     detail: Option<String>,
 }
 
@@ -3066,6 +3067,7 @@ impl NativeV2MultiBlockDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled: false,
             detail: None,
         }
     }
@@ -3073,6 +3075,7 @@ impl NativeV2MultiBlockDestinationLoadError {
     fn with_source(
         transport: SnapshotV2DeviceTransportKind,
         terminal: bool,
+        cancelled: bool,
         source: &(dyn std::error::Error + 'static),
     ) -> Self {
         let mut leaf = source;
@@ -3082,12 +3085,17 @@ impl NativeV2MultiBlockDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled,
             detail: Some(leaf.to_string()),
         }
     }
 
     const fn is_terminal(&self) -> bool {
         self.terminal
+    }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 }
 
@@ -3098,6 +3106,7 @@ impl fmt::Debug for NativeV2MultiBlockDestinationLoadError {
             .debug_struct("NativeV2MultiBlockDestinationLoadError")
             .field("transport", &self.transport)
             .field("terminal", &self.terminal)
+            .field("cancelled", &self.cancelled)
             .field("has_detail", &self.detail.is_some())
             .field("state", &"<redacted>")
             .finish()
@@ -3131,6 +3140,7 @@ impl std::error::Error for NativeV2MultiBlockDestinationLoadError {}
 pub(crate) struct NativeV2StorageDestinationLoadError {
     transport: SnapshotV2DeviceTransportKind,
     terminal: bool,
+    cancelled: bool,
     detail: Option<String>,
 }
 
@@ -3140,6 +3150,7 @@ impl NativeV2StorageDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled: false,
             detail: None,
         }
     }
@@ -3147,6 +3158,7 @@ impl NativeV2StorageDestinationLoadError {
     fn with_source(
         transport: SnapshotV2DeviceTransportKind,
         terminal: bool,
+        cancelled: bool,
         source: &(dyn std::error::Error + 'static),
     ) -> Self {
         let mut leaf = source;
@@ -3156,12 +3168,17 @@ impl NativeV2StorageDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled,
             detail: Some(leaf.to_string()),
         }
     }
 
     const fn is_terminal(&self) -> bool {
         self.terminal
+    }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 }
 
@@ -3172,6 +3189,7 @@ impl fmt::Debug for NativeV2StorageDestinationLoadError {
             .debug_struct("NativeV2StorageDestinationLoadError")
             .field("transport", &self.transport)
             .field("terminal", &self.terminal)
+            .field("cancelled", &self.cancelled)
             .field("has_detail", &self.detail.is_some())
             .field("state", &"<redacted>")
             .finish()
@@ -3204,6 +3222,7 @@ impl std::error::Error for NativeV2StorageDestinationLoadError {}
 #[cfg(target_os = "macos")]
 pub(crate) struct NativeV2SerialDestinationLoadError {
     terminal: bool,
+    cancelled: bool,
     detail: Option<String>,
 }
 
@@ -3212,23 +3231,33 @@ impl NativeV2SerialDestinationLoadError {
     const fn new(terminal: bool) -> Self {
         Self {
             terminal,
+            cancelled: false,
             detail: None,
         }
     }
 
-    fn with_source(terminal: bool, source: &(dyn std::error::Error + 'static)) -> Self {
+    fn with_source(
+        terminal: bool,
+        cancelled: bool,
+        source: &(dyn std::error::Error + 'static),
+    ) -> Self {
         let mut leaf = source;
         while let Some(next) = leaf.source() {
             leaf = next;
         }
         Self {
             terminal,
+            cancelled,
             detail: Some(leaf.to_string()),
         }
     }
 
     const fn is_terminal(&self) -> bool {
         self.terminal
+    }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 }
 
@@ -3238,6 +3267,7 @@ impl fmt::Debug for NativeV2SerialDestinationLoadError {
         formatter
             .debug_struct("NativeV2SerialDestinationLoadError")
             .field("terminal", &self.terminal)
+            .field("cancelled", &self.cancelled)
             .field("has_detail", &self.detail.is_some())
             .field("state", &"<redacted>")
             .finish()
@@ -3270,6 +3300,7 @@ impl std::error::Error for NativeV2SerialDestinationLoadError {}
 pub(crate) struct NativeV2EntropyDestinationLoadError {
     transport: SnapshotV2DeviceTransportKind,
     terminal: bool,
+    cancelled: bool,
     detail: Option<String>,
 }
 
@@ -3279,6 +3310,7 @@ impl NativeV2EntropyDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled: false,
             detail: None,
         }
     }
@@ -3286,6 +3318,7 @@ impl NativeV2EntropyDestinationLoadError {
     fn with_source(
         transport: SnapshotV2DeviceTransportKind,
         terminal: bool,
+        cancelled: bool,
         source: &(dyn std::error::Error + 'static),
     ) -> Self {
         let mut leaf = source;
@@ -3295,12 +3328,17 @@ impl NativeV2EntropyDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled,
             detail: Some(leaf.to_string()),
         }
     }
 
     const fn is_terminal(&self) -> bool {
         self.terminal
+    }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 }
 
@@ -3311,6 +3349,7 @@ impl fmt::Debug for NativeV2EntropyDestinationLoadError {
             .debug_struct("NativeV2EntropyDestinationLoadError")
             .field("transport", &self.transport)
             .field("terminal", &self.terminal)
+            .field("cancelled", &self.cancelled)
             .field("has_detail", &self.detail.is_some())
             .field("state", &"<redacted>")
             .finish()
@@ -3344,6 +3383,7 @@ impl std::error::Error for NativeV2EntropyDestinationLoadError {}
 pub(crate) struct NativeV2BalloonDestinationLoadError {
     transport: SnapshotV2DeviceTransportKind,
     terminal: bool,
+    cancelled: bool,
     detail: Option<String>,
 }
 
@@ -3353,6 +3393,7 @@ impl NativeV2BalloonDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled: false,
             detail: None,
         }
     }
@@ -3360,6 +3401,7 @@ impl NativeV2BalloonDestinationLoadError {
     fn with_source(
         transport: SnapshotV2DeviceTransportKind,
         terminal: bool,
+        cancelled: bool,
         source: &(dyn std::error::Error + 'static),
     ) -> Self {
         let mut leaf = source;
@@ -3369,12 +3411,17 @@ impl NativeV2BalloonDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled,
             detail: Some(leaf.to_string()),
         }
     }
 
     const fn is_terminal(&self) -> bool {
         self.terminal
+    }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 }
 
@@ -3385,6 +3432,7 @@ impl fmt::Debug for NativeV2BalloonDestinationLoadError {
             .debug_struct("NativeV2BalloonDestinationLoadError")
             .field("transport", &self.transport)
             .field("terminal", &self.terminal)
+            .field("cancelled", &self.cancelled)
             .field("has_detail", &self.detail.is_some())
             .field("state", &"<redacted>")
             .finish()
@@ -3418,6 +3466,7 @@ impl std::error::Error for NativeV2BalloonDestinationLoadError {}
 pub(crate) struct NativeV2MemoryHotplugDestinationLoadError {
     transport: SnapshotV2DeviceTransportKind,
     terminal: bool,
+    cancelled: bool,
     detail: Option<String>,
 }
 
@@ -3427,6 +3476,7 @@ impl NativeV2MemoryHotplugDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled: false,
             detail: None,
         }
     }
@@ -3434,6 +3484,7 @@ impl NativeV2MemoryHotplugDestinationLoadError {
     fn with_source(
         transport: SnapshotV2DeviceTransportKind,
         terminal: bool,
+        cancelled: bool,
         source: &(dyn std::error::Error + 'static),
     ) -> Self {
         let mut leaf = source;
@@ -3443,12 +3494,17 @@ impl NativeV2MemoryHotplugDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled,
             detail: Some(leaf.to_string()),
         }
     }
 
     const fn is_terminal(&self) -> bool {
         self.terminal
+    }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 }
 
@@ -3459,6 +3515,7 @@ impl fmt::Debug for NativeV2MemoryHotplugDestinationLoadError {
             .debug_struct("NativeV2MemoryHotplugDestinationLoadError")
             .field("transport", &self.transport)
             .field("terminal", &self.terminal)
+            .field("cancelled", &self.cancelled)
             .field("has_detail", &self.detail.is_some())
             .field("state", &"<redacted>")
             .finish()
@@ -3492,6 +3549,7 @@ impl std::error::Error for NativeV2MemoryHotplugDestinationLoadError {}
 pub(crate) struct NativeV2NetworkDestinationLoadError {
     transport: SnapshotV2DeviceTransportKind,
     terminal: bool,
+    cancelled: bool,
 }
 
 #[cfg(target_os = "macos")]
@@ -3500,19 +3558,29 @@ impl NativeV2NetworkDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled: false,
         }
     }
 
     fn with_source(
         transport: SnapshotV2DeviceTransportKind,
         terminal: bool,
+        cancelled: bool,
         _source: &(dyn std::error::Error + 'static),
     ) -> Self {
-        Self::new(transport, terminal)
+        Self {
+            transport,
+            terminal,
+            cancelled,
+        }
     }
 
     const fn is_terminal(&self) -> bool {
         self.terminal
+    }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 }
 
@@ -3523,6 +3591,7 @@ impl fmt::Debug for NativeV2NetworkDestinationLoadError {
             .debug_struct("NativeV2NetworkDestinationLoadError")
             .field("transport", &self.transport)
             .field("terminal", &self.terminal)
+            .field("cancelled", &self.cancelled)
             .field("state", &"<redacted>")
             .finish()
     }
@@ -3551,6 +3620,7 @@ impl std::error::Error for NativeV2NetworkDestinationLoadError {}
 pub(crate) struct NativeV2VsockDestinationLoadError {
     transport: SnapshotV2DeviceTransportKind,
     terminal: bool,
+    cancelled: bool,
 }
 
 #[cfg(target_os = "macos")]
@@ -3559,19 +3629,37 @@ impl NativeV2VsockDestinationLoadError {
         Self {
             transport,
             terminal,
+            cancelled: false,
+        }
+    }
+
+    const fn cancelled(transport: SnapshotV2DeviceTransportKind, terminal: bool) -> Self {
+        Self {
+            transport,
+            terminal,
+            cancelled: true,
         }
     }
 
     fn with_source(
         transport: SnapshotV2DeviceTransportKind,
         terminal: bool,
+        cancelled: bool,
         _source: &(dyn std::error::Error + 'static),
     ) -> Self {
-        Self::new(transport, terminal)
+        Self {
+            transport,
+            terminal,
+            cancelled,
+        }
     }
 
     const fn is_terminal(&self) -> bool {
         self.terminal
+    }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
     }
 }
 
@@ -3582,6 +3670,7 @@ impl fmt::Debug for NativeV2VsockDestinationLoadError {
             .debug_struct("NativeV2VsockDestinationLoadError")
             .field("transport", &self.transport)
             .field("terminal", &self.terminal)
+            .field("cancelled", &self.cancelled)
             .field("state", &"<redacted>")
             .finish()
     }
@@ -4329,6 +4418,38 @@ fn native_v2_snapshot_load_is_cancelled(error: &NativeV2SnapshotLoadError) -> bo
     match error {
         NativeV2SnapshotLoadError::Cancelled => true,
         NativeV2SnapshotLoadError::Artifact(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::RestoreResources(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::MultiBlockBundle(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::MultiBlockDestination(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::StorageBundle(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::StorageDestination(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::SerialBundle(source)
+        | NativeV2SnapshotLoadError::EntropyBundle(source)
+        | NativeV2SnapshotLoadError::BalloonBundle(source)
+        | NativeV2SnapshotLoadError::MemoryHotplugBundle(source)
+        | NativeV2SnapshotLoadError::NetworkBundle(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::SerialDestination(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::EntropyDestination(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::BalloonDestination(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::MemoryHotplugDestination(source) => source.is_cancelled(),
+        NativeV2SnapshotLoadError::NetworkPreparation(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::NetworkDestination(source) => source.is_cancelled(),
+        NativeV2SnapshotLoadError::VsockPreparation(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::VsockRestoreResources(source) => source.is_cancelled(),
+        #[cfg(target_os = "macos")]
+        NativeV2SnapshotLoadError::VsockDestination(source) => source.is_cancelled(),
         NativeV2SnapshotLoadError::AfterResourceAdoption { source } => {
             native_v2_snapshot_load_is_cancelled(source)
         }
@@ -11208,6 +11329,10 @@ impl std::error::Error for PreparedHvfSnapshotV2MultiBlockControllerError {}
 #[cfg(target_os = "macos")]
 trait HvfSnapshotV2RestoreDisposition {
     fn is_terminal(&self) -> bool;
+
+    fn is_cancelled(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -11274,6 +11399,10 @@ where
                 true
             }
         }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Restore(source) if source.is_cancelled())
     }
 }
 
@@ -11371,6 +11500,28 @@ where
                     )
             }
             Self::Commit(source) => source.is_terminal(),
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        match self {
+            Self::Construction(
+                PreparedSnapshotV2MultiBlockDestinationConstructionError::Construction {
+                    source,
+                    completion_abort: None,
+                },
+            ) => source.is_cancelled(),
+            Self::Commit(PreparedSnapshotV2MultiBlockDestinationCommitError::Controller {
+                source: PreparedHvfSnapshotV2MultiBlockControllerError::Cancelled,
+                destination_cleanup: None,
+                completion_abort: None,
+            }) => true,
+            Self::Construction(_)
+            | Self::Commit(
+                PreparedSnapshotV2MultiBlockDestinationCommitError::InvalidState
+                | PreparedSnapshotV2MultiBlockDestinationCommitError::Controller { .. }
+                | PreparedSnapshotV2MultiBlockDestinationCommitError::Completion { .. },
+            ) => false,
         }
     }
 }
@@ -11666,6 +11817,28 @@ where
                     )
             }
             Self::Commit(source) => source.is_terminal(),
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        match self {
+            Self::Construction(
+                PreparedSnapshotV2StorageDestinationConstructionError::Construction {
+                    source,
+                    completion_abort: None,
+                },
+            ) => source.is_cancelled(),
+            Self::Commit(PreparedSnapshotV2StorageDestinationCommitError::Controller {
+                source: PreparedHvfSnapshotV2StorageControllerError::Cancelled,
+                destination_cleanup: None,
+                completion_abort: None,
+            }) => true,
+            Self::Construction(_)
+            | Self::Commit(
+                PreparedSnapshotV2StorageDestinationCommitError::InvalidState
+                | PreparedSnapshotV2StorageDestinationCommitError::Controller { .. }
+                | PreparedSnapshotV2StorageDestinationCommitError::Completion { .. },
+            ) => false,
         }
     }
 }
@@ -12123,6 +12296,23 @@ impl HvfSnapshotV2SerialConstructionError {
             | Self::BalloonPlan(_)
             | Self::MemoryHotplugPlan(_)
             | Self::InvalidOwners { .. } => true,
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        match self {
+            Self::StorageAdoption(source) => source.is_cancelled(),
+            Self::NetworkMmio(source) => source.is_cancelled(),
+            Self::NetworkPci(source) => source.is_cancelled(),
+            Self::Process(source) => source.is_cancelled(),
+            Self::TransportPolicy { .. }
+            | Self::StorageMmioPlan { .. }
+            | Self::StoragePciPlan { .. }
+            | Self::EntropyPciPlan { .. }
+            | Self::BalloonPlan(_)
+            | Self::MemoryHotplugPlan(_)
+            | Self::NetworkPlan(_)
+            | Self::InvalidOwners { .. } => false,
         }
     }
 }
@@ -12689,6 +12879,29 @@ impl PrepareHvfSnapshotV2SerialDestinationError {
                         } if source.is_terminal()
                     )
             }
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        match self {
+            Self::Construction(
+                PreparedSnapshotV2SerialDestinationConstructionError::Construction {
+                    source,
+                    owners_cleanup: None,
+                    completion_abort: None,
+                },
+            ) => source.is_cancelled(),
+            Self::Commit(PreparedSnapshotV2SerialDestinationCommitError::Controller {
+                source: PreparedHvfSnapshotV2SerialControllerError::Cancelled,
+                destination_cleanup: None,
+                completion_abort: None,
+            }) => true,
+            Self::Construction(_)
+            | Self::Commit(
+                PreparedSnapshotV2SerialDestinationCommitError::InvalidState
+                | PreparedSnapshotV2SerialDestinationCommitError::Controller { .. }
+                | PreparedSnapshotV2SerialDestinationCommitError::Completion { .. },
+            ) => false,
         }
     }
 }
@@ -14810,11 +15023,12 @@ fn prepare_hvf_native_v2_vsock_destination(
         unavailable_diagnostics: (),
     };
     if !cancellation.try_seal_commit() {
-        let _ = destination.shutdown();
-        return Err(NativeV2VsockDestinationLoadError::new(
-            expected_transport,
-            true,
-        ));
+        let cleanup_failed = destination.shutdown().is_err();
+        return Err(if cleanup_failed {
+            NativeV2VsockDestinationLoadError::new(expected_transport, true)
+        } else {
+            NativeV2VsockDestinationLoadError::cancelled(expected_transport, true)
+        });
     }
     match destination.prepare_controller(machine, boot, resume_requested) {
         Ok(committed) => Ok(committed),
@@ -15869,10 +16083,12 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
                 )
                 .map_err(|source| {
                     let terminal = source.is_terminal();
+                    let cancelled = source.is_cancelled();
                     NativeV2SnapshotLoadError::MultiBlockDestination(
                         NativeV2MultiBlockDestinationLoadError::with_source(
                             SnapshotV2DeviceTransportKind::Mmio,
                             terminal,
+                            cancelled,
                             &source,
                         ),
                     )
@@ -15898,10 +16114,12 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
                 )
                 .map_err(|source| {
                     let terminal = source.is_terminal();
+                    let cancelled = source.is_cancelled();
                     NativeV2SnapshotLoadError::MultiBlockDestination(
                         NativeV2MultiBlockDestinationLoadError::with_source(
                             SnapshotV2DeviceTransportKind::Pci,
                             terminal,
+                            cancelled,
                             &source,
                         ),
                     )
@@ -16075,10 +16293,12 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
             )
             .map_err(|source| {
                 let terminal = source.is_terminal();
+                let cancelled = source.is_cancelled();
                 NativeV2SnapshotLoadError::StorageDestination(
                     NativeV2StorageDestinationLoadError::with_source(
                         SnapshotV2DeviceTransportKind::Mmio,
                         terminal,
+                        cancelled,
                         &source,
                     ),
                 )
@@ -16102,10 +16322,12 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
             )
             .map_err(|source| {
                 let terminal = source.is_terminal();
+                let cancelled = source.is_cancelled();
                 NativeV2SnapshotLoadError::StorageDestination(
                     NativeV2StorageDestinationLoadError::with_source(
                         SnapshotV2DeviceTransportKind::Pci,
                         terminal,
+                        cancelled,
                         &source,
                     ),
                 )
@@ -16216,8 +16438,9 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
             })
             .map_err(|source| {
                 let terminal = source.is_terminal();
+                let cancelled = source.is_cancelled();
                 NativeV2SnapshotLoadError::SerialDestination(
-                    NativeV2SerialDestinationLoadError::with_source(terminal, &source),
+                    NativeV2SerialDestinationLoadError::with_source(terminal, cancelled, &source),
                 )
             })?;
         let serial_output = destination.serial_output_clone().ok_or_else(|| {
@@ -16398,10 +16621,12 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
                 };
                 result.map_err(|source| {
                     let terminal = source.is_terminal();
+                    let cancelled = source.is_cancelled();
                     NativeV2SnapshotLoadError::MemoryHotplugDestination(
                         NativeV2MemoryHotplugDestinationLoadError::with_source(
                             expected_transport,
                             terminal,
+                            cancelled,
                             &source,
                         ),
                     )
@@ -16525,10 +16750,12 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
                 )
                 .map_err(|source| {
                     let terminal = source.is_terminal();
+                    let cancelled = source.is_cancelled();
                     NativeV2SnapshotLoadError::MemoryHotplugDestination(
                         NativeV2MemoryHotplugDestinationLoadError::with_source(
                             expected_transport,
                             terminal,
+                            cancelled,
                             &source,
                         ),
                     )
@@ -16724,10 +16951,12 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
         )
         .map_err(|source| {
             let terminal = source.is_terminal();
+            let cancelled = source.is_cancelled();
             NativeV2SnapshotLoadError::NetworkDestination(
                 NativeV2NetworkDestinationLoadError::with_source(
                     expected_transport,
                     terminal,
+                    cancelled,
                     &source,
                 ),
             )
@@ -17008,6 +17237,7 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
                     NativeV2VsockDestinationLoadError::with_source(
                         expected_transport,
                         source.is_terminal(),
+                        source.is_cancelled(),
                         &source,
                     ),
                 )
@@ -17029,6 +17259,7 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
                     NativeV2VsockDestinationLoadError::with_source(
                         expected_transport,
                         source.is_terminal(),
+                        source.is_cancelled(),
                         &source,
                     ),
                 )
@@ -17169,10 +17400,12 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
         )
         .map_err(|source| {
             let terminal = source.is_terminal();
+            let cancelled = source.is_cancelled();
             NativeV2SnapshotLoadError::EntropyDestination(
                 NativeV2EntropyDestinationLoadError::with_source(
                     expected_transport,
                     terminal,
+                    cancelled,
                     &source,
                 ),
             )
@@ -17338,10 +17571,12 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
         };
         let (destination, controller_commit) = result.map_err(|source| {
             let terminal = source.is_terminal();
+            let cancelled = source.is_cancelled();
             NativeV2SnapshotLoadError::BalloonDestination(
                 NativeV2BalloonDestinationLoadError::with_source(
                     expected_transport,
                     terminal,
+                    cancelled,
                     &source,
                 ),
             )
@@ -22277,6 +22512,27 @@ impl ProcessSnapshotV2VsockRestoreResourceError {
     pub(crate) const fn cleanup_uncertain(&self) -> bool {
         self.cleanup_uncertain
     }
+
+    pub(crate) const fn is_cancelled(&self) -> bool {
+        if self.cleanup_uncertain {
+            return false;
+        }
+        match &self.kind {
+            ProcessSnapshotV2VsockRestoreResourceErrorKind::Cancelled => true,
+            ProcessSnapshotV2VsockRestoreResourceErrorKind::Files(source) => source.is_cancelled(),
+            ProcessSnapshotV2VsockRestoreResourceErrorKind::Network(source) => {
+                source.is_cancelled()
+            }
+            ProcessSnapshotV2VsockRestoreResourceErrorKind::CandidateMismatch
+            | ProcessSnapshotV2VsockRestoreResourceErrorKind::Allocation
+            | ProcessSnapshotV2VsockRestoreResourceErrorKind::FileCompletion(_)
+            | ProcessSnapshotV2VsockRestoreResourceErrorKind::NetworkPlan(_)
+            | ProcessSnapshotV2VsockRestoreResourceErrorKind::BindingAllocation(_)
+            | ProcessSnapshotV2VsockRestoreResourceErrorKind::Binding(_)
+            | ProcessSnapshotV2VsockRestoreResourceErrorKind::Take(_)
+            | ProcessSnapshotV2VsockRestoreResourceErrorKind::Unconsumed { .. } => false,
+        }
+    }
 }
 
 impl fmt::Debug for ProcessSnapshotV2VsockRestoreResourceError {
@@ -22847,6 +23103,13 @@ impl ProcessSnapshotV2NetworkRestoreResourceError {
 
     pub(crate) const fn disposition(&self) -> ProcessSnapshotV2NetworkRestoreResourceDisposition {
         self.disposition
+    }
+
+    pub(crate) const fn is_cancelled(&self) -> bool {
+        matches!(
+            self.kind,
+            ProcessSnapshotV2NetworkRestoreResourceErrorKind::Cancelled
+        ) && !self.cleanup_uncertain
     }
 }
 
@@ -25136,6 +25399,7 @@ enum ProcessSnapshotV2VsockMmioRestoreDisposition {
 struct ProcessSnapshotV2VsockMmioRestoreError {
     stage: ProcessSnapshotV2VsockMmioRestoreStage,
     disposition: ProcessSnapshotV2VsockMmioRestoreDisposition,
+    cancelled: bool,
 }
 
 impl ProcessSnapshotV2VsockMmioRestoreError {
@@ -25143,6 +25407,25 @@ impl ProcessSnapshotV2VsockMmioRestoreError {
         Self {
             stage,
             disposition: ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable,
+            cancelled: false,
+        }
+    }
+
+    const fn cancelled(
+        stage: ProcessSnapshotV2VsockMmioRestoreStage,
+        terminal: bool,
+        cleanup_uncertain: bool,
+    ) -> Self {
+        Self {
+            stage,
+            disposition: if cleanup_uncertain {
+                ProcessSnapshotV2VsockMmioRestoreDisposition::TerminalCleanup
+            } else if terminal {
+                ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal
+            } else {
+                ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable
+            },
+            cancelled: !cleanup_uncertain,
         }
     }
 
@@ -25157,6 +25440,7 @@ impl ProcessSnapshotV2VsockMmioRestoreError {
             } else {
                 ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal
             },
+            cancelled: false,
         }
     }
 
@@ -25167,6 +25451,16 @@ impl ProcessSnapshotV2VsockMmioRestoreError {
         if source.cleanup_uncertain() {
             return Self::terminal(stage, true);
         }
+        if source.is_cancelled() {
+            return Self::cancelled(
+                stage,
+                matches!(
+                    source.disposition(),
+                    ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal
+                ),
+                false,
+            );
+        }
         match source.disposition() {
             ProcessSnapshotV2NetworkRestoreResourceDisposition::Retryable => Self::retryable(stage),
             ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal => {
@@ -25175,10 +25469,17 @@ impl ProcessSnapshotV2VsockMmioRestoreError {
         }
     }
 
-    fn from_hvf(source: &HvfSnapshotV2VsockMmioRestoreError, cleanup_uncertain: bool) -> Self {
+    fn from_hvf(
+        source: &HvfSnapshotV2VsockMmioRestoreError,
+        cleanup_uncertain: bool,
+        cancelled: bool,
+    ) -> Self {
         let stage = ProcessSnapshotV2VsockMmioRestoreStage::Hvf(source.stage());
         if source.has_incomplete_cleanup() || cleanup_uncertain {
             return Self::terminal(stage, true);
+        }
+        if cancelled {
+            return Self::cancelled(stage, source.is_terminal(), false);
         }
         match source.disposition() {
             HvfSnapshotV2NetworkMmioRestoreDisposition::Retryable => Self::retryable(stage),
@@ -25192,6 +25493,7 @@ impl ProcessSnapshotV2VsockMmioRestoreError {
     fn from_adoption(
         source: &ProcessSnapshotV2VsockAdoptionError<HvfSnapshotV2VsockMmioRestoreError>,
         cleanup_uncertain: bool,
+        cancelled: bool,
     ) -> Self {
         match source {
             ProcessSnapshotV2VsockAdoptionError::Resources(source) => {
@@ -25211,14 +25513,18 @@ impl ProcessSnapshotV2VsockMmioRestoreError {
                     disposition,
                 },
             ) => {
-                let mapped = Self::from_hvf(source, cleanup_uncertain);
+                let mapped = Self::from_hvf(source, cleanup_uncertain, cancelled);
                 if matches!(disposition, VsockRestoreDisposition::Terminal)
                     && matches!(
                         mapped.disposition,
                         ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable
                     )
                 {
-                    Self::terminal(mapped.stage, cleanup_uncertain)
+                    if mapped.is_cancelled() {
+                        Self::cancelled(mapped.stage, true, cleanup_uncertain)
+                    } else {
+                        Self::terminal(mapped.stage, cleanup_uncertain)
+                    }
                 } else {
                     mapped
                 }
@@ -25247,6 +25553,10 @@ impl ProcessSnapshotV2VsockMmioRestoreError {
             ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable
         )
     }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
+    }
 }
 
 impl fmt::Debug for ProcessSnapshotV2VsockMmioRestoreError {
@@ -25255,6 +25565,7 @@ impl fmt::Debug for ProcessSnapshotV2VsockMmioRestoreError {
             .debug_struct("ProcessSnapshotV2VsockMmioRestoreError")
             .field("stage", &self.stage)
             .field("disposition", &self.disposition)
+            .field("cancelled", &self.cancelled)
             .field("state", &"<redacted>")
             .finish()
     }
@@ -25558,6 +25869,7 @@ enum ProcessSnapshotV2VsockPciRestoreDisposition {
 struct ProcessSnapshotV2VsockPciRestoreError {
     stage: ProcessSnapshotV2VsockPciRestoreStage,
     disposition: ProcessSnapshotV2VsockPciRestoreDisposition,
+    cancelled: bool,
 }
 
 impl ProcessSnapshotV2VsockPciRestoreError {
@@ -25565,6 +25877,25 @@ impl ProcessSnapshotV2VsockPciRestoreError {
         Self {
             stage,
             disposition: ProcessSnapshotV2VsockPciRestoreDisposition::Retryable,
+            cancelled: false,
+        }
+    }
+
+    const fn cancelled(
+        stage: ProcessSnapshotV2VsockPciRestoreStage,
+        terminal: bool,
+        cleanup_uncertain: bool,
+    ) -> Self {
+        Self {
+            stage,
+            disposition: if cleanup_uncertain {
+                ProcessSnapshotV2VsockPciRestoreDisposition::TerminalCleanup
+            } else if terminal {
+                ProcessSnapshotV2VsockPciRestoreDisposition::Terminal
+            } else {
+                ProcessSnapshotV2VsockPciRestoreDisposition::Retryable
+            },
+            cancelled: !cleanup_uncertain,
         }
     }
 
@@ -25579,6 +25910,7 @@ impl ProcessSnapshotV2VsockPciRestoreError {
             } else {
                 ProcessSnapshotV2VsockPciRestoreDisposition::Terminal
             },
+            cancelled: false,
         }
     }
 
@@ -25589,6 +25921,16 @@ impl ProcessSnapshotV2VsockPciRestoreError {
         if source.cleanup_uncertain() {
             return Self::terminal(stage, true);
         }
+        if source.is_cancelled() {
+            return Self::cancelled(
+                stage,
+                matches!(
+                    source.disposition(),
+                    ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal
+                ),
+                false,
+            );
+        }
         match source.disposition() {
             ProcessSnapshotV2NetworkRestoreResourceDisposition::Retryable => Self::retryable(stage),
             ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal => {
@@ -25597,10 +25939,17 @@ impl ProcessSnapshotV2VsockPciRestoreError {
         }
     }
 
-    fn from_hvf(source: &HvfSnapshotV2VsockPciRestoreError, cleanup_uncertain: bool) -> Self {
+    fn from_hvf(
+        source: &HvfSnapshotV2VsockPciRestoreError,
+        cleanup_uncertain: bool,
+        cancelled: bool,
+    ) -> Self {
         let stage = ProcessSnapshotV2VsockPciRestoreStage::Hvf(source.stage());
         if source.has_incomplete_cleanup() || cleanup_uncertain {
             return Self::terminal(stage, true);
+        }
+        if cancelled {
+            return Self::cancelled(stage, source.is_terminal(), false);
         }
         match source.disposition() {
             HvfSnapshotV2NetworkPciRestoreDisposition::Retryable => Self::retryable(stage),
@@ -25614,6 +25963,7 @@ impl ProcessSnapshotV2VsockPciRestoreError {
     fn from_adoption(
         source: &ProcessSnapshotV2VsockAdoptionError<HvfSnapshotV2VsockPciRestoreError>,
         cleanup_uncertain: bool,
+        cancelled: bool,
     ) -> Self {
         match source {
             ProcessSnapshotV2VsockAdoptionError::Resources(source) => {
@@ -25633,14 +25983,18 @@ impl ProcessSnapshotV2VsockPciRestoreError {
                     disposition,
                 },
             ) => {
-                let mapped = Self::from_hvf(source, cleanup_uncertain);
+                let mapped = Self::from_hvf(source, cleanup_uncertain, cancelled);
                 if matches!(disposition, VsockRestoreDisposition::Terminal)
                     && matches!(
                         mapped.disposition,
                         ProcessSnapshotV2VsockPciRestoreDisposition::Retryable
                     )
                 {
-                    Self::terminal(mapped.stage, cleanup_uncertain)
+                    if mapped.is_cancelled() {
+                        Self::cancelled(mapped.stage, true, cleanup_uncertain)
+                    } else {
+                        Self::terminal(mapped.stage, cleanup_uncertain)
+                    }
                 } else {
                     mapped
                 }
@@ -25668,6 +26022,10 @@ impl ProcessSnapshotV2VsockPciRestoreError {
             ProcessSnapshotV2VsockPciRestoreDisposition::Retryable
         )
     }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
+    }
 }
 
 impl fmt::Debug for ProcessSnapshotV2VsockPciRestoreError {
@@ -25676,6 +26034,7 @@ impl fmt::Debug for ProcessSnapshotV2VsockPciRestoreError {
             .debug_struct("ProcessSnapshotV2VsockPciRestoreError")
             .field("stage", &self.stage)
             .field("disposition", &self.disposition)
+            .field("cancelled", &self.cancelled)
             .field("state", &"<redacted>")
             .finish()
     }
@@ -26089,6 +26448,7 @@ enum ProcessSnapshotV2NetworkMmioRestoreDisposition {
 struct ProcessSnapshotV2NetworkMmioRestoreError {
     stage: ProcessSnapshotV2NetworkMmioRestoreStage,
     disposition: ProcessSnapshotV2NetworkMmioRestoreDisposition,
+    cancelled: bool,
 }
 
 impl ProcessSnapshotV2NetworkMmioRestoreError {
@@ -26103,6 +26463,25 @@ impl ProcessSnapshotV2NetworkMmioRestoreError {
         Self {
             stage,
             disposition: ProcessSnapshotV2NetworkMmioRestoreDisposition::Retryable,
+            cancelled: false,
+        }
+    }
+
+    const fn cancelled(
+        stage: ProcessSnapshotV2NetworkMmioRestoreStage,
+        terminal: bool,
+        cleanup_uncertain: bool,
+    ) -> Self {
+        Self {
+            stage,
+            disposition: if cleanup_uncertain {
+                ProcessSnapshotV2NetworkMmioRestoreDisposition::TerminalCleanup
+            } else if terminal {
+                ProcessSnapshotV2NetworkMmioRestoreDisposition::Terminal
+            } else {
+                ProcessSnapshotV2NetworkMmioRestoreDisposition::Retryable
+            },
+            cancelled: !cleanup_uncertain,
         }
     }
 
@@ -26117,6 +26496,7 @@ impl ProcessSnapshotV2NetworkMmioRestoreError {
             } else {
                 ProcessSnapshotV2NetworkMmioRestoreDisposition::Terminal
             },
+            cancelled: false,
         }
     }
 
@@ -26126,6 +26506,16 @@ impl ProcessSnapshotV2NetworkMmioRestoreError {
     ) -> Self {
         if source.cleanup_uncertain {
             return Self::terminal(stage, true);
+        }
+        if source.is_cancelled() {
+            return Self::cancelled(
+                stage,
+                matches!(
+                    source.disposition(),
+                    ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal
+                ),
+                false,
+            );
         }
         match source.disposition() {
             ProcessSnapshotV2NetworkRestoreResourceDisposition::Retryable => Self::retryable(stage),
@@ -26156,6 +26546,10 @@ impl ProcessSnapshotV2NetworkMmioRestoreError {
             ),
         }
     }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
+    }
 }
 
 impl fmt::Debug for ProcessSnapshotV2NetworkMmioRestoreError {
@@ -26164,6 +26558,7 @@ impl fmt::Debug for ProcessSnapshotV2NetworkMmioRestoreError {
             .debug_struct("ProcessSnapshotV2NetworkMmioRestoreError")
             .field("stage", &self.stage)
             .field("disposition", &self.disposition)
+            .field("cancelled", &self.cancelled)
             .field("state", &"<redacted>")
             .finish()
     }
@@ -26695,8 +27090,10 @@ where
     C: Fn(ProcessSnapshotV2VsockMmioRestoreStage) -> bool,
 {
     if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::ResourcePreparation) {
-        return Err(ProcessSnapshotV2VsockMmioRestoreError::retryable(
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::cancelled(
             ProcessSnapshotV2VsockMmioRestoreStage::ResourcePreparation,
+            false,
+            false,
         ));
     }
     let batch = {
@@ -26721,16 +27118,11 @@ where
 
     if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation) {
         let evidence = staged.shutdown_evidence();
-        return Err(if evidence.terminal {
-            ProcessSnapshotV2VsockMmioRestoreError::terminal(
-                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
-                evidence.cleanup_uncertain,
-            )
-        } else {
-            ProcessSnapshotV2VsockMmioRestoreError::retryable(
-                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
-            )
-        });
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::cancelled(
+            ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+            evidence.terminal,
+            evidence.cleanup_uncertain,
+        ));
     }
 
     let (
@@ -26896,11 +27288,11 @@ where
                 .as_ref()
                 .is_some_and(|batch| batch.taken_count != 0);
             let evidence = staged.shutdown_evidence();
-            return Err(if already_consumed || evidence.terminal {
-                ProcessSnapshotV2VsockMmioRestoreError::terminal(stage, evidence.cleanup_uncertain)
-            } else {
-                ProcessSnapshotV2VsockMmioRestoreError::retryable(stage)
-            });
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::cancelled(
+                stage,
+                already_consumed || evidence.terminal,
+                evidence.cleanup_uncertain,
+            ));
         }
         let Some(batch) = staged.batch.as_mut() else {
             drop((block_backings, pmem_backings, serial_output));
@@ -27072,16 +27464,11 @@ where
             .as_ref()
             .is_some_and(|batch| batch.taken_count != 0);
         let evidence = staged.shutdown_evidence();
-        return Err(if already_consumed || evidence.terminal {
-            ProcessSnapshotV2VsockMmioRestoreError::terminal(
-                ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
-                evidence.cleanup_uncertain,
-            )
-        } else {
-            ProcessSnapshotV2VsockMmioRestoreError::retryable(
-                ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
-            )
-        });
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::cancelled(
+            ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
+            already_consumed || evidence.terminal,
+            evidence.cleanup_uncertain,
+        ));
     }
     let Some(endpoint) = staged.serial_endpoint.take() else {
         drop(platform_plan);
@@ -27131,6 +27518,7 @@ where
         .unwrap_or(HvfSnapshotV2NetworkMmioMemoryInput::ProductOwned);
     let vsock_metrics = SharedVsockDeviceMetrics::default();
 
+    let hvf_cancellation_observed = Cell::new(false);
     let restored = match vsock_key {
         Some(key) => {
             let Some(batch) = staged.batch.as_mut() else {
@@ -27152,7 +27540,13 @@ where
                     Some(resource),
                     vsock_metrics,
                     now,
-                    |stage| cancelled(ProcessSnapshotV2VsockMmioRestoreStage::Hvf(stage)),
+                    |stage| {
+                        let is_cancelled =
+                            cancelled(ProcessSnapshotV2VsockMmioRestoreStage::Hvf(stage));
+                        hvf_cancellation_observed
+                            .set(hvf_cancellation_observed.get() || is_cancelled);
+                        is_cancelled
+                    },
                 )
             }) {
                 Ok((hvf, guard)) => {
@@ -27164,6 +27558,7 @@ where
                     return Err(ProcessSnapshotV2VsockMmioRestoreError::from_adoption(
                         &source,
                         cleanup_uncertain,
+                        hvf_cancellation_observed.get(),
                     ));
                 }
             }
@@ -27180,7 +27575,12 @@ where
                 None,
                 vsock_metrics,
                 now,
-                |stage| cancelled(ProcessSnapshotV2VsockMmioRestoreStage::Hvf(stage)),
+                |stage| {
+                    let is_cancelled =
+                        cancelled(ProcessSnapshotV2VsockMmioRestoreStage::Hvf(stage));
+                    hvf_cancellation_observed.set(hvf_cancellation_observed.get() || is_cancelled);
+                    is_cancelled
+                },
             ) {
                 Ok(hvf) => hvf,
                 Err(source) => {
@@ -27188,6 +27588,7 @@ where
                     return Err(ProcessSnapshotV2VsockMmioRestoreError::from_hvf(
                         &source,
                         cleanup_uncertain,
+                        hvf_cancellation_observed.get(),
                     ));
                 }
             }
@@ -27197,8 +27598,9 @@ where
 
     if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::BatchFinish) {
         let cleanup_uncertain = staged.shutdown();
-        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::cancelled(
             ProcessSnapshotV2VsockMmioRestoreStage::BatchFinish,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -27231,7 +27633,15 @@ where
         .is_ok(),
         _ => false,
     };
-    if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::CompleteRecapture) || !equivalent {
+    if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::CompleteRecapture) {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::cancelled(
+            ProcessSnapshotV2VsockMmioRestoreStage::CompleteRecapture,
+            true,
+            cleanup_uncertain,
+        ));
+    }
+    if !equivalent {
         let cleanup_uncertain = staged.shutdown();
         return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
             ProcessSnapshotV2VsockMmioRestoreStage::CompleteRecapture,
@@ -27241,8 +27651,9 @@ where
 
     if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::Assembly) {
         let cleanup_uncertain = staged.shutdown();
-        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::cancelled(
             ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -27268,8 +27679,9 @@ where
 
     if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::GateCommit) {
         let cleanup_uncertain = staged.shutdown();
-        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::cancelled(
             ProcessSnapshotV2VsockMmioRestoreStage::GateCommit,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -27533,8 +27945,10 @@ where
     C: Fn(ProcessSnapshotV2VsockPciRestoreStage) -> bool,
 {
     if cancelled(ProcessSnapshotV2VsockPciRestoreStage::ResourcePreparation) {
-        return Err(ProcessSnapshotV2VsockPciRestoreError::retryable(
+        return Err(ProcessSnapshotV2VsockPciRestoreError::cancelled(
             ProcessSnapshotV2VsockPciRestoreStage::ResourcePreparation,
+            false,
+            false,
         ));
     }
     let batch = {
@@ -27559,16 +27973,11 @@ where
 
     if cancelled(ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation) {
         let evidence = staged.shutdown_evidence();
-        return Err(if evidence.terminal {
-            ProcessSnapshotV2VsockPciRestoreError::terminal(
-                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
-                evidence.cleanup_uncertain,
-            )
-        } else {
-            ProcessSnapshotV2VsockPciRestoreError::retryable(
-                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
-            )
-        });
+        return Err(ProcessSnapshotV2VsockPciRestoreError::cancelled(
+            ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+            evidence.terminal,
+            evidence.cleanup_uncertain,
+        ));
     }
 
     let (
@@ -27734,11 +28143,11 @@ where
                 .as_ref()
                 .is_some_and(|batch| batch.taken_count != 0);
             let evidence = staged.shutdown_evidence();
-            return Err(if already_consumed || evidence.terminal {
-                ProcessSnapshotV2VsockPciRestoreError::terminal(stage, evidence.cleanup_uncertain)
-            } else {
-                ProcessSnapshotV2VsockPciRestoreError::retryable(stage)
-            });
+            return Err(ProcessSnapshotV2VsockPciRestoreError::cancelled(
+                stage,
+                already_consumed || evidence.terminal,
+                evidence.cleanup_uncertain,
+            ));
         }
         let Some(batch) = staged.batch.as_mut() else {
             drop((block_backings, pmem_backings, serial_output));
@@ -27895,16 +28304,11 @@ where
             .as_ref()
             .is_some_and(|batch| batch.taken_count != 0);
         let evidence = staged.shutdown_evidence();
-        return Err(if already_consumed || evidence.terminal {
-            ProcessSnapshotV2VsockPciRestoreError::terminal(
-                ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
-                evidence.cleanup_uncertain,
-            )
-        } else {
-            ProcessSnapshotV2VsockPciRestoreError::retryable(
-                ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
-            )
-        });
+        return Err(ProcessSnapshotV2VsockPciRestoreError::cancelled(
+            ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
+            already_consumed || evidence.terminal,
+            evidence.cleanup_uncertain,
+        ));
     }
     let Some(endpoint) = staged.serial_endpoint.take() else {
         drop(platform_plan);
@@ -27954,6 +28358,7 @@ where
         .unwrap_or(HvfSnapshotV2NetworkPciMemoryInput::ProductOwned);
     let vsock_metrics = SharedVsockDeviceMetrics::default();
 
+    let hvf_cancellation_observed = Cell::new(false);
     let restored = match vsock_key {
         Some(key) => {
             let Some(batch) = staged.batch.as_mut() else {
@@ -27975,7 +28380,13 @@ where
                     Some(resource),
                     vsock_metrics,
                     now,
-                    |stage| cancelled(ProcessSnapshotV2VsockPciRestoreStage::Hvf(stage)),
+                    |stage| {
+                        let is_cancelled =
+                            cancelled(ProcessSnapshotV2VsockPciRestoreStage::Hvf(stage));
+                        hvf_cancellation_observed
+                            .set(hvf_cancellation_observed.get() || is_cancelled);
+                        is_cancelled
+                    },
                 )
             }) {
                 Ok((hvf, guard)) => {
@@ -27987,6 +28398,7 @@ where
                     return Err(ProcessSnapshotV2VsockPciRestoreError::from_adoption(
                         &source,
                         cleanup_uncertain,
+                        hvf_cancellation_observed.get(),
                     ));
                 }
             }
@@ -28003,7 +28415,11 @@ where
                 None,
                 vsock_metrics,
                 now,
-                |stage| cancelled(ProcessSnapshotV2VsockPciRestoreStage::Hvf(stage)),
+                |stage| {
+                    let is_cancelled = cancelled(ProcessSnapshotV2VsockPciRestoreStage::Hvf(stage));
+                    hvf_cancellation_observed.set(hvf_cancellation_observed.get() || is_cancelled);
+                    is_cancelled
+                },
             ) {
                 Ok(hvf) => hvf,
                 Err(source) => {
@@ -28011,6 +28427,7 @@ where
                     return Err(ProcessSnapshotV2VsockPciRestoreError::from_hvf(
                         &source,
                         cleanup_uncertain,
+                        hvf_cancellation_observed.get(),
                     ));
                 }
             }
@@ -28020,8 +28437,9 @@ where
 
     if cancelled(ProcessSnapshotV2VsockPciRestoreStage::BatchFinish) {
         let cleanup_uncertain = staged.shutdown();
-        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+        return Err(ProcessSnapshotV2VsockPciRestoreError::cancelled(
             ProcessSnapshotV2VsockPciRestoreStage::BatchFinish,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -28054,7 +28472,15 @@ where
         .is_ok(),
         _ => false,
     };
-    if cancelled(ProcessSnapshotV2VsockPciRestoreStage::CompleteRecapture) || !equivalent {
+    if cancelled(ProcessSnapshotV2VsockPciRestoreStage::CompleteRecapture) {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::cancelled(
+            ProcessSnapshotV2VsockPciRestoreStage::CompleteRecapture,
+            true,
+            cleanup_uncertain,
+        ));
+    }
+    if !equivalent {
         let cleanup_uncertain = staged.shutdown();
         return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
             ProcessSnapshotV2VsockPciRestoreStage::CompleteRecapture,
@@ -28064,8 +28490,9 @@ where
 
     if cancelled(ProcessSnapshotV2VsockPciRestoreStage::Assembly) {
         let cleanup_uncertain = staged.shutdown();
-        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+        return Err(ProcessSnapshotV2VsockPciRestoreError::cancelled(
             ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -28091,8 +28518,9 @@ where
 
     if cancelled(ProcessSnapshotV2VsockPciRestoreStage::GateCommit) {
         let cleanup_uncertain = staged.shutdown();
-        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+        return Err(ProcessSnapshotV2VsockPciRestoreError::cancelled(
             ProcessSnapshotV2VsockPciRestoreStage::GateCommit,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -28360,6 +28788,7 @@ enum ProcessSnapshotV2NetworkPciRestoreDisposition {
 struct ProcessSnapshotV2NetworkPciRestoreError {
     stage: ProcessSnapshotV2NetworkPciRestoreStage,
     disposition: ProcessSnapshotV2NetworkPciRestoreDisposition,
+    cancelled: bool,
 }
 
 impl ProcessSnapshotV2NetworkPciRestoreError {
@@ -28374,6 +28803,25 @@ impl ProcessSnapshotV2NetworkPciRestoreError {
         Self {
             stage,
             disposition: ProcessSnapshotV2NetworkPciRestoreDisposition::Retryable,
+            cancelled: false,
+        }
+    }
+
+    const fn cancelled(
+        stage: ProcessSnapshotV2NetworkPciRestoreStage,
+        terminal: bool,
+        cleanup_uncertain: bool,
+    ) -> Self {
+        Self {
+            stage,
+            disposition: if cleanup_uncertain {
+                ProcessSnapshotV2NetworkPciRestoreDisposition::TerminalCleanup
+            } else if terminal {
+                ProcessSnapshotV2NetworkPciRestoreDisposition::Terminal
+            } else {
+                ProcessSnapshotV2NetworkPciRestoreDisposition::Retryable
+            },
+            cancelled: !cleanup_uncertain,
         }
     }
 
@@ -28388,6 +28836,7 @@ impl ProcessSnapshotV2NetworkPciRestoreError {
             } else {
                 ProcessSnapshotV2NetworkPciRestoreDisposition::Terminal
             },
+            cancelled: false,
         }
     }
 
@@ -28397,6 +28846,16 @@ impl ProcessSnapshotV2NetworkPciRestoreError {
     ) -> Self {
         if source.cleanup_uncertain {
             return Self::terminal(stage, true);
+        }
+        if source.is_cancelled() {
+            return Self::cancelled(
+                stage,
+                matches!(
+                    source.disposition(),
+                    ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal
+                ),
+                false,
+            );
         }
         match source.disposition() {
             ProcessSnapshotV2NetworkRestoreResourceDisposition::Retryable => Self::retryable(stage),
@@ -28427,6 +28886,10 @@ impl ProcessSnapshotV2NetworkPciRestoreError {
             ),
         }
     }
+
+    const fn is_cancelled(&self) -> bool {
+        self.cancelled
+    }
 }
 
 impl fmt::Debug for ProcessSnapshotV2NetworkPciRestoreError {
@@ -28435,6 +28898,7 @@ impl fmt::Debug for ProcessSnapshotV2NetworkPciRestoreError {
             .debug_struct("ProcessSnapshotV2NetworkPciRestoreError")
             .field("stage", &self.stage)
             .field("disposition", &self.disposition)
+            .field("cancelled", &self.cancelled)
             .field("state", &"<redacted>")
             .finish()
     }
@@ -28619,9 +29083,14 @@ where
     F: ProcessVmnetPacketIoBackendFactory<Backend = B>,
     C: FnMut(ProcessSnapshotV2NetworkMmioRestoreStage) -> bool,
 {
-    if cancelled(ProcessSnapshotV2NetworkMmioRestoreStage::ResourcePreparation)
-        || !resource_plan.matches_mmio_platform_plan(&platform_plan)
-    {
+    if cancelled(ProcessSnapshotV2NetworkMmioRestoreStage::ResourcePreparation) {
+        return Err(ProcessSnapshotV2NetworkMmioRestoreError::cancelled(
+            ProcessSnapshotV2NetworkMmioRestoreStage::ResourcePreparation,
+            false,
+            false,
+        ));
+    }
+    if !resource_plan.matches_mmio_platform_plan(&platform_plan) {
         return Err(ProcessSnapshotV2NetworkMmioRestoreError::retryable(
             ProcessSnapshotV2NetworkMmioRestoreStage::ResourcePreparation,
         ));
@@ -28698,11 +29167,11 @@ where
         if cancelled(stage) {
             let cleanup_uncertain =
                 abort_unfinished_process_snapshot_v2_network_resources(batch, resources);
-            return Err(if cleanup_uncertain {
-                ProcessSnapshotV2NetworkMmioRestoreError::terminal(stage, true)
-            } else {
-                ProcessSnapshotV2NetworkMmioRestoreError::retryable(stage)
-            });
+            return Err(ProcessSnapshotV2NetworkMmioRestoreError::cancelled(
+                stage,
+                false,
+                cleanup_uncertain,
+            ));
         }
         let Some(endpoint) = platform_plan.network().get(index) else {
             let cleanup_uncertain =
@@ -28740,16 +29209,11 @@ where
     if cancelled(ProcessSnapshotV2NetworkMmioRestoreStage::ProviderFinish) {
         let cleanup_uncertain =
             abort_unfinished_process_snapshot_v2_network_resources(batch, resources);
-        return Err(if cleanup_uncertain {
-            ProcessSnapshotV2NetworkMmioRestoreError::terminal(
-                ProcessSnapshotV2NetworkMmioRestoreStage::ProviderFinish,
-                true,
-            )
-        } else {
-            ProcessSnapshotV2NetworkMmioRestoreError::retryable(
-                ProcessSnapshotV2NetworkMmioRestoreStage::ProviderFinish,
-            )
-        });
+        return Err(ProcessSnapshotV2NetworkMmioRestoreError::cancelled(
+            ProcessSnapshotV2NetworkMmioRestoreStage::ProviderFinish,
+            false,
+            cleanup_uncertain,
+        ));
     }
     let completion = match batch.finish() {
         Ok(completion) => completion,
@@ -28778,16 +29242,11 @@ where
     if cancelled(ProcessSnapshotV2NetworkMmioRestoreStage::HvfConstruction) {
         let cleanup_uncertain =
             abort_completed_process_snapshot_v2_network_resources(completion, resources);
-        return Err(if cleanup_uncertain {
-            ProcessSnapshotV2NetworkMmioRestoreError::terminal(
-                ProcessSnapshotV2NetworkMmioRestoreStage::HvfConstruction,
-                true,
-            )
-        } else {
-            ProcessSnapshotV2NetworkMmioRestoreError::retryable(
-                ProcessSnapshotV2NetworkMmioRestoreStage::HvfConstruction,
-            )
-        });
+        return Err(ProcessSnapshotV2NetworkMmioRestoreError::cancelled(
+            ProcessSnapshotV2NetworkMmioRestoreStage::HvfConstruction,
+            false,
+            cleanup_uncertain,
+        ));
     }
 
     let staged_hvf = match OwnedHvfArm64BootSession::restore_snapshot_v2_network_mmio(
@@ -28811,13 +29270,16 @@ where
         }
     };
 
-    if cancelled(ProcessSnapshotV2NetworkMmioRestoreStage::CompleteRecapture)
-        || restored_process_snapshot_v2_network_is_equivalent(
-            &staged_hvf,
-            &completion,
-            &resources,
-            now,
-        )
+    if cancelled(ProcessSnapshotV2NetworkMmioRestoreStage::CompleteRecapture) {
+        let cleanup_uncertain =
+            abort_staged_process_snapshot_v2_network_mmio(staged_hvf, completion, resources);
+        return Err(ProcessSnapshotV2NetworkMmioRestoreError::cancelled(
+            ProcessSnapshotV2NetworkMmioRestoreStage::CompleteRecapture,
+            true,
+            cleanup_uncertain,
+        ));
+    }
+    if restored_process_snapshot_v2_network_is_equivalent(&staged_hvf, &completion, &resources, now)
         .is_err()
     {
         let cleanup_uncertain =
@@ -28831,8 +29293,9 @@ where
     if cancelled(ProcessSnapshotV2NetworkMmioRestoreStage::Assembly) {
         let cleanup_uncertain =
             abort_staged_process_snapshot_v2_network_mmio(staged_hvf, completion, resources);
-        return Err(ProcessSnapshotV2NetworkMmioRestoreError::terminal(
+        return Err(ProcessSnapshotV2NetworkMmioRestoreError::cancelled(
             ProcessSnapshotV2NetworkMmioRestoreStage::Assembly,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -28858,8 +29321,9 @@ where
 
     if cancelled(ProcessSnapshotV2NetworkMmioRestoreStage::GateCommit) {
         let cleanup_uncertain = owners.shutdown().is_err();
-        return Err(ProcessSnapshotV2NetworkMmioRestoreError::terminal(
+        return Err(ProcessSnapshotV2NetworkMmioRestoreError::cancelled(
             ProcessSnapshotV2NetworkMmioRestoreStage::GateCommit,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -29007,9 +29471,14 @@ where
     F: ProcessVmnetPacketIoBackendFactory<Backend = B>,
     C: FnMut(ProcessSnapshotV2NetworkPciRestoreStage) -> bool,
 {
-    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation)
-        || !resource_plan.matches_pci_platform_plan(&platform_plan)
-    {
+    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation) {
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::cancelled(
+            ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+            false,
+            false,
+        ));
+    }
+    if !resource_plan.matches_pci_platform_plan(&platform_plan) {
         return Err(ProcessSnapshotV2NetworkPciRestoreError::retryable(
             ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
         ));
@@ -29086,11 +29555,11 @@ where
         if cancelled(stage) {
             let cleanup_uncertain =
                 abort_unfinished_process_snapshot_v2_network_resources(batch, resources);
-            return Err(if cleanup_uncertain {
-                ProcessSnapshotV2NetworkPciRestoreError::terminal(stage, true)
-            } else {
-                ProcessSnapshotV2NetworkPciRestoreError::retryable(stage)
-            });
+            return Err(ProcessSnapshotV2NetworkPciRestoreError::cancelled(
+                stage,
+                false,
+                cleanup_uncertain,
+            ));
         }
         let Some(endpoint) = platform_plan.network().get(index) else {
             let cleanup_uncertain =
@@ -29128,16 +29597,11 @@ where
     if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish) {
         let cleanup_uncertain =
             abort_unfinished_process_snapshot_v2_network_resources(batch, resources);
-        return Err(if cleanup_uncertain {
-            ProcessSnapshotV2NetworkPciRestoreError::terminal(
-                ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish,
-                true,
-            )
-        } else {
-            ProcessSnapshotV2NetworkPciRestoreError::retryable(
-                ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish,
-            )
-        });
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::cancelled(
+            ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish,
+            false,
+            cleanup_uncertain,
+        ));
     }
     let completion = match batch.finish() {
         Ok(completion) => completion,
@@ -29166,16 +29630,11 @@ where
     if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction) {
         let cleanup_uncertain =
             abort_completed_process_snapshot_v2_network_resources(completion, resources);
-        return Err(if cleanup_uncertain {
-            ProcessSnapshotV2NetworkPciRestoreError::terminal(
-                ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction,
-                true,
-            )
-        } else {
-            ProcessSnapshotV2NetworkPciRestoreError::retryable(
-                ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction,
-            )
-        });
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::cancelled(
+            ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction,
+            false,
+            cleanup_uncertain,
+        ));
     }
 
     let staged_hvf = match OwnedHvfArm64BootSession::restore_snapshot_v2_network_pci(
@@ -29199,14 +29658,22 @@ where
         }
     };
 
-    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::CompleteRecapture)
-        || restored_process_snapshot_v2_network_pci_is_equivalent(
-            &staged_hvf,
-            &completion,
-            &resources,
-            now,
-        )
-        .is_err()
+    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::CompleteRecapture) {
+        let cleanup_uncertain =
+            abort_staged_process_snapshot_v2_network_pci(staged_hvf, completion, resources);
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::cancelled(
+            ProcessSnapshotV2NetworkPciRestoreStage::CompleteRecapture,
+            true,
+            cleanup_uncertain,
+        ));
+    }
+    if restored_process_snapshot_v2_network_pci_is_equivalent(
+        &staged_hvf,
+        &completion,
+        &resources,
+        now,
+    )
+    .is_err()
     {
         let cleanup_uncertain =
             abort_staged_process_snapshot_v2_network_pci(staged_hvf, completion, resources);
@@ -29219,8 +29686,9 @@ where
     if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::Assembly) {
         let cleanup_uncertain =
             abort_staged_process_snapshot_v2_network_pci(staged_hvf, completion, resources);
-        return Err(ProcessSnapshotV2NetworkPciRestoreError::terminal(
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::cancelled(
             ProcessSnapshotV2NetworkPciRestoreStage::Assembly,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -29246,8 +29714,9 @@ where
 
     if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::GateCommit) {
         let cleanup_uncertain = owners.shutdown().is_err();
-        return Err(ProcessSnapshotV2NetworkPciRestoreError::terminal(
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::cancelled(
             ProcessSnapshotV2NetworkPciRestoreStage::GateCommit,
+            true,
             cleanup_uncertain,
         ));
     }
@@ -46370,6 +46839,108 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn snapshot_load_logger_outcome_recognizes_all_destination_cancellations() {
+        let source = std::io::Error::other("private destination detail");
+        let transport = SnapshotV2DeviceTransportKind::Mmio;
+        let errors = [
+            NativeV2SnapshotLoadError::MultiBlockDestination(
+                super::NativeV2MultiBlockDestinationLoadError::with_source(
+                    transport, false, true, &source,
+                ),
+            ),
+            NativeV2SnapshotLoadError::StorageDestination(
+                super::NativeV2StorageDestinationLoadError::with_source(
+                    transport, true, true, &source,
+                ),
+            ),
+            NativeV2SnapshotLoadError::SerialDestination(
+                super::NativeV2SerialDestinationLoadError::with_source(true, true, &source),
+            ),
+            NativeV2SnapshotLoadError::EntropyDestination(
+                super::NativeV2EntropyDestinationLoadError::with_source(
+                    transport, true, true, &source,
+                ),
+            ),
+            NativeV2SnapshotLoadError::BalloonDestination(
+                super::NativeV2BalloonDestinationLoadError::with_source(
+                    transport, true, true, &source,
+                ),
+            ),
+            NativeV2SnapshotLoadError::MemoryHotplugDestination(
+                super::NativeV2MemoryHotplugDestinationLoadError::with_source(
+                    transport, true, true, &source,
+                ),
+            ),
+            NativeV2SnapshotLoadError::NetworkDestination(
+                super::NativeV2NetworkDestinationLoadError::with_source(
+                    transport, true, true, &source,
+                ),
+            ),
+            NativeV2SnapshotLoadError::VsockDestination(
+                super::NativeV2VsockDestinationLoadError::with_source(
+                    transport, true, true, &source,
+                ),
+            ),
+        ];
+
+        for error in errors {
+            assert_eq!(
+                native_snapshot_load_logger_outcome(&NativeSnapshotLoadError::NativeV2(error)),
+                LoggerSnapshotOutcome::LoadCancelled
+            );
+        }
+
+        let failed =
+            NativeSnapshotLoadError::NativeV2(NativeV2SnapshotLoadError::VsockDestination(
+                super::NativeV2VsockDestinationLoadError::with_source(
+                    transport, true, false, &source,
+                ),
+            ));
+        assert_eq!(
+            native_snapshot_load_logger_outcome(&failed),
+            LoggerSnapshotOutcome::LoadFailed
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn process_snapshot_load_cancellation_fails_closed_on_cleanup_uncertainty() {
+        assert!(
+            !super::ProcessSnapshotV2NetworkMmioRestoreError::cancelled(
+                super::ProcessSnapshotV2NetworkMmioRestoreStage::GateCommit,
+                true,
+                true,
+            )
+            .is_cancelled()
+        );
+        assert!(
+            !super::ProcessSnapshotV2NetworkPciRestoreError::cancelled(
+                super::ProcessSnapshotV2NetworkPciRestoreStage::GateCommit,
+                true,
+                true,
+            )
+            .is_cancelled()
+        );
+        assert!(
+            !super::ProcessSnapshotV2VsockMmioRestoreError::cancelled(
+                super::ProcessSnapshotV2VsockMmioRestoreStage::GateCommit,
+                true,
+                true,
+            )
+            .is_cancelled()
+        );
+        assert!(
+            !super::ProcessSnapshotV2VsockPciRestoreError::cancelled(
+                super::ProcessSnapshotV2VsockPciRestoreStage::GateCommit,
+                true,
+                true,
+            )
+            .is_cancelled()
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
     fn public_native_v2_diff_load_materializes_zero_root_and_dispatches_paused_session() {
         let (snapshot, load) =
             native_v2_diff_snapshot_load_fixture("public-diff-load-paused", false);
@@ -58770,6 +59341,7 @@ mod tests {
                 .expect_err("injected PCI process owner cancellation should reject");
                 assert_eq!(error.stage, cancel_stage);
                 assert_eq!(error.disposition, expected_disposition);
+                assert!(error.is_cancelled());
                 let diagnostics = format!("{error:?} {error}");
                 assert!(diagnostics.contains("<redacted>"));
                 assert!(!diagnostics.contains("eth0"));
@@ -58972,6 +59544,7 @@ mod tests {
             .expect_err("injected process owner cancellation should reject");
             assert_eq!(error.stage, cancel_stage);
             assert_eq!(error.disposition, expected_disposition);
+            assert!(error.is_cancelled());
             let diagnostics = format!("{error:?} {error}");
             assert!(diagnostics.contains("<redacted>"));
             assert!(!diagnostics.contains("eth0"));
@@ -59318,6 +59891,7 @@ mod tests {
                 .expect_err("injected exact-2.12 PCI owner cancellation should reject");
                 assert_eq!(error.stage, cancel_stage);
                 assert_eq!(error.disposition, expected_disposition);
+                assert!(error.is_cancelled());
                 let diagnostics = format!("{error:?} {error}");
                 assert!(diagnostics.contains("<redacted>"));
                 assert!(
@@ -59479,6 +60053,7 @@ mod tests {
             .expect_err("injected exact-2.12 owner cancellation should reject");
             assert_eq!(error.stage, cancel_stage);
             assert_eq!(error.disposition, expected_disposition);
+            assert!(error.is_cancelled());
             let diagnostics = format!("{error:?} {error}");
             assert!(diagnostics.contains("<redacted>"));
             assert!(!diagnostics.contains(destination_socket.path().to_string_lossy().as_ref()));

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -4328,6 +4328,7 @@ enum NativeSnapshotLoadError {
 fn native_v2_snapshot_load_is_cancelled(error: &NativeV2SnapshotLoadError) -> bool {
     match error {
         NativeV2SnapshotLoadError::Cancelled => true,
+        NativeV2SnapshotLoadError::Artifact(source) => source.is_cancelled(),
         NativeV2SnapshotLoadError::AfterResourceAdoption { source } => {
             native_v2_snapshot_load_is_cancelled(source)
         }
@@ -36258,8 +36259,8 @@ mod tests {
     use bangbang_runtime::fdt::{Arm64FdtRegion, Arm64FdtVirtioMmioDevice};
     use bangbang_runtime::interrupt::GuestInterruptLine;
     use bangbang_runtime::logger::{
-        LoggerConfigInput, LoggerLevel, LoggerLifecycleOutcome, ProcessStdoutLogger,
-        ProcessTerminalCategory,
+        LoggerConfigInput, LoggerLevel, LoggerLifecycleOutcome, LoggerSnapshotOutcome,
+        ProcessStdoutLogger, ProcessTerminalCategory,
     };
     use bangbang_runtime::machine::{MachineConfig, MachineConfigInput, MachineConfigPatchInput};
     use bangbang_runtime::memory::{
@@ -36333,7 +36334,8 @@ mod tests {
     use bangbang_runtime::snapshot_artifact::{
         NativeSnapshotArtifactFamily, NativeV2SnapshotCandidateState, SnapshotArtifactOutput,
         SnapshotCommitDurability, SnapshotPublicationStage, load_native_snapshot_artifacts,
-        load_snapshot_artifacts,
+        load_prepared_native_snapshot_memory_path_with_cancel, load_snapshot_artifacts,
+        prepare_native_snapshot_state_path,
     };
     use bangbang_runtime::snapshot_balloon_v2_9::{
         NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION, SnapshotV2BalloonState,
@@ -36499,8 +36501,8 @@ mod tests {
         ProcessSnapshotV2VsockLoadRequest, ProcessVmm, ProcessVmnetAuthority,
         ProcessVmnetPacketIoBackendFactory, SerialGrantState, SnapshotCreateSession,
         SnapshotV1LoadSuccess, SnapshotV2LoadSuccess, default_hvf_boot_run_loop_step_limit,
-        default_hvf_boot_session_config, native_v2_platform_capture_is_terminal,
-        prepare_process_snapshot_v2_network_restore_plan,
+        default_hvf_boot_session_config, native_snapshot_load_logger_outcome,
+        native_v2_platform_capture_is_terminal, prepare_process_snapshot_v2_network_restore_plan,
         prepare_process_snapshot_v2_vsock_candidate, require_native_v1_composite_record,
         snapshot_destination_machine_config, vsock_capture_error_from_boot_run_loop_command,
     };
@@ -46339,6 +46341,31 @@ mod tests {
             "operation=snapshot-load outcome=cancelled\n"
         );
         cancelled_snapshot.assert_no_staging();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn snapshot_load_logger_outcome_recognizes_artifact_cancellation_after_adoption() {
+        let (snapshot, _) =
+            native_v2_snapshot_load_fixture("snapshot-load-artifact-cancelled", false);
+        let paths = snapshot.paths();
+        let prepared = prepare_native_snapshot_state_path(paths.state())
+            .expect("native-v2 state should prepare");
+        let artifact_error =
+            load_prepared_native_snapshot_memory_path_with_cancel(prepared, paths.memory(), || {
+                true
+            })
+            .expect_err("cancelled artifact load should fail");
+        let error =
+            NativeSnapshotLoadError::NativeV2(NativeV2SnapshotLoadError::AfterResourceAdoption {
+                source: Box::new(NativeV2SnapshotLoadError::Artifact(artifact_error)),
+            });
+
+        assert_eq!(
+            native_snapshot_load_logger_outcome(&error),
+            LoggerSnapshotOutcome::LoadCancelled
+        );
+        snapshot.assert_no_staging();
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::collections::{BTreeMap, TryReserveError};
 use std::ffi::OsString;
 use std::fmt;
@@ -16,8 +17,6 @@ use std::sync::{Arc, Condvar, Mutex, MutexGuard, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-#[cfg(test)]
-use bangbang_hvf::HvfArm64BootVsockCaptureErrorKind;
 use bangbang_hvf::{
     HvfArm64BootBalloonCaptureError, HvfArm64BootBalloonCaptureState,
     HvfArm64BootBalloonDeviceConfig, HvfArm64BootEntropyCaptureError,
@@ -38,9 +37,10 @@ use bangbang_hvf::{
     HvfArm64BootStorageCaptureError, HvfArm64BootStorageCaptureErrorKind,
     HvfArm64BootStorageCaptureStage, HvfArm64BootTimerDeviceConfig, HvfArm64BootVcpuError,
     HvfArm64BootVsockCaptureDisposition, HvfArm64BootVsockCaptureError,
-    HvfArm64BootVsockCaptureStage, HvfArm64BootVsockCaptureState, HvfBackend, HvfSnapshotV1Bundle,
-    HvfSnapshotV1BundleError, HvfSnapshotV1RestoreCleanup, HvfSnapshotV1RestoreDisposition,
-    HvfSnapshotV1RestoreError, HvfSnapshotV1State, HvfSnapshotV2BalloonMmioPlatformPlan,
+    HvfArm64BootVsockCaptureErrorKind, HvfArm64BootVsockCaptureStage,
+    HvfArm64BootVsockCaptureState, HvfBackend, HvfSnapshotV1Bundle, HvfSnapshotV1BundleError,
+    HvfSnapshotV1RestoreCleanup, HvfSnapshotV1RestoreDisposition, HvfSnapshotV1RestoreError,
+    HvfSnapshotV1State, HvfSnapshotV2BalloonMmioPlatformPlan,
     HvfSnapshotV2BalloonMmioProcessConfig, HvfSnapshotV2BalloonMmioRestoreError,
     HvfSnapshotV2BalloonPciPlatformPlan, HvfSnapshotV2BalloonPciRestoreError,
     HvfSnapshotV2BalloonPreparedProduct, HvfSnapshotV2BalloonState, HvfSnapshotV2BootState,
@@ -130,8 +130,9 @@ use bangbang_runtime::entropy::{EntropyConfig, EntropyMmioLayout};
 use bangbang_runtime::lazy_memory::LazyGuestMemoryConsumerProfile;
 use bangbang_runtime::logger::{
     EmergencyLogger, LoggerApiControlOutcome, LoggerApiResultOutcome, LoggerApiRoute,
-    LoggerConfigInput, LoggerHttpMethod, ProcessStartupOutcome, ProcessStdoutLogger,
-    ProcessTerminalCategory,
+    LoggerApiWorkerOutcome, LoggerConfigInput, LoggerDeviceKind, LoggerHttpMethod,
+    LoggerLifecycleOutcome, LoggerObservabilityOutcome, LoggerProcessSignalOutcome,
+    LoggerSnapshotOutcome, ProcessStartupOutcome, ProcessStdoutLogger, ProcessTerminalCategory,
 };
 use bangbang_runtime::machine::{MachineConfigInput, MachineConfigPatchInput};
 use bangbang_runtime::memory::{GuestAddress, GuestMemory, GuestMemoryRange};
@@ -2449,6 +2450,21 @@ pub(crate) enum SnapshotCaptureReadyPreflightError {
 }
 
 impl SnapshotCaptureReadyPreflightError {
+    fn is_cancelled(&self) -> bool {
+        match self {
+            Self::Storage(source) => {
+                source.kind() == HvfArm64BootStorageCaptureErrorKind::Cancelled
+            }
+            Self::Vsock(source) => source.kind() == HvfArm64BootVsockCaptureErrorKind::Cancelled,
+            Self::Balloon(_)
+            | Self::MemoryHotplug(_)
+            | Self::Entropy(_)
+            | Self::Serial(_)
+            | Self::Network(_)
+            | Self::SessionUnavailable => false,
+        }
+    }
+
     fn into_native_v1(self) -> NativeV1SnapshotPublicationError {
         match self {
             Self::Storage(source) => NativeV1SnapshotPublicationError::StoragePreflight(source),
@@ -2597,6 +2613,39 @@ fn native_v2_snapshot_publication_action_error(
         NativeV2SnapshotPublicationError::Preflight(source) => source,
         NativeV2SnapshotPublicationError::Profile(_) => VmmActionError::SnapshotUnsupported,
         error => VmmActionError::SnapshotCreate(BackendError::Hypervisor(error.to_string())),
+    }
+}
+
+fn native_v2_snapshot_publication_logger_outcome(
+    error: &NativeV2SnapshotPublicationError,
+) -> LoggerSnapshotOutcome {
+    match error {
+        NativeV2SnapshotPublicationError::CaptureReadyPreflight(source)
+            if source.is_cancelled() =>
+        {
+            LoggerSnapshotOutcome::CreateCancelled
+        }
+        NativeV2SnapshotPublicationError::Transaction(transaction)
+            if transaction.producer().is_some_and(|producer| {
+                matches!(
+                    producer.source(),
+                    NativeV2SnapshotPublicationProducerError::Capture(
+                        NativeV2SnapshotCaptureError::Cancelled { .. }
+                    )
+                )
+            }) =>
+        {
+            LoggerSnapshotOutcome::CreateCancelled
+        }
+        NativeV2SnapshotPublicationError::Preflight(_)
+        | NativeV2SnapshotPublicationError::CaptureReadyPreflight(_)
+        | NativeV2SnapshotPublicationError::Profile(_)
+        | NativeV2SnapshotPublicationError::Resource(_)
+        | NativeV2SnapshotPublicationError::SessionUnavailable
+        | NativeV2SnapshotPublicationError::ConfigurationUnavailable => {
+            LoggerSnapshotOutcome::CreateRejected
+        }
+        NativeV2SnapshotPublicationError::Transaction(_) => LoggerSnapshotOutcome::CreateFailed,
     }
 }
 
@@ -4276,6 +4325,40 @@ enum NativeSnapshotLoadError {
     NativeV2(NativeV2SnapshotLoadError),
 }
 
+fn native_v2_snapshot_load_is_cancelled(error: &NativeV2SnapshotLoadError) -> bool {
+    match error {
+        NativeV2SnapshotLoadError::Cancelled => true,
+        NativeV2SnapshotLoadError::AfterResourceAdoption { source } => {
+            native_v2_snapshot_load_is_cancelled(source)
+        }
+        _ => false,
+    }
+}
+
+fn native_snapshot_load_logger_outcome(error: &NativeSnapshotLoadError) -> LoggerSnapshotOutcome {
+    match error {
+        NativeSnapshotLoadError::NativeV2(source)
+            if native_v2_snapshot_load_is_cancelled(source) =>
+        {
+            LoggerSnapshotOutcome::LoadCancelled
+        }
+        NativeSnapshotLoadError::Preflight(_)
+        | NativeSnapshotLoadError::ProcessTerminal
+        | NativeSnapshotLoadError::Resource(_)
+        | NativeSnapshotLoadError::NativeV1(NativeV1SnapshotLoadError::Preflight(_))
+        | NativeSnapshotLoadError::NativeV1(NativeV1SnapshotLoadError::ProcessTerminal)
+        | NativeSnapshotLoadError::NativeV1(NativeV1SnapshotLoadError::Resource(_))
+        | NativeSnapshotLoadError::NativeV2(NativeV2SnapshotLoadError::Preflight(_))
+        | NativeSnapshotLoadError::NativeV2(NativeV2SnapshotLoadError::ProcessTerminal)
+        | NativeSnapshotLoadError::NativeV2(NativeV2SnapshotLoadError::Resource(_)) => {
+            LoggerSnapshotOutcome::LoadRejected
+        }
+        NativeSnapshotLoadError::Artifact(_)
+        | NativeSnapshotLoadError::NativeV1(_)
+        | NativeSnapshotLoadError::NativeV2(_) => LoggerSnapshotOutcome::LoadFailed,
+    }
+}
+
 impl fmt::Display for NativeSnapshotLoadError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -4375,6 +4458,12 @@ impl fmt::Debug for BlockBackingUpdate {
             Self::Provided(_) => formatter.write_str("Provided(<owned>)"),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProcessSessionShutdownStatus {
+    Succeeded,
+    Failed,
 }
 
 pub(crate) trait ProcessSessionDiagnostics {
@@ -4535,6 +4624,10 @@ pub(crate) trait ProcessSessionDiagnostics {
 
     fn process_exit_status(&self) -> ProcessSessionExitStatus {
         ProcessSessionExitStatus::Running
+    }
+
+    fn shutdown(&mut self) -> ProcessSessionShutdownStatus {
+        ProcessSessionShutdownStatus::Succeeded
     }
 }
 
@@ -4850,7 +4943,10 @@ impl BootRunLoopPmemDeviceUpdater {
 pub(crate) enum ProcessSessionExitStatus {
     #[default]
     Running,
-    GuestRequestedStop,
+    GuestPoweroff,
+    GuestReset,
+    WorkerExited,
+    WorkerFailed,
     Terminal,
 }
 
@@ -4865,8 +4961,10 @@ impl ProcessSessionExitStatus {
     pub(crate) const fn decision(self) -> ProcessSessionExitDecision {
         match self {
             Self::Running => ProcessSessionExitDecision::Continue,
-            Self::GuestRequestedStop => ProcessSessionExitDecision::ExitSuccessfully,
-            Self::Terminal => ProcessSessionExitDecision::ExitWithFailure,
+            Self::GuestPoweroff | Self::GuestReset => ProcessSessionExitDecision::ExitSuccessfully,
+            Self::WorkerExited | Self::WorkerFailed | Self::Terminal => {
+                ProcessSessionExitDecision::ExitWithFailure
+            }
         }
     }
 }
@@ -5370,6 +5468,8 @@ pub(crate) trait VmmRequestHandler {
     fn process_exit_status(&self) -> ProcessSessionExitStatus {
         ProcessSessionExitStatus::Running
     }
+
+    fn record_shutdown_wakeup(&mut self) {}
 }
 
 #[derive(Debug)]
@@ -5475,6 +5575,63 @@ impl fmt::Debug for ProcessVmnetAuthority {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveDeviceLifecycleOperation {
+    Attach,
+    Update,
+    Detach,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LiveDeviceLifecycleAction {
+    kind: LoggerDeviceKind,
+    operation: LiveDeviceLifecycleOperation,
+}
+
+impl LiveDeviceLifecycleAction {
+    const fn succeeded(self) -> LoggerLifecycleOutcome {
+        match self.operation {
+            LiveDeviceLifecycleOperation::Attach => {
+                LoggerLifecycleOutcome::DeviceAttachSucceeded(self.kind)
+            }
+            LiveDeviceLifecycleOperation::Update => {
+                LoggerLifecycleOutcome::DeviceUpdateSucceeded(self.kind)
+            }
+            LiveDeviceLifecycleOperation::Detach => {
+                LoggerLifecycleOutcome::DeviceDetachSucceeded(self.kind)
+            }
+        }
+    }
+
+    const fn rejected(self) -> LoggerLifecycleOutcome {
+        match self.operation {
+            LiveDeviceLifecycleOperation::Attach => {
+                LoggerLifecycleOutcome::DeviceAttachRejected(self.kind)
+            }
+            LiveDeviceLifecycleOperation::Update => {
+                LoggerLifecycleOutcome::DeviceUpdateRejected(self.kind)
+            }
+            LiveDeviceLifecycleOperation::Detach => {
+                LoggerLifecycleOutcome::DeviceDetachRejected(self.kind)
+            }
+        }
+    }
+
+    const fn failed(self) -> LoggerLifecycleOutcome {
+        match self.operation {
+            LiveDeviceLifecycleOperation::Attach => {
+                LoggerLifecycleOutcome::DeviceAttachFailed(self.kind)
+            }
+            LiveDeviceLifecycleOperation::Update => {
+                LoggerLifecycleOutcome::DeviceUpdateFailed(self.kind)
+            }
+            LiveDeviceLifecycleOperation::Detach => {
+                LoggerLifecycleOutcome::DeviceDetachFailed(self.kind)
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct ProcessVmm<S>
 where
@@ -5485,6 +5642,7 @@ where
     started_session: Option<S::Session>,
     metrics_session_epoch: Option<Instant>,
     initial_metrics_attempted: bool,
+    terminal_convergence_attempted: bool,
     terminal_logger_attempted: bool,
     terminal_metrics_attempted: bool,
     process_metrics_diagnostics: MetricsDiagnostics,
@@ -5493,6 +5651,11 @@ where
     snapshot_capture_cancellation: NativeV1SnapshotCaptureCancellation,
     terminal_snapshot_load_failure: bool,
     terminal_instance_start_failure: bool,
+    instance_start_backend_attempted: bool,
+    live_device_backend_attempted: bool,
+    observed_process_exit_status: Cell<Option<ProcessSessionExitStatus>>,
+    shutdown_wakeup_observed: bool,
+    terminal_session_metrics: Option<MetricsDiagnostics>,
     pci_enabled: bool,
     vmnet_authority: ProcessVmnetAuthority,
     grant_authority: Option<GrantAuthority>,
@@ -5595,6 +5758,7 @@ where
             started_session: None,
             metrics_session_epoch: None,
             initial_metrics_attempted: false,
+            terminal_convergence_attempted: false,
             terminal_logger_attempted: false,
             terminal_metrics_attempted: false,
             process_metrics_diagnostics: MetricsDiagnostics::default(),
@@ -5603,6 +5767,11 @@ where
             snapshot_capture_cancellation: NativeV1SnapshotCaptureCancellation::default(),
             terminal_snapshot_load_failure: false,
             terminal_instance_start_failure: false,
+            instance_start_backend_attempted: false,
+            live_device_backend_attempted: false,
+            observed_process_exit_status: Cell::new(None),
+            shutdown_wakeup_observed: false,
+            terminal_session_metrics: None,
             pci_enabled: false,
             vmnet_authority: ProcessVmnetAuthority::Direct,
             grant_authority: None,
@@ -5761,8 +5930,82 @@ where
         self.controller.serial_config()
     }
 
+    fn live_device_lifecycle_action(
+        &self,
+        action: &VmmAction,
+    ) -> Option<LiveDeviceLifecycleAction> {
+        if self.controller.instance_info().state == bangbang_runtime::InstanceState::NotStarted {
+            return None;
+        }
+
+        match action {
+            VmmAction::PutDrive(input) => Some(LiveDeviceLifecycleAction {
+                kind: LoggerDeviceKind::Block,
+                operation: if self
+                    .controller
+                    .drive_configs()
+                    .iter()
+                    .any(|config| config.drive_id() == input.path_drive_id())
+                {
+                    LiveDeviceLifecycleOperation::Update
+                } else {
+                    LiveDeviceLifecycleOperation::Attach
+                },
+            }),
+            VmmAction::UpdateBlockDevice(_) => Some(LiveDeviceLifecycleAction {
+                kind: LoggerDeviceKind::Block,
+                operation: LiveDeviceLifecycleOperation::Update,
+            }),
+            VmmAction::PutNetworkInterface(input) => Some(LiveDeviceLifecycleAction {
+                kind: LoggerDeviceKind::Network,
+                operation: if self
+                    .controller
+                    .network_interface_configs()
+                    .iter()
+                    .any(|config| config.iface_id() == input.path_iface_id())
+                {
+                    LiveDeviceLifecycleOperation::Update
+                } else {
+                    LiveDeviceLifecycleOperation::Attach
+                },
+            }),
+            VmmAction::UpdateNetworkInterface(_) => Some(LiveDeviceLifecycleAction {
+                kind: LoggerDeviceKind::Network,
+                operation: LiveDeviceLifecycleOperation::Update,
+            }),
+            VmmAction::PutPmem(input) => Some(LiveDeviceLifecycleAction {
+                kind: LoggerDeviceKind::Pmem,
+                operation: if self
+                    .controller
+                    .pmem_configs()
+                    .iter()
+                    .any(|config| config.id() == input.id())
+                {
+                    LiveDeviceLifecycleOperation::Update
+                } else {
+                    LiveDeviceLifecycleOperation::Attach
+                },
+            }),
+            VmmAction::PatchPmem(_) => Some(LiveDeviceLifecycleAction {
+                kind: LoggerDeviceKind::Pmem,
+                operation: LiveDeviceLifecycleOperation::Update,
+            }),
+            VmmAction::HotUnplugDevice(input) => Some(LiveDeviceLifecycleAction {
+                kind: match input.kind() {
+                    HotUnplugDeviceKind::Drive => LoggerDeviceKind::Block,
+                    HotUnplugDeviceKind::NetworkInterface => LoggerDeviceKind::Network,
+                    HotUnplugDeviceKind::Pmem => LoggerDeviceKind::Pmem,
+                },
+                operation: LiveDeviceLifecycleOperation::Detach,
+            }),
+            _ => None,
+        }
+    }
+
     pub(crate) fn handle_action(&mut self, action: VmmAction) -> Result<VmmData, VmmActionError> {
         let had_started_session = self.has_started_session();
+        let live_device_lifecycle = self.live_device_lifecycle_action(&action);
+        self.live_device_backend_attempted = false;
         let result = match action {
             VmmAction::InstanceStart => self.start_instance(),
             VmmAction::PutBootSource(input) => self.put_boot_source(input),
@@ -5803,6 +6046,17 @@ where
             VmmAction::FlushMetrics => self.flush_metrics(),
             action => self.controller.handle_action(action),
         };
+
+        if let Some(action) = live_device_lifecycle {
+            let outcome = if result.is_ok() {
+                action.succeeded()
+            } else if self.live_device_backend_attempted {
+                action.failed()
+            } else {
+                action.rejected()
+            };
+            let _ = self.controller.log_lifecycle(outcome);
+        }
 
         if !had_started_session && self.has_started_session() {
             debug_assert!(self.metrics_session_epoch.is_none());
@@ -6042,6 +6296,24 @@ where
     }
 
     fn start_instance(&mut self) -> Result<VmmData, VmmActionError> {
+        self.instance_start_backend_attempted = false;
+        let result = self.start_instance_inner();
+        let outcome = if result.is_ok() {
+            let _ = self
+                .controller
+                .async_logger()
+                .log_api_worker(LoggerApiWorkerOutcome::Running);
+            LoggerLifecycleOutcome::VmStartSucceeded
+        } else if self.instance_start_backend_attempted {
+            LoggerLifecycleOutcome::VmStartFailed
+        } else {
+            LoggerLifecycleOutcome::VmStartRejected
+        };
+        let _ = self.controller.log_lifecycle(outcome);
+        result
+    }
+
+    fn start_instance_inner(&mut self) -> Result<VmmData, VmmActionError> {
         if self.terminal_snapshot_load_failure || self.terminal_instance_start_failure {
             return Err(VmmActionError::InstanceStart(BackendError::InvalidState(
                 "process cannot construct another VM after a terminal construction failure",
@@ -6215,6 +6487,7 @@ where
         let mut started_session = None;
         let mut terminal_start_failure = false;
 
+        self.instance_start_backend_attempted = true;
         let result = controller.start_instance_with(|controller| {
             match starter.start_with_startup_resources(
                 controller,
@@ -6222,10 +6495,13 @@ where
                 startup_resources,
             ) {
                 Ok(session) => {
+                    let _ =
+                        controller.log_lifecycle(LoggerLifecycleOutcome::BackendStartupSucceeded);
                     started_session = Some(session);
                     Ok(())
                 }
                 Err(source) => {
+                    let _ = controller.log_lifecycle(LoggerLifecycleOutcome::BackendStartupFailed);
                     terminal_start_failure =
                         source.disposition() == InstanceStartDisposition::Terminal;
                     Err(source.into_source())
@@ -6404,11 +6680,14 @@ where
             ),
             None => BlockBackingUpdate::ConfiguredPath,
         };
-        self.started_session
+        let session = self
+            .started_session
             .as_mut()
             .ok_or(VmmActionError::DriveUpdate(
                 DriveUpdateError::ActiveSessionUnavailable,
-            ))?
+            ))?;
+        self.live_device_backend_attempted = true;
+        session
             .update_block_device(
                 &config,
                 backing_update,
@@ -6512,11 +6791,14 @@ where
                 })?;
                 #[cfg(target_os = "macos")]
                 let drive_id = config.drive_id().to_string();
-                self.started_session
-                    .as_mut()
-                    .ok_or(VmmActionError::DriveRuntimeMutation(
-                        DriveRuntimeMutationError::ActiveSessionUnavailable,
-                    ))?
+                let session =
+                    self.started_session
+                        .as_mut()
+                        .ok_or(VmmActionError::DriveRuntimeMutation(
+                            DriveRuntimeMutationError::ActiveSessionUnavailable,
+                        ))?;
+                self.live_device_backend_attempted = true;
+                session
                     .insert_runtime_block_device(RuntimeBlockDeviceResource::vhost_user(
                         config, frontend,
                     ))
@@ -6568,6 +6850,7 @@ where
                         DriveRuntimeMutationError::ActiveSessionUnavailable,
                     )
                 })?;
+                self.live_device_backend_attempted = true;
                 session
                     .insert_runtime_block_device(RuntimeBlockDeviceResource::prepared(
                         prepared_device,
@@ -6601,6 +6884,7 @@ where
                 DriveRuntimeMutationError::ActiveSessionUnavailable,
             )
         })?;
+        self.live_device_backend_attempted = true;
         session
             .remove_runtime_block_device(prepared.drive_id())
             .map_err(VmmActionError::DriveRuntimeMutation)?;
@@ -6634,6 +6918,7 @@ where
                 NetworkRuntimeMutationError::ActiveSessionUnavailable,
             )
         })?;
+        self.live_device_backend_attempted = true;
         session
             .insert_runtime_network_device(config, self.vmnet_authority)
             .map_err(VmmActionError::NetworkRuntimeMutation)?;
@@ -6663,6 +6948,7 @@ where
                 NetworkRuntimeMutationError::ActiveSessionUnavailable,
             )
         })?;
+        self.live_device_backend_attempted = true;
         session
             .remove_runtime_network_device(prepared.iface_id())
             .map_err(VmmActionError::NetworkRuntimeMutation)?;
@@ -6796,6 +7082,7 @@ where
         let session = self.started_session.as_mut().ok_or({
             VmmActionError::PmemRuntimeMutation(PmemRuntimeMutationError::ActiveSessionUnavailable)
         })?;
+        self.live_device_backend_attempted = true;
         session
             .insert_runtime_pmem_device(config, backing)
             .map_err(VmmActionError::PmemRuntimeMutation)?;
@@ -6823,6 +7110,7 @@ where
         let session = self.started_session.as_mut().ok_or({
             VmmActionError::PmemRuntimeMutation(PmemRuntimeMutationError::ActiveSessionUnavailable)
         })?;
+        self.live_device_backend_attempted = true;
         session
             .remove_runtime_pmem_device(prepared.pmem_id())
             .map_err(VmmActionError::PmemRuntimeMutation)?;
@@ -6881,52 +7169,141 @@ where
     }
 
     fn pause_instance(&mut self) -> Result<VmmData, VmmActionError> {
-        let transition = self.controller.preflight_pause_instance()?;
+        let transition = match self.controller.preflight_pause_instance() {
+            Ok(transition) => transition,
+            Err(error) => {
+                let _ = self
+                    .controller
+                    .log_lifecycle(LoggerLifecycleOutcome::VmPauseRejected);
+                return Err(error);
+            }
+        };
         let Some(session) = self.started_session.as_mut() else {
+            let _ = self
+                .controller
+                .log_lifecycle(LoggerLifecycleOutcome::VmPauseFailed);
             return Err(VmmActionError::Lifecycle(BackendError::InvalidState(
                 "active session unavailable",
             )));
         };
 
         if transition == VmStateTransition::AlreadyInTargetState {
+            let _ = self
+                .controller
+                .log_lifecycle(LoggerLifecycleOutcome::VmPauseUnchanged);
             return Ok(VmmData::Empty);
         }
-        session.pause().map_err(VmmActionError::Lifecycle)?;
-        self.controller.pause_instance()
+        if let Err(error) = session.pause() {
+            let _ = self
+                .controller
+                .log_lifecycle(LoggerLifecycleOutcome::VmPauseFailed);
+            return Err(VmmActionError::Lifecycle(error));
+        }
+        let result = self.controller.pause_instance();
+        let outcome = if result.is_ok() {
+            LoggerLifecycleOutcome::VmPauseSucceeded
+        } else {
+            LoggerLifecycleOutcome::VmPauseFailed
+        };
+        let _ = self.controller.log_lifecycle(outcome);
+        result
     }
 
     fn resume_instance(&mut self) -> Result<VmmData, VmmActionError> {
-        let transition = self.controller.preflight_resume_instance()?;
+        self.resume_instance_with_lifecycle_log(true)
+    }
+
+    fn resume_instance_with_lifecycle_log(
+        &mut self,
+        log_lifecycle: bool,
+    ) -> Result<VmmData, VmmActionError> {
+        let transition = match self.controller.preflight_resume_instance() {
+            Ok(transition) => transition,
+            Err(error) => {
+                if log_lifecycle {
+                    let _ = self
+                        .controller
+                        .log_lifecycle(LoggerLifecycleOutcome::VmResumeRejected);
+                }
+                return Err(error);
+            }
+        };
         let Some(session) = self.started_session.as_mut() else {
+            if log_lifecycle {
+                let _ = self
+                    .controller
+                    .log_lifecycle(LoggerLifecycleOutcome::VmResumeFailed);
+            }
             return Err(VmmActionError::Lifecycle(BackendError::InvalidState(
                 "active session unavailable",
             )));
         };
 
         if transition == VmStateTransition::AlreadyInTargetState {
+            if log_lifecycle {
+                let _ = self
+                    .controller
+                    .log_lifecycle(LoggerLifecycleOutcome::VmResumeUnchanged);
+            }
             return Ok(VmmData::Empty);
         }
-        session.resume().map_err(VmmActionError::Lifecycle)?;
-        self.controller.resume_instance()
+        if let Err(error) = session.resume() {
+            if log_lifecycle {
+                let _ = self
+                    .controller
+                    .log_lifecycle(LoggerLifecycleOutcome::VmResumeFailed);
+            }
+            return Err(VmmActionError::Lifecycle(error));
+        }
+        let result = self.controller.resume_instance();
+        if log_lifecycle {
+            let outcome = if result.is_ok() {
+                LoggerLifecycleOutcome::VmResumeSucceeded
+            } else {
+                LoggerLifecycleOutcome::VmResumeFailed
+            };
+            let _ = self.controller.log_lifecycle(outcome);
+        }
+        result
     }
 
     fn create_snapshot(&mut self, input: SnapshotCreateInput) -> Result<VmmData, VmmActionError> {
-        match input.snapshot_type() {
+        let publication = match input.snapshot_type() {
             SnapshotType::Full => self.publish_native_v2_snapshot(&input),
             SnapshotType::Diff => self.publish_native_v2_diff_snapshot(&input),
-        }
-        .map_err(native_v2_snapshot_publication_action_error)?;
-        Ok(VmmData::Empty)
+        };
+        let outcome = publication
+            .as_ref()
+            .map_or_else(native_v2_snapshot_publication_logger_outcome, |_| {
+                LoggerSnapshotOutcome::CreateSucceeded
+            });
+        let result = publication
+            .map_err(native_v2_snapshot_publication_action_error)
+            .map(|_| VmmData::Empty);
+        let _ = self.controller.log_snapshot(outcome);
+        result
     }
 
     fn load_snapshot(&mut self, input: SnapshotLoadInput) -> Result<VmmData, VmmActionError> {
-        let resume_requested = self
-            .restore_native_snapshot(&input)
-            .map_err(native_snapshot_load_action_error)?;
-        if resume_requested {
-            self.resume_instance()
-                .map_err(native_v1_snapshot_resume_action_error)?;
+        let resume_requested = match self.restore_native_snapshot(&input) {
+            Ok(resume_requested) => resume_requested,
+            Err(error) => {
+                let outcome = native_snapshot_load_logger_outcome(&error);
+                let error = native_snapshot_load_action_error(error);
+                let _ = self.controller.log_snapshot(outcome);
+                return Err(error);
+            }
+        };
+        if resume_requested && let Err(error) = self.resume_instance_with_lifecycle_log(false) {
+            let error = native_v1_snapshot_resume_action_error(error);
+            let _ = self
+                .controller
+                .log_snapshot(LoggerSnapshotOutcome::LoadFailed);
+            return Err(error);
         }
+        let _ = self
+            .controller
+            .log_snapshot(LoggerSnapshotOutcome::LoadSucceeded);
         Ok(VmmData::Empty)
     }
 
@@ -6952,6 +7329,7 @@ where
                     .ok_or(VmmActionError::DriveUpdate(
                         DriveUpdateError::ActiveSessionUnavailable,
                     ))?;
+                self.live_device_backend_attempted = true;
                 session
                     .update_block_device(
                         &updated_config,
@@ -6995,6 +7373,7 @@ where
                 } else {
                     BlockBackingUpdate::Unchanged
                 };
+                self.live_device_backend_attempted = true;
                 session
                     .update_block_device(
                         &updated_config,
@@ -7033,6 +7412,7 @@ where
                 ));
             };
 
+            self.live_device_backend_attempted = true;
             session
                 .update_network_interface(update)
                 .map_err(VmmActionError::NetworkInterfaceUpdate)?;
@@ -7059,6 +7439,7 @@ where
                 ));
             };
 
+            self.live_device_backend_attempted = true;
             session
                 .update_pmem(update)
                 .map_err(VmmActionError::PmemUpdate)?;
@@ -7265,7 +7646,12 @@ where
         }
 
         self.initial_metrics_attempted = true;
-        let _ = self.flush_automatic_metrics();
+        if self.flush_automatic_metrics().is_err() {
+            let _ = self
+                .controller
+                .async_logger()
+                .log_observability(LoggerObservabilityOutcome::MetricsWorkerFailed);
+        }
     }
 
     pub(crate) fn emergency_logger(&self) -> EmergencyLogger {
@@ -7274,6 +7660,48 @@ where
 
     pub(crate) fn handle_terminal_observability(&mut self, category: ProcessTerminalCategory) {
         self.handle_initial_metrics_flush();
+        if !self.terminal_convergence_attempted {
+            self.terminal_convergence_attempted = true;
+            let logger = self.controller.async_logger();
+            if category == ProcessTerminalCategory::Cancelled {
+                let _ =
+                    logger.log_process_signal(LoggerProcessSignalOutcome::CancellationRequested);
+            } else if self.shutdown_wakeup_observed {
+                let _ = logger.log_process_signal(LoggerProcessSignalOutcome::HostSignalReceived);
+            }
+
+            let _ = self.process_exit_status();
+            let worker_outcome_observed = self.observed_process_exit_status.get().is_some();
+            let session_shutdown = self.started_session.take().map(|mut session| {
+                self.terminal_session_metrics = Some(session.metrics_diagnostics());
+                session.shutdown()
+            });
+            if let Some(status) = session_shutdown {
+                if !worker_outcome_observed {
+                    let _ = logger.log_api_worker(LoggerApiWorkerOutcome::Stopped);
+                }
+                let outcome = match status {
+                    ProcessSessionShutdownStatus::Succeeded => {
+                        LoggerLifecycleOutcome::VmStopSucceeded
+                    }
+                    ProcessSessionShutdownStatus::Failed => LoggerLifecycleOutcome::VmStopFailed,
+                };
+                let _ = self.controller.log_lifecycle(outcome);
+            }
+
+            let orderly =
+                matches!(
+                    category,
+                    ProcessTerminalCategory::Success | ProcessTerminalCategory::Cancelled
+                ) && !matches!(session_shutdown, Some(ProcessSessionShutdownStatus::Failed));
+            let shutdown_outcome = if orderly {
+                LoggerProcessSignalOutcome::ShutdownOrderly
+            } else {
+                LoggerProcessSignalOutcome::ShutdownAbnormal
+            };
+            let _ = logger.log_process_signal(shutdown_outcome);
+        }
+
         self.controller.settle_emergency_logger_loss();
         if !self.terminal_logger_attempted {
             self.terminal_logger_attempted = true;
@@ -7283,12 +7711,19 @@ where
     }
 
     fn handle_periodic_metrics_flush(&mut self) {
-        let _ = self.flush_automatic_metrics();
+        if self.flush_automatic_metrics().is_err() {
+            let _ = self
+                .controller
+                .async_logger()
+                .log_observability(LoggerObservabilityOutcome::MetricsWorkerFailed);
+        }
     }
 
     pub(crate) fn handle_terminal_metrics_flush(&mut self) {
         self.handle_initial_metrics_flush();
-        if !self.has_started_session() || self.terminal_metrics_attempted {
+        if (self.started_session.is_none() && self.terminal_session_metrics.is_none())
+            || self.terminal_metrics_attempted
+        {
             return;
         }
 
@@ -7332,6 +7767,7 @@ where
             .started_session
             .as_ref()
             .map(ProcessSessionDiagnostics::metrics_diagnostics)
+            .or_else(|| self.terminal_session_metrics.clone())
             .unwrap_or_default();
         let signal_diagnostics = self
             .process_signal_metrics
@@ -7359,14 +7795,46 @@ where
         Ok(())
     }
 
+    pub(crate) fn record_shutdown_wakeup(&mut self) {
+        self.shutdown_wakeup_observed = true;
+    }
+
     pub(crate) fn process_exit_status(&self) -> ProcessSessionExitStatus {
-        if self.terminal_snapshot_load_failure || self.terminal_instance_start_failure {
-            return ProcessSessionExitStatus::Terminal;
+        let status = if self.terminal_snapshot_load_failure || self.terminal_instance_start_failure
+        {
+            ProcessSessionExitStatus::Terminal
+        } else {
+            self.started_session
+                .as_ref()
+                .map(ProcessSessionDiagnostics::process_exit_status)
+                .unwrap_or_default()
+        };
+        if !matches!(
+            status,
+            ProcessSessionExitStatus::Running | ProcessSessionExitStatus::Terminal
+        ) && self.observed_process_exit_status.get().is_none()
+        {
+            self.observed_process_exit_status.set(Some(status));
+            let logger = self.controller.async_logger();
+            match status {
+                ProcessSessionExitStatus::GuestPoweroff => {
+                    let _ = logger.log_api_worker(LoggerApiWorkerOutcome::Exited);
+                    let _ = logger.log_process_signal(LoggerProcessSignalOutcome::GuestPoweroff);
+                }
+                ProcessSessionExitStatus::GuestReset => {
+                    let _ = logger.log_api_worker(LoggerApiWorkerOutcome::Exited);
+                    let _ = logger.log_process_signal(LoggerProcessSignalOutcome::GuestReset);
+                }
+                ProcessSessionExitStatus::WorkerExited => {
+                    let _ = logger.log_api_worker(LoggerApiWorkerOutcome::Exited);
+                }
+                ProcessSessionExitStatus::WorkerFailed => {
+                    let _ = logger.log_api_worker(LoggerApiWorkerOutcome::Failed);
+                }
+                ProcessSessionExitStatus::Running | ProcessSessionExitStatus::Terminal => {}
+            }
         }
-        self.started_session
-            .as_ref()
-            .map(ProcessSessionDiagnostics::process_exit_status)
-            .unwrap_or_default()
+        status
     }
 
     fn resume_native_v2_snapshot_if_requested(
@@ -7376,15 +7844,16 @@ where
         if !resume_requested {
             return Ok(false);
         }
-        self.resume_instance().map_err(|error| {
-            let source = match error {
-                VmmActionError::Lifecycle(source) => source,
-                _ => BackendError::InvalidState(
-                    "restored native-v2 resume failed before running-state commit",
-                ),
-            };
-            NativeV2SnapshotLoadError::Resume(source)
-        })?;
+        self.resume_instance_with_lifecycle_log(false)
+            .map_err(|error| {
+                let source = match error {
+                    VmmActionError::Lifecycle(source) => source,
+                    _ => BackendError::InvalidState(
+                        "restored native-v2 resume failed before running-state commit",
+                    ),
+                };
+                NativeV2SnapshotLoadError::Resume(source)
+            })?;
         Ok(true)
     }
 
@@ -10321,6 +10790,10 @@ where
 
     fn process_exit_status(&self) -> ProcessSessionExitStatus {
         ProcessVmm::process_exit_status(self)
+    }
+
+    fn record_shutdown_wakeup(&mut self) {
+        ProcessVmm::record_shutdown_wakeup(self);
     }
 }
 
@@ -30335,10 +30808,9 @@ impl BootRunLoopProcessExit for HvfArm64BootRunLoopOutcome {
             Self::StepLimitReached { .. } | Self::Wakeup { .. } => {
                 ProcessSessionExitStatus::Running
             }
-            Self::GuestShutdown { .. } | Self::GuestReset { .. } => {
-                ProcessSessionExitStatus::GuestRequestedStop
-            }
-            _ => ProcessSessionExitStatus::Terminal,
+            Self::GuestShutdown { .. } => ProcessSessionExitStatus::GuestPoweroff,
+            Self::GuestReset { .. } => ProcessSessionExitStatus::GuestReset,
+            _ => ProcessSessionExitStatus::WorkerExited,
         }
     }
 }
@@ -31838,9 +32310,9 @@ where
         let _ = self.control.request_stop();
     }
 
-    fn stop_and_join(&mut self) {
+    fn stop_and_join(&mut self) -> ProcessSessionShutdownStatus {
         let Some(worker) = self.worker.take() else {
-            return;
+            return ProcessSessionShutdownStatus::Succeeded;
         };
 
         // Snapshot memory I/O is cooperative. Signal it before shutdown can
@@ -31855,7 +32327,13 @@ where
         // A stop error can mean an in-flight vCPU run was not canceled; avoid
         // turning cleanup into an unbounded join in that error path.
         if stop_requested || was_paused || worker.is_finished() {
-            let _ = worker.join();
+            if worker.join().is_ok() {
+                ProcessSessionShutdownStatus::Succeeded
+            } else {
+                ProcessSessionShutdownStatus::Failed
+            }
+        } else {
+            ProcessSessionShutdownStatus::Failed
         }
     }
 }
@@ -35186,6 +35664,21 @@ impl ProcessSessionDiagnostics for HvfProcessSession {
     fn process_exit_status(&self) -> ProcessSessionExitStatus {
         self.diagnostics().process_exit_status()
     }
+
+    fn shutdown(&mut self) -> ProcessSessionShutdownStatus {
+        match self {
+            Self::Boot(session) => session.stop_and_join(),
+            Self::SnapshotV2(session) => session.stop_and_join(),
+            #[cfg(target_os = "macos")]
+            Self::SerialSnapshotV2(destination) => {
+                if destination.cleanup().is_ok() {
+                    ProcessSessionShutdownStatus::Succeeded
+                } else {
+                    ProcessSessionShutdownStatus::Failed
+                }
+            }
+        }
+    }
 }
 
 impl<S> ProcessSessionDiagnostics for BootRunLoopSupervisor<S>
@@ -35661,8 +36154,12 @@ where
             BootRunLoopWorkerStatus::Running => ProcessSessionExitStatus::Running,
             BootRunLoopWorkerStatus::Paused => ProcessSessionExitStatus::Running,
             BootRunLoopWorkerStatus::Exited(outcome) => outcome.process_exit_status(),
-            BootRunLoopWorkerStatus::Failed(_) => ProcessSessionExitStatus::Terminal,
+            BootRunLoopWorkerStatus::Failed(_) => ProcessSessionExitStatus::WorkerFailed,
         }
+    }
+
+    fn shutdown(&mut self) -> ProcessSessionShutdownStatus {
+        self.stop_and_join()
     }
 }
 
@@ -35671,7 +36168,7 @@ where
     S: BootRunLoopSession,
 {
     fn drop(&mut self) {
-        self.stop_and_join();
+        let _ = self.stop_and_join();
     }
 }
 
@@ -35761,7 +36258,8 @@ mod tests {
     use bangbang_runtime::fdt::{Arm64FdtRegion, Arm64FdtVirtioMmioDevice};
     use bangbang_runtime::interrupt::GuestInterruptLine;
     use bangbang_runtime::logger::{
-        LoggerConfigInput, ProcessStdoutLogger, ProcessTerminalCategory,
+        LoggerConfigInput, LoggerLevel, LoggerLifecycleOutcome, ProcessStdoutLogger,
+        ProcessTerminalCategory,
     };
     use bangbang_runtime::machine::{MachineConfig, MachineConfigInput, MachineConfigPatchInput};
     use bangbang_runtime::memory::{
@@ -35990,18 +36488,19 @@ mod tests {
         ProcessNetworkPacketIoProvider, ProcessNetworkPacketIoProviderBuildError,
         ProcessNetworkPacketIoRegistry, ProcessNetworkPacketIoRegistryError,
         ProcessNetworkPacketIoStopError, ProcessRuntimeNetworkPacketIoProvider,
-        ProcessSessionDiagnostics, ProcessSessionExitStatus, ProcessSnapshotV2BalloonLoadRequest,
-        ProcessSnapshotV2DiffLoadRequest, ProcessSnapshotV2EntropyLoadRequest,
-        ProcessSnapshotV2MemoryHotplugLoadRequest, ProcessSnapshotV2MultiBlockLoadRequest,
-        ProcessSnapshotV2MultiBlockLoadSuccess, ProcessSnapshotV2NetworkLoadRequest,
-        ProcessSnapshotV2NetworkRestorePlanError, ProcessSnapshotV2RootLoadCompletion,
-        ProcessSnapshotV2RootLoadRequest, ProcessSnapshotV2RootLoadSuccess,
-        ProcessSnapshotV2SerialLoadRequest, ProcessSnapshotV2StorageLoadRequest,
-        ProcessSnapshotV2StorageLoadSuccess, ProcessSnapshotV2VsockLoadRequest, ProcessVmm,
-        ProcessVmnetAuthority, ProcessVmnetPacketIoBackendFactory, SerialGrantState,
-        SnapshotCreateSession, SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
-        default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
-        native_v2_platform_capture_is_terminal, prepare_process_snapshot_v2_network_restore_plan,
+        ProcessSessionDiagnostics, ProcessSessionExitStatus, ProcessSessionShutdownStatus,
+        ProcessSnapshotV2BalloonLoadRequest, ProcessSnapshotV2DiffLoadRequest,
+        ProcessSnapshotV2EntropyLoadRequest, ProcessSnapshotV2MemoryHotplugLoadRequest,
+        ProcessSnapshotV2MultiBlockLoadRequest, ProcessSnapshotV2MultiBlockLoadSuccess,
+        ProcessSnapshotV2NetworkLoadRequest, ProcessSnapshotV2NetworkRestorePlanError,
+        ProcessSnapshotV2RootLoadCompletion, ProcessSnapshotV2RootLoadRequest,
+        ProcessSnapshotV2RootLoadSuccess, ProcessSnapshotV2SerialLoadRequest,
+        ProcessSnapshotV2StorageLoadRequest, ProcessSnapshotV2StorageLoadSuccess,
+        ProcessSnapshotV2VsockLoadRequest, ProcessVmm, ProcessVmnetAuthority,
+        ProcessVmnetPacketIoBackendFactory, SerialGrantState, SnapshotCreateSession,
+        SnapshotV1LoadSuccess, SnapshotV2LoadSuccess, default_hvf_boot_run_loop_step_limit,
+        default_hvf_boot_session_config, native_v2_platform_capture_is_terminal,
+        prepare_process_snapshot_v2_network_restore_plan,
         prepare_process_snapshot_v2_vsock_candidate, require_native_v1_composite_record,
         snapshot_destination_machine_config, vsock_capture_error_from_boot_run_loop_command,
     };
@@ -36590,6 +37089,8 @@ mod tests {
         memory_hotplug_status_count: usize,
         last_memory_hotplug_status_requested_size_mib: Option<u64>,
         memory_hotplug_status_result: Option<Result<MemoryHotplugStatus, MemoryHotplugStatusError>>,
+        process_exit_status: ProcessSessionExitStatus,
+        shutdown_status: ProcessSessionShutdownStatus,
     }
 
     impl FakeSession {
@@ -36666,7 +37167,21 @@ mod tests {
                 memory_hotplug_status_count: 0,
                 last_memory_hotplug_status_requested_size_mib: None,
                 memory_hotplug_status_result: None,
+                process_exit_status: ProcessSessionExitStatus::Running,
+                shutdown_status: ProcessSessionShutdownStatus::Succeeded,
             }
+        }
+
+        fn with_process_exit_status(id: u64, status: ProcessSessionExitStatus) -> Self {
+            let mut session = Self::new(id);
+            session.process_exit_status = status;
+            session
+        }
+
+        fn with_shutdown_status(id: u64, status: ProcessSessionShutdownStatus) -> Self {
+            let mut session = Self::new(id);
+            session.shutdown_status = status;
+            session
         }
 
         fn with_block_update_result(id: u64, result: DriveUpdateError) -> Self {
@@ -37104,6 +37619,14 @@ mod tests {
                 None => Ok(MemoryHotplugStatus::new(config, 0, requested_size_mib)),
             }
         }
+
+        fn process_exit_status(&self) -> ProcessSessionExitStatus {
+            self.process_exit_status
+        }
+
+        fn shutdown(&mut self) -> ProcessSessionShutdownStatus {
+            self.shutdown_status
+        }
     }
 
     impl SnapshotCreateSession for FakeSession {
@@ -37157,9 +37680,10 @@ mod tests {
             storage_configs,
             network_configs,
             mmds_config,
+            mmds_state: _,
             vsock_config,
             expected_transport: transport,
-            ..
+            cancellation,
         } = request;
         let has_block = !storage_configs.drives().is_empty();
         let has_pmem = !storage_configs.pmem().is_empty();
@@ -37178,17 +37702,24 @@ mod tests {
         destination
             .publish(|mut writer| {
                 session.native_snapshot_producer_count += 1;
+                if cancellation.is_cancelled() {
+                    return Err(NativeV2SnapshotPublicationProducerError::Capture(
+                        NativeV2SnapshotCaptureError::Cancelled {
+                            stage: NativeV2SnapshotCaptureStage::Source,
+                        },
+                    ));
+                }
                 let binding =
-                    write_snapshot_v2_memory_image_with_cancel(&memory, &mut writer, |_| false)
-                        .map_err(|source| {
-                            NativeV2SnapshotPublicationProducerError::Capture(
-                                NativeV2SnapshotCaptureError::Platform {
-                                    source: HvfArm64BootSnapshotV2CaptureError::MemoryImage {
-                                        source,
-                                    },
-                                },
-                            )
-                        })?;
+                    write_snapshot_v2_memory_image_with_cancel(&memory, &mut writer, |_| {
+                        cancellation.is_cancelled()
+                    })
+                    .map_err(|source| {
+                        NativeV2SnapshotPublicationProducerError::Capture(
+                            NativeV2SnapshotCaptureError::Platform {
+                                source: HvfArm64BootSnapshotV2CaptureError::MemoryImage { source },
+                            },
+                        )
+                    })?;
                 let memory = binding.encode().map_err(|source| {
                     NativeV2SnapshotPublicationProducerError::Capture(
                         NativeV2SnapshotCaptureError::Encode {
@@ -39399,7 +39930,7 @@ mod tests {
         fn process_exit_status(&self) -> super::ProcessSessionExitStatus {
             match self {
                 Self::StepLimitReached | Self::Wakeup => super::ProcessSessionExitStatus::Running,
-                Self::Terminal => super::ProcessSessionExitStatus::GuestRequestedStop,
+                Self::Terminal => super::ProcessSessionExitStatus::GuestPoweroff,
             }
         }
     }
@@ -39411,7 +39942,11 @@ mod tests {
             super::ProcessSessionExitDecision::Continue
         );
         assert_eq!(
-            super::ProcessSessionExitStatus::GuestRequestedStop.decision(),
+            super::ProcessSessionExitStatus::GuestPoweroff.decision(),
+            super::ProcessSessionExitDecision::ExitSuccessfully
+        );
+        assert_eq!(
+            super::ProcessSessionExitStatus::GuestReset.decision(),
             super::ProcessSessionExitDecision::ExitSuccessfully
         );
         assert_eq!(
@@ -39426,13 +39961,13 @@ mod tests {
             super::BootRunLoopProcessExit::process_exit_status(
                 &super::HvfArm64BootRunLoopOutcome::GuestShutdown { steps: 1 },
             ),
-            super::ProcessSessionExitStatus::GuestRequestedStop
+            super::ProcessSessionExitStatus::GuestPoweroff
         );
         assert_eq!(
             super::BootRunLoopProcessExit::process_exit_status(
                 &super::HvfArm64BootRunLoopOutcome::GuestReset { steps: 1 },
             ),
-            super::ProcessSessionExitStatus::GuestRequestedStop
+            super::ProcessSessionExitStatus::GuestReset
         );
         assert_eq!(
             super::BootRunLoopProcessExit::process_exit_status(
@@ -39441,7 +39976,7 @@ mod tests {
                     reason: 1,
                 },
             ),
-            super::ProcessSessionExitStatus::Terminal
+            super::ProcessSessionExitStatus::WorkerExited
         );
     }
 
@@ -45697,6 +46232,113 @@ mod tests {
             fs::read_to_string(metrics.path()).expect("metrics output should read"),
             "{\"vmm\":{\"metrics_flush_count\":1}}\n{\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn snapshot_load_logger_closes_success_rejection_failure_and_cancellation() {
+        let (success_snapshot, success_input) =
+            native_v2_snapshot_load_fixture("snapshot-load-log-success", false);
+        let success_log = TempFilePath::create("private-snapshot-load-success-log");
+        let mut success = ProcessVmm::with_starter(
+            "snapshot-load-success",
+            "0.1.0",
+            "bangbang",
+            FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::Success),
+        );
+        success
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(success_log.path()),
+            ))
+            .expect("success logger should configure");
+        success
+            .handle_action(VmmAction::LoadSnapshot(success_input))
+            .expect("snapshot load should succeed");
+        assert_eq!(
+            fs::read_to_string(success_log.path()).expect("success log should read"),
+            "operation=snapshot-load outcome=succeeded\n"
+        );
+        success_snapshot.assert_no_staging();
+
+        let rejected_log = TempFilePath::create("private-snapshot-load-rejected-log");
+        let mut rejected = ProcessVmm::with_starter(
+            "snapshot-load-rejected",
+            "0.1.0",
+            "bangbang",
+            FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::Success),
+        );
+        rejected
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(rejected_log.path()),
+            ))
+            .expect("rejection logger should configure");
+        rejected
+            .handle_action(VmmAction::PutSerial(
+                SerialConfigInput::new().with_serial_out_path("/private/rejected-serial"),
+            ))
+            .expect("serial configuration should make the destination non-fresh");
+        assert!(
+            rejected
+                .handle_action(VmmAction::LoadSnapshot(snapshot_load_input(false)))
+                .is_err()
+        );
+        assert_eq!(
+            fs::read_to_string(rejected_log.path()).expect("rejection log should read"),
+            "operation=snapshot-load outcome=rejected\n"
+        );
+
+        let (failed_snapshot, failed_input) =
+            native_v2_snapshot_load_fixture("snapshot-load-log-failed", true);
+        let failed_log = TempFilePath::create("private-snapshot-load-failed-log");
+        let mut failed = ProcessVmm::with_starter(
+            "snapshot-load-failed",
+            "0.1.0",
+            "bangbang",
+            FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::ResumeFailure),
+        );
+        failed
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(failed_log.path()),
+            ))
+            .expect("failure logger should configure");
+        assert!(
+            failed
+                .handle_action(VmmAction::LoadSnapshot(failed_input))
+                .is_err()
+        );
+        assert_eq!(
+            fs::read_to_string(failed_log.path()).expect("failure log should read"),
+            "operation=snapshot-load outcome=failed\n"
+        );
+        failed_snapshot.assert_no_staging();
+
+        let (cancelled_snapshot, cancelled_input) =
+            native_v2_snapshot_load_fixture("snapshot-load-log-cancelled", false);
+        let cancellation = NativeV2SnapshotCaptureCancellation::default();
+        let cancelled_log = TempFilePath::create("private-snapshot-load-cancelled-log");
+        let mut cancelled = ProcessVmm::with_starter(
+            "snapshot-load-cancelled",
+            "0.1.0",
+            "bangbang",
+            FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::Success),
+        )
+        .with_snapshot_capture_cancellation(cancellation.clone());
+        cancelled
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(cancelled_log.path()),
+            ))
+            .expect("cancellation logger should configure");
+        cancellation.cancel();
+        assert!(
+            cancelled
+                .handle_action(VmmAction::LoadSnapshot(cancelled_input))
+                .is_err()
+        );
+        assert_eq!(
+            fs::read_to_string(cancelled_log.path()).expect("cancellation log should read"),
+            "operation=snapshot-load outcome=cancelled\n"
+        );
+        cancelled_snapshot.assert_no_staging();
     }
 
     #[cfg(target_os = "macos")]
@@ -53837,7 +54479,7 @@ mod tests {
         );
         assert_eq!(
             supervisor.process_exit_status(),
-            super::ProcessSessionExitStatus::GuestRequestedStop
+            super::ProcessSessionExitStatus::GuestPoweroff
         );
         assert!(supervisor.process_exit_wakeup_fd().is_some());
         supervisor
@@ -55619,7 +56261,7 @@ mod tests {
         );
         assert_eq!(
             supervisor.process_exit_status(),
-            super::ProcessSessionExitStatus::Terminal
+            super::ProcessSessionExitStatus::WorkerFailed
         );
         supervisor
             .drain_process_exit_wakeup()
@@ -55982,6 +56624,71 @@ mod tests {
             .expect("started session should remain available");
         assert_eq!(session.pause_count, 1);
         assert_eq!(session.resume_count, 0);
+    }
+
+    #[test]
+    fn lifecycle_logger_distinguishes_pause_resume_results_without_error_payloads() {
+        let output = TempFilePath::create("pause-resume-lifecycle");
+        let mut vmm = configured_vmm(FakeStarter::success(121));
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new()
+                .with_log_path(output.path())
+                .with_level(LoggerLevel::Debug),
+        ))
+        .expect("logger should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("startup should succeed");
+        vmm.handle_action(VmmAction::Pause)
+            .expect("pause should succeed");
+        vmm.handle_action(VmmAction::Pause)
+            .expect("duplicate pause should succeed");
+        vmm.handle_action(VmmAction::Resume)
+            .expect("resume should succeed");
+        vmm.handle_action(VmmAction::Resume)
+            .expect("duplicate resume should succeed");
+
+        let output = fs::read_to_string(output.path()).expect("logger output should read");
+        for expected in [
+            "operation=vm-pause outcome=succeeded\n",
+            "operation=vm-pause outcome=unchanged\n",
+            "operation=vm-resume outcome=succeeded\n",
+            "operation=vm-resume outcome=unchanged\n",
+        ] {
+            assert_eq!(output.matches(expected).count(), 1);
+        }
+
+        let failed_output = TempFilePath::create("pause-lifecycle-failed");
+        let mut failed = configured_vmm(FakeStarter::success_with_session(
+            FakeSession::with_pause_result(
+                122,
+                BackendError::Hypervisor("private-pause-error".to_owned()),
+            ),
+        ));
+        failed
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(failed_output.path()),
+            ))
+            .expect("logger should configure");
+        failed
+            .handle_action(VmmAction::InstanceStart)
+            .expect("startup should succeed");
+        assert!(failed.handle_action(VmmAction::Pause).is_err());
+        let output = fs::read_to_string(failed_output.path()).expect("logger output should read");
+        assert!(output.contains("operation=vm-pause outcome=failed\n"));
+        assert!(!output.contains("private-pause-error"));
+
+        let rejected_output = TempFilePath::create("pause-lifecycle-rejected");
+        let mut rejected = configured_vmm(FakeStarter::success(123));
+        rejected
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(rejected_output.path()),
+            ))
+            .expect("logger should configure");
+        assert!(rejected.handle_action(VmmAction::Pause).is_err());
+        assert_eq!(
+            fs::read_to_string(rejected_output.path()).expect("logger output should read"),
+            "operation=vm-pause outcome=rejected\n"
+        );
     }
 
     #[test]
@@ -56886,6 +57593,208 @@ mod tests {
             .expect("started session should remain available");
         assert_eq!(session.snapshot_create_barrier_count, 0);
         assert_eq!(session.native_snapshot_publication_count, 0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn snapshot_create_logger_closes_success_rejection_failure_and_cancellation() {
+        let success_directory = TempSnapshotDirectory::new("snapshot-log-success");
+        let success_paths = success_directory.paths();
+        let success_log = TempFilePath::create("private-snapshot-success-log");
+        let mut success = snapshot_profile_vmm(FakeStarter::success(127));
+        success
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(success_log.path()),
+            ))
+            .expect("success logger should configure");
+        success
+            .handle_action(VmmAction::InstanceStart)
+            .expect("success source should start");
+        success
+            .handle_action(VmmAction::Pause)
+            .expect("success source should pause");
+        success
+            .handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
+                SnapshotType::Full,
+                success_paths.state(),
+                success_paths.memory(),
+            )))
+            .expect("snapshot should succeed");
+        let output = fs::read_to_string(success_log.path()).expect("success log should read");
+        assert!(output.contains("operation=snapshot-create outcome=succeeded\n"));
+        assert!(
+            !output.contains(
+                success_paths
+                    .state()
+                    .to_str()
+                    .expect("success state path should be UTF-8")
+            )
+        );
+        assert!(
+            !output.contains(
+                success_paths
+                    .memory()
+                    .to_str()
+                    .expect("success memory path should be UTF-8")
+            )
+        );
+
+        let rejected_log = TempFilePath::create("private-snapshot-rejected-log");
+        let mut rejected = configured_vmm(FakeStarter::success(128));
+        rejected
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(rejected_log.path()),
+            ))
+            .expect("rejection logger should configure");
+        assert!(
+            rejected
+                .handle_action(snapshot_create_action(SnapshotType::Full))
+                .is_err()
+        );
+        assert_eq!(
+            fs::read_to_string(rejected_log.path()).expect("rejection log should read"),
+            "operation=snapshot-create outcome=rejected\n"
+        );
+
+        let failed_directory = TempSnapshotDirectory::new("snapshot-log-failed");
+        let failed_paths = failed_directory.paths();
+        fs::write(failed_paths.state(), b"private-existing-snapshot-state")
+            .expect("existing snapshot state should create a publication collision");
+        let failed_log = TempFilePath::create("private-snapshot-failed-log");
+        let mut failed = snapshot_profile_vmm(FakeStarter::success(129));
+        failed
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(failed_log.path()),
+            ))
+            .expect("failure logger should configure");
+        failed
+            .handle_action(VmmAction::InstanceStart)
+            .expect("failure source should start");
+        failed
+            .handle_action(VmmAction::Pause)
+            .expect("failure source should pause");
+        assert!(
+            failed
+                .handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
+                    SnapshotType::Full,
+                    failed_paths.state(),
+                    failed_paths.memory(),
+                )))
+                .is_err()
+        );
+        let output = fs::read_to_string(failed_log.path()).expect("failure log should read");
+        assert!(output.contains("operation=snapshot-create outcome=failed\n"));
+        assert!(
+            !output.contains(
+                failed_paths
+                    .state()
+                    .to_str()
+                    .expect("failed state path should be UTF-8")
+            )
+        );
+        assert!(
+            !output.contains(
+                failed_paths
+                    .memory()
+                    .to_str()
+                    .expect("failed memory path should be UTF-8")
+            )
+        );
+
+        let cancellation = NativeV2SnapshotCaptureCancellation::default();
+        let cancelled_directory = TempSnapshotDirectory::new("snapshot-log-cancelled");
+        let cancelled_paths = cancelled_directory.paths();
+        let cancelled_log = TempFilePath::create("private-snapshot-cancelled-log");
+        let mut cancelled = snapshot_profile_vmm(FakeStarter::success(130))
+            .with_snapshot_capture_cancellation(cancellation.clone());
+        cancelled
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(cancelled_log.path()),
+            ))
+            .expect("cancellation logger should configure");
+        cancelled
+            .handle_action(VmmAction::InstanceStart)
+            .expect("cancelled source should start");
+        cancelled
+            .handle_action(VmmAction::Pause)
+            .expect("cancelled source should pause");
+        cancellation.cancel();
+        assert!(
+            cancelled
+                .handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
+                    SnapshotType::Full,
+                    cancelled_paths.state(),
+                    cancelled_paths.memory(),
+                )))
+                .is_err()
+        );
+        let output = fs::read_to_string(cancelled_log.path()).expect("cancelled log should read");
+        assert!(output.contains("operation=snapshot-create outcome=cancelled\n"));
+        assert!(
+            !output.contains(
+                cancelled_paths
+                    .state()
+                    .to_str()
+                    .expect("cancelled state path should be UTF-8")
+            )
+        );
+        assert!(
+            !output.contains(
+                cancelled_paths
+                    .memory()
+                    .to_str()
+                    .expect("cancelled memory path should be UTF-8")
+            )
+        );
+
+        let preflight_directory = TempSnapshotDirectory::new("snapshot-log-preflight-cancelled");
+        let preflight_paths = preflight_directory.paths();
+        let preflight_log = TempFilePath::create("private-snapshot-preflight-cancelled-log");
+        let mut preflight_cancelled = snapshot_profile_vmm(
+            FakeStarter::success(131).with_snapshot_storage_preflight_failure(
+                HvfArm64BootStorageCaptureError::cancelled(),
+            ),
+        );
+        preflight_cancelled
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(preflight_log.path()),
+            ))
+            .expect("preflight cancellation logger should configure");
+        preflight_cancelled
+            .handle_action(VmmAction::InstanceStart)
+            .expect("preflight cancellation source should start");
+        preflight_cancelled
+            .handle_action(VmmAction::Pause)
+            .expect("preflight cancellation source should pause");
+        assert!(
+            preflight_cancelled
+                .handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
+                    SnapshotType::Full,
+                    preflight_paths.state(),
+                    preflight_paths.memory(),
+                )))
+                .is_err()
+        );
+        let output = fs::read_to_string(preflight_log.path())
+            .expect("preflight cancellation log should read");
+        assert!(output.contains("operation=snapshot-create outcome=cancelled\n"));
+        assert!(!output.contains("operation=snapshot-create outcome=rejected\n"));
+        assert!(
+            !output.contains(
+                preflight_paths
+                    .state()
+                    .to_str()
+                    .expect("preflight cancellation state path should be UTF-8")
+            )
+        );
+        assert!(
+            !output.contains(
+                preflight_paths
+                    .memory()
+                    .to_str()
+                    .expect("preflight cancellation memory path should be UTF-8")
+            )
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -62895,8 +63804,13 @@ mod tests {
         let block = TempFilePath::create("mixed-runtime-block");
         let second_block = TempFilePath::create("mixed-runtime-second-block");
         let pmem = TempFilePath::create_with_bytes("mixed-runtime-pmem", b"pmem");
+        let logger = TempFilePath::create("mixed-runtime-logger");
         let mut vmm = configured_vmm(FakeStarter::success(88));
         vmm.pci_enabled = true;
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new().with_log_path(logger.path()),
+        ))
+        .expect("logger should configure before startup");
         vmm.handle_action(VmmAction::PutDrive(DriveConfigInput::new(
             "rootfs",
             "rootfs",
@@ -63062,6 +63976,164 @@ mod tests {
                 "block:remove:shared",
             ]
         );
+
+        let output = fs::read_to_string(logger.path()).expect("logger output should read");
+        for (kind, attach_count, update_count, detach_count) in
+            [("block", 2, 1, 2), ("network", 2, 0, 2), ("pmem", 2, 0, 2)]
+        {
+            assert_eq!(
+                output
+                    .matches(&format!(
+                        "device-kind={kind} operation=device-attach outcome=succeeded\n"
+                    ))
+                    .count(),
+                attach_count
+            );
+            assert_eq!(
+                output
+                    .matches(&format!(
+                        "device-kind={kind} operation=device-update outcome=succeeded\n"
+                    ))
+                    .count(),
+                update_count
+            );
+            assert_eq!(
+                output
+                    .matches(&format!(
+                        "device-kind={kind} operation=device-detach outcome=succeeded\n"
+                    ))
+                    .count(),
+                detach_count
+            );
+        }
+        assert_eq!(
+            output
+                .matches("device-kind=pmem operation=device-update outcome=rejected\n")
+                .count(),
+            1
+        );
+        assert_eq!(
+            output
+                .matches("device-kind=network operation=device-update outcome=rejected\n")
+                .count(),
+            1
+        );
+        assert_eq!(
+            output
+                .matches("device-kind=network operation=device-attach outcome=rejected\n")
+                .count(),
+            1
+        );
+        for forbidden in [
+            SHARED_ID,
+            SHARED_MAC,
+            "vmnet:shared",
+            root.path().to_str().expect("root path should be UTF-8"),
+            block.path().to_str().expect("block path should be UTF-8"),
+            pmem.path().to_str().expect("pmem path should be UTF-8"),
+        ] {
+            assert!(!output.contains(forbidden), "logger leaked {forbidden:?}");
+        }
+    }
+
+    #[test]
+    fn live_device_backend_failures_use_closed_kind_and_operation_only() {
+        let block_backing = TempFilePath::create("private-block-backing");
+        let block_log = TempFilePath::create("private-block-log");
+        let mut block = configured_vmm(FakeStarter::success_with_session(
+            FakeSession::with_block_insert_result(
+                124,
+                DriveRuntimeMutationError::PublishDevice {
+                    message: "private-block-backend-error".to_owned(),
+                },
+            ),
+        ));
+        block.pci_enabled = true;
+        block
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(block_log.path()),
+            ))
+            .expect("block logger should configure");
+        block
+            .handle_action(VmmAction::InstanceStart)
+            .expect("block VM should start");
+        assert!(
+            block
+                .handle_action(VmmAction::PutDrive(DriveConfigInput::new(
+                    "private_block_id",
+                    "private_block_id",
+                    block_backing.path(),
+                    false,
+                )))
+                .is_err()
+        );
+        let output = fs::read_to_string(block_log.path()).expect("block logger should read");
+        assert!(output.contains("device-kind=block operation=device-attach outcome=failed\n"));
+        assert!(!output.contains("private_block_id"));
+        assert!(!output.contains("private-block-backend-error"));
+
+        let network_log = TempFilePath::create("private-network-log");
+        let mut network = configured_vmm(FakeStarter::success_with_session(
+            FakeSession::with_network_insert_result(
+                125,
+                NetworkRuntimeMutationError::PublishDevice {
+                    message: "private-network-backend-error".to_owned(),
+                },
+            ),
+        ));
+        network.pci_enabled = true;
+        network
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(network_log.path()),
+            ))
+            .expect("network logger should configure");
+        network
+            .handle_action(VmmAction::InstanceStart)
+            .expect("network VM should start");
+        assert!(
+            network
+                .handle_action(VmmAction::PutNetworkInterface(
+                    NetworkInterfaceConfigInput::new(
+                        "private_network_id",
+                        "private_network_id",
+                        "vmnet:private-network-host",
+                    ),
+                ))
+                .is_err()
+        );
+        let output = fs::read_to_string(network_log.path()).expect("network logger should read");
+        assert!(output.contains("device-kind=network operation=device-attach outcome=failed\n"));
+        assert!(!output.contains("private_network_id"));
+        assert!(!output.contains("private-network-backend-error"));
+
+        let pmem_backing = TempFilePath::create_with_bytes("private-pmem-backing", b"pmem");
+        let pmem_log = TempFilePath::create("private-pmem-log");
+        let mut pmem = configured_vmm(FakeStarter::success_with_session(
+            FakeSession::with_pmem_insert_result(
+                126,
+                PmemRuntimeMutationError::PublishDevice {
+                    message: "private-pmem-backend-error".to_owned(),
+                },
+            ),
+        ));
+        pmem.pci_enabled = true;
+        pmem.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new().with_log_path(pmem_log.path()),
+        ))
+        .expect("pmem logger should configure");
+        pmem.handle_action(VmmAction::InstanceStart)
+            .expect("pmem VM should start");
+        assert!(
+            pmem.handle_action(VmmAction::PutPmem(PmemConfigInput::new(
+                "private_pmem_id",
+                pmem_backing.path().display().to_string(),
+            )))
+            .is_err()
+        );
+        let output = fs::read_to_string(pmem_log.path()).expect("pmem logger should read");
+        assert!(output.contains("device-kind=pmem operation=device-attach outcome=failed\n"));
+        assert!(!output.contains("private_pmem_id"));
+        assert!(!output.contains("private-pmem-backend-error"));
     }
 
     #[test]
@@ -63955,7 +65027,12 @@ mod tests {
         );
         assert_eq!(
             fs::read_to_string(logger.path()).expect("logger output should read"),
-            "action=InstanceStart\n"
+            concat!(
+                "operation=backend-startup outcome=succeeded\n",
+                "action=InstanceStart\n",
+                "operation=boot-worker outcome=running\n",
+                "operation=vm-start outcome=succeeded\n",
+            )
         );
     }
 
@@ -63998,7 +65075,12 @@ mod tests {
         );
         assert_eq!(
             fs::read_to_string(logger.path()).expect("logger output should read"),
-            "action=InstanceStart\n"
+            concat!(
+                "operation=backend-startup outcome=succeeded\n",
+                "action=InstanceStart\n",
+                "operation=boot-worker outcome=running\n",
+                "operation=vm-start outcome=succeeded\n",
+            )
         );
     }
 
@@ -64028,12 +65110,202 @@ mod tests {
         assert_eq!(
             fs::read_to_string(output.path()).expect("combined output should read"),
             concat!(
+                "operation=backend-startup outcome=succeeded\n",
                 "action=InstanceStart\n",
+                "operation=boot-worker outcome=running\n",
+                "operation=vm-start outcome=succeeded\n",
                 "{\"vmm\":{\"metrics_flush_count\":1}}\n",
+                "operation=vm-stop outcome=succeeded\n",
+                "operation=shutdown outcome=orderly\n",
                 "event=process-exit category=success\n",
                 "{\"vmm\":{\"metrics_flush_count\":1}}\n",
             )
         );
+    }
+
+    #[test]
+    fn terminal_convergence_orders_signal_worker_stop_vm_stop_and_final_record_once() {
+        let output = TempFilePath::create("terminal-convergence-signal");
+        let mut vmm =
+            ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", FakeStarter::success(19));
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new()
+                .with_log_path(output.path())
+                .with_level(LoggerLevel::Debug),
+        ))
+        .expect("logger should configure");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/private/terminal-kernel",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("startup should succeed");
+
+        vmm.record_shutdown_wakeup();
+        vmm.handle_terminal_observability(ProcessTerminalCategory::Success);
+        vmm.handle_terminal_observability(ProcessTerminalCategory::Panic);
+
+        let output = fs::read_to_string(output.path()).expect("logger output should read");
+        assert_eq!(
+            output,
+            concat!(
+                "operation=backend-startup outcome=succeeded\n",
+                "action=InstanceStart\n",
+                "operation=boot-worker outcome=running\n",
+                "operation=vm-start outcome=succeeded\n",
+                "operation=host-signal outcome=received\n",
+                "operation=boot-worker outcome=stopped\n",
+                "operation=vm-stop outcome=succeeded\n",
+                "operation=shutdown outcome=orderly\n",
+                "event=process-exit category=success\n",
+            )
+        );
+        assert!(!output.contains("terminal-kernel"));
+    }
+
+    #[test]
+    fn terminal_cleanup_failure_is_logged_without_replacing_terminal_category() {
+        let output = TempFilePath::create("terminal-convergence-failure");
+        let session = FakeSession::with_shutdown_status(20, ProcessSessionShutdownStatus::Failed);
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            "0.1.0",
+            "bangbang",
+            FakeStarter::success_with_session(session),
+        );
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new()
+                .with_log_path(output.path())
+                .with_level(LoggerLevel::Debug),
+        ))
+        .expect("logger should configure");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/private/failing-cleanup-kernel",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("startup should succeed");
+
+        vmm.handle_terminal_observability(ProcessTerminalCategory::Success);
+
+        let output = fs::read_to_string(output.path()).expect("logger output should read");
+        assert!(output.contains("operation=boot-worker outcome=stopped\n"));
+        assert!(output.contains("operation=vm-stop outcome=failed\n"));
+        assert!(output.contains("operation=shutdown outcome=abnormal\n"));
+        assert!(output.ends_with("event=process-exit category=success\n"));
+        assert!(!output.contains("failing-cleanup-kernel"));
+    }
+
+    #[test]
+    fn process_exit_observation_distinguishes_guest_and_worker_outcomes_once() {
+        for (status, decision, expected_worker, expected_power) in [
+            (
+                ProcessSessionExitStatus::GuestPoweroff,
+                super::ProcessSessionExitDecision::ExitSuccessfully,
+                "operation=boot-worker outcome=exited\n",
+                Some("operation=guest-power outcome=poweroff\n"),
+            ),
+            (
+                ProcessSessionExitStatus::GuestReset,
+                super::ProcessSessionExitDecision::ExitSuccessfully,
+                "operation=boot-worker outcome=exited\n",
+                Some("operation=guest-power outcome=reset\n"),
+            ),
+            (
+                ProcessSessionExitStatus::WorkerExited,
+                super::ProcessSessionExitDecision::ExitWithFailure,
+                "operation=boot-worker outcome=exited\n",
+                None,
+            ),
+            (
+                ProcessSessionExitStatus::WorkerFailed,
+                super::ProcessSessionExitDecision::ExitWithFailure,
+                "operation=boot-worker outcome=failed\n",
+                None,
+            ),
+        ] {
+            let output = TempFilePath::create("process-exit-observation");
+            let session = FakeSession::with_process_exit_status(21, status);
+            let mut vmm = ProcessVmm::with_starter(
+                "demo-1",
+                "0.1.0",
+                "bangbang",
+                FakeStarter::success_with_session(session),
+            );
+            vmm.handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(output.path()),
+            ))
+            .expect("logger should configure");
+            vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                "/private/guest-kernel",
+            )))
+            .expect("boot source should configure");
+            vmm.handle_action(VmmAction::InstanceStart)
+                .expect("startup should succeed");
+
+            assert_eq!(vmm.process_exit_status(), status);
+            assert_eq!(vmm.process_exit_status().decision(), decision);
+            let _ = vmm
+                .controller
+                .log_lifecycle(LoggerLifecycleOutcome::VmStopSucceeded);
+
+            let output = fs::read_to_string(output.path()).expect("logger output should read");
+            assert_eq!(output.matches(expected_worker).count(), 1);
+            if let Some(expected_power) = expected_power {
+                assert_eq!(output.matches(expected_power).count(), 1);
+            } else {
+                assert!(!output.contains("operation=guest-power"));
+            }
+            assert!(!output.contains("guest-kernel"));
+        }
+    }
+
+    #[test]
+    fn start_rejection_and_backend_failure_are_closed_and_redacted() {
+        let rejected_output = TempFilePath::create("start-rejected");
+        let mut rejected =
+            ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", FakeStarter::success(22));
+        rejected
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(rejected_output.path()),
+            ))
+            .expect("logger should configure");
+        assert!(rejected.handle_action(VmmAction::InstanceStart).is_err());
+        assert_eq!(
+            fs::read_to_string(rejected_output.path()).expect("rejected logger should read"),
+            "operation=vm-start outcome=rejected\n"
+        );
+
+        let failed_output = TempFilePath::create("start-failed");
+        let mut failed = ProcessVmm::with_starter(
+            "demo-2",
+            "0.1.0",
+            "bangbang",
+            FakeStarter::failure(BackendError::Hypervisor(
+                "private-backend-start-sentinel".to_owned(),
+            )),
+        );
+        failed
+            .handle_action(VmmAction::PutLogger(
+                LoggerConfigInput::new().with_log_path(failed_output.path()),
+            ))
+            .expect("logger should configure");
+        failed
+            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                "/private/failing-kernel",
+            )))
+            .expect("boot source should configure");
+        assert!(failed.handle_action(VmmAction::InstanceStart).is_err());
+        let output = fs::read_to_string(failed_output.path()).expect("failed logger should read");
+        assert_eq!(
+            output,
+            concat!(
+                "operation=backend-startup outcome=failed\n",
+                "operation=vm-start outcome=failed\n",
+            )
+        );
+        assert!(!output.contains("private-backend-start-sentinel"));
+        assert!(!output.contains("failing-kernel"));
     }
 
     #[test]
@@ -64054,7 +65326,10 @@ mod tests {
 
         assert_eq!(
             fs::read_to_string(output.path()).expect("combined output should read"),
-            "event=process-exit category=configuration\n"
+            concat!(
+                "operation=shutdown outcome=abnormal\n",
+                "event=process-exit category=configuration\n",
+            )
         );
     }
 
@@ -64087,8 +65362,13 @@ mod tests {
         assert_eq!(
             fs::read_to_string(logger.path()).expect("logger output should read"),
             concat!(
+                "operation=backend-startup outcome=succeeded\n",
                 "action=InstanceStart\n",
+                "operation=boot-worker outcome=running\n",
+                "operation=vm-start outcome=succeeded\n",
                 "event=process-panic\n",
+                "operation=vm-stop outcome=succeeded\n",
+                "operation=shutdown outcome=abnormal\n",
                 "event=process-exit category=panic\n",
             )
         );

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -18205,6 +18205,9 @@ mod macos_arm64 {
             if record == "event=process-panic" || is_closed_control_logger_line(record) {
                 continue;
             }
+            if is_closed_host_outcome_logger_line(record) {
+                continue;
+            }
 
             assert!(
                 is_api_request_logger_line(record),
@@ -18285,6 +18288,9 @@ mod macos_arm64 {
     }
 
     fn expected_logger_record_level(record: &str) -> Option<&'static str> {
+        if let Some(level) = closed_host_outcome_logger_level(record) {
+            return Some(level);
+        }
         match record {
             "operation=server outcome=stopped" => Some("Debug"),
             "operation=connection outcome=failed"
@@ -18335,6 +18341,72 @@ mod macos_arm64 {
         )
     }
 
+    fn is_closed_host_outcome_logger_line(line: &str) -> bool {
+        closed_host_outcome_logger_level(line).is_some()
+    }
+
+    fn closed_host_outcome_logger_level(line: &str) -> Option<&'static str> {
+        let level = match line {
+            "operation=vm-pause outcome=unchanged"
+            | "operation=vm-resume outcome=unchanged"
+            | "operation=boot-worker outcome=stopped" => "Debug",
+            "operation=snapshot-create outcome=cancelled"
+            | "operation=snapshot-load outcome=cancelled" => "Warn",
+            "operation=backend-startup outcome=failed"
+            | "operation=vm-start outcome=rejected"
+            | "operation=vm-start outcome=failed"
+            | "operation=vm-pause outcome=rejected"
+            | "operation=vm-pause outcome=failed"
+            | "operation=vm-resume outcome=rejected"
+            | "operation=vm-resume outcome=failed"
+            | "operation=vm-stop outcome=failed"
+            | "operation=boot-worker outcome=failed"
+            | "operation=metrics-worker outcome=failed"
+            | "operation=snapshot-create outcome=rejected"
+            | "operation=snapshot-create outcome=failed"
+            | "operation=snapshot-load outcome=rejected"
+            | "operation=snapshot-load outcome=failed"
+            | "operation=shutdown outcome=abnormal" => "Error",
+            "operation=backend-startup outcome=succeeded"
+            | "operation=vm-start outcome=succeeded"
+            | "operation=vm-pause outcome=succeeded"
+            | "operation=vm-resume outcome=succeeded"
+            | "operation=vm-stop outcome=succeeded"
+            | "operation=boot-worker outcome=running"
+            | "operation=boot-worker outcome=exited"
+            | "operation=host-signal outcome=received"
+            | "operation=cancellation outcome=requested"
+            | "operation=guest-power outcome=poweroff"
+            | "operation=guest-power outcome=reset"
+            | "operation=shutdown outcome=orderly"
+            | "operation=snapshot-create outcome=succeeded"
+            | "operation=snapshot-load outcome=succeeded" => "Info",
+            _ => return closed_live_device_outcome_logger_level(line),
+        };
+        Some(level)
+    }
+
+    fn closed_live_device_outcome_logger_level(line: &str) -> Option<&'static str> {
+        let mut fields = line.split(' ');
+        let kind = fields.next()?.strip_prefix("device-kind=")?;
+        let operation = fields.next()?.strip_prefix("operation=")?;
+        let outcome = fields.next()?.strip_prefix("outcome=")?;
+        if fields.next().is_some()
+            || !matches!(kind, "block" | "network" | "pmem")
+            || !matches!(
+                operation,
+                "device-attach" | "device-update" | "device-detach"
+            )
+        {
+            return None;
+        }
+        match outcome {
+            "succeeded" => Some("Info"),
+            "rejected" | "failed" => Some("Error"),
+            _ => None,
+        }
+    }
+
     fn is_api_request_logger_line(line: &str) -> bool {
         let Some(rest) = line.strip_prefix("The API server received a ") else {
             return false;
@@ -18355,8 +18427,15 @@ mod macos_arm64 {
         });
 
         assert_eq!(
-            output, "action=InstanceStart\noperation=process-startup outcome=running\n",
-            "no-api logger output should include only action and process startup records"
+            output,
+            concat!(
+                "operation=backend-startup outcome=succeeded\n",
+                "action=InstanceStart\n",
+                "operation=boot-worker outcome=running\n",
+                "operation=vm-start outcome=succeeded\n",
+                "operation=process-startup outcome=running\n",
+            ),
+            "no-api logger output should include the closed startup lifecycle"
         );
     }
 
@@ -18400,6 +18479,31 @@ mod macos_arm64 {
              level=Info origin=crates/runtime/src/logger.rs:7 action=request outcome=no-content\n",
             LoggerPrefixExpectation::LevelOrigin,
         );
+    }
+
+    #[test]
+    fn logger_output_accepts_only_closed_host_outcomes_with_exact_levels() {
+        for (record, level) in [
+            ("operation=backend-startup outcome=succeeded", "Info"),
+            ("operation=vm-pause outcome=unchanged", "Debug"),
+            ("operation=boot-worker outcome=failed", "Error"),
+            ("operation=snapshot-load outcome=cancelled", "Warn"),
+            ("operation=guest-power outcome=reset", "Info"),
+            ("operation=shutdown outcome=abnormal", "Error"),
+            (
+                "device-kind=network operation=device-update outcome=rejected",
+                "Error",
+            ),
+        ] {
+            assert_eq!(closed_host_outcome_logger_level(record), Some(level));
+        }
+        for malformed in [
+            "operation=vm-start outcome=private-error",
+            "device-kind=private operation=device-update outcome=failed",
+            "device-kind=block operation=device-update outcome=failed id=secret",
+        ] {
+            assert_eq!(closed_host_outcome_logger_level(malformed), None);
+        }
     }
 
     #[test]

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -484,6 +484,8 @@ fn executable_logs_success_terminal_record_after_api_shutdown() {
         concat!(
             "operation=server outcome=running\n",
             "operation=process-startup outcome=running\n",
+            "operation=host-signal outcome=received\n",
+            "operation=shutdown outcome=orderly\n",
             "event=process-exit category=success\n",
         )
     );
@@ -511,7 +513,10 @@ fn executable_logs_configuration_terminal_record_after_logger_setup() {
     assert_eq!(output.status.code(), Some(BAD_CONFIGURATION_EXIT_CODE));
     assert_eq!(
         fs::read_to_string(&logger_path).expect("terminal logger output should be readable"),
-        "event=process-exit category=configuration\n"
+        concat!(
+            "operation=shutdown outcome=abnormal\n",
+            "event=process-exit category=configuration\n",
+        )
     );
 }
 
@@ -535,7 +540,10 @@ fn executable_logs_process_failure_terminal_record_after_logger_setup() {
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(
         fs::read_to_string(&logger_path).expect("terminal logger output should be readable"),
-        "event=process-exit category=process-failure\n"
+        concat!(
+            "operation=shutdown outcome=abnormal\n",
+            "event=process-exit category=process-failure\n",
+        )
     );
 }
 
@@ -1195,8 +1203,13 @@ fn executable_rejects_empty_mutating_api_requests_without_stopping() {
 fn executable_handles_sigint_shutdown_cleanly() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");
+    let logger_path = test_dir.path().join("sigint.log");
     let instance_id = test_dir.instance_id();
-    let bangbang = BangbangProcess::start(&socket_path, &instance_id);
+    let bangbang = BangbangProcess::start_with_extra_args(
+        &socket_path,
+        &instance_id,
+        &["--log-path", path_text(&logger_path)],
+    );
 
     assert!(
         socket_path.exists(),
@@ -1204,6 +1217,16 @@ fn executable_handles_sigint_shutdown_cleanly() {
     );
 
     assert_clean_shutdown(bangbang.interrupt(), &socket_path, "bangbang SIGINT");
+    assert_eq!(
+        fs::read_to_string(&logger_path).expect("SIGINT logger output should be readable"),
+        concat!(
+            "operation=server outcome=running\n",
+            "operation=process-startup outcome=running\n",
+            "operation=host-signal outcome=received\n",
+            "operation=shutdown outcome=orderly\n",
+            "event=process-exit category=success\n",
+        )
+    );
 }
 
 #[test]

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -16335,6 +16335,28 @@ impl OutputGrantFixture {
             has_terminal, terminal,
             "terminal logger output should follow the configured module filter"
         );
+        if terminal {
+            let logger = std::str::from_utf8(&logger)
+                .expect("granted logger output should remain valid UTF-8");
+            let mut previous = 0usize;
+            for expected in [
+                "operation=boot-worker outcome=exited\n",
+                "operation=guest-power outcome=poweroff\n",
+                "operation=vm-stop outcome=succeeded\n",
+                "operation=shutdown outcome=orderly\n",
+                "event=process-exit category=success\n",
+            ] {
+                let offset = logger[previous..]
+                    .find(expected)
+                    .map(|offset| previous + offset)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "terminal production logger should contain {expected:?} in order: {logger}"
+                        )
+                    });
+                previous = offset + expected.len();
+            }
+        }
 
         let metrics = fs::read_to_string(metrics_path).expect("granted metrics output should read");
         let seed = std::str::from_utf8(OUTPUT_METRICS_SEED).expect("metrics seed should be UTF-8");

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -725,6 +725,11 @@ impl VmmController {
         self.logger_state.boot_timer_logger()
     }
 
+    /// Returns the narrow process-owned asynchronous logger capability.
+    pub fn async_logger(&self) -> logger::AsyncLogger {
+        self.logger_state.async_logger()
+    }
+
     /// Returns the narrow panic-record admission handle for this controller.
     pub fn emergency_logger(&self) -> logger::EmergencyLogger {
         self.logger_state.emergency_logger()
@@ -1631,6 +1636,16 @@ impl VmmController {
     #[track_caller]
     fn log_action(&self, action: logger::LoggerAction) -> bool {
         self.logger_state.log_action(action)
+    }
+
+    #[track_caller]
+    pub fn log_lifecycle(&self, outcome: logger::LoggerLifecycleOutcome) -> bool {
+        self.logger_state.log_lifecycle(outcome)
+    }
+
+    #[track_caller]
+    pub fn log_snapshot(&self, outcome: logger::LoggerSnapshotOutcome) -> bool {
+        self.logger_state.log_snapshot(outcome)
     }
 
     #[track_caller]

--- a/crates/runtime/src/logger.rs
+++ b/crates/runtime/src/logger.rs
@@ -25,7 +25,9 @@ use rate_limiter::{LogRateLimitDecision, LoggerRateLimitIdentity, LoggerRateLimi
 
 pub use event::{
     LoggerAction, LoggerApiControlOutcome, LoggerApiResultOutcome, LoggerApiRoute,
-    LoggerHttpMethod, PanicLogRecords, ProcessStartupOutcome, ProcessTerminalCategory,
+    LoggerApiWorkerOutcome, LoggerDeviceKind, LoggerHttpMethod, LoggerLifecycleOutcome,
+    LoggerObservabilityOutcome, LoggerProcessSignalOutcome, LoggerSnapshotOutcome, PanicLogRecords,
+    ProcessStartupOutcome, ProcessTerminalCategory,
 };
 pub use process_stdout::{ProcessStdoutLogger, ProcessStdoutLoggerError};
 
@@ -34,6 +36,9 @@ const API_REQUEST_LOG_MODULE: &str = "bangbang_runtime::api_server";
 const MINIMAL_ACTION_LOG_MODULE: &str = "bangbang_runtime::vmm_action";
 const PROCESS_LOG_MODULE: &str = "bangbang::process";
 const PANIC_LOG_MODULE: &str = "bangbang::panic";
+const LIFECYCLE_LOG_MODULE: &str = "bangbang_runtime::lifecycle";
+const SNAPSHOT_LOG_MODULE: &str = "bangbang_runtime::snapshot";
+const WORKER_LOG_MODULE: &str = "bangbang::worker";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum LoggerLevel {
@@ -433,6 +438,25 @@ impl BootTimerLogRateLimiter {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct ObservabilityWorkerLogRateLimiter {
+    inner: LoggerRateLimiters,
+}
+
+impl ObservabilityWorkerLogRateLimiter {
+    #[cfg(test)]
+    fn with_clock(clock: Arc<dyn LogRateLimiterClock>) -> Self {
+        Self {
+            inner: LoggerRateLimiters::with_clock(clock),
+        }
+    }
+
+    fn check(&self) -> LogRateLimitDecision {
+        self.inner
+            .check(LoggerRateLimitIdentity::ObservabilityWorker)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BootTimerLogger {
     producer: Option<LoggerProducer>,
@@ -489,7 +513,99 @@ impl BootTimerLogger {
             LogBatch::two(recovery, boot)
         };
 
-        producer.deliver_guest(batch)
+        producer.deliver_nonblocking(batch)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn wait_for_delivery_for_test(&self) -> bool {
+        self.producer
+            .as_ref()
+            .is_none_or(LoggerProducer::wait_for_idle_for_test)
+    }
+}
+
+/// Narrow, cloneable admission capability for process-owned asynchronous events.
+#[derive(Debug, Clone)]
+pub struct AsyncLogger {
+    producer: Option<LoggerProducer>,
+    level: LoggerLevel,
+    show_level: bool,
+    show_log_origin: bool,
+    module: Option<String>,
+    metrics: SharedLoggerMetrics,
+    observability_rate_limiter: ObservabilityWorkerLogRateLimiter,
+}
+
+impl AsyncLogger {
+    #[track_caller]
+    pub fn log_api_worker(&self, outcome: LoggerApiWorkerOutcome) -> bool {
+        self.log_unrestricted(outcome.level(), LoggerEvent::ApiWorker(outcome))
+    }
+
+    #[track_caller]
+    pub fn log_process_signal(&self, outcome: LoggerProcessSignalOutcome) -> bool {
+        self.log_unrestricted(outcome.level(), LoggerEvent::ProcessSignal(outcome))
+    }
+
+    #[track_caller]
+    pub fn log_observability(&self, outcome: LoggerObservabilityOutcome) -> bool {
+        let level = outcome.level();
+        if !self.level.allows(level)
+            || !module_filter_allows(self.module.as_deref(), WORKER_LOG_MODULE)
+        {
+            return false;
+        }
+        let Some(producer) = &self.producer else {
+            return false;
+        };
+        let suppressed = match self.observability_rate_limiter.check() {
+            LogRateLimitDecision::Admitted { suppressed } => suppressed,
+            LogRateLimitDecision::Denied => {
+                self.metrics.record_rate_limited_log();
+                return false;
+            }
+        };
+        let origin = LogOrigin::from(Location::caller());
+        let outcome = LogRecord::encode(
+            self.show_level,
+            self.show_log_origin,
+            origin,
+            level,
+            LoggerEvent::Observability(outcome),
+        );
+        let batch = if suppressed == 0 {
+            LogBatch::one(outcome)
+        } else {
+            let recovery = LogRecord::encode(
+                self.show_level,
+                self.show_log_origin,
+                origin,
+                LoggerLevel::Warn,
+                LoggerEvent::RateLimitRecovery { suppressed },
+            );
+            LogBatch::two(recovery, outcome)
+        };
+        producer.deliver_nonblocking(batch)
+    }
+
+    #[track_caller]
+    fn log_unrestricted(&self, level: LoggerLevel, event: LoggerEvent) -> bool {
+        if !self.level.allows(level)
+            || !module_filter_allows(self.module.as_deref(), WORKER_LOG_MODULE)
+        {
+            return false;
+        }
+        let Some(producer) = &self.producer else {
+            return false;
+        };
+        let record = LogRecord::encode(
+            self.show_level,
+            self.show_log_origin,
+            LogOrigin::from(Location::caller()),
+            level,
+            event,
+        );
+        producer.deliver_nonblocking(LogBatch::one(record))
     }
 
     #[cfg(test)]
@@ -510,6 +626,7 @@ pub struct LoggerState {
     panic_records: Arc<PanicLogRecords>,
     emergency_logger: EmergencyLogger,
     boot_timer_rate_limiter: BootTimerLogRateLimiter,
+    observability_rate_limiter: ObservabilityWorkerLogRateLimiter,
     delivery_config: LoggerDeliveryConfig,
 }
 
@@ -524,6 +641,10 @@ impl fmt::Debug for LoggerState {
             .field("module", &self.module.as_ref().map(|_| "<redacted>"))
             .field("metrics", &self.metrics)
             .field("boot_timer_rate_limiter", &self.boot_timer_rate_limiter)
+            .field(
+                "observability_rate_limiter",
+                &self.observability_rate_limiter,
+            )
             .field("delivery_config", &self.delivery_config)
             .finish()
     }
@@ -565,6 +686,7 @@ impl LoggerState {
             panic_records,
             emergency_logger,
             boot_timer_rate_limiter: BootTimerLogRateLimiter::default(),
+            observability_rate_limiter: ObservabilityWorkerLogRateLimiter::default(),
             delivery_config: LoggerDeliveryConfig::default(),
         }
     }
@@ -843,6 +965,60 @@ impl LoggerState {
         }
     }
 
+    pub fn async_logger(&self) -> AsyncLogger {
+        AsyncLogger {
+            producer: self.delivery.as_ref().map(LoggerDelivery::producer),
+            level: self.level,
+            show_level: self.show_level,
+            show_log_origin: self.show_log_origin,
+            module: self.module.clone(),
+            metrics: self.metrics.clone(),
+            observability_rate_limiter: self.observability_rate_limiter.clone(),
+        }
+    }
+
+    #[track_caller]
+    pub fn log_lifecycle(&self, outcome: LoggerLifecycleOutcome) -> bool {
+        let level = outcome.level();
+        if !self.level.allows(level)
+            || !module_filter_allows(self.module.as_deref(), LIFECYCLE_LOG_MODULE)
+        {
+            return false;
+        }
+        let Some(delivery) = &self.delivery else {
+            return false;
+        };
+        let record = LogRecord::encode(
+            self.show_level,
+            self.show_log_origin,
+            LogOrigin::from(Location::caller()),
+            level,
+            LoggerEvent::Lifecycle(outcome),
+        );
+        delivery.producer().deliver_host(LogBatch::one(record))
+    }
+
+    #[track_caller]
+    pub fn log_snapshot(&self, outcome: LoggerSnapshotOutcome) -> bool {
+        let level = outcome.level();
+        if !self.level.allows(level)
+            || !module_filter_allows(self.module.as_deref(), SNAPSHOT_LOG_MODULE)
+        {
+            return false;
+        }
+        let Some(delivery) = &self.delivery else {
+            return false;
+        };
+        let record = LogRecord::encode(
+            self.show_level,
+            self.show_log_origin,
+            LogOrigin::from(Location::caller()),
+            level,
+            LoggerEvent::Snapshot(outcome),
+        );
+        delivery.producer().deliver_host(LogBatch::one(record))
+    }
+
     #[track_caller]
     pub fn log_boot_timer(&self, wall_time_us: u64, cpu_time_us: u64) -> bool {
         self.boot_timer_logger()
@@ -909,9 +1085,12 @@ mod tests {
     use super::delivery::WorkerObserver;
     use super::{
         BootTimerLogRateLimiter, LogRateLimitDecision, LogRateLimiterClock, LoggerAction,
-        LoggerApiControlOutcome, LoggerApiResultOutcome, LoggerApiRoute, LoggerConfigError,
-        LoggerConfigInput, LoggerDeliveryConfig, LoggerHttpMethod, LoggerLevel, LoggerState,
-        ProcessStartupOutcome, ProcessTerminalCategory, SharedLoggerMetrics,
+        LoggerApiControlOutcome, LoggerApiResultOutcome, LoggerApiRoute, LoggerApiWorkerOutcome,
+        LoggerConfigError, LoggerConfigInput, LoggerDeliveryConfig, LoggerDeviceKind,
+        LoggerHttpMethod, LoggerLevel, LoggerLifecycleOutcome, LoggerObservabilityOutcome,
+        LoggerProcessSignalOutcome, LoggerSnapshotOutcome, LoggerState,
+        ObservabilityWorkerLogRateLimiter, ProcessStartupOutcome, ProcessTerminalCategory,
+        SharedLoggerMetrics,
     };
 
     static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
@@ -1187,6 +1366,83 @@ mod tests {
         assert!(!state.log_api_result(LoggerApiResultOutcome::BadRequest));
         assert!(!state.log_process_startup(ProcessStartupOutcome::Running));
         assert_eq!(metrics.missed_log_count(), 3);
+    }
+
+    #[test]
+    fn closed_lifecycle_snapshot_and_async_events_use_fixed_shapes() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let mut state = LoggerState::default();
+        state.configure_test_writer(SharedWriter(output.clone()));
+
+        assert!(state.log_lifecycle(LoggerLifecycleOutcome::BackendStartupSucceeded));
+        assert!(
+            state.log_lifecycle(LoggerLifecycleOutcome::DeviceAttachSucceeded(
+                LoggerDeviceKind::Block,
+            ))
+        );
+        assert!(state.log_snapshot(LoggerSnapshotOutcome::LoadCancelled));
+        let logger = state.async_logger();
+        assert!(logger.log_api_worker(LoggerApiWorkerOutcome::Running));
+        assert!(logger.log_process_signal(LoggerProcessSignalOutcome::GuestReset));
+        assert!(logger.log_observability(LoggerObservabilityOutcome::MetricsWorkerFailed));
+        assert!(logger.wait_for_delivery_for_test());
+
+        assert_eq!(
+            String::from_utf8(output.lock().expect("output lock should succeed").clone())
+                .expect("logger output should be UTF-8"),
+            concat!(
+                "operation=backend-startup outcome=succeeded\n",
+                "device-kind=block operation=device-attach outcome=succeeded\n",
+                "operation=snapshot-load outcome=cancelled\n",
+                "operation=boot-worker outcome=running\n",
+                "operation=guest-power outcome=reset\n",
+                "operation=metrics-worker outcome=failed\n",
+            )
+        );
+    }
+
+    #[test]
+    fn observability_worker_has_an_independent_nonblocking_limiter() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let metrics = SharedLoggerMetrics::default();
+        let clock = Arc::new(TestClock::default());
+        let mut state = LoggerState::with_shared_metrics(metrics.clone());
+        state.observability_rate_limiter =
+            ObservabilityWorkerLogRateLimiter::with_clock(clock.clone());
+        state.configure_test_writer(SharedWriter(output.clone()));
+        let logger = state.async_logger();
+
+        for _ in 0..10 {
+            assert!(logger.log_observability(LoggerObservabilityOutcome::MetricsWorkerFailed));
+        }
+        assert!(!logger.log_observability(LoggerObservabilityOutcome::MetricsWorkerFailed));
+        assert_eq!(metrics.rate_limited_log_count(), 1);
+
+        clock.set(500);
+        assert!(logger.log_observability(LoggerObservabilityOutcome::MetricsWorkerFailed));
+        assert!(logger.wait_for_delivery_for_test());
+        let output = String::from_utf8(output.lock().expect("output lock should succeed").clone())
+            .expect("logger output should be UTF-8");
+        assert_eq!(
+            output
+                .matches("operation=metrics-worker outcome=failed\n")
+                .count(),
+            11
+        );
+        assert!(output.contains("1 messages were suppressed due to rate limiting\n"));
+    }
+
+    #[test]
+    fn disconnected_async_logger_counts_exact_loss_without_waiting() {
+        let metrics = SharedLoggerMetrics::default();
+        let mut state = LoggerState::with_shared_metrics(metrics.clone());
+        state.configure_test_writer(FailingWriter);
+        let logger = state.async_logger();
+        assert!(state.disconnect_delivery_for_test());
+
+        assert!(!logger.log_api_worker(LoggerApiWorkerOutcome::Failed));
+        assert!(!logger.log_process_signal(LoggerProcessSignalOutcome::ShutdownAbnormal));
+        assert_eq!(metrics.missed_log_count(), 2);
     }
 
     #[test]

--- a/crates/runtime/src/logger/delivery.rs
+++ b/crates/runtime/src/logger/delivery.rs
@@ -286,7 +286,7 @@ impl fmt::Debug for LoggerProducer {
 }
 
 impl LoggerProducer {
-    pub(super) fn deliver_guest(&self, batch: LogBatch) -> bool {
+    pub(super) fn deliver_nonblocking(&self, batch: LogBatch) -> bool {
         let record_count = batch.len();
         match self.sender.try_send(WorkerMessage::batch(batch, None)) {
             Ok(()) => true,
@@ -1198,10 +1198,10 @@ mod tests {
         let producer = delivery.producer();
         let emergency = delivery.emergency_ingress();
 
-        assert!(producer.deliver_guest(LogBatch::one(record(LoggerAction::InstanceStart))));
+        assert!(producer.deliver_nonblocking(LogBatch::one(record(LoggerAction::InstanceStart))));
         gate.wait_until_entered();
-        assert!(producer.deliver_guest(LogBatch::one(record(LoggerAction::FlushMetrics))));
-        assert!(!producer.deliver_guest(LogBatch::one(record(LoggerAction::InstanceStart))));
+        assert!(producer.deliver_nonblocking(LogBatch::one(record(LoggerAction::FlushMetrics))));
+        assert!(!producer.deliver_nonblocking(LogBatch::one(record(LoggerAction::InstanceStart))));
         assert!(emergency.publish_once(super::PanicRecordPrefix::Plain));
         assert_eq!(metrics.missed_log_count(), 1);
 
@@ -1310,7 +1310,7 @@ mod tests {
         .expect("worker should spawn");
         let producer = delivery.producer();
 
-        assert!(producer.deliver_guest(LogBatch::one(record(LoggerAction::InstanceStart))));
+        assert!(producer.deliver_nonblocking(LogBatch::one(record(LoggerAction::InstanceStart))));
         gate.wait_until_entered();
         assert!(!producer.deliver_host(LogBatch::one(record(LoggerAction::FlushMetrics))));
         assert_eq!(metrics.missed_log_count(), 1);
@@ -1358,10 +1358,10 @@ mod tests {
         .expect("worker should spawn");
         let producer = delivery.producer();
 
-        assert!(producer.deliver_guest(LogBatch::one(record(LoggerAction::InstanceStart))));
+        assert!(producer.deliver_nonblocking(LogBatch::one(record(LoggerAction::InstanceStart))));
         gate.wait_until_entered();
-        assert!(producer.deliver_guest(LogBatch::one(record(LoggerAction::FlushMetrics))));
-        assert!(!producer.deliver_guest(LogBatch::two(
+        assert!(producer.deliver_nonblocking(LogBatch::one(record(LoggerAction::FlushMetrics))));
+        assert!(!producer.deliver_nonblocking(LogBatch::two(
             record(LoggerAction::InstanceStart),
             record(LoggerAction::FlushMetrics),
         )));
@@ -1386,7 +1386,7 @@ mod tests {
         let producer = delivery.producer();
 
         assert!(delivery.disconnect_for_test());
-        assert!(!producer.deliver_guest(LogBatch::two(
+        assert!(!producer.deliver_nonblocking(LogBatch::two(
             record(LoggerAction::InstanceStart),
             record(LoggerAction::FlushMetrics),
         )));

--- a/crates/runtime/src/logger/event.rs
+++ b/crates/runtime/src/logger/event.rs
@@ -182,6 +182,299 @@ impl ProcessStartupOutcome {
     }
 }
 
+/// Fixed public device kinds admitted by host lifecycle records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerDeviceKind {
+    Block,
+    Network,
+    Pmem,
+}
+
+impl LoggerDeviceKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Block => "block",
+            Self::Network => "network",
+            Self::Pmem => "pmem",
+        }
+    }
+}
+
+/// Fixed VM lifecycle and host-control outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerLifecycleOutcome {
+    BackendStartupSucceeded,
+    BackendStartupFailed,
+    VmStartSucceeded,
+    VmStartRejected,
+    VmStartFailed,
+    VmPauseSucceeded,
+    VmPauseUnchanged,
+    VmPauseRejected,
+    VmPauseFailed,
+    VmResumeSucceeded,
+    VmResumeUnchanged,
+    VmResumeRejected,
+    VmResumeFailed,
+    VmStopSucceeded,
+    VmStopFailed,
+    DeviceAttachSucceeded(LoggerDeviceKind),
+    DeviceAttachRejected(LoggerDeviceKind),
+    DeviceAttachFailed(LoggerDeviceKind),
+    DeviceUpdateSucceeded(LoggerDeviceKind),
+    DeviceUpdateRejected(LoggerDeviceKind),
+    DeviceUpdateFailed(LoggerDeviceKind),
+    DeviceDetachSucceeded(LoggerDeviceKind),
+    DeviceDetachRejected(LoggerDeviceKind),
+    DeviceDetachFailed(LoggerDeviceKind),
+}
+
+impl LoggerLifecycleOutcome {
+    pub const fn operation(self) -> &'static str {
+        match self {
+            Self::BackendStartupSucceeded | Self::BackendStartupFailed => "backend-startup",
+            Self::VmStartSucceeded | Self::VmStartRejected | Self::VmStartFailed => "vm-start",
+            Self::VmPauseSucceeded
+            | Self::VmPauseUnchanged
+            | Self::VmPauseRejected
+            | Self::VmPauseFailed => "vm-pause",
+            Self::VmResumeSucceeded
+            | Self::VmResumeUnchanged
+            | Self::VmResumeRejected
+            | Self::VmResumeFailed => "vm-resume",
+            Self::VmStopSucceeded | Self::VmStopFailed => "vm-stop",
+            Self::DeviceAttachSucceeded(_)
+            | Self::DeviceAttachRejected(_)
+            | Self::DeviceAttachFailed(_) => "device-attach",
+            Self::DeviceUpdateSucceeded(_)
+            | Self::DeviceUpdateRejected(_)
+            | Self::DeviceUpdateFailed(_) => "device-update",
+            Self::DeviceDetachSucceeded(_)
+            | Self::DeviceDetachRejected(_)
+            | Self::DeviceDetachFailed(_) => "device-detach",
+        }
+    }
+
+    pub const fn outcome(self) -> &'static str {
+        match self {
+            Self::BackendStartupSucceeded
+            | Self::VmStartSucceeded
+            | Self::VmPauseSucceeded
+            | Self::VmResumeSucceeded
+            | Self::VmStopSucceeded
+            | Self::DeviceAttachSucceeded(_)
+            | Self::DeviceUpdateSucceeded(_)
+            | Self::DeviceDetachSucceeded(_) => "succeeded",
+            Self::VmPauseUnchanged | Self::VmResumeUnchanged => "unchanged",
+            Self::VmStartRejected
+            | Self::VmPauseRejected
+            | Self::VmResumeRejected
+            | Self::DeviceAttachRejected(_)
+            | Self::DeviceUpdateRejected(_)
+            | Self::DeviceDetachRejected(_) => "rejected",
+            Self::BackendStartupFailed
+            | Self::VmStartFailed
+            | Self::VmPauseFailed
+            | Self::VmResumeFailed
+            | Self::VmStopFailed
+            | Self::DeviceAttachFailed(_)
+            | Self::DeviceUpdateFailed(_)
+            | Self::DeviceDetachFailed(_) => "failed",
+        }
+    }
+
+    pub const fn device_kind(self) -> Option<LoggerDeviceKind> {
+        match self {
+            Self::DeviceAttachSucceeded(kind)
+            | Self::DeviceAttachRejected(kind)
+            | Self::DeviceAttachFailed(kind)
+            | Self::DeviceUpdateSucceeded(kind)
+            | Self::DeviceUpdateRejected(kind)
+            | Self::DeviceUpdateFailed(kind)
+            | Self::DeviceDetachSucceeded(kind)
+            | Self::DeviceDetachRejected(kind)
+            | Self::DeviceDetachFailed(kind) => Some(kind),
+            _ => None,
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::VmPauseUnchanged | Self::VmResumeUnchanged => LoggerLevel::Debug,
+            Self::BackendStartupFailed
+            | Self::VmStartRejected
+            | Self::VmStartFailed
+            | Self::VmPauseRejected
+            | Self::VmPauseFailed
+            | Self::VmResumeRejected
+            | Self::VmResumeFailed
+            | Self::VmStopFailed
+            | Self::DeviceAttachRejected(_)
+            | Self::DeviceAttachFailed(_)
+            | Self::DeviceUpdateRejected(_)
+            | Self::DeviceUpdateFailed(_)
+            | Self::DeviceDetachRejected(_)
+            | Self::DeviceDetachFailed(_) => LoggerLevel::Error,
+            Self::BackendStartupSucceeded
+            | Self::VmStartSucceeded
+            | Self::VmPauseSucceeded
+            | Self::VmResumeSucceeded
+            | Self::VmStopSucceeded
+            | Self::DeviceAttachSucceeded(_)
+            | Self::DeviceUpdateSucceeded(_)
+            | Self::DeviceDetachSucceeded(_) => LoggerLevel::Info,
+        }
+    }
+}
+
+/// Fixed snapshot request outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerSnapshotOutcome {
+    CreateSucceeded,
+    CreateRejected,
+    CreateFailed,
+    CreateCancelled,
+    LoadSucceeded,
+    LoadRejected,
+    LoadFailed,
+    LoadCancelled,
+}
+
+impl LoggerSnapshotOutcome {
+    pub const fn operation(self) -> &'static str {
+        match self {
+            Self::CreateSucceeded
+            | Self::CreateRejected
+            | Self::CreateFailed
+            | Self::CreateCancelled => "snapshot-create",
+            Self::LoadSucceeded | Self::LoadRejected | Self::LoadFailed | Self::LoadCancelled => {
+                "snapshot-load"
+            }
+        }
+    }
+
+    pub const fn outcome(self) -> &'static str {
+        match self {
+            Self::CreateSucceeded | Self::LoadSucceeded => "succeeded",
+            Self::CreateRejected | Self::LoadRejected => "rejected",
+            Self::CreateFailed | Self::LoadFailed => "failed",
+            Self::CreateCancelled | Self::LoadCancelled => "cancelled",
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::CreateSucceeded | Self::LoadSucceeded => LoggerLevel::Info,
+            Self::CreateCancelled | Self::LoadCancelled => LoggerLevel::Warn,
+            Self::CreateRejected | Self::CreateFailed | Self::LoadRejected | Self::LoadFailed => {
+                LoggerLevel::Error
+            }
+        }
+    }
+}
+
+/// Fixed process-observed boot-worker outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerApiWorkerOutcome {
+    Running,
+    Exited,
+    Stopped,
+    Failed,
+}
+
+impl LoggerApiWorkerOutcome {
+    pub const fn operation(self) -> &'static str {
+        "boot-worker"
+    }
+
+    pub const fn outcome(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Exited => "exited",
+            Self::Stopped => "stopped",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::Running | Self::Exited => LoggerLevel::Info,
+            Self::Stopped => LoggerLevel::Debug,
+            Self::Failed => LoggerLevel::Error,
+        }
+    }
+}
+
+/// Fixed process-observed metrics-worker outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerObservabilityOutcome {
+    MetricsWorkerFailed,
+}
+
+impl LoggerObservabilityOutcome {
+    pub const fn operation(self) -> &'static str {
+        match self {
+            Self::MetricsWorkerFailed => "metrics-worker",
+        }
+    }
+
+    pub const fn outcome(self) -> &'static str {
+        match self {
+            Self::MetricsWorkerFailed => "failed",
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::MetricsWorkerFailed => LoggerLevel::Error,
+        }
+    }
+}
+
+/// Fixed deferred signal and process-shutdown convergence outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerProcessSignalOutcome {
+    HostSignalReceived,
+    CancellationRequested,
+    GuestPoweroff,
+    GuestReset,
+    ShutdownOrderly,
+    ShutdownAbnormal,
+}
+
+impl LoggerProcessSignalOutcome {
+    pub const fn operation(self) -> &'static str {
+        match self {
+            Self::HostSignalReceived => "host-signal",
+            Self::CancellationRequested => "cancellation",
+            Self::GuestPoweroff | Self::GuestReset => "guest-power",
+            Self::ShutdownOrderly | Self::ShutdownAbnormal => "shutdown",
+        }
+    }
+
+    pub const fn outcome(self) -> &'static str {
+        match self {
+            Self::HostSignalReceived => "received",
+            Self::CancellationRequested => "requested",
+            Self::GuestPoweroff => "poweroff",
+            Self::GuestReset => "reset",
+            Self::ShutdownOrderly => "orderly",
+            Self::ShutdownAbnormal => "abnormal",
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::ShutdownAbnormal => LoggerLevel::Error,
+            Self::HostSignalReceived
+            | Self::CancellationRequested
+            | Self::GuestPoweroff
+            | Self::GuestReset
+            | Self::ShutdownOrderly => LoggerLevel::Info,
+        }
+    }
+}
+
 /// Stable process termination categories emitted by the executable lifecycle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProcessTerminalCategory {
@@ -223,6 +516,7 @@ impl LoggerAction {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum LoggerEvent {
     ApiControl(LoggerApiControlOutcome),
+    ApiWorker(LoggerApiWorkerOutcome),
     ApiRequest {
         method: LoggerHttpMethod,
         route: LoggerApiRoute,
@@ -233,12 +527,16 @@ pub(super) enum LoggerEvent {
         wall_time_us: u64,
         cpu_time_us: u64,
     },
+    Lifecycle(LoggerLifecycleOutcome),
+    Observability(LoggerObservabilityOutcome),
     RateLimitRecovery {
         suppressed: u64,
     },
     ProcessPanic,
+    ProcessSignal(LoggerProcessSignalOutcome),
     ProcessStartup(ProcessStartupOutcome),
     ProcessExit(ProcessTerminalCategory),
+    Snapshot(LoggerSnapshotOutcome),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -308,6 +606,12 @@ impl LogRecord {
                 encoder.push_str(" outcome=");
                 encoder.push_str(outcome.outcome());
             }
+            LoggerEvent::ApiWorker(outcome) => {
+                encoder.push_str("operation=");
+                encoder.push_str(outcome.operation());
+                encoder.push_str(" outcome=");
+                encoder.push_str(outcome.outcome());
+            }
             LoggerEvent::ApiRequest { method, route } => {
                 encoder.push_str("The API server received a ");
                 encoder.push_str(method.as_str());
@@ -337,11 +641,34 @@ impl LogRecord {
                 encoder.push_u64(cpu_time_us / 1_000);
                 encoder.push_str(" CPU ms");
             }
+            LoggerEvent::Lifecycle(outcome) => {
+                if let Some(kind) = outcome.device_kind() {
+                    encoder.push_str("device-kind=");
+                    encoder.push_str(kind.as_str());
+                    encoder.push_byte(b' ');
+                }
+                encoder.push_str("operation=");
+                encoder.push_str(outcome.operation());
+                encoder.push_str(" outcome=");
+                encoder.push_str(outcome.outcome());
+            }
+            LoggerEvent::Observability(outcome) => {
+                encoder.push_str("operation=");
+                encoder.push_str(outcome.operation());
+                encoder.push_str(" outcome=");
+                encoder.push_str(outcome.outcome());
+            }
             LoggerEvent::RateLimitRecovery { suppressed } => {
                 encoder.push_u64(suppressed);
                 encoder.push_str(" messages were suppressed due to rate limiting");
             }
             LoggerEvent::ProcessPanic => encoder.push_str("event=process-panic"),
+            LoggerEvent::ProcessSignal(outcome) => {
+                encoder.push_str("operation=");
+                encoder.push_str(outcome.operation());
+                encoder.push_str(" outcome=");
+                encoder.push_str(outcome.outcome());
+            }
             LoggerEvent::ProcessStartup(outcome) => {
                 encoder.push_str("operation=process-startup outcome=");
                 encoder.push_str(outcome.as_str());
@@ -349,6 +676,12 @@ impl LogRecord {
             LoggerEvent::ProcessExit(category) => {
                 encoder.push_str("event=process-exit category=");
                 encoder.push_str(category.as_str());
+            }
+            LoggerEvent::Snapshot(outcome) => {
+                encoder.push_str("operation=");
+                encoder.push_str(outcome.operation());
+                encoder.push_str(" outcome=");
+                encoder.push_str(outcome.outcome());
             }
         }
 
@@ -636,8 +969,10 @@ fn utf8_prefix_len(value: &str, maximum: usize) -> usize {
 mod tests {
     use super::{
         LogOrigin, LogRecord, LoggerAction, LoggerApiControlOutcome, LoggerApiResultOutcome,
-        LoggerApiRoute, LoggerEvent, LoggerHttpMethod, MAX_LOG_RECORD_BYTES, PanicLogRecords,
-        ProcessStartupOutcome, ProcessTerminalCategory, normalize_origin,
+        LoggerApiRoute, LoggerApiWorkerOutcome, LoggerDeviceKind, LoggerEvent, LoggerHttpMethod,
+        LoggerLifecycleOutcome, LoggerObservabilityOutcome, LoggerProcessSignalOutcome,
+        LoggerSnapshotOutcome, MAX_LOG_RECORD_BYTES, PanicLogRecords, ProcessStartupOutcome,
+        ProcessTerminalCategory, normalize_origin,
     };
     use crate::logger::LoggerLevel;
 
@@ -795,6 +1130,303 @@ mod tests {
             startup.as_str(),
             "operation=process-startup outcome=running\n"
         );
+    }
+
+    fn assert_closed_event(event: LoggerEvent, level: LoggerLevel, body: &str) {
+        let origin = LogOrigin::new("crates/runtime/src/logger/event.rs", 77);
+        for (show_level, show_origin) in
+            [(false, false), (true, false), (false, true), (true, true)]
+        {
+            let record = LogRecord::encode(show_level, show_origin, origin, level, event);
+            let mut expected = String::new();
+            if show_level {
+                expected.push_str("level=");
+                expected.push_str(level.as_str());
+                expected.push(' ');
+            }
+            if show_origin {
+                expected.push_str("origin=crates/runtime/src/logger/event.rs:77 ");
+            }
+            expected.push_str(body);
+            expected.push('\n');
+
+            assert_eq!(record.as_str(), expected);
+            assert!(record.as_bytes().len() <= MAX_LOG_RECORD_BYTES);
+            assert!(std::str::from_utf8(record.as_bytes()).is_ok());
+        }
+    }
+
+    #[test]
+    fn encodes_every_closed_host_worker_snapshot_and_signal_outcome() {
+        let lifecycle_cases = [
+            (
+                LoggerLifecycleOutcome::BackendStartupSucceeded,
+                LoggerLevel::Info,
+                "operation=backend-startup outcome=succeeded",
+            ),
+            (
+                LoggerLifecycleOutcome::BackendStartupFailed,
+                LoggerLevel::Error,
+                "operation=backend-startup outcome=failed",
+            ),
+            (
+                LoggerLifecycleOutcome::VmStartSucceeded,
+                LoggerLevel::Info,
+                "operation=vm-start outcome=succeeded",
+            ),
+            (
+                LoggerLifecycleOutcome::VmStartRejected,
+                LoggerLevel::Error,
+                "operation=vm-start outcome=rejected",
+            ),
+            (
+                LoggerLifecycleOutcome::VmStartFailed,
+                LoggerLevel::Error,
+                "operation=vm-start outcome=failed",
+            ),
+            (
+                LoggerLifecycleOutcome::VmPauseSucceeded,
+                LoggerLevel::Info,
+                "operation=vm-pause outcome=succeeded",
+            ),
+            (
+                LoggerLifecycleOutcome::VmPauseUnchanged,
+                LoggerLevel::Debug,
+                "operation=vm-pause outcome=unchanged",
+            ),
+            (
+                LoggerLifecycleOutcome::VmPauseRejected,
+                LoggerLevel::Error,
+                "operation=vm-pause outcome=rejected",
+            ),
+            (
+                LoggerLifecycleOutcome::VmPauseFailed,
+                LoggerLevel::Error,
+                "operation=vm-pause outcome=failed",
+            ),
+            (
+                LoggerLifecycleOutcome::VmResumeSucceeded,
+                LoggerLevel::Info,
+                "operation=vm-resume outcome=succeeded",
+            ),
+            (
+                LoggerLifecycleOutcome::VmResumeUnchanged,
+                LoggerLevel::Debug,
+                "operation=vm-resume outcome=unchanged",
+            ),
+            (
+                LoggerLifecycleOutcome::VmResumeRejected,
+                LoggerLevel::Error,
+                "operation=vm-resume outcome=rejected",
+            ),
+            (
+                LoggerLifecycleOutcome::VmResumeFailed,
+                LoggerLevel::Error,
+                "operation=vm-resume outcome=failed",
+            ),
+            (
+                LoggerLifecycleOutcome::VmStopSucceeded,
+                LoggerLevel::Info,
+                "operation=vm-stop outcome=succeeded",
+            ),
+            (
+                LoggerLifecycleOutcome::VmStopFailed,
+                LoggerLevel::Error,
+                "operation=vm-stop outcome=failed",
+            ),
+        ];
+        for (outcome, level, expected) in lifecycle_cases {
+            assert_eq!(outcome.level(), level);
+            assert_closed_event(LoggerEvent::Lifecycle(outcome), level, expected);
+        }
+
+        for (kind, kind_text) in [
+            (LoggerDeviceKind::Block, "block"),
+            (LoggerDeviceKind::Network, "network"),
+            (LoggerDeviceKind::Pmem, "pmem"),
+        ] {
+            for (outcome, operation, outcome_text, level) in [
+                (
+                    LoggerLifecycleOutcome::DeviceAttachSucceeded(kind),
+                    "device-attach",
+                    "succeeded",
+                    LoggerLevel::Info,
+                ),
+                (
+                    LoggerLifecycleOutcome::DeviceAttachRejected(kind),
+                    "device-attach",
+                    "rejected",
+                    LoggerLevel::Error,
+                ),
+                (
+                    LoggerLifecycleOutcome::DeviceAttachFailed(kind),
+                    "device-attach",
+                    "failed",
+                    LoggerLevel::Error,
+                ),
+                (
+                    LoggerLifecycleOutcome::DeviceUpdateSucceeded(kind),
+                    "device-update",
+                    "succeeded",
+                    LoggerLevel::Info,
+                ),
+                (
+                    LoggerLifecycleOutcome::DeviceUpdateRejected(kind),
+                    "device-update",
+                    "rejected",
+                    LoggerLevel::Error,
+                ),
+                (
+                    LoggerLifecycleOutcome::DeviceUpdateFailed(kind),
+                    "device-update",
+                    "failed",
+                    LoggerLevel::Error,
+                ),
+                (
+                    LoggerLifecycleOutcome::DeviceDetachSucceeded(kind),
+                    "device-detach",
+                    "succeeded",
+                    LoggerLevel::Info,
+                ),
+                (
+                    LoggerLifecycleOutcome::DeviceDetachRejected(kind),
+                    "device-detach",
+                    "rejected",
+                    LoggerLevel::Error,
+                ),
+                (
+                    LoggerLifecycleOutcome::DeviceDetachFailed(kind),
+                    "device-detach",
+                    "failed",
+                    LoggerLevel::Error,
+                ),
+            ] {
+                assert_eq!(outcome.level(), level);
+                assert_closed_event(
+                    LoggerEvent::Lifecycle(outcome),
+                    level,
+                    &format!(
+                        "device-kind={kind_text} operation={operation} outcome={outcome_text}"
+                    ),
+                );
+            }
+        }
+
+        for (outcome, level, expected) in [
+            (
+                LoggerSnapshotOutcome::CreateSucceeded,
+                LoggerLevel::Info,
+                "operation=snapshot-create outcome=succeeded",
+            ),
+            (
+                LoggerSnapshotOutcome::CreateRejected,
+                LoggerLevel::Error,
+                "operation=snapshot-create outcome=rejected",
+            ),
+            (
+                LoggerSnapshotOutcome::CreateFailed,
+                LoggerLevel::Error,
+                "operation=snapshot-create outcome=failed",
+            ),
+            (
+                LoggerSnapshotOutcome::CreateCancelled,
+                LoggerLevel::Warn,
+                "operation=snapshot-create outcome=cancelled",
+            ),
+            (
+                LoggerSnapshotOutcome::LoadSucceeded,
+                LoggerLevel::Info,
+                "operation=snapshot-load outcome=succeeded",
+            ),
+            (
+                LoggerSnapshotOutcome::LoadRejected,
+                LoggerLevel::Error,
+                "operation=snapshot-load outcome=rejected",
+            ),
+            (
+                LoggerSnapshotOutcome::LoadFailed,
+                LoggerLevel::Error,
+                "operation=snapshot-load outcome=failed",
+            ),
+            (
+                LoggerSnapshotOutcome::LoadCancelled,
+                LoggerLevel::Warn,
+                "operation=snapshot-load outcome=cancelled",
+            ),
+        ] {
+            assert_eq!(outcome.level(), level);
+            assert_closed_event(LoggerEvent::Snapshot(outcome), level, expected);
+        }
+
+        for (outcome, level, expected) in [
+            (
+                LoggerApiWorkerOutcome::Running,
+                LoggerLevel::Info,
+                "operation=boot-worker outcome=running",
+            ),
+            (
+                LoggerApiWorkerOutcome::Exited,
+                LoggerLevel::Info,
+                "operation=boot-worker outcome=exited",
+            ),
+            (
+                LoggerApiWorkerOutcome::Stopped,
+                LoggerLevel::Debug,
+                "operation=boot-worker outcome=stopped",
+            ),
+            (
+                LoggerApiWorkerOutcome::Failed,
+                LoggerLevel::Error,
+                "operation=boot-worker outcome=failed",
+            ),
+        ] {
+            assert_eq!(outcome.level(), level);
+            assert_closed_event(LoggerEvent::ApiWorker(outcome), level, expected);
+        }
+
+        let observability = LoggerObservabilityOutcome::MetricsWorkerFailed;
+        assert_eq!(observability.level(), LoggerLevel::Error);
+        assert_closed_event(
+            LoggerEvent::Observability(observability),
+            LoggerLevel::Error,
+            "operation=metrics-worker outcome=failed",
+        );
+
+        for (outcome, level, expected) in [
+            (
+                LoggerProcessSignalOutcome::HostSignalReceived,
+                LoggerLevel::Info,
+                "operation=host-signal outcome=received",
+            ),
+            (
+                LoggerProcessSignalOutcome::CancellationRequested,
+                LoggerLevel::Info,
+                "operation=cancellation outcome=requested",
+            ),
+            (
+                LoggerProcessSignalOutcome::GuestPoweroff,
+                LoggerLevel::Info,
+                "operation=guest-power outcome=poweroff",
+            ),
+            (
+                LoggerProcessSignalOutcome::GuestReset,
+                LoggerLevel::Info,
+                "operation=guest-power outcome=reset",
+            ),
+            (
+                LoggerProcessSignalOutcome::ShutdownOrderly,
+                LoggerLevel::Info,
+                "operation=shutdown outcome=orderly",
+            ),
+            (
+                LoggerProcessSignalOutcome::ShutdownAbnormal,
+                LoggerLevel::Error,
+                "operation=shutdown outcome=abnormal",
+            ),
+        ] {
+            assert_eq!(outcome.level(), level);
+            assert_closed_event(LoggerEvent::ProcessSignal(outcome), level, expected);
+        }
     }
 
     #[test]

--- a/crates/runtime/src/logger/rate_limiter.rs
+++ b/crates/runtime/src/logger/rate_limiter.rs
@@ -39,6 +39,7 @@ impl LogRateLimiterClock for SystemLogRateLimiterClock {
 pub(super) enum LoggerRateLimitIdentity {
     BootTimer,
     ApiRequest,
+    ObservabilityWorker,
 }
 
 impl LoggerRateLimitIdentity {
@@ -46,11 +47,17 @@ impl LoggerRateLimitIdentity {
         match self {
             Self::BootTimer => 0,
             Self::ApiRequest => 1,
+            Self::ObservabilityWorker => 2,
         }
     }
 }
 
-const LOGGER_RATE_LIMIT_IDENTITY_COUNT: usize = LoggerRateLimitIdentity::ApiRequest.index() + 1;
+const LOGGER_RATE_LIMIT_IDENTITIES: [LoggerRateLimitIdentity; 3] = [
+    LoggerRateLimitIdentity::BootTimer,
+    LoggerRateLimitIdentity::ApiRequest,
+    LoggerRateLimitIdentity::ObservabilityWorker,
+];
+const LOGGER_RATE_LIMIT_IDENTITY_COUNT: usize = LOGGER_RATE_LIMIT_IDENTITIES.len();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum LogRateLimitDecision {

--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -4752,6 +4752,23 @@ impl SnapshotArtifactLoadError {
     pub const fn failure(&self) -> &SnapshotArtifactLoadFailure {
         &self.failure
     }
+
+    /// Returns whether cooperative cancellation caused the load failure.
+    pub const fn is_cancelled(&self) -> bool {
+        matches!(
+            &self.failure,
+            SnapshotArtifactLoadFailure::Cancelled
+                | SnapshotArtifactLoadFailure::MemoryHotplugMaterialization(
+                    SnapshotV2MemoryHotplugMaterializationError::Cancelled { .. }
+                )
+                | SnapshotArtifactLoadFailure::DiffVerification(
+                    SnapshotV2DiffVerifyError::Cancelled { .. }
+                )
+                | SnapshotArtifactLoadFailure::DiffMaterialization(
+                    SnapshotV2DiffMaterializationError::Cancelled { .. }
+                )
+        )
+    }
 }
 
 impl fmt::Display for SnapshotArtifactLoadError {

--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -1700,6 +1700,13 @@ pub enum NativeV2NetworkSnapshotPreparationError {
     Topology(SnapshotV2NetworkRestorePreparationError),
 }
 
+impl NativeV2NetworkSnapshotPreparationError {
+    /// Returns whether preparation stopped at an explicit cancellation checkpoint.
+    pub const fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Topology(source) if source.is_cancelled())
+    }
+}
+
 impl fmt::Debug for NativeV2NetworkSnapshotPreparationError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, formatter)
@@ -2063,6 +2070,19 @@ pub enum NativeV2VsockSnapshotPreparationError {
     Manifest(SnapshotRestoreManifestError),
     /// Owner-free network topology preparation failed.
     Network(SnapshotV2NetworkRestorePreparationError),
+}
+
+impl NativeV2VsockSnapshotPreparationError {
+    /// Returns whether preparation stopped at an explicit cancellation checkpoint.
+    pub const fn is_cancelled(&self) -> bool {
+        match self {
+            Self::Vsock(source) => source.is_cancelled(),
+            Self::Network(source) => source.is_cancelled(),
+            Self::NetworkOverridesWithoutDevice
+            | Self::DestinationTransport
+            | Self::Manifest(_) => false,
+        }
+    }
 }
 
 impl fmt::Debug for NativeV2VsockSnapshotPreparationError {

--- a/crates/runtime/src/snapshot_artifact/tests.rs
+++ b/crates/runtime/src/snapshot_artifact/tests.rs
@@ -1307,11 +1307,47 @@ fn exact_minor_eleven_candidate_propagates_stable_network_cancellation() {
         })
         .expect_err("completion cancellation must prevent publication");
 
+    assert!(error.is_cancelled());
     assert!(matches!(
         error,
         NativeV2NetworkSnapshotPreparationError::Topology(
             SnapshotV2NetworkRestorePreparationError::Cancelled {
                 stage: SnapshotV2NetworkRestorePreparationStage::Completion,
+            }
+        )
+    ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_twelve_candidate_reports_vsock_topology_cancellation() {
+    let vsock_payload = fixture_bytes(include_str!(
+        "../snapshot_vsock_v2_12/fixtures/inactive-mmio.hex"
+    ));
+    let (candidate, memory) = exact_minor_twelve_candidate(None, Some(&vsock_payload));
+    let error = candidate
+        .prepare_with_cancel(
+            &memory,
+            SnapshotV2DeviceTransportKind::Mmio,
+            &[],
+            None,
+            |stage| {
+                matches!(
+                    stage,
+                    NativeV2VsockSnapshotPreparationStage::Vsock(
+                        SnapshotV2VsockRestorePreparationStage::Completion
+                    )
+                )
+            },
+        )
+        .expect_err("vsock completion cancellation must prevent publication");
+
+    assert!(error.is_cancelled());
+    assert!(matches!(
+        error,
+        NativeV2VsockSnapshotPreparationError::Vsock(
+            SnapshotV2VsockRestorePreparationError::Cancelled {
+                stage: SnapshotV2VsockRestorePreparationStage::Completion,
             }
         )
     ));

--- a/crates/runtime/src/snapshot_artifact/tests.rs
+++ b/crates/runtime/src/snapshot_artifact/tests.rs
@@ -3689,6 +3689,7 @@ fn diff_zero_root_materialization_cancellation_cleans_up_and_retries() {
             cancellation_polls.fetch_add(1, Ordering::SeqCst) > 12
         })
         .expect_err("materialization cancellation should abort the load");
+    assert!(error.is_cancelled());
     assert_eq!(
         error.stage(),
         SnapshotArtifactLoadStage::MemoryMaterialization

--- a/crates/runtime/src/snapshot_network_restore_v2_11.rs
+++ b/crates/runtime/src/snapshot_network_restore_v2_11.rs
@@ -931,6 +931,13 @@ pub enum SnapshotV2NetworkRestorePreparationError {
     },
 }
 
+impl SnapshotV2NetworkRestorePreparationError {
+    /// Returns whether preparation stopped at an explicit cancellation checkpoint.
+    pub const fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Cancelled { .. })
+    }
+}
+
 impl fmt::Debug for SnapshotV2NetworkRestorePreparationError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
@@ -2073,6 +2080,7 @@ mod tests {
                 |stage| stage == target,
             )
             .expect_err("targeted cancellation should fail");
+            assert!(error.is_cancelled());
             assert!(matches!(
                 error,
                 SnapshotV2NetworkRestorePreparationError::Cancelled { stage } if stage == target

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
@@ -607,6 +607,13 @@ pub enum SnapshotV2VsockRestorePreparationError {
     },
 }
 
+impl SnapshotV2VsockRestorePreparationError {
+    /// Returns whether preparation stopped at an explicit cancellation checkpoint.
+    pub const fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Cancelled { .. })
+    }
+}
+
 impl fmt::Debug for SnapshotV2VsockRestorePreparationError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, formatter)

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
@@ -532,6 +532,7 @@ fn cancellation_and_allocation_checkpoints_are_deterministic() {
             },
         )
         .expect_err("selected cancellation stage should stop preparation");
+        assert!(error.is_cancelled());
         assert!(matches!(
             error,
             SnapshotV2VsockRestorePreparationError::Cancelled { stage } if stage == target

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -509,23 +509,40 @@ Parser rejections instead emit one fixed `request-parse` control outcome and no
 result. Fixed control events additionally cover server start/stop, discarded
 connection failure, deprecated requests, and successful pause/resume or
 snapshot completion. Normal readiness has one
-`operation=process-startup outcome=running` record. The boot timer is the one
-bounded guest-triggered logger callsite. Its per-controller/per-identity atomic
-GCRA admits an initial
+`operation=process-startup outcome=running` record.
+
+Typed host outcome records additionally cover backend startup; VM
+start/pause/resume/stop; block, network, and pmem live attach/update/detach;
+snapshot create/load success, rejection, failure, and cancellation; boot-worker
+running/exited/stopped/failed status; metrics-worker failure; host signal and
+cancellation receipt; guest poweroff/reset convergence; and orderly or abnormal
+shutdown. Only fixed operation, outcome, and optional device-kind values reach
+encoding. IDs, paths, MAC addresses, descriptors, guest values, and raw errors
+are discarded first. Lifecycle and snapshot calls use bounded host receipts;
+worker, signal, and observability calls make one nonblocking queue attempt.
+Snapshot-internal resume does not duplicate an ordinary VM-resume record, and
+terminal convergence records observed worker/power status before cleanup,
+VM-stop, shutdown, and the final process category.
+
+The boot timer is the bounded guest-triggered timing callsite. Its
+per-controller/per-identity atomic GCRA admits an initial
 burst of ten records, refills the five-second budget at one token per 500 ms,
 uses at most 16 compare/exchange attempts, increments
 `logger.rate_limited_log_count` for every denied record, and emits one
 unrestricted `Warn` recovery record before the next admitted boot-time record.
+Repeated asynchronous metrics-worker failures use a separate
+`logger-rate.observability-worker` identity, so they cannot consume or recover
+the boot-timer budget.
 Unconfigured or filtered records do not consume the limiter and are not missed
 deliveries.
 
 Each controller has one fixed 256-message queue and one worker that exclusively
-owns the sink. A boot-timer/vCPU caller encodes and attempts `try_send` once; it
-does no sink I/O and waits for neither capacity nor completion. API/action
-callers may wait at most one second for a receipt to preserve the ordinary
-output-before-return case, but timeout is only a conservatively counted
-unconfirmed record and never changes the functional result. The worker makes
-one `write` and, after a complete write, one `flush` per record. Queue full or
+owns the sink. A guest or asynchronous caller encodes and attempts `try_send`
+once; it does no sink I/O and waits for neither capacity nor completion.
+Bounded host callers may wait at most one second for a receipt to preserve the
+ordinary output-before-return case, but timeout is only a conservatively
+counted unconfirmed record and never changes the functional result. The worker
+makes one `write` and, after a complete write, one `flush` per record. Queue full or
 disconnect, receipt timeout, zero/short/error writes, and flush failure
 increment the saturating `logger.missed_log_count` exactly once per affected
 record; suffixes are not retried and output durability is not claimed. A

--- a/docs/security.md
+++ b/docs/security.md
@@ -2129,14 +2129,17 @@ is resource-specific:
 - Successfully parsed API requests encode closed method/route-template lines
   before dispatch and exactly one closed HTTP result afterward. Parser
   rejections encode a fixed control outcome and no result. Other closed host
-  events cover server/connection/request control, normal startup, successful
-  actions, panic, and convergence. They intentionally omit resource selectors,
-  request/response bodies, fault strings, paths, and guest values; optional
-  origins are implementation-owned and cannot expose absolute build-host paths.
-  Every record is valid UTF-8 and at most 512 bytes including newline. These
-  host records are unrestricted and use at most a one-second receipt; guest
-  boot-timer records use immediate admission, a bounded atomic
-  ten-per-five-second limiter, and one ordered recovery warning. Queue,
+  events cover server/connection/request control, normal startup, backend and
+  VM lifecycle, live device controls, snapshots, workers, signals, guest power,
+  shutdown, panic, and convergence. They intentionally omit resource
+  selectors, request/response bodies, fault strings, paths, and guest values;
+  optional origins are implementation-owned and cannot expose absolute
+  build-host paths. Every record is valid UTF-8 and at most 512 bytes including
+  newline. Ordinary host lifecycle and snapshot records use at most a
+  one-second receipt; callbacks and workers use immediate admission. Guest
+  boot-timer records use a bounded atomic ten-per-five-second limiter and one
+  ordered recovery warning, while repeated metrics-worker failures use a
+  separate limiter identity. Queue,
   timeout, zero/short/error write, or flush failure increments exact
   missed-delivery accounting but cannot change the API, action, startup, or
   guest-MMIO result. A stalled sink preserves old state without accumulating
@@ -2889,22 +2892,34 @@ receipt, closed control/result, process startup, and action events are
 unrestricted host VMM records; they can expose only fixed method/route,
 operation, outcome, and action vocabulary, not runtime selectors,
 request/response bodies, faults, host paths, or guest serial output. The
-guest-triggerable boot-timer callsite alone uses a bounded limiter and emits one
-unrestricted warning when delivery recovers. Logger filtering, queue pressure,
-timeout ambiguity, and sink failures never change the API, action, readiness,
-or guest outcome; rate-limited records and exact per-record delivery failures
-are observable only through process-local counters.
+guest-triggerable boot-timer callsite uses a bounded limiter and emits one
+unrestricted warning when delivery recovers; repeated metrics-worker failures
+use an independent `logger-rate.observability-worker` identity. Logger
+filtering, queue pressure, timeout ambiguity, and sink failures never change
+the API, action, readiness, VM lifecycle, snapshot, or guest outcome;
+rate-limited records and exact per-record delivery failures are observable only
+through process-local counters.
+
+Host lifecycle records use only fixed backend/VM operation and outcome values.
+Live block, network, and pmem controls add a fixed device kind, never the
+device ID, backing path, MAC address, provider name, or backend error. Snapshot
+records distinguish create/load success, rejection, failure, and cancellation
+without state or memory paths. Boot-worker and metrics-worker callbacks use a
+narrow cloned logger facade with no configuration or sink authority and never
+wait for completion.
 
 Process convergence adds only fixed, non-user-derived logger records. Normal
-records are `event=process-exit category=<fixed-category>` under the
-`bangbang::process` filter; a catchable main-runtime panic can first emit
+records first distinguish a host signal or cancellation request, observed
+boot-worker and guest poweroff/reset status, VM-stop cleanup, and orderly or
+abnormal shutdown before `event=process-exit category=<fixed-category>` under
+the `bangbang::process` filter. A catchable main-runtime panic can first emit
 `event=process-panic` under `bangbang::panic` and then the fixed `panic`
-terminal category. The five terminal categories, levels, optional
-level/origin prefixes, 512-byte ceiling, and callsites are compiled in. These
-records never incorporate `PanicHookInfo`, panic payloads, error strings,
-paths, selectors, descriptors, credentials, guest/register data, or API
-bodies. A filtered or unconfigured panic path uses only the plain fixed record
-through a precreated stderr worker.
+terminal category. The closed operations/outcomes, five terminal categories,
+levels, optional level/origin prefixes, 512-byte ceiling, and callsites are
+compiled in. These records never incorporate `PanicHookInfo`, panic payloads,
+error strings, paths, selectors, descriptors, credentials, guest/register
+data, or API bodies. A filtered or unconfigured panic path uses only the plain
+fixed record through a precreated stderr worker.
 
 The ordinary executable exclusively owns the process-global Rust panic hook
 after private binder dispatch and before contained bootstrap. It retains the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1528,6 +1528,21 @@ command never creates, carries forward, or rewrites semantic classes in
 `logger-producer-audit.json`; missing or stale mappings require human review.
 The class policy and safe-field boundary are documented in the
 [logger producer contract](../compat/firecracker/v1.16.0/logger-contract.md).
+The current overlay has exactly 13 implemented, 11 planned, and seven
+not-applicable classes, representing 82 implemented, 324 planned, and 62
+not-applicable source mappings. The remaining planned classes are all owned by
+#1809.
+
+Host lifecycle logger coverage exercises backend and VM transitions, all three
+live device kinds, boot-worker observation, automatic metrics failures,
+snapshot create/load success/rejection/failure/cancellation, host signals,
+guest power convergence, cancellation, cleanup failure, and terminal ordering.
+Tests assert the exact closed vocabulary and verify that paths, identifiers,
+MAC addresses, descriptors, guest values, and raw errors never reach a record.
+Runtime logger tests separately prove bounded host receipts, nonblocking async
+delivery, the independent observability limiter, filtering, and exact loss
+accounting. Process and signed integration targets verify the executable
+ordering boundary.
 
 The final parent gate is:
 

--- a/tools/firecracker-capability-audit/src/logger_model.rs
+++ b/tools/firecracker-capability-audit/src/logger_model.rs
@@ -261,15 +261,20 @@ pub enum LoggerNonApplicableReason {
 #[serde(rename_all = "kebab-case")]
 pub enum LoggerCompiledEvent {
     ApiControl,
+    ApiWorker,
     ApiRequest,
     ApiResult,
     InstanceStart,
     FlushMetrics,
     BootTime,
+    Lifecycle,
+    Observability,
     RateLimitRecovery,
     ProcessStartup,
     ProcessPanic,
     ProcessExit,
+    ProcessSignal,
+    Snapshot,
 }
 
 /// Human-owned policy and evidence for one coherent semantic producer class.

--- a/tools/firecracker-capability-audit/src/logger_validate.rs
+++ b/tools/firecracker-capability-audit/src/logger_validate.rs
@@ -29,7 +29,7 @@ const EXPECTED_EXAMPLE: usize = 22;
 const EXPECTED_DIRECT: usize = 466;
 const EXPECTED_MACRO_TEMPLATE: usize = 2;
 const LOGGER_EXTRACTOR: &str = "rust-logger-macro-v1";
-const PLANNED_ISSUES: [&str; 2] = ["#1808", "#1809"];
+const PLANNED_ISSUES: [&str; 1] = ["#1809"];
 
 /// Validate the checked logger source manifest and human classification overlay.
 pub fn validate_logger_producers(
@@ -540,7 +540,7 @@ fn validate_class(
                 .is_some_and(|issue| PLANNED_ISSUES.contains(&issue))
             {
                 errors.push(format!(
-                    "planned logger class must be owned by #1808 or #1809: {}",
+                    "planned logger class must be owned by #1809: {}",
                     class.id
                 ));
             }
@@ -681,11 +681,17 @@ fn validate_compiled_event_set(classes: &[LoggerProducerClass], errors: &mut Vec
             LoggerCompiledEvent::ApiControl,
             "logger.api-control.outcome",
         ),
+        (LoggerCompiledEvent::ApiWorker, "logger.api-worker.outcome"),
         (LoggerCompiledEvent::ApiRequest, "logger.api.request"),
         (LoggerCompiledEvent::ApiResult, "logger.api.result"),
         (LoggerCompiledEvent::InstanceStart, "logger.api.result"),
         (LoggerCompiledEvent::FlushMetrics, "logger.api.result"),
         (LoggerCompiledEvent::BootTime, "logger.boot.time"),
+        (LoggerCompiledEvent::Lifecycle, "logger.lifecycle.outcome"),
+        (
+            LoggerCompiledEvent::Observability,
+            "logger.observability.outcome",
+        ),
         (
             LoggerCompiledEvent::RateLimitRecovery,
             "logger.limiter.recovery",
@@ -696,6 +702,11 @@ fn validate_compiled_event_set(classes: &[LoggerProducerClass], errors: &mut Vec
         ),
         (LoggerCompiledEvent::ProcessPanic, "logger.process.panic"),
         (LoggerCompiledEvent::ProcessExit, "logger.process.exit"),
+        (
+            LoggerCompiledEvent::ProcessSignal,
+            "logger.process-signal.outcome",
+        ),
+        (LoggerCompiledEvent::Snapshot, "logger.snapshot.outcome"),
     ]);
     let actual = classes
         .iter()

--- a/tools/firecracker-capability-audit/tests/checked_inventory.rs
+++ b/tools/firecracker-capability-audit/tests/checked_inventory.rs
@@ -98,7 +98,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
         ),
         (
             "logger.api-worker.outcome",
-            LoggerClassDisposition::Planned,
+            LoggerClassDisposition::Implemented,
             5,
         ),
         ("logger.api.request", LoggerClassDisposition::Implemented, 1),
@@ -122,7 +122,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
         ),
         (
             "logger.lifecycle.outcome",
-            LoggerClassDisposition::Planned,
+            LoggerClassDisposition::Implemented,
             24,
         ),
         (
@@ -177,13 +177,13 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
         ),
         (
             "logger.observability.outcome",
-            LoggerClassDisposition::Planned,
+            LoggerClassDisposition::Implemented,
             4,
         ),
         ("logger.pmem.outcome", LoggerClassDisposition::Planned, 18),
         (
             "logger.process-signal.outcome",
-            LoggerClassDisposition::Planned,
+            LoggerClassDisposition::Implemented,
             5,
         ),
         (
@@ -204,7 +204,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
         ("logger.serial.outcome", LoggerClassDisposition::Planned, 12),
         (
             "logger.snapshot.outcome",
-            LoggerClassDisposition::Planned,
+            LoggerClassDisposition::Implemented,
             18,
         ),
         (
@@ -308,7 +308,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             .iter()
             .filter(|class| class.disposition == LoggerClassDisposition::Implemented)
             .count(),
-        8
+        13
     );
     assert_eq!(
         audit
@@ -316,7 +316,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             .iter()
             .filter(|class| class.disposition == LoggerClassDisposition::Planned)
             .count(),
-        16
+        11
     );
     assert_eq!(
         audit
@@ -342,8 +342,8 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
     assert_eq!(
         mapped_dispositions,
         BTreeMap::from([
-            (LoggerClassDisposition::Implemented, 26),
-            (LoggerClassDisposition::Planned, 380),
+            (LoggerClassDisposition::Implemented, 82),
+            (LoggerClassDisposition::Planned, 324),
             (LoggerClassDisposition::NotApplicable, 62),
         ])
     );
@@ -359,10 +359,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             *counts.entry(issue).or_insert(0_usize) += 1;
             counts
         });
-    assert_eq!(
-        planned_owners,
-        BTreeMap::from([("#1808", 5), ("#1809", 11)])
-    );
+    assert_eq!(planned_owners, BTreeMap::from([("#1809", 11)]));
 
     let compiled_events = audit
         .classes
@@ -373,15 +370,20 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
         compiled_events,
         BTreeSet::from([
             LoggerCompiledEvent::ApiControl,
+            LoggerCompiledEvent::ApiWorker,
             LoggerCompiledEvent::ApiRequest,
             LoggerCompiledEvent::ApiResult,
             LoggerCompiledEvent::InstanceStart,
             LoggerCompiledEvent::FlushMetrics,
             LoggerCompiledEvent::BootTime,
+            LoggerCompiledEvent::Lifecycle,
+            LoggerCompiledEvent::Observability,
             LoggerCompiledEvent::RateLimitRecovery,
             LoggerCompiledEvent::ProcessStartup,
             LoggerCompiledEvent::ProcessPanic,
             LoggerCompiledEvent::ProcessExit,
+            LoggerCompiledEvent::ProcessSignal,
+            LoggerCompiledEvent::Snapshot,
         ])
     );
     let planned_with_compiled_events = audit


### PR DESCRIPTION
## Summary

- add closed, redacted logger events for host lifecycle, snapshots, boot-worker state, metrics-worker failures, signals, guest power convergence, and shutdown
- preserve action/process results through bounded host delivery and nonblocking asynchronous delivery, with an independent observability limiter
- promote exactly the five #1808 logger audit classes and extend unit, process, signed executable, and production-bundle coverage

## Scope exclusions

- low-level backend, vCPU, transport, and device causes remain owned by #1809
- aggregate logger capability certification remains owned by #1810

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented `aarch64-apple-darwin` signed-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` (Apple Silicon, no unsupported-platform bypass)

Closes #1808

Parent: #1786
