### PR TITLE
feat: log redacted device outcomes

### DIFF
--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -64,7 +64,7 @@ reviewed delta.
 | [Snapshot editor state](snapshot-editor-contract.md) | Native-state version/vCPU/VM inspection, finite reviewed-register editing, no-clobber publication, signed Full/Diff product restore, and the exact twelve-row closure |
 | [Snapshot Wave 6](snapshot-wave6-contract.md) | Exact 70-row load, artifact, version, device, tool, time/identity, portability, and downstream-owner certification |
 | [Observability, tools, and specification](observability-tools-specification-contract.md) | Exact Wave 7 ownership, core API certification, x86 CPUID/MSR platform exclusions, and retained downstream handoffs |
-| [Logger producers](logger-contract.md) | Exact 468-invocation source closure, 15 implemented configuration/API/host-lifecycle/worker/snapshot/backend/transport classes, safe fields, bounded default-stdout admission/forwarding policy, and remaining #1809 ownership |
+| [Logger producers](logger-contract.md) | Exact 468-invocation source closure, 19 implemented configuration/API/host-lifecycle/worker/snapshot/backend/transport/storage/network/vsock classes, safe fields, bounded default-stdout admission/forwarding policy, and five remaining #1809 classes |
 
 ## Dispositions
 

--- a/compat/firecracker/v1.16.0/logger-contract.md
+++ b/compat/firecracker/v1.16.0/logger-contract.md
@@ -68,14 +68,13 @@ source calls only when subsystem, observable outcome, target fields, delivery,
 module/origin behavior, limiter policy, disposition, and delivery owner agree.
 There are no path selectors and no `other`, `unknown`, or catch-all class.
 
-The 31 classes contain 15 implemented classes, 9 planned classes, and 7 exact
-not-applicable classes. Across source mappings this is 182 implemented, 224
+The 31 classes contain 19 implemented classes, 5 planned classes, and 7 exact
+not-applicable classes. Across source mappings this is 312 implemented, 94
 planned, and 62 not-applicable invocations.
 
 `planned` is an explicit intermediate delivery state. The remaining owner is:
 
-- #1809: storage, network/MMDS, vsock, memory-device, serial, entropy, and
-  time/identity outcomes.
+- #1809: balloon, memory-hotplug, serial, entropy, and time/identity outcomes.
 
 Delivery validation accepts those named planned classes. Final validation
 rejects every planned class.
@@ -107,6 +106,18 @@ the budget required by a later terminal vCPU outcome. Expected device
 rate-limiter rejection remains exact in metrics and is a debug record rather
 than a warning.
 
+Issue #1815 closes block, pmem, network/MMDS, and vsock outcomes. Device-owned
+observers consume the final typed queue result shared by MMIO and product PCI,
+then emit at most one record for each nonzero summary category rather than one
+record per request, packet, descriptor, connection, or byte. Failure and
+rejection categories are admitted before success categories. High-fanout vsock
+summaries use one fixed-capacity delivery batch after MMIO or product-PCI
+interrupt handling, so logging cannot extend the device-to-guest publication
+window. Narrow HVF supplements cover packet-provider acquisition and MMIO
+interrupt delivery; product-PCI endpoint owners cover MSI delivery. MMDS
+detours and transactional token-key rotation are fixed outcomes, and neither
+token nor key material can enter a record.
+
 ## Closed class ledger
 
 `Mappings` is the exact number of source identities assigned to the class.
@@ -120,13 +131,13 @@ Owners apply only to planned work.
 | `logger.api.result` | `implemented` | closed HTTP result plus retained actions | 5 |
 | `logger.backend.outcome` | `implemented` | typed HVF backend, vCPU, interrupt, and timer outcomes | 26 |
 | `logger.balloon.outcome` | `planned` | #1809 | 28 |
-| `logger.block.outcome` | `planned` | #1809 | 34 |
+| `logger.block.outcome` | `implemented` | fixed block request, queue, async, vhost-user, and interrupt outcomes | 34 |
 | `logger.boot.time` | `implemented` | bounded boot timing | 1 |
 | `logger.entropy.outcome` | `planned` | #1809 | 16 |
 | `logger.lifecycle.outcome` | `implemented` | fixed VM and live-device lifecycle | 24 |
 | `logger.limiter.recovery` | `implemented` | bounded suppressed count | 1 |
 | `logger.memory-hotplug.outcome` | `planned` | #1809 | 22 |
-| `logger.network.outcome` | `planned` | #1809 | 26 |
+| `logger.network.outcome` | `implemented` | fixed network, provider, MMDS, and interrupt outcomes | 26 |
 | `logger.nonapp.example` | `not-applicable` | `example-only` | 22 |
 | `logger.nonapp.fuzzing` | `not-applicable` | `developer-instrumentation` | 1 |
 | `logger.nonapp.gdb` | `not-applicable` | `developer-instrumentation` | 19 |
@@ -135,7 +146,7 @@ Owners apply only to planned work.
 | `logger.nonapp.tracing` | `not-applicable` | `tracing-owned` | 2 |
 | `logger.nonapp.x86` | `not-applicable` | `x86-only` | 15 |
 | `logger.observability.outcome` | `implemented` | rate-limited metrics-worker failure | 4 |
-| `logger.pmem.outcome` | `planned` | #1809 | 18 |
+| `logger.pmem.outcome` | `implemented` | fixed pmem flush, queue, limiter, and interrupt outcomes | 18 |
 | `logger.process-signal.outcome` | `implemented` | fixed signal and shutdown convergence | 5 |
 | `logger.process-startup.outcome` | `implemented` | fixed normal startup outcome | 5 |
 | `logger.process.exit` | `implemented` | fixed terminal category | 3 |
@@ -144,7 +155,7 @@ Owners apply only to planned work.
 | `logger.snapshot.outcome` | `implemented` | fixed create/load result | 18 |
 | `logger.time-identity.outcome` | `planned` | #1809 | 16 |
 | `logger.transport.outcome` | `implemented` | typed generic MMIO, virtio, PCI, queue, and interrupt outcomes | 74 |
-| `logger.vsock.outcome` | `planned` | #1809 | 52 |
+| `logger.vsock.outcome` | `implemented` | fixed vsock queue, connection, reset, and interrupt outcomes | 52 |
 
 The outcome classes are semantic, not raw-line mirrors. Their fixed
 `device-kind`, `operation`, and `outcome` values distinguish the public result;
@@ -170,6 +181,9 @@ The implemented host-owned records have exact fixed shapes:
   `device-kind=<balloon|block|entropy|memory-hotplug|network|pmem|serial|vsock>`
   plus `operation=<closed-transport-operation>
   outcome=<closed-transport-outcome>`;
+- block, pmem, network/MMDS, and vsock data planes:
+  `device-kind=<block|pmem|network|vsock>
+  operation=<closed-device-operation> outcome=<closed-device-outcome>`;
 - snapshots: `operation=<snapshot-create|snapshot-load>
   outcome=<succeeded|rejected|failed|cancelled>`;
 - worker and observability status:
@@ -223,9 +237,9 @@ including a host-only member of the same semantic class. This is deliberately
 conservative: it cannot grant a producer a blocking or unrestricted path.
 
 Every guest-capable class is rate-limited under its own fixed class identity.
-Backend and transport use `logger-rate.backend.outcome` and
-`logger-rate.transport.outcome`; the repeating asynchronous metrics-worker
-class independently uses `logger-rate.observability-worker`. The sole exception is
+Backend, transport, block, pmem, network, and vsock use their corresponding
+`logger-rate.<class>.outcome` identities; the repeating asynchronous
+metrics-worker class independently uses `logger-rate.observability-worker`. The sole exception is
 `logger.limiter.recovery`, which must be unrestricted to report a prior
 admitted recovery without recursively limiting itself. Queue,
 receipt, write, flush, and replacement loss never changes the request, VM,

--- a/compat/firecracker/v1.16.0/logger-producer-audit.json
+++ b/compat/firecracker/v1.16.0/logger-producer-audit.json
@@ -340,9 +340,65 @@
         "operation",
         "outcome"
       ],
-      "disposition": "planned",
-      "rationale": "All mapped upstream calls report the same semantic block device outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
-      "delivery_issue": "#1809"
+      "disposition": "implemented",
+      "rationale": "All mapped upstream calls converge on one bounded block notification, request, async-engine, vhost-user, configuration, or interrupt outcome per nonzero summary category. The typed device owner emits a closed level and fixed fields after the complete queue batch while discarding raw errors, paths, identifiers, descriptors, addresses, byte counts, and guest values.",
+      "compiled_events": [
+        "block"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "MMIO interrupt-delivery supplement for completed block batches"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "device-owned block, async-engine, vhost-user, and PCI interrupt outcome convergence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "closed nonblocking GuestLogger block producer"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed block outcome encoding and level selection"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/rate_limiter.rs",
+          "anchor": "independent block outcome limiter identity"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed MMIO and product-PCI block outcome reachability"
+        },
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "block interrupt result and redaction tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/launcher/tests/production_bundle_e2e.rs",
+          "anchor": "contained product-PCI block outcome and output-grant redaction"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "block queue, limiter, async, vhost-user, and unchanged-result tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "block filtering, limiting, delivery, and exact encoding tests"
+        }
+      ]
     },
     {
       "id": "logger.boot.time",
@@ -558,9 +614,80 @@
         "operation",
         "outcome"
       ],
-      "disposition": "planned",
-      "rationale": "All mapped upstream calls report the same semantic network or MMDS outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
-      "delivery_issue": "#1809"
+      "disposition": "implemented",
+      "rationale": "All mapped upstream calls converge on one bounded network queue, packet-provider, MMDS detour, token-key, or interrupt outcome per nonzero summary category. Device, provider, and token-authority owners emit closed levels only after typed results are known while discarding packets, tokens, keys, errors, paths, interface identifiers, MAC addresses, descriptors, byte counts, addresses, and guest values.",
+      "compiled_events": [
+        "network"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "packet-provider and MMIO interrupt outcome supplements"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "controller logger attachment to normal and restored MMDS state"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "closed nonblocking GuestLogger network producer"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed network and MMDS outcome encoding and level selection"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/rate_limiter.rs",
+          "anchor": "independent network outcome limiter identity"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/mmds_token.rs",
+          "anchor": "transactional MMDS token-key rotation outcome owner"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/network.rs",
+          "anchor": "device-owned RX, TX, limiter, MMDS-detour, and PCI interrupt outcome convergence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/startup.rs",
+          "anchor": "MMIO packet-provider acquisition failure owner"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "network provider, interrupt, partial-result, and redaction tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/launcher/tests/production_bundle_e2e.rs",
+          "anchor": "contained product-PCI MMDS detour and output-grant redaction"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "network filtering, limiting, delivery, and exact encoding tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/mmds_token.rs",
+          "anchor": "successful and failed rotation logging with key and token redaction"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/network.rs",
+          "anchor": "RX, TX, MMDS detour, limiter, and unchanged-result tests"
+        }
+      ]
     },
     {
       "id": "logger.nonapp.example",
@@ -738,9 +865,60 @@
         "operation",
         "outcome"
       ],
-      "disposition": "planned",
-      "rationale": "All mapped upstream calls report the same semantic pmem device outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
-      "delivery_issue": "#1809"
+      "disposition": "implemented",
+      "rationale": "All mapped upstream calls converge on one bounded pmem flush, request, queue, limiter, or interrupt outcome per nonzero summary category. The typed device owner observes the complete queue result, selects a closed level, and discards raw errors, paths, identifiers, descriptors, addresses, byte counts, and guest values.",
+      "compiled_events": [
+        "pmem"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "MMIO interrupt-delivery supplement for completed pmem batches"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "closed nonblocking GuestLogger pmem producer"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed pmem outcome encoding and level selection"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/rate_limiter.rs",
+          "anchor": "independent pmem outcome limiter identity"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "device-owned flush, request, limiter, and PCI interrupt outcome convergence"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "pmem interrupt result and redaction tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/launcher/tests/production_bundle_e2e.rs",
+          "anchor": "contained product-PCI pmem flush and output-grant redaction"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "pmem filtering, limiting, delivery, and exact encoding tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "pmem flush, parse, limiter, and unchanged-result tests"
+        }
+      ]
     },
     {
       "id": "logger.process-signal.outcome",
@@ -1180,9 +1358,60 @@
         "operation",
         "outcome"
       ],
-      "disposition": "planned",
-      "rationale": "All mapped upstream calls report the same semantic vsock transport or connection outcome; the closed outcome selects level while Bangbang discards raw errors, paths, identifiers, descriptors, addresses, and guest values.",
-      "delivery_issue": "#1809"
+      "disposition": "implemented",
+      "rationale": "All mapped upstream calls converge on one bounded vsock queue, connection, reset, or interrupt outcome per nonzero notification-batch category. The device-owned observer covers MMIO and product PCI, emits failure categories before success categories, and discards sockets, paths, connection keys, ports, packet headers, payloads, errors, descriptors, addresses, byte counts, and guest values.",
+      "compiled_events": [
+        "vsock"
+      ],
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "MMIO queue and transport-reset interrupt outcome supplements"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "closed nonblocking GuestLogger vsock producer"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/event.rs",
+          "anchor": "closed vsock outcome encoding and level selection"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/rate_limiter.rs",
+          "anchor": "independent vsock outcome limiter identity"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/vsock.rs",
+          "anchor": "device-owned queue, connection, reset, and PCI interrupt outcome convergence"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "vsock interrupt, partial-result, and reset tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/launcher/tests/production_bundle_e2e.rs",
+          "anchor": "contained MMIO vsock traffic and output-grant redaction"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "vsock filtering, limiting, delivery, and exact encoding tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/vsock.rs",
+          "anchor": "vsock queue, connection, reset, and unchanged-result tests"
+        }
+      ]
     }
   ],
   "mappings": [

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -17,6 +17,10 @@ mod vhost_user_block;
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod macos_arm64 {
+    use super::{
+        closed_backend_outcome_logger_level, closed_device_data_outcome_logger_level,
+        closed_transport_outcome_logger_level,
+    };
     use std::fs;
     use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
     use std::net::Shutdown;
@@ -6986,6 +6990,24 @@ mod macos_arm64 {
             &socket_path,
             &format!("bangbang remaining-device {transport}"),
         );
+        let logger_output = fs::read_to_string(&logger_path)
+            .expect("remaining-device logger output should be readable after shutdown");
+        assert!(
+            logger_output
+                .lines()
+                .any(|record| record == "device-kind=block operation=request outcome=succeeded"),
+            "signed {transport} block activity should reach the closed block producer; output:\n{logger_output}"
+        );
+        for forbidden in [
+            path_text(&control_path),
+            instance_id.as_str(),
+            REMAINING_DEVICE_SUCCESS_MARKER,
+        ] {
+            assert!(
+                !logger_output.contains(forbidden),
+                "signed {transport} device logger output must redact dynamic identity or guest data {forbidden:?}; output:\n{logger_output}"
+            );
+        }
 
         reset_zeroed_block_backing(&control_path, 8);
         let reused = if enable_pci {
@@ -7027,6 +7049,7 @@ mod macos_arm64 {
         let data_backing_path = test_dir.path().join("data.img");
         let pmem_backing_path = test_dir.path().join("pmem.img");
         let serial_output_path = test_dir.path().join("serial.out");
+        let logger_path = test_dir.path().join("all-virtio-logger.out");
         let metrics_path = test_dir.path().join("metrics.out");
         let uds_path = test_dir.path().join("pci-vsock.sock");
         let host_port_path = vsock_port_path(&uds_path, DIRECT_ROOTFS_VSOCK_PORT);
@@ -7049,6 +7072,14 @@ mod macos_arm64 {
         let mut bangbang =
             BangbangProcess::start_with_extra_args(&socket_path, &instance_id, &["--enable-pci"]);
 
+        assert_no_content_response(
+            &http_put_json(
+                &socket_path,
+                "/logger",
+                &format!(r#"{{"log_path":{}}}"#, json_string(path_text(&logger_path))),
+            ),
+            "PUT /logger product PCI",
+        );
         assert_no_content_response(
             &http_put_json(
                 &socket_path,
@@ -7416,6 +7447,31 @@ mod macos_arm64 {
             &socket_path,
             "bangbang all-virtio product PCI",
         );
+        let logger_output = fs::read_to_string(&logger_path)
+            .expect("all-virtio product PCI logger output should be readable");
+        for record in [
+            "device-kind=block operation=request outcome=succeeded",
+            "device-kind=pmem operation=flush outcome=succeeded",
+            "device-kind=network operation=mmds-request outcome=detoured",
+            "device-kind=vsock operation=guest-connection outcome=retained",
+        ] {
+            assert!(
+                logger_output.lines().any(|line| line == record),
+                "all-virtio product PCI should reach {record}; output:\n{logger_output}"
+            );
+        }
+        for forbidden in [
+            path_text(&data_backing_path),
+            path_text(&pmem_backing_path),
+            path_text(&uds_path),
+            "06:00:00:00:00:01",
+            "BANGBANG_MMDS_GUEST_VALUE",
+        ] {
+            assert!(
+                !logger_output.contains(forbidden),
+                "all-virtio product PCI device records must redact {forbidden:?}; output:\n{logger_output}"
+            );
+        }
         assert!(
             !uds_path.exists(),
             "product PCI shutdown should remove the owned main vsock listener"
@@ -18205,6 +18261,9 @@ mod macos_arm64 {
             if record == "event=process-panic" || is_closed_control_logger_line(record) {
                 continue;
             }
+            if is_rate_limit_recovery_logger_line(record) {
+                continue;
+            }
             if is_closed_host_outcome_logger_line(record) {
                 continue;
             }
@@ -18292,6 +18351,7 @@ mod macos_arm64 {
             return Some(level);
         }
         match record {
+            record if is_rate_limit_recovery_logger_line(record) => Some("Warn"),
             "operation=server outcome=stopped" => Some("Debug"),
             "operation=connection outcome=failed"
             | "operation=request-parse outcome=bad-request"
@@ -18341,6 +18401,12 @@ mod macos_arm64 {
         )
     }
 
+    fn is_rate_limit_recovery_logger_line(line: &str) -> bool {
+        line.strip_suffix(" messages were suppressed due to rate limiting")
+            .and_then(|count| count.parse::<u64>().ok())
+            .is_some_and(|count| count != 0)
+    }
+
     fn is_closed_host_outcome_logger_line(line: &str) -> bool {
         closed_host_outcome_logger_level(line).is_some()
     }
@@ -18381,7 +18447,12 @@ mod macos_arm64 {
             | "operation=shutdown outcome=orderly"
             | "operation=snapshot-create outcome=succeeded"
             | "operation=snapshot-load outcome=succeeded" => "Info",
-            _ => return closed_live_device_outcome_logger_level(line),
+            _ => {
+                return closed_live_device_outcome_logger_level(line)
+                    .or_else(|| closed_device_data_outcome_logger_level(line))
+                    .or_else(|| closed_backend_outcome_logger_level(line))
+                    .or_else(|| closed_transport_outcome_logger_level(line));
+            }
         };
         Some(level)
     }
@@ -18426,20 +18497,52 @@ mod macos_arm64 {
             panic!("logger output {} should be readable: {err}", path.display())
         });
 
-        assert_eq!(
-            output,
-            concat!(
-                "operation=backend-startup outcome=succeeded\n",
-                "action=InstanceStart\n",
-                "operation=boot-worker outcome=running\n",
-                "operation=vm-start outcome=succeeded\n",
-                "operation=process-startup outcome=running\n",
-                "device-kind=block operation=device-reset outcome=succeeded\n",
-                "device-kind=vsock operation=device-reset outcome=succeeded\n",
-                "device-kind=block operation=device-activation outcome=succeeded\n",
-                "device-kind=vsock operation=device-activation outcome=succeeded\n",
-            ),
-            "no-api logger output should include the closed startup lifecycle"
+        const HOST_STARTUP: &[&str] = &[
+            "operation=backend-startup outcome=succeeded",
+            "action=InstanceStart",
+            "operation=boot-worker outcome=running",
+            "operation=vm-start outcome=succeeded",
+            "operation=process-startup outcome=running",
+        ];
+        let records = output.lines().collect::<Vec<_>>();
+        assert!(
+            records.starts_with(HOST_STARTUP),
+            "no-api logger output should start with the closed host startup lifecycle; output:\n{output}"
+        );
+        assert!(
+            records.iter().skip(HOST_STARTUP.len()).all(|record| {
+                closed_device_data_outcome_logger_level(record).is_some()
+                    || closed_transport_outcome_logger_level(record).is_some()
+                    || is_rate_limit_recovery_logger_line(record)
+            }),
+            "no-api logger output should contain only closed device or limiter records after startup; output:\n{output}"
+        );
+
+        let position = |record: &str| {
+            records
+                .iter()
+                .position(|candidate| *candidate == record)
+                .unwrap_or_else(|| {
+                    panic!("no-api logger output should contain {record}; output:\n{output}")
+                })
+        };
+        let block_reset = position("device-kind=block operation=device-reset outcome=succeeded");
+        let block_activation =
+            position("device-kind=block operation=device-activation outcome=succeeded");
+        let block_request = position("device-kind=block operation=request outcome=succeeded");
+        assert!(
+            block_reset < block_activation && block_activation < block_request,
+            "no-api block records should preserve reset, activation, then request order; output:\n{output}"
+        );
+
+        let vsock_reset = position("device-kind=vsock operation=device-reset outcome=succeeded");
+        let vsock_activation =
+            position("device-kind=vsock operation=device-activation outcome=succeeded");
+        let vsock_connection =
+            position("device-kind=vsock operation=host-connection outcome=accepted");
+        assert!(
+            vsock_reset < vsock_activation && vsock_activation < vsock_connection,
+            "no-api vsock records should preserve reset, activation, then accepted connection order; output:\n{output}"
         );
     }
 
@@ -18478,6 +18581,10 @@ mod macos_arm64 {
              level=Info origin=crates/runtime/src/logger.rs:2 action=request outcome=ok\n\
              level=Info origin=crates/runtime/src/logger.rs:3 action=InstanceStart\n\
              level=Warn origin=crates/runtime/src/logger.rs:4 operation=request outcome=deprecated\n\
+             level=Info origin=crates/runtime/src/block.rs:5 device-kind=block operation=request outcome=succeeded\n\
+             level=Error origin=crates/runtime/src/pmem.rs:6 device-kind=pmem operation=flush outcome=failed\n\
+             level=Warn origin=crates/runtime/src/network.rs:7 device-kind=network operation=packet-provider outcome=partial\n\
+             level=Debug origin=crates/runtime/src/vsock.rs:8 device-kind=vsock operation=host-connection outcome=pending\n\
              level=Info origin=crates/runtime/src/logger.rs:5 The API server received a Put request on \"/actions\".\n\
              level=Info origin=crates/runtime/src/logger.rs:6 action=FlushMetrics\n\
              level=Info origin=crates/runtime/src/logger.rs:7 action=request outcome=no-content\n",
@@ -18498,6 +18605,17 @@ mod macos_arm64 {
                 "device-kind=network operation=device-update outcome=rejected",
                 "Error",
             ),
+            ("operation=virtual-timer outcome=activated", "Debug"),
+            ("operation=vcpu-exit outcome=guest-shutdown", "Info"),
+            (
+                "device-kind=block operation=device-activation outcome=succeeded",
+                "Info",
+            ),
+            (
+                "device-kind=network operation=rate-limiter outcome=rejected",
+                "Debug",
+            ),
+            ("operation=mmio-registration outcome=failed", "Error"),
         ] {
             assert_eq!(closed_host_outcome_logger_level(record), Some(level));
         }
@@ -18505,8 +18623,89 @@ mod macos_arm64 {
             "operation=vm-start outcome=private-error",
             "device-kind=private operation=device-update outcome=failed",
             "device-kind=block operation=device-update outcome=failed id=secret",
+            "device-kind=block operation=pci-publication outcome=succeeded",
+            "operation=vcpu-exit outcome=private",
         ] {
             assert_eq!(closed_host_outcome_logger_level(malformed), None);
+        }
+    }
+
+    #[test]
+    fn logger_output_accepts_only_closed_device_data_outcomes_with_exact_levels() {
+        for (record, level) in [
+            (
+                "device-kind=block operation=rate-limiter outcome=throttled",
+                "Debug",
+            ),
+            (
+                "device-kind=block operation=request outcome=succeeded",
+                "Info",
+            ),
+            (
+                "device-kind=block operation=vhost-user-notification outcome=disconnected",
+                "Warn",
+            ),
+            (
+                "device-kind=block operation=interrupt-delivery outcome=failed",
+                "Error",
+            ),
+            (
+                "device-kind=pmem operation=rate-limiter outcome=resumed",
+                "Debug",
+            ),
+            ("device-kind=pmem operation=flush outcome=succeeded", "Info"),
+            (
+                "device-kind=pmem operation=queue-notification outcome=unsupported",
+                "Warn",
+            ),
+            (
+                "device-kind=pmem operation=status-write outcome=failed",
+                "Error",
+            ),
+            (
+                "device-kind=network operation=rx-buffer outcome=unavailable",
+                "Debug",
+            ),
+            (
+                "device-kind=network operation=mmds-request outcome=detoured",
+                "Info",
+            ),
+            (
+                "device-kind=network operation=tx-frame outcome=spoof-rejected",
+                "Warn",
+            ),
+            (
+                "device-kind=network operation=mmds-token-key outcome=failed",
+                "Error",
+            ),
+            (
+                "device-kind=vsock operation=guest-connection outcome=ignored",
+                "Debug",
+            ),
+            (
+                "device-kind=vsock operation=connection-reset outcome=queued",
+                "Info",
+            ),
+            (
+                "device-kind=vsock operation=host-connection outcome=dropped",
+                "Warn",
+            ),
+            (
+                "device-kind=vsock operation=transport-reset outcome=failed",
+                "Error",
+            ),
+        ] {
+            assert_eq!(closed_device_data_outcome_logger_level(record), Some(level));
+        }
+
+        for malformed in [
+            "device-kind=block operation=request outcome=private-error",
+            "device-kind=pmem operation=request outcome=succeeded",
+            "device-kind=network operation=host-connection outcome=accepted",
+            "device-kind=vsock operation=tx-frame outcome=spoof-rejected",
+            "device-kind=block operation=request outcome=succeeded id=secret",
+        ] {
+            assert_eq!(closed_device_data_outcome_logger_level(malformed), None);
         }
     }
 
@@ -19558,4 +19757,172 @@ mod macos_arm64 {
 
         Ok(libc::timespec { tv_sec, tv_nsec })
     }
+}
+
+fn closed_device_data_outcome_logger_level(line: &str) -> Option<&'static str> {
+    let mut fields = line.split(' ');
+    let kind = fields.next()?.strip_prefix("device-kind=")?;
+    let operation = fields.next()?.strip_prefix("operation=")?;
+    let outcome = fields.next()?.strip_prefix("outcome=")?;
+    if fields.next().is_some() {
+        return None;
+    }
+
+    match (kind, operation, outcome) {
+        ("block", "rate-limiter", "throttled" | "resumed")
+        | ("block", "async-engine", "throttled")
+        | ("pmem", "rate-limiter", "throttled" | "resumed")
+        | ("network", "rx-buffer", "unavailable")
+        | ("network", "rate-limiter", "throttled" | "resumed")
+        | ("vsock", "host-connection", "pending")
+        | ("vsock", "guest-connection", "ignored") => Some("Debug"),
+
+        ("block", "request", "succeeded")
+        | ("block", "vhost-user-notification", "succeeded")
+        | ("block", "vhost-user-config", "succeeded")
+        | ("pmem", "flush", "succeeded")
+        | ("network", "rx" | "tx", "succeeded")
+        | ("network", "mmds-request", "detoured")
+        | ("network", "mmds-token-key", "rotated")
+        | ("vsock", "rx" | "tx", "succeeded")
+        | ("vsock", "host-connection", "accepted" | "completed")
+        | ("vsock", "guest-connection", "retained" | "forwarded" | "updated" | "closed")
+        | ("vsock", "connection-reset", "queued")
+        | ("vsock", "transport-reset", "succeeded") => Some("Info"),
+
+        ("block", "request", "unsupported")
+        | ("block", "queue-notification", "unsupported")
+        | ("block", "vhost-user-notification", "disconnected")
+        | ("pmem", "queue-notification", "unsupported")
+        | ("network", "rx-buffer", "too-small")
+        | ("network", "tx-frame", "spoof-rejected")
+        | ("network", "queue-notification", "unsupported")
+        | ("network", "packet-provider", "partial")
+        | ("vsock", "rx-buffer", "too-small")
+        | ("vsock", "queue-notification", "unsupported")
+        | ("vsock", "host-connection", "dropped")
+        | ("vsock", "guest-connection", "dropped")
+        | ("vsock", "connection-reset", "dropped") => Some("Warn"),
+
+        ("block", "request-parse" | "request-io" | "status-write", "failed")
+        | ("block", "queue-dispatch", "failed")
+        | ("block", "queue-notification", "inactive")
+        | ("block", "async-engine", "failed")
+        | ("block", "vhost-user-notification", "failed" | "terminal")
+        | ("block", "vhost-user-config", "failed")
+        | ("block", "interrupt-delivery", "failed")
+        | ("pmem", "flush" | "request-parse" | "status-write", "failed")
+        | ("pmem", "queue-dispatch", "failed")
+        | ("pmem", "queue-notification", "inactive")
+        | ("pmem", "interrupt-delivery", "failed")
+        | ("network", "rx-buffer", "malformed")
+        | ("network", "rx-provider", "failed")
+        | ("network", "tx-frame", "malformed")
+        | ("network", "tx-provider", "failed")
+        | ("network", "queue-dispatch", "failed")
+        | ("network", "queue-notification", "inactive")
+        | ("network", "packet-provider", "failed")
+        | ("network", "mmds-token-key", "failed")
+        | ("network", "interrupt-delivery", "failed")
+        | ("vsock", "rx-buffer" | "tx-packet", "malformed")
+        | ("vsock", "queue-dispatch", "failed")
+        | ("vsock", "queue-notification", "inactive")
+        | ("vsock", "transport-reset" | "interrupt-delivery", "failed") => Some("Error"),
+        _ => None,
+    }
+}
+
+fn closed_backend_outcome_logger_level(line: &str) -> Option<&'static str> {
+    match line {
+        "operation=virtual-timer outcome=activated" => Some("Debug"),
+        "operation=vcpu-exit outcome=guest-shutdown"
+        | "operation=vcpu-exit outcome=guest-reset" => Some("Info"),
+        "operation=vcpu-exit outcome=unsupported" => Some("Warn"),
+        "operation=cache-configuration outcome=failed"
+        | "operation=memory-map outcome=failed"
+        | "operation=memory-discard outcome=failed"
+        | "operation=vm-create outcome=failed"
+        | "operation=vm-cleanup outcome=failed"
+        | "operation=vcpu-start outcome=failed"
+        | "operation=vcpu-run outcome=failed"
+        | "operation=mmio-dispatch outcome=failed"
+        | "operation=interrupt-delivery outcome=failed"
+        | "operation=virtual-timer outcome=failed" => Some("Error"),
+        _ => None,
+    }
+}
+
+fn closed_transport_outcome_logger_level(line: &str) -> Option<&'static str> {
+    if let Some((operation, outcome)) = parse_transport_outcome_without_device(line) {
+        return match (operation, outcome) {
+            ("mmio-registration" | "mmio-release", "succeeded") => Some("Debug"),
+            ("publication-rollback", "succeeded") | ("used-ring", "rejected") => Some("Warn"),
+            (
+                "mmio-registration" | "mmio-release" | "mmio-access" | "publication-rollback",
+                "failed",
+            ) => Some("Error"),
+            _ => None,
+        };
+    }
+
+    let mut fields = line.split(' ');
+    let kind = fields.next()?.strip_prefix("device-kind=")?;
+    let operation = fields.next()?.strip_prefix("operation=")?;
+    let outcome = fields.next()?.strip_prefix("outcome=")?;
+    if fields.next().is_some()
+        || !matches!(
+            kind,
+            "balloon"
+                | "block"
+                | "entropy"
+                | "memory-hotplug"
+                | "network"
+                | "pmem"
+                | "serial"
+                | "vsock"
+        )
+    {
+        return None;
+    }
+
+    match (operation, outcome) {
+        ("queue-notification", "succeeded")
+        | ("msi-configuration", "succeeded")
+        | ("interrupt-delivery", "delivered")
+        | ("rate-limiter", "rejected") => Some("Debug"),
+        ("device-activation" | "device-reset", "succeeded")
+        | ("pci-publication", "published")
+        | ("pci-removal", "removed") => Some("Info"),
+        (
+            "feature-negotiation"
+            | "device-config"
+            | "queue-configuration"
+            | "used-ring"
+            | "pci-config",
+            "rejected",
+        )
+        | ("device-reset", "unsupported")
+        | ("publication-rollback", "succeeded") => Some("Warn"),
+        (
+            "mmio-access"
+            | "device-config"
+            | "queue-notification"
+            | "device-activation"
+            | "device-reset"
+            | "pci-publication"
+            | "pci-removal"
+            | "msi-configuration"
+            | "interrupt-delivery"
+            | "publication-rollback",
+            "failed",
+        ) => Some("Error"),
+        _ => None,
+    }
+}
+
+fn parse_transport_outcome_without_device(line: &str) -> Option<(&str, &str)> {
+    let mut fields = line.split(' ');
+    let operation = fields.next()?.strip_prefix("operation=")?;
+    let outcome = fields.next()?.strip_prefix("outcome=")?;
+    (fields.next().is_none()).then_some((operation, outcome))
 }

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -37685,6 +37685,9 @@ mod tests {
     use bangbang_runtime::interrupt::{
         DeviceInterruptKind, GuestInterruptLine, InterruptSignalError, InterruptSink,
     };
+    use bangbang_runtime::logger::{
+        GuestLogger, LoggerApiControlOutcome, LoggerConfigInput, LoggerState,
+    };
     use bangbang_runtime::machine::MachineConfigInput;
     use bangbang_runtime::memory::{
         GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange, aarch64,
@@ -40342,6 +40345,41 @@ mod tests {
     impl Drop for TempFile {
         fn drop(&mut self) {
             let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    struct TestGuestLoggerCapture {
+        state: LoggerState,
+        logger: GuestLogger,
+        file: TempFile,
+    }
+
+    impl TestGuestLoggerCapture {
+        fn new(name: &str) -> Self {
+            let file = temp_file(name, &[]);
+            let mut state = LoggerState::default();
+            state
+                .configure(LoggerConfigInput::new().with_log_path(file.path()))
+                .expect("test guest logger should configure");
+            let logger = state.guest_logger();
+            Self {
+                state,
+                logger,
+                file,
+            }
+        }
+
+        fn logger(&self) -> &GuestLogger {
+            &self.logger
+        }
+
+        fn output_after_barrier(&self) -> String {
+            assert!(
+                self.state
+                    .log_api_control(LoggerApiControlOutcome::RequestDeprecated),
+                "host record should provide a logger delivery barrier"
+            );
+            fs::read_to_string(self.file.path()).expect("test guest logger output should read")
         }
     }
 
@@ -44418,6 +44456,20 @@ mod tests {
             ),
             DeviceInterruptKind::Queue.status().bits()
         );
+        let capture = TestGuestLoggerCapture::new("block-interrupt-failure-logger");
+        let observed_result: Result<_, HvfArm64BootBlockNotificationDispatchError> = Ok(result);
+        super::observe_block_interrupt_delivery(capture.logger(), &observed_result);
+        let logger_output = capture.output_after_barrier();
+        assert_eq!(
+            logger_output
+                .lines()
+                .filter(|line| {
+                    *line == "device-kind=block operation=interrupt-delivery outcome=failed"
+                })
+                .count(),
+            1,
+            "MMIO block signal failure should emit one class supplement; output:\n{logger_output}"
+        );
     }
 
     #[test]
@@ -44796,6 +44848,20 @@ mod tests {
                     .with_event_fails(1)
                     .with_queue_event_count(1),
             )
+        );
+        let capture = TestGuestLoggerCapture::new("pmem-interrupt-failure-logger");
+        let observed_result: Result<_, HvfArm64BootPmemNotificationDispatchError> = Ok(result);
+        super::observe_pmem_interrupt_delivery(capture.logger(), &observed_result);
+        let logger_output = capture.output_after_barrier();
+        assert_eq!(
+            logger_output
+                .lines()
+                .filter(|line| {
+                    *line == "device-kind=pmem operation=interrupt-delivery outcome=failed"
+                })
+                .count(),
+            1,
+            "MMIO pmem signal failure should emit one class supplement; output:\n{logger_output}"
         );
     }
 
@@ -45353,8 +45419,10 @@ mod tests {
 
     #[test]
     fn network_notification_packet_io_dispatch_preserves_pending_on_provider_failure() {
+        let capture = TestGuestLoggerCapture::new("network-provider-failure-logger");
         let (mut memory, mut runtime, mut mmio_dispatcher) =
             boot_runtime_with_networks(&[("eth0", "tap0")]);
+        mmio_dispatcher.attach_guest_logger(capture.logger().clone());
         configure_boot_network_queues(&mut runtime, &mut mmio_dispatcher, 0);
         write_network_tx_header(&mut memory);
         memory
@@ -45410,6 +45478,19 @@ mod tests {
                 NetworkInterfaceMetrics::default().with_event_fails(1),
             )
         );
+        let logger_output = capture.output_after_barrier();
+        assert_eq!(
+            logger_output
+                .lines()
+                .filter(|line| {
+                    *line == "device-kind=network operation=packet-provider outcome=failed"
+                })
+                .count(),
+            1,
+            "provider acquisition failure should emit one closed supplement; output:\n{logger_output}"
+        );
+        assert!(!logger_output.contains("eth0"));
+        assert!(!logger_output.contains("tap0"));
 
         let retried =
             dispatch_boot_network_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
@@ -45567,6 +45648,20 @@ mod tests {
                 VirtioMmioRegister::InterruptStatus
             ),
             DeviceInterruptKind::Queue.status().bits()
+        );
+        let capture = TestGuestLoggerCapture::new("network-interrupt-failure-logger");
+        let observed_result: Result<_, HvfArm64BootNetworkNotificationDispatchError> = Ok(result);
+        super::observe_network_interrupt_delivery(capture.logger(), &observed_result);
+        let logger_output = capture.output_after_barrier();
+        assert_eq!(
+            logger_output
+                .lines()
+                .filter(|line| {
+                    *line == "device-kind=network operation=interrupt-delivery outcome=failed"
+                })
+                .count(),
+            1,
+            "MMIO network signal failure should emit one class supplement; output:\n{logger_output}"
         );
     }
 
@@ -46018,6 +46113,20 @@ mod tests {
                 .with_muxer_event_fails(1)
                 .with_tx_queue_event_count(1)
                 .with_tx_packets_count(1)
+        );
+        let capture = TestGuestLoggerCapture::new("vsock-interrupt-failure-logger");
+        let observed_result: Result<_, HvfArm64BootVsockNotificationDispatchError> = Ok(result);
+        super::observe_vsock_interrupt_delivery(capture.logger(), &observed_result);
+        let logger_output = capture.output_after_barrier();
+        assert_eq!(
+            logger_output
+                .lines()
+                .filter(|line| {
+                    *line == "device-kind=vsock operation=interrupt-delivery outcome=failed"
+                })
+                .count(),
+            1,
+            "MMIO vsock signal failure should emit one class supplement; output:\n{logger_output}"
         );
     }
 

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -50,7 +50,10 @@ use bangbang_runtime::fdt::{
 use bangbang_runtime::interrupt::{
     DeviceInterruptKind, DeviceInterruptTriggerError, GuestInterruptLine, InterruptSink,
 };
-use bangbang_runtime::logger::{GuestLogger, LoggerBackendOutcome};
+use bangbang_runtime::logger::{
+    GuestLogger, LoggerBackendOutcome, LoggerBlockOutcome, LoggerNetworkOutcome, LoggerPmemOutcome,
+    LoggerVsockOutcome,
+};
 use bangbang_runtime::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryBacking, GuestMemoryLayout,
     GuestMemoryRange,
@@ -2170,6 +2173,7 @@ impl HvfArm64BootPciDataDevices {
         memory: &mut GuestMemory,
         mut packet_io: Option<&mut dyn Arm64BootNetworkPacketIoProvider>,
         metrics: &SharedNetworkInterfaceMetricsRegistry,
+        guest_logger: &GuestLogger,
     ) -> Option<Duration> {
         for device in &mut self.network {
             let mut retry_after = None;
@@ -2197,6 +2201,7 @@ impl HvfArm64BootPciDataDevices {
                         }
                         Err(_) => {
                             metrics.record_event_failure_for_interface(&device.iface_id);
+                            guest_logger.log_network(LoggerNetworkOutcome::PacketProviderFailed);
                             device.retry_deadline = None;
                             continue;
                         }
@@ -11396,6 +11401,8 @@ fn capture_ready_vsock_state_with_cancel(
         ));
     }
 
+    let guest_logger = owner.backend.guest_logger();
+
     let mmio = owner.runtime_resources.vsock_device.as_ref();
     let pci = owner
         .pci_data_devices
@@ -11549,6 +11556,7 @@ fn capture_ready_vsock_state_with_cancel(
                 });
                 if !delivered {
                     owner.session_metrics.record_event_queue_signal_failure();
+                    guest_logger.log_vsock(LoggerVsockOutcome::InterruptDeliveryFailed);
                     return Err(vsock_capture_error(
                         HvfArm64BootVsockCaptureErrorKind::InterruptDelivery,
                         HvfArm64BootVsockCaptureStage::InterruptDelivery,
@@ -16506,6 +16514,7 @@ impl HvfArm64BootSession<'_> {
             Ok(dispatches) => record_block_signal_metrics(&self.block_device_metrics, dispatches),
             Err(_) => self.block_device_metrics.record_event_failure(),
         }
+        observe_block_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
     }
 
@@ -16570,6 +16579,7 @@ impl HvfArm64BootSession<'_> {
             }
             Err(_) => self.network_interface_metrics.record_event_failure(),
         }
+        observe_network_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
     }
 
@@ -16616,6 +16626,7 @@ impl HvfArm64BootSession<'_> {
             }
             Err(_) => self.network_interface_metrics.record_event_failure(),
         }
+        observe_network_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
     }
 
@@ -16653,11 +16664,16 @@ impl HvfArm64BootSession<'_> {
         };
 
         record_vsock_runtime_dispatch_metrics(&self.vsock_device_metrics, dispatches.as_slice());
-        let result = collect_or_signal_vsock_queue_interrupts(dispatches, &self.gic);
+        let result = collect_or_signal_vsock_queue_interrupts(
+            dispatches,
+            &self.gic,
+            &self.backend.guest_logger(),
+        );
         match &result {
             Ok(dispatches) => record_vsock_signal_metrics(&self.vsock_device_metrics, dispatches),
             Err(_) => self.vsock_device_metrics.record_muxer_event_failure(),
         }
+        observe_vsock_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
     }
 
@@ -18445,6 +18461,7 @@ fn publish_snapshot_v2_vsock_pci(
     memory: &GuestMemory,
     input: HvfSnapshotV2VsockPciRestoreInput<'_>,
     failure_index: usize,
+    guest_logger: &GuestLogger,
 ) -> Result<RestoredHvfSnapshotV2VsockPciMetadata, HvfSnapshotV2NetworkPciBatchFailure> {
     let HvfSnapshotV2VsockPciRestoreInput {
         endpoint,
@@ -18492,13 +18509,17 @@ fn publish_snapshot_v2_vsock_pci(
     let sbdf = endpoint.sbdf();
     let bar_range = endpoint.bar_range();
     let bar_region_id = endpoint.bar_region_id();
-    let prepared = match endpoint.state().clone().into_pci_endpoint(
-        &config,
-        memory,
-        resource,
-        bar_region_id,
-        interrupts.registry(),
-    ) {
+    let prepared = match endpoint
+        .state()
+        .clone()
+        .into_pci_endpoint_with_guest_logger(
+            &config,
+            memory,
+            resource,
+            bar_region_id,
+            interrupts.registry(),
+            guest_logger.clone(),
+        ) {
         Ok(prepared) => prepared,
         Err(_) => {
             let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
@@ -20112,11 +20133,20 @@ impl OwnedHvfArm64BootSession {
                     session, stage,
                 ));
             }
+            let guest_logger = session.backend.guest_logger();
             let reconstruction = session
                 .backend
                 .mapped_guest_memory()
                 .ok()
-                .and_then(|memory| capture.reconstruct_snapshot_handler(memory, resource).ok());
+                .and_then(|memory| {
+                    capture
+                        .reconstruct_snapshot_handler_with_guest_logger(
+                            memory,
+                            resource,
+                            guest_logger,
+                        )
+                        .ok()
+                });
             let Some(handler) = reconstruction else {
                 return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
                     session, stage,
@@ -20938,6 +20968,7 @@ impl OwnedHvfArm64BootSession {
                                 pci_data_devices,
                                 ..
                             } = &mut session;
+                            let guest_logger = backend.guest_logger();
                             let memory = backend.mapped_guest_memory();
                             match (memory, pci_data_devices.as_mut()) {
                                 (Ok(memory), Some(manager)) => publish_snapshot_v2_vsock_pci(
@@ -20945,6 +20976,7 @@ impl OwnedHvfArm64BootSession {
                                     memory,
                                     vsock,
                                     network_count,
+                                    &guest_logger,
                                 ),
                                 _ => Err(HvfSnapshotV2NetworkPciBatchFailure {
                                     index: network_count,
@@ -27045,6 +27077,7 @@ impl OwnedHvfArm64BootSession {
         }
 
         if let Some(vsock) = vsock_publication.take() {
+            let guest_logger = platform.backend().guest_logger();
             let memory = match platform.guest_memory() {
                 Ok(memory) => memory,
                 Err(_) => fail_after_platform!(
@@ -27059,7 +27092,13 @@ impl OwnedHvfArm64BootSession {
                     HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
                 ),
             };
-            match publish_snapshot_v2_vsock_pci(manager, memory, vsock, following_vsock_index) {
+            match publish_snapshot_v2_vsock_pci(
+                manager,
+                memory,
+                vsock,
+                following_vsock_index,
+                &guest_logger,
+            ) {
                 Ok(vsock) => match restored_network.as_mut() {
                     Some(network) if network.vsock.is_none() => network.vsock = Some(vsock),
                     _ => fail_after_platform!(
@@ -30433,6 +30472,7 @@ impl OwnedHvfArm64BootSession {
             Ok(dispatches) => record_block_signal_metrics(&self.block_device_metrics, dispatches),
             Err(_) => self.block_device_metrics.record_event_failure(),
         }
+        observe_block_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
     }
 
@@ -30497,6 +30537,7 @@ impl OwnedHvfArm64BootSession {
             }
             Err(_) => self.network_interface_metrics.record_event_failure(),
         }
+        observe_network_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
     }
 
@@ -30543,6 +30584,7 @@ impl OwnedHvfArm64BootSession {
             }
             Err(_) => self.network_interface_metrics.record_event_failure(),
         }
+        observe_network_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
     }
 
@@ -30580,11 +30622,16 @@ impl OwnedHvfArm64BootSession {
         };
 
         record_vsock_runtime_dispatch_metrics(&self.vsock_device_metrics, dispatches.as_slice());
-        let result = collect_or_signal_vsock_queue_interrupts(dispatches, &self.gic);
+        let result = collect_or_signal_vsock_queue_interrupts(
+            dispatches,
+            &self.gic,
+            &self.backend.guest_logger(),
+        );
         match &result {
             Ok(dispatches) => record_vsock_signal_metrics(&self.vsock_device_metrics, dispatches),
             Err(_) => self.vsock_device_metrics.record_muxer_event_failure(),
         }
+        observe_vsock_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
     }
 
@@ -33963,22 +34010,31 @@ fn collect_network_notification_dispatches(
     Ok(HvfArm64BootNetworkNotificationDispatches::new_with_retry_after(devices, retry_after))
 }
 
+#[cfg(test)]
 fn collect_vsock_notification_dispatches(
     dispatches: Arm64BootVsockNotificationDispatches,
 ) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError> {
+    collect_vsock_notification_dispatches_with_logger(dispatches, None)
+}
+
+fn collect_vsock_notification_dispatches_with_logger(
+    dispatches: Arm64BootVsockNotificationDispatches,
+    logger: Option<&GuestLogger>,
+) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError> {
     let runtime_dispatches = dispatches.into_vec();
     let mut devices = Vec::new();
-    devices
-        .try_reserve_exact(runtime_dispatches.len())
-        .map_err(
-            |source| HvfArm64BootVsockNotificationDispatchError::ResultAllocation { source },
-        )?;
+    if let Err(source) = devices.try_reserve_exact(runtime_dispatches.len()) {
+        observe_runtime_vsock_notification_dispatches(logger, &runtime_dispatches);
+        return Err(HvfArm64BootVsockNotificationDispatchError::ResultAllocation { source });
+    }
 
     for dispatch in runtime_dispatches {
         devices.push(HvfArm64BootVsockNotificationDispatch::new(dispatch, None));
     }
 
-    Ok(HvfArm64BootVsockNotificationDispatches::new(devices))
+    let dispatches = HvfArm64BootVsockNotificationDispatches::new(devices);
+    observe_hvf_vsock_notification_dispatches(logger, &dispatches);
+    Ok(dispatches)
 }
 
 fn collect_balloon_notification_dispatches(
@@ -34196,11 +34252,12 @@ fn dispatch_pci_network_notifications(
     metrics: &SharedNetworkInterfaceMetricsRegistry,
 ) -> Result<HvfArm64BootNetworkNotificationDispatches, HvfArm64BootNetworkNotificationDispatchError>
 {
+    let guest_logger = backend.guest_logger();
     let memory = backend.mapped_guest_memory_mut().map_err(|source| {
         HvfArm64BootNetworkNotificationDispatchError::MapGuestMemory { source }
     })?;
     Ok(HvfArm64BootNetworkNotificationDispatches::from_pci_retry(
-        devices.dispatch_network(memory, packet_io, metrics),
+        devices.dispatch_network(memory, packet_io, metrics, &guest_logger),
     ))
 }
 
@@ -34237,6 +34294,7 @@ fn dispatch_pmem_queue_notifications_and_signal_interrupts(
         Ok(dispatches) => record_pmem_signal_metrics(metrics, dispatches),
         Err(_) => metrics.record_event_failure(),
     }
+    observe_pmem_interrupt_delivery(&backend.guest_logger(), &result);
     result
 }
 
@@ -34581,6 +34639,78 @@ fn record_vsock_signal_metrics(
     }
 }
 
+fn observe_block_interrupt_delivery(
+    logger: &GuestLogger,
+    result: &Result<
+        HvfArm64BootBlockNotificationDispatches,
+        HvfArm64BootBlockNotificationDispatchError,
+    >,
+) {
+    if matches!(
+        result,
+        Ok(dispatches) if dispatches.has_signal_failure()
+    ) || matches!(
+        result,
+        Err(HvfArm64BootBlockNotificationDispatchError::CreateSignalSink { .. })
+    ) {
+        logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
+    }
+}
+
+fn observe_pmem_interrupt_delivery(
+    logger: &GuestLogger,
+    result: &Result<
+        HvfArm64BootPmemNotificationDispatches,
+        HvfArm64BootPmemNotificationDispatchError,
+    >,
+) {
+    if matches!(
+        result,
+        Ok(dispatches) if dispatches.has_signal_failure()
+    ) || matches!(
+        result,
+        Err(HvfArm64BootPmemNotificationDispatchError::CreateSignalSink { .. })
+    ) {
+        logger.log_pmem(LoggerPmemOutcome::InterruptDeliveryFailed);
+    }
+}
+
+fn observe_network_interrupt_delivery(
+    logger: &GuestLogger,
+    result: &Result<
+        HvfArm64BootNetworkNotificationDispatches,
+        HvfArm64BootNetworkNotificationDispatchError,
+    >,
+) {
+    if matches!(
+        result,
+        Ok(dispatches) if dispatches.has_signal_failure()
+    ) || matches!(
+        result,
+        Err(HvfArm64BootNetworkNotificationDispatchError::CreateSignalSink { .. })
+    ) {
+        logger.log_network(LoggerNetworkOutcome::InterruptDeliveryFailed);
+    }
+}
+
+fn observe_vsock_interrupt_delivery(
+    logger: &GuestLogger,
+    result: &Result<
+        HvfArm64BootVsockNotificationDispatches,
+        HvfArm64BootVsockNotificationDispatchError,
+    >,
+) {
+    if matches!(
+        result,
+        Ok(dispatches) if dispatches.has_signal_failure()
+    ) || matches!(
+        result,
+        Err(HvfArm64BootVsockNotificationDispatchError::CreateSignalSink { .. })
+    ) {
+        logger.log_vsock(LoggerVsockOutcome::InterruptDeliveryFailed);
+    }
+}
+
 #[cfg(test)]
 fn record_balloon_dispatch_metrics(
     metrics: &SharedBalloonDeviceMetrics,
@@ -34813,16 +34943,21 @@ fn collect_or_signal_network_queue_interrupts(
 fn collect_or_signal_vsock_queue_interrupts(
     dispatches: Arm64BootVsockNotificationDispatches,
     gic: &HvfGicMetadata,
+    logger: &GuestLogger,
 ) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError> {
     if !dispatches.needs_queue_interrupt() {
-        return collect_vsock_notification_dispatches(dispatches);
+        return collect_vsock_notification_dispatches_with_logger(dispatches, Some(logger));
     }
 
-    let signaler = HvfGicSpiSignaler::from_metadata(gic).map_err(|source| {
-        HvfArm64BootVsockNotificationDispatchError::CreateSignalSink { source }
-    })?;
+    let signaler = match HvfGicSpiSignaler::from_metadata(gic) {
+        Ok(signaler) => signaler,
+        Err(source) => {
+            observe_runtime_vsock_notification_dispatches(Some(logger), dispatches.as_slice());
+            return Err(HvfArm64BootVsockNotificationDispatchError::CreateSignalSink { source });
+        }
+    };
 
-    signal_vsock_queue_interrupts(dispatches, &signaler)
+    signal_vsock_queue_interrupts_with_logger(dispatches, &signaler, Some(logger))
 }
 
 fn collect_or_signal_balloon_queue_interrupts(
@@ -34904,17 +35039,25 @@ fn signal_network_queue_interrupts(
     Ok(HvfArm64BootNetworkNotificationDispatches::new_with_retry_after(devices, retry_after))
 }
 
+#[cfg(test)]
 fn signal_vsock_queue_interrupts(
     dispatches: Arm64BootVsockNotificationDispatches,
     signaler: &dyn InterruptSink,
 ) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError> {
+    signal_vsock_queue_interrupts_with_logger(dispatches, signaler, None)
+}
+
+fn signal_vsock_queue_interrupts_with_logger(
+    dispatches: Arm64BootVsockNotificationDispatches,
+    signaler: &dyn InterruptSink,
+    logger: Option<&GuestLogger>,
+) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError> {
     let runtime_dispatches = dispatches.into_vec();
     let mut devices = Vec::new();
-    devices
-        .try_reserve_exact(runtime_dispatches.len())
-        .map_err(
-            |source| HvfArm64BootVsockNotificationDispatchError::ResultAllocation { source },
-        )?;
+    if let Err(source) = devices.try_reserve_exact(runtime_dispatches.len()) {
+        observe_runtime_vsock_notification_dispatches(logger, &runtime_dispatches);
+        return Err(HvfArm64BootVsockNotificationDispatchError::ResultAllocation { source });
+    }
 
     for dispatch in runtime_dispatches {
         let signal_error = if dispatch.needs_queue_interrupt() {
@@ -34928,7 +35071,36 @@ fn signal_vsock_queue_interrupts(
         ));
     }
 
-    Ok(HvfArm64BootVsockNotificationDispatches::new(devices))
+    let dispatches = HvfArm64BootVsockNotificationDispatches::new(devices);
+    observe_hvf_vsock_notification_dispatches(logger, &dispatches);
+    Ok(dispatches)
+}
+
+fn observe_runtime_vsock_notification_dispatches(
+    logger: Option<&GuestLogger>,
+    dispatches: &[Arm64BootVsockNotificationDispatch],
+) {
+    let Some(logger) = logger else {
+        return;
+    };
+    for dispatch in dispatches {
+        dispatch.outcome().observe_with_guest_logger(logger);
+    }
+}
+
+fn observe_hvf_vsock_notification_dispatches(
+    logger: Option<&GuestLogger>,
+    dispatches: &HvfArm64BootVsockNotificationDispatches,
+) {
+    let Some(logger) = logger else {
+        return;
+    };
+    for dispatch in dispatches.as_slice() {
+        dispatch
+            .dispatch()
+            .outcome()
+            .observe_with_guest_logger(logger);
+    }
 }
 
 fn signal_balloon_queue_interrupts(
@@ -35992,6 +36164,9 @@ fn prepare_arm64_boot_session_parts_with_cache<'vm>(
 ) -> Result<PreparedHvfArm64BootSession<'vm>, HvfArm64BootSessionError> {
     let guest_logger = controller.guest_logger();
     backend.attach_guest_logger(guest_logger.clone());
+    let _ = controller
+        .mmds_state_handle()
+        .attach_guest_logger(guest_logger.clone());
     let pvtime_contention_probe = config.pvtime_contention_probe.clone();
     let serial_input = startup_resources
         .take_serial_input()

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -2226,7 +2226,15 @@ fn run_certified_production_vsock_snapshot_restore(
     let source_fixture = SnapshotVsockSourceGrantFixture::new_with_read_only_root(&format!(
         "{transport}-vsock-certified-source"
     ));
-    let source_sensitive = source_fixture.sensitive_strings();
+    let source_logger = DeviceLoggerGrant::add_to_manifest(
+        &source_fixture.snapshot.manifest,
+        &format!("{transport}-vsock-certified-source"),
+    );
+    let source_sensitive = source_fixture
+        .sensitive_strings()
+        .into_iter()
+        .chain(source_logger.sensitive_strings())
+        .collect::<Vec<_>>();
     let source_guest_listeners = bind_certified_production_vsock_guest_listeners(
         &source_fixture,
         &SNAPSHOT_VSOCK_CERTIFY_SOURCE_GUEST_PORTS,
@@ -2239,6 +2247,7 @@ fn run_certified_production_vsock_snapshot_restore(
         enable_pci,
     );
     source_fixture.snapshot.replace_source_file_pathnames();
+    source_logger.replace_source_pathname();
     configure_and_start_certified_production_vsock_source(&source.socket, transport);
     assert_socket_mode(
         &source_fixture.socket(),
@@ -2351,6 +2360,13 @@ fn run_certified_production_vsock_snapshot_restore(
         .assert_replacement_pathnames_unused(&format!(
             "production {transport} certified vsock source"
         ));
+    source_logger.assert_records(
+        &[
+            "device-kind=vsock operation=rx outcome=succeeded",
+            "device-kind=vsock operation=tx outcome=succeeded",
+        ],
+        source_fixture.sensitive_strings(),
+    );
 
     if !enable_pci {
         run_certified_production_vsock_hostile_loads(bundle, &artifacts, baseline_sessions);
@@ -2886,6 +2902,11 @@ fn configure_and_start_certified_production_vsock_source(socket: &Path, context:
             "metrics",
         ),
         (
+            "/logger",
+            serde_json::json!({"log_path": OUTPUT_LOGGER_REF}),
+            "logger",
+        ),
+        (
             "/boot-source",
             serde_json::json!({
                 "kernel_image_path": SNAPSHOT_KERNEL_REF,
@@ -2964,7 +2985,12 @@ fn run_certified_production_vsock_destination(
         recapture,
         use_override,
     );
-    let sensitive = fixture.sensitive_strings();
+    let logger = DeviceLoggerGrant::add_to_manifest(&fixture.snapshot.manifest, case);
+    let sensitive = fixture
+        .sensitive_strings()
+        .into_iter()
+        .chain(logger.sensitive_strings())
+        .collect::<Vec<_>>();
     let guest_listeners = bind_certified_production_vsock_guest_listeners(
         &fixture,
         &SNAPSHOT_VSOCK_CERTIFY_FRESH_GUEST_PORTS,
@@ -2979,10 +3005,20 @@ fn run_certified_production_vsock_destination(
     );
     let worker = only_worker_pid(&running.child);
     let opened = fixture.snapshot.replace_source_pathnames();
+    logger.replace_source_pathname();
     let state_before =
         fs::read(&opened.state).expect("production certified destination state should read");
     let memory_before =
         fs::read(&opened.memory).expect("production certified destination memory should read");
+    assert_http_status(
+        &http_put(
+            &running.socket,
+            "/logger",
+            &serde_json::json!({"log_path": OUTPUT_LOGGER_REF}).to_string(),
+        ),
+        204,
+        &format!("configure production {case} certified destination logger"),
+    );
     assert_http_status(
         &http_put(
             &running.socket,
@@ -3205,6 +3241,14 @@ fn run_certified_production_vsock_destination(
         .assert_replacement_pathnames_unused(&format!(
             "production {case} certified vsock destination"
         ));
+    logger.assert_records(
+        &[
+            "device-kind=vsock operation=transport-reset outcome=succeeded",
+            "device-kind=vsock operation=rx outcome=succeeded",
+            "device-kind=vsock operation=tx outcome=succeeded",
+        ],
+        fixture.sensitive_strings(),
+    );
     opened
 }
 
@@ -8116,6 +8160,7 @@ fn grant_test_bundle_recovers_recorded_snapshot_staging_after_worker_sigkill() {
 fn normal_bundle_routes_guest_vsock_through_launcher_broker_without_helpers() {
     let bundle = production_bundle();
     let fixture = SocketDirectoryGrantFixture::new("guest-vsock");
+    let logger = fixture.devices.add_logger_grant("guest-vsock");
     let mut listeners = Vec::new();
     for &(port, _, _) in GRANTED_VSOCK_EXCHANGES {
         let path = fixture.vsock_port_path(port);
@@ -8127,11 +8172,22 @@ fn normal_bundle_routes_guest_vsock_through_launcher_broker_without_helpers() {
     }
 
     let mut running = spawn_ready_socket_grant_api_launcher(&bundle, &fixture, "guest-vsock");
+    logger.replace_source_pathname();
     assert_socket_mode(&fixture.api_socket(), 0o600, "granted API socket");
     let worker = only_worker_pid(&running.child);
     assert!(
         child_pids(worker).is_empty(),
         "short-lived API binder must be reaped before readiness"
+    );
+
+    assert_http_status(
+        &http_put(
+            &running.socket,
+            "/logger",
+            &serde_json::json!({"log_path": OUTPUT_LOGGER_REF}).to_string(),
+        ),
+        204,
+        "PUT granted-vsock logger grant",
     );
 
     assert_http_status(
@@ -8247,6 +8303,20 @@ fn normal_bundle_routes_guest_vsock_through_launcher_broker_without_helpers() {
     assert!(!fixture.api_socket().exists());
     assert!(!fixture.vsock_socket().exists());
     assert!(session_entries().is_empty());
+    let mut forbidden = fixture.sensitive_strings();
+    forbidden.push(
+        std::str::from_utf8(GRANTED_VSOCK_MARKER)
+            .expect("vsock marker should be UTF-8")
+            .to_owned(),
+    );
+    for (_, guest_payload, host_payload) in GRANTED_VSOCK_EXCHANGES {
+        forbidden.push(String::from_utf8_lossy(guest_payload).into_owned());
+        forbidden.push(String::from_utf8_lossy(host_payload).into_owned());
+    }
+    logger.assert_records(
+        &["device-kind=vsock operation=tx outcome=succeeded"],
+        forbidden,
+    );
 }
 
 #[test]
@@ -8503,6 +8573,7 @@ fn normal_bundle_brokers_multiple_contained_vhost_user_children_without_helpers(
 fn normal_bundle_certifies_aggregate_storage_semantics_through_contained_grants() {
     let bundle = production_bundle();
     let fixture = SocketDirectoryGrantFixture::new_with_vhost_user("storage-certification");
+    let logger = fixture.devices.add_logger_grant("storage-certification");
     let vhost_socket = fixture.vhost_user_socket(VHOST_USER_SOCKET_CHILD_ONE);
     let vhost_backing = fixture.vhost_user_backing("storage-certification-vhost.img");
 
@@ -8575,10 +8646,21 @@ fn normal_bundle_certifies_aggregate_storage_semantics_through_contained_grants(
         &["--enable-pci"],
     );
     fixture.devices.replace_source_pathnames();
+    logger.replace_source_pathname();
     let worker = only_worker_pid(&running.child);
     assert!(
         child_pids(worker).is_empty(),
         "contained aggregate setup must not retain a broker helper",
+    );
+
+    assert_http_status(
+        &http_put(
+            &running.socket,
+            "/logger",
+            &serde_json::json!({"log_path": OUTPUT_LOGGER_REF}).to_string(),
+        ),
+        204,
+        "PUT contained aggregate logger grant",
     );
 
     assert_http_status(
@@ -9131,6 +9213,21 @@ fn normal_bundle_certifies_aggregate_storage_semantics_through_contained_grants(
     assert!(!vhost_socket.exists());
     assert!(!fixture.api_socket().exists());
     assert!(session_entries().is_empty());
+    logger.assert_records(
+        &[
+            "device-kind=block operation=request outcome=succeeded",
+            "device-kind=pmem operation=flush outcome=succeeded",
+        ],
+        fixture.sensitive_strings().into_iter().chain([
+            path_text(&vhost_backing).to_owned(),
+            std::str::from_utf8(STORAGE_CONTROL_GUEST_MARKER)
+                .expect("storage marker should be UTF-8")
+                .to_owned(),
+            std::str::from_utf8(STORAGE_PMEM_GUEST_MARKER)
+                .expect("pmem marker should be UTF-8")
+                .to_owned(),
+        ]),
+    );
     for (path, marker) in [
         (&fixture.devices.data, STORAGE_CONTROL_GUEST_MARKER),
         (&fixture.devices.replacement, STORAGE_ASYNC_GUEST_MARKER),
@@ -11676,6 +11773,7 @@ fn normal_bundle_hotplugs_contained_macos_block_special_media_over_pci() {
 fn normal_bundle_hotplugs_mmds_network_without_vmnet_authority() {
     let bundle = production_bundle();
     let fixture = GuestDeviceGrantFixture::new("runtime-network-hotplug");
+    let logger = fixture.add_logger_grant("runtime-network-hotplug");
     resize_and_write_file_marker_at(&fixture.data, 1536, 0, &[]);
     let mut running = spawn_ready_device_grant_api_launcher_with_extra_args(
         &bundle,
@@ -11684,6 +11782,17 @@ fn normal_bundle_hotplugs_mmds_network_without_vmnet_authority() {
         &["--enable-pci"],
     );
     fixture.replace_source_pathnames();
+    logger.replace_source_pathname();
+
+    assert_http_status(
+        &http_put(
+            &running.socket,
+            "/logger",
+            &serde_json::json!({"log_path": OUTPUT_LOGGER_REF}).to_string(),
+        ),
+        204,
+        "PUT contained network-hotplug logger grant",
+    );
 
     assert_http_status(
         &http_put(
@@ -11888,6 +11997,16 @@ fn normal_bundle_hotplugs_mmds_network_without_vmnet_authority() {
     );
 
     stop_running_launcher(&mut running, "contained runtime network hotplug guest");
+    logger.assert_records(
+        &["device-kind=network operation=mmds-request outcome=detoured"],
+        fixture.sensitive_strings().into_iter().chain([
+            "06:00:00:00:00:42".to_owned(),
+            "BANGBANG_MMDS_GUEST_VALUE".to_owned(),
+            std::str::from_utf8(NETWORK_HOTPLUG_SUCCESS_MARKER)
+                .expect("network marker should be UTF-8")
+                .to_owned(),
+        ]),
+    );
 }
 
 #[test]
@@ -15852,6 +15971,94 @@ struct GuestDeviceGrantFixture {
     manifest: PathBuf,
 }
 
+#[derive(Debug)]
+struct DeviceLoggerGrant {
+    source: PathBuf,
+    opened: PathBuf,
+}
+
+impl DeviceLoggerGrant {
+    fn add_to_manifest(manifest_path: &Path, case: &str) -> Self {
+        let canonical_root = manifest_path
+            .parent()
+            .expect("device grant manifest should have a canonical parent");
+        let logger = Self {
+            source: canonical_root.join(format!("external-{case}-logger.out")),
+            opened: canonical_root.join(format!("opened-{case}-logger.out")),
+        };
+        fs::write(&logger.source, OUTPUT_LOGGER_SEED).expect("device logger fixture should write");
+
+        let mut manifest: serde_json::Value = serde_json::from_slice(
+            &fs::read(manifest_path).expect("device grant manifest should read"),
+        )
+        .expect("device grant manifest should parse");
+        manifest
+            .get_mut("grants")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("device grant manifest should contain grants")
+            .push(serde_json::json!({
+                "id": OUTPUT_LOGGER_ID,
+                "role": "logger-sink",
+                "access": "write-only",
+                "source": path_text(&logger.source),
+            }));
+        fs::write(
+            manifest_path,
+            serde_json::to_vec(&manifest).expect("device logger grant should serialize"),
+        )
+        .expect("device logger grant manifest should write");
+        logger
+    }
+
+    fn replace_source_pathname(&self) {
+        fs::rename(&self.source, &self.opened).expect("launcher-opened device logger should move");
+        fs::write(&self.source, OUTPUT_REPLACEMENT)
+            .expect("replacement device logger should write");
+    }
+
+    fn sensitive_strings(&self) -> impl Iterator<Item = String> + '_ {
+        [
+            path_text(&self.source),
+            path_text(&self.opened),
+            OUTPUT_LOGGER_ID,
+            OUTPUT_LOGGER_REF,
+        ]
+        .into_iter()
+        .map(str::to_owned)
+    }
+
+    fn assert_records(&self, expected: &[&str], forbidden: impl IntoIterator<Item = String>) {
+        let output = fs::read_to_string(&self.opened)
+            .expect("launcher-opened device logger output should read");
+        assert!(
+            output.starts_with(std::str::from_utf8(OUTPUT_LOGGER_SEED).unwrap()),
+            "device logger should preserve its seeded output"
+        );
+        for record in expected {
+            assert!(
+                output.lines().any(|line| line == *record),
+                "production device logger should contain {record:?}; output:\n{output}"
+            );
+        }
+        for value in forbidden.into_iter().chain([
+            path_text(&self.source).to_owned(),
+            path_text(&self.opened).to_owned(),
+            OUTPUT_LOGGER_ID.to_owned(),
+            OUTPUT_LOGGER_REF.to_owned(),
+        ]) {
+            assert!(
+                !output.contains(&value),
+                "production device logger should redact {value:?}; output:\n{output}"
+            );
+        }
+        assert_eq!(
+            fs::read(&self.source).expect("replacement device logger should read"),
+            OUTPUT_REPLACEMENT,
+            "launcher-opened logger identity must not follow a pathname replacement"
+        );
+    }
+}
+
 impl GuestDeviceGrantFixture {
     fn new(case: &str) -> Self {
         let root = TestDir::new(&format!("device-grant-{case}"));
@@ -16012,6 +16219,10 @@ impl GuestDeviceGrantFixture {
         create_sized_file(&self.pmem_reuse, PMEM_BACKING_LEN);
         create_sized_file(&self.storage_pmem, PMEM_BACKING_LEN);
         create_sized_file(&self.read_only_data, 512);
+    }
+
+    fn add_logger_grant(&self, case: &str) -> DeviceLoggerGrant {
+        DeviceLoggerGrant::add_to_manifest(&self.manifest, case)
     }
 
     fn sensitive_strings(&self) -> Vec<String> {

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -24,7 +24,7 @@ use bangbang_vhost_user::{
     create_call_notifier, create_kick_notifier,
 };
 
-use crate::logger::{GuestLogger, LoggerDeviceKind, LoggerTransportOutcome};
+use crate::logger::{GuestLogger, LoggerBlockOutcome, LoggerDeviceKind, LoggerTransportOutcome};
 use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryBacking, GuestMemoryError,
     GuestMemoryRange, GuestMemoryRegionBacking, GuestMemorySharedBacking,
@@ -6615,6 +6615,21 @@ impl VirtioBlockDevice {
         &mut self,
         cache_type: DriveCacheType,
     ) -> Result<VirtioBlockConfigSpace, VhostUserBlockConfigRefreshError> {
+        let result = self.refreshed_vhost_user_config_unobserved(cache_type);
+        if let Some(logger) = &self.guest_logger {
+            logger.log_block(if result.is_ok() {
+                LoggerBlockOutcome::VhostUserConfigSucceeded
+            } else {
+                LoggerBlockOutcome::VhostUserConfigFailed
+            });
+        }
+        result
+    }
+
+    fn refreshed_vhost_user_config_unobserved(
+        &mut self,
+        cache_type: DriveCacheType,
+    ) -> Result<VirtioBlockConfigSpace, VhostUserBlockConfigRefreshError> {
         let VirtioBlockBackend::VhostUser(backend) = &mut self.backend else {
             return Err(VhostUserBlockConfigRefreshError::UnsupportedBackend);
         };
@@ -6655,6 +6670,18 @@ impl VirtioBlockDevice {
     }
 
     fn dispatch_drained_queue_notifications(
+        &mut self,
+        memory: &mut GuestMemory,
+        drained_notifications: Vec<usize>,
+    ) -> Result<VirtioBlockDeviceNotificationDispatch, VirtioBlockDeviceNotificationError> {
+        let had_pending_rate_limited_queue = self.pending_rate_limited_queue;
+        let result =
+            self.dispatch_drained_queue_notifications_unobserved(memory, drained_notifications);
+        self.observe_notification_result(&result, had_pending_rate_limited_queue);
+        result
+    }
+
+    fn dispatch_drained_queue_notifications_unobserved(
         &mut self,
         memory: &mut GuestMemory,
         drained_notifications: Vec<usize>,
@@ -6759,6 +6786,61 @@ impl VirtioBlockDevice {
         }
     }
 
+    fn observe_notification_result(
+        &self,
+        result: &Result<VirtioBlockDeviceNotificationDispatch, VirtioBlockDeviceNotificationError>,
+        had_pending_rate_limited_queue: bool,
+    ) {
+        let Some(logger) = &self.guest_logger else {
+            return;
+        };
+
+        match result {
+            Ok(dispatch) => {
+                if let Some(queue) = dispatch.queue_dispatch() {
+                    observe_block_queue_dispatch(logger, queue, had_pending_rate_limited_queue);
+                }
+                if dispatch.vhost_user_kicks() != 0 || dispatch.vhost_user_calls() != 0 {
+                    logger.log_block(LoggerBlockOutcome::VhostUserNotificationSucceeded);
+                }
+            }
+            Err(VirtioBlockDeviceNotificationError::Inactive { .. }) => {
+                logger.log_block(LoggerBlockOutcome::QueueNotificationInactive);
+            }
+            Err(VirtioBlockDeviceNotificationError::UnsupportedQueue { .. }) => {
+                logger.log_block(LoggerBlockOutcome::QueueNotificationUnsupported);
+            }
+            Err(VirtioBlockDeviceNotificationError::QueueDispatch { source, .. }) => {
+                logger.log_block(LoggerBlockOutcome::QueueDispatchFailed);
+                if matches!(source, VirtioBlockQueueDispatchError::AsyncRuntime { .. }) {
+                    logger.log_block(LoggerBlockOutcome::AsyncEngineFailed);
+                }
+                observe_block_queue_dispatch(
+                    logger,
+                    source.completed_dispatch(),
+                    had_pending_rate_limited_queue,
+                );
+            }
+            Err(VirtioBlockDeviceNotificationError::VhostUser { calls, source, .. }) => {
+                logger.log_block(match source {
+                    VhostUserBlockNotificationError::Kick(_)
+                    | VhostUserBlockNotificationError::Call(_) => {
+                        LoggerBlockOutcome::VhostUserNotificationFailed
+                    }
+                    VhostUserBlockNotificationError::Closed => {
+                        LoggerBlockOutcome::VhostUserDisconnected
+                    }
+                    VhostUserBlockNotificationError::Terminal => {
+                        LoggerBlockOutcome::VhostUserTerminal
+                    }
+                });
+                if *calls != 0 {
+                    logger.log_block(LoggerBlockOutcome::VhostUserNotificationSucceeded);
+                }
+            }
+        }
+    }
+
     pub fn activate_block(
         &mut self,
         activation: VirtioMmioDeviceActivation<'_>,
@@ -6844,6 +6926,40 @@ impl VirtioBlockDevice {
             }
         }
     }
+}
+
+fn observe_block_queue_dispatch(
+    logger: &GuestLogger,
+    dispatch: &VirtioBlockQueueDispatch,
+    had_pending_rate_limited_queue: bool,
+) {
+    for outcome in block_queue_outcomes(dispatch, had_pending_rate_limited_queue)
+        .into_iter()
+        .flatten()
+    {
+        logger.log_block(outcome);
+    }
+}
+
+fn block_queue_outcomes(
+    dispatch: &VirtioBlockQueueDispatch,
+    had_pending_rate_limited_queue: bool,
+) -> [Option<LoggerBlockOutcome>; 8] {
+    [
+        (dispatch.parse_failures() != 0).then_some(LoggerBlockOutcome::RequestParseFailed),
+        (dispatch.io_errors() != 0).then_some(LoggerBlockOutcome::RequestIoFailed),
+        (dispatch.unsupported_requests() != 0).then_some(LoggerBlockOutcome::RequestUnsupported),
+        (dispatch.status_write_failures() != 0).then_some(LoggerBlockOutcome::StatusWriteFailed),
+        (dispatch.rate_limiter_throttled_requests() != 0)
+            .then_some(LoggerBlockOutcome::RateLimiterThrottled),
+        (dispatch.rate_limiter_throttled_requests() == 0
+            && had_pending_rate_limited_queue
+            && dispatch.processed_requests() != 0)
+            .then_some(LoggerBlockOutcome::RateLimiterResumed),
+        (dispatch.io_engine_throttled_events() != 0)
+            .then_some(LoggerBlockOutcome::AsyncEngineThrottled),
+        (dispatch.successful_requests() != 0).then_some(LoggerBlockOutcome::RequestSucceeded),
+    ]
 }
 
 fn mark_async_engine_terminal(io_engine: &mut VirtioBlockFileIoEngine) {
@@ -8377,6 +8493,13 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
             })
             .map_err(VirtioPciDeviceOperationError::Endpoint)?;
         let endpoint = work.drain_interrupt_intents();
+        if endpoint.is_err() {
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
+                }
+            });
+        }
         VirtioPciDeviceOperationError::combine(dispatch, endpoint)
     }
 
@@ -8427,6 +8550,13 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
             })
             .map_err(VirtioPciDeviceOperationError::Endpoint)?;
         let endpoint = work.drain_interrupt_intents();
+        if endpoint.is_err() {
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
+                }
+            });
+        }
         VirtioPciDeviceOperationError::combine(dispatch, endpoint)
     }
 
@@ -8457,7 +8587,15 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
             Ok::<(), VirtioPciEndpointError>(())
         })??;
         if backing_changed {
-            work.drain_interrupt_intents()?;
+            let endpoint = work.drain_interrupt_intents();
+            if endpoint.is_err() {
+                let _ = work.with_core_mut(|core| {
+                    if let Some(logger) = &core.activation.guest_logger {
+                        logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
+                    }
+                });
+            }
+            endpoint?;
         }
         Ok(())
     }
@@ -8508,6 +8646,13 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
             } else {
                 Ok(())
             };
+        if endpoint.is_err() {
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
+                }
+            });
+        }
         VirtioPciDeviceOperationError::combine(update, endpoint)
     }
 
@@ -8553,6 +8698,11 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
             })??;
 
         if let Err(source) = work.drain_interrupt_intents() {
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
+                }
+            });
             let message = source.to_string();
             if source.delivery_ambiguous() {
                 return Err(DriveUpdateError::TerminalActiveSessionCommand { message });
@@ -9032,6 +9182,7 @@ mod tests {
     };
 
     use crate::interrupt::DeviceInterruptKind;
+    use crate::logger::{LoggerBlockOutcome, LoggerTestCapture};
     use crate::memory::{
         GuestAddress, GuestMemory, GuestMemoryBacking, GuestMemoryLayout, GuestMemoryRange,
     };
@@ -12990,6 +13141,9 @@ mod tests {
     #[test]
     fn vhost_user_config_refresh_rejects_pre_activation_without_frontend_io() {
         let (_config_space, mut device, _memory) = prepare_disconnected_test_vhost_user_device();
+        let capture = LoggerTestCapture::default();
+        let (_logger_state, logger) = capture.configured_guest_logger();
+        VirtioMmioDeviceActivationHandler::attach_guest_logger(&mut device, logger.clone());
 
         let error = device
             .refreshed_vhost_user_config(DriveCacheType::Unsafe)
@@ -12998,6 +13152,11 @@ mod tests {
         assert_eq!(error, VhostUserBlockConfigRefreshError::Inactive);
         assert!(!device.is_activated());
         assert!(device.vhost_user_call_fd().is_some());
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture.output(),
+            "device-kind=block operation=vhost-user-config outcome=failed\n"
+        );
     }
 
     #[test]
@@ -14307,6 +14466,9 @@ mod tests {
         device
             .activate_block(VirtioMmioDeviceActivation::new(&registers, &queues))
             .expect("vhost-user block should activate");
+        let capture = LoggerTestCapture::default();
+        let (_logger_state, logger) = capture.configured_guest_logger();
+        VirtioMmioDeviceActivationHandler::attach_guest_logger(&mut device, logger.clone());
         assert!(device.is_activated());
         assert!(device.vhost_user_call_fd().is_some());
 
@@ -14350,6 +14512,15 @@ mod tests {
                 ..
             }
         ));
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture.output(),
+            concat!(
+                "device-kind=block operation=vhost-user-notification outcome=succeeded\n",
+                "device-kind=block operation=vhost-user-notification outcome=disconnected\n",
+                "device-kind=block operation=vhost-user-notification outcome=terminal\n",
+            )
+        );
     }
 
     #[test]
@@ -15006,6 +15177,9 @@ mod tests {
         handler
             .write_register(VirtioMmioRegister::QueueNotify, 0)
             .expect("queue notification should record after failed DRIVER_OK");
+        let capture = LoggerTestCapture::default();
+        let (_logger_state, logger) = capture.configured_guest_logger();
+        handler.attach_guest_logger(logger.clone());
 
         let error = handler
             .dispatch_block_queue_notifications(&mut memory)
@@ -15020,6 +15194,58 @@ mod tests {
         assert_eq!(read_interrupt_status(&handler), 0);
         assert!(handler.pending_queue_notifications().is_empty());
         assert!(!handler.activation_handler().is_activated());
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture.output(),
+            "device-kind=block operation=queue-notification outcome=inactive\n"
+        );
+    }
+
+    #[test]
+    fn block_logger_summary_is_failure_first_deduplicated_and_distinguishes_resume() {
+        let dispatch = VirtioBlockQueueDispatch {
+            processed_requests: 12,
+            successful_requests: 3,
+            parse_failures: 2,
+            io_errors: 2,
+            unsupported_requests: 2,
+            status_write_failures: 2,
+            rate_limiter_throttled_requests: 2,
+            io_engine_throttled_events: 2,
+            ..VirtioBlockQueueDispatch::default()
+        };
+
+        assert_eq!(
+            super::block_queue_outcomes(&dispatch, true)
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>(),
+            vec![
+                LoggerBlockOutcome::RequestParseFailed,
+                LoggerBlockOutcome::RequestIoFailed,
+                LoggerBlockOutcome::RequestUnsupported,
+                LoggerBlockOutcome::StatusWriteFailed,
+                LoggerBlockOutcome::RateLimiterThrottled,
+                LoggerBlockOutcome::AsyncEngineThrottled,
+                LoggerBlockOutcome::RequestSucceeded,
+            ]
+        );
+
+        let resumed = VirtioBlockQueueDispatch {
+            processed_requests: 1,
+            successful_requests: 1,
+            ..VirtioBlockQueueDispatch::default()
+        };
+        assert_eq!(
+            super::block_queue_outcomes(&resumed, true)
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>(),
+            vec![
+                LoggerBlockOutcome::RateLimiterResumed,
+                LoggerBlockOutcome::RequestSucceeded,
+            ]
+        );
     }
 
     #[test]

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -9182,7 +9182,7 @@ mod tests {
     };
 
     use crate::interrupt::DeviceInterruptKind;
-    use crate::logger::{LoggerBlockOutcome, LoggerTestCapture};
+    use crate::logger::{LoggerBlockOutcome, LoggerConfigInput, LoggerTestCapture};
     use crate::memory::{
         GuestAddress, GuestMemory, GuestMemoryBacking, GuestMemoryLayout, GuestMemoryRange,
     };
@@ -13314,10 +13314,20 @@ mod tests {
     fn vhost_user_pci_refresh_rolls_back_confirmed_interrupt_failure() {
         let mut refreshed = [0_u8; VIRTIO_BLOCK_CONFIG_SIZE];
         refreshed[..8].copy_from_slice(&2_u64.to_le_bytes());
+        let capture = LoggerTestCapture::default();
+        let (mut logger_state, initial_logger) = capture.configured_guest_logger();
+        drop(initial_logger);
+        logger_state
+            .configure(LoggerConfigInput::new().with_show_log_origin(true))
+            .expect("origin-prefixed PCI logger should configure");
+        let logger = logger_state.guest_logger();
         let (endpoint, _memory, peer, signals) = vhost_user_refresh_pci_endpoint(
             TestVhostUserConfigReply::Exact(refreshed),
             Some(false),
         );
+        let mut bar_handler = endpoint.bar_handler();
+        bar_handler.attach_guest_logger(logger.clone());
+        drop(bar_handler);
         let original = vhost_user_pci_config_snapshot(&endpoint);
 
         let error = endpoint
@@ -13334,6 +13344,34 @@ mod tests {
                 .lock()
                 .expect("test signal count should remain available"),
             0
+        );
+        assert!(logger.wait_for_delivery_for_test());
+        let output = capture.output();
+        let interrupt_suffix = "device-kind=block operation=interrupt-delivery outcome=failed";
+        let interrupt_records = output
+            .lines()
+            .filter(|line| line.ends_with(interrupt_suffix))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            interrupt_records.len(),
+            2,
+            "generic transport and block class owners should each emit once; output:\n{output}"
+        );
+        assert_eq!(
+            interrupt_records
+                .iter()
+                .filter(|line| line.contains("origin=crates/runtime/src/virtio_pci.rs:"))
+                .count(),
+            1,
+            "generic PCI transport owner should emit once; output:\n{output}"
+        );
+        assert_eq!(
+            interrupt_records
+                .iter()
+                .filter(|line| line.contains("origin=crates/runtime/src/block.rs:"))
+                .count(),
+            1,
+            "block class supplement should emit once; output:\n{output}"
         );
         peer.join().expect("refresh peer should finish");
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1622,7 +1622,7 @@ impl VmmController {
             .unwrap_or(0);
         self.network_interface_configs = network_configs;
         self.vsock_config = vsock_config;
-        self.mmds_state = mmds_state.unwrap_or_else(|| {
+        let mmds_state = mmds_state.unwrap_or_else(|| {
             let data_store_limit_bytes = self
                 .mmds_state
                 .with(mmds::MmdsState::data_store_limit_bytes)
@@ -1632,6 +1632,8 @@ impl VmmController {
                 &self.instance_info.id,
             ))
         });
+        let _ = mmds_state.attach_guest_logger(self.guest_logger());
+        self.mmds_state = mmds_state;
         self.snapshot_load_history_fresh = false;
         self.instance_info.state = InstanceState::Paused;
         resume_requested

--- a/crates/runtime/src/logger.rs
+++ b/crates/runtime/src/logger.rs
@@ -25,10 +25,10 @@ use rate_limiter::{LogRateLimitDecision, LoggerRateLimitIdentity, LoggerRateLimi
 
 pub use event::{
     LoggerAction, LoggerApiControlOutcome, LoggerApiResultOutcome, LoggerApiRoute,
-    LoggerApiWorkerOutcome, LoggerBackendOutcome, LoggerDeviceKind, LoggerHttpMethod,
-    LoggerLifecycleOutcome, LoggerObservabilityOutcome, LoggerProcessSignalOutcome,
-    LoggerSnapshotOutcome, LoggerTransportOutcome, PanicLogRecords, ProcessStartupOutcome,
-    ProcessTerminalCategory,
+    LoggerApiWorkerOutcome, LoggerBackendOutcome, LoggerBlockOutcome, LoggerDeviceKind,
+    LoggerHttpMethod, LoggerLifecycleOutcome, LoggerNetworkOutcome, LoggerObservabilityOutcome,
+    LoggerPmemOutcome, LoggerProcessSignalOutcome, LoggerSnapshotOutcome, LoggerTransportOutcome,
+    LoggerVsockOutcome, PanicLogRecords, ProcessStartupOutcome, ProcessTerminalCategory,
 };
 pub use process_stdout::{ProcessStdoutLogger, ProcessStdoutLoggerError};
 
@@ -493,6 +493,78 @@ impl TransportOutcomeLogRateLimiter {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct BlockOutcomeLogRateLimiter {
+    inner: LoggerRateLimiters,
+}
+
+impl BlockOutcomeLogRateLimiter {
+    #[cfg(test)]
+    fn with_clock(clock: Arc<dyn LogRateLimiterClock>) -> Self {
+        Self {
+            inner: LoggerRateLimiters::with_clock(clock),
+        }
+    }
+
+    fn check(&self) -> LogRateLimitDecision {
+        self.inner.check(LoggerRateLimitIdentity::BlockOutcome)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct PmemOutcomeLogRateLimiter {
+    inner: LoggerRateLimiters,
+}
+
+impl PmemOutcomeLogRateLimiter {
+    #[cfg(test)]
+    fn with_clock(clock: Arc<dyn LogRateLimiterClock>) -> Self {
+        Self {
+            inner: LoggerRateLimiters::with_clock(clock),
+        }
+    }
+
+    fn check(&self) -> LogRateLimitDecision {
+        self.inner.check(LoggerRateLimitIdentity::PmemOutcome)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct NetworkOutcomeLogRateLimiter {
+    inner: LoggerRateLimiters,
+}
+
+impl NetworkOutcomeLogRateLimiter {
+    #[cfg(test)]
+    fn with_clock(clock: Arc<dyn LogRateLimiterClock>) -> Self {
+        Self {
+            inner: LoggerRateLimiters::with_clock(clock),
+        }
+    }
+
+    fn check(&self) -> LogRateLimitDecision {
+        self.inner.check(LoggerRateLimitIdentity::NetworkOutcome)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct VsockOutcomeLogRateLimiter {
+    inner: LoggerRateLimiters,
+}
+
+impl VsockOutcomeLogRateLimiter {
+    #[cfg(test)]
+    fn with_clock(clock: Arc<dyn LogRateLimiterClock>) -> Self {
+        Self {
+            inner: LoggerRateLimiters::with_clock(clock),
+        }
+    }
+
+    fn check(&self) -> LogRateLimitDecision {
+        self.inner.check(LoggerRateLimitIdentity::VsockOutcome)
+    }
+}
+
 impl ObservabilityWorkerLogRateLimiter {
     #[cfg(test)]
     fn with_clock(clock: Arc<dyn LogRateLimiterClock>) -> Self {
@@ -687,6 +759,10 @@ struct GuestLoggerInner {
     metrics: SharedLoggerMetrics,
     backend_rate_limiter: BackendOutcomeLogRateLimiter,
     transport_rate_limiter: TransportOutcomeLogRateLimiter,
+    block_rate_limiter: BlockOutcomeLogRateLimiter,
+    pmem_rate_limiter: PmemOutcomeLogRateLimiter,
+    network_rate_limiter: NetworkOutcomeLogRateLimiter,
+    vsock_rate_limiter: VsockOutcomeLogRateLimiter,
 }
 
 impl fmt::Debug for GuestLogger {
@@ -701,6 +777,10 @@ impl fmt::Debug for GuestLogger {
             .field("metrics", &self.inner.metrics)
             .field("backend_rate_limiter", &self.inner.backend_rate_limiter)
             .field("transport_rate_limiter", &self.inner.transport_rate_limiter)
+            .field("block_rate_limiter", &self.inner.block_rate_limiter)
+            .field("pmem_rate_limiter", &self.inner.pmem_rate_limiter)
+            .field("network_rate_limiter", &self.inner.network_rate_limiter)
+            .field("vsock_rate_limiter", &self.inner.vsock_rate_limiter)
             .finish()
     }
 }
@@ -734,6 +814,56 @@ impl GuestLogger {
             DEVICE_LOG_MODULE,
             LoggerEvent::Transport(outcome),
             || self.inner.transport_rate_limiter.check(),
+        );
+    }
+
+    #[track_caller]
+    pub fn log_block(&self, outcome: LoggerBlockOutcome) {
+        self.log_limited(
+            outcome.level(),
+            DEVICE_LOG_MODULE,
+            LoggerEvent::Block(outcome),
+            || self.inner.block_rate_limiter.check(),
+        );
+    }
+
+    #[track_caller]
+    pub fn log_pmem(&self, outcome: LoggerPmemOutcome) {
+        self.log_limited(
+            outcome.level(),
+            DEVICE_LOG_MODULE,
+            LoggerEvent::Pmem(outcome),
+            || self.inner.pmem_rate_limiter.check(),
+        );
+    }
+
+    #[track_caller]
+    pub fn log_network(&self, outcome: LoggerNetworkOutcome) {
+        self.log_limited(
+            outcome.level(),
+            DEVICE_LOG_MODULE,
+            LoggerEvent::Network(outcome),
+            || self.inner.network_rate_limiter.check(),
+        );
+    }
+
+    #[track_caller]
+    pub fn log_vsock(&self, outcome: LoggerVsockOutcome) {
+        self.log_limited(
+            outcome.level(),
+            DEVICE_LOG_MODULE,
+            LoggerEvent::Vsock(outcome),
+            || self.inner.vsock_rate_limiter.check(),
+        );
+    }
+
+    #[track_caller]
+    pub(crate) fn log_vsock_summary(&self, outcomes: impl IntoIterator<Item = LoggerVsockOutcome>) {
+        self.log_limited_summary(
+            outcomes
+                .into_iter()
+                .map(|outcome| (outcome.level(), LoggerEvent::Vsock(outcome))),
+            || self.inner.vsock_rate_limiter.check(),
         );
     }
 
@@ -789,6 +919,64 @@ impl GuestLogger {
         let _delivered = producer.deliver_nonblocking(batch);
     }
 
+    #[track_caller]
+    fn log_limited_summary(
+        &self,
+        events: impl IntoIterator<Item = (LoggerLevel, LoggerEvent)>,
+        mut check_limiter: impl FnMut() -> LogRateLimitDecision,
+    ) {
+        if !module_filter_allows(self.inner.module.as_deref(), DEVICE_LOG_MODULE) {
+            return;
+        }
+        let Some(producer) = &self.inner.producer else {
+            return;
+        };
+        let origin = LogOrigin::from(Location::caller());
+        let mut batch = LogBatch::empty();
+        let mut suppressed = 0_u64;
+        for (level, event) in events {
+            if !self.inner.level.allows(level) {
+                continue;
+            }
+            match check_limiter() {
+                LogRateLimitDecision::Admitted {
+                    suppressed: recovered,
+                } => {
+                    suppressed = suppressed.saturating_add(recovered);
+                    let record = LogRecord::encode(
+                        self.inner.show_level,
+                        self.inner.show_log_origin,
+                        origin,
+                        level,
+                        event,
+                    );
+                    if !batch.push(record) {
+                        self.inner.metrics.record_missed_logs(1);
+                    }
+                }
+                LogRateLimitDecision::Denied => {
+                    self.inner.metrics.record_rate_limited_log();
+                }
+            }
+        }
+        if batch.is_empty() {
+            return;
+        }
+        if suppressed != 0 {
+            let recovery = LogRecord::encode(
+                self.inner.show_level,
+                self.inner.show_log_origin,
+                origin,
+                LoggerLevel::Warn,
+                LoggerEvent::RateLimitRecovery { suppressed },
+            );
+            if !batch.prepend(recovery) {
+                self.inner.metrics.record_missed_logs(1);
+            }
+        }
+        let _delivered = producer.deliver_nonblocking(batch);
+    }
+
     #[cfg(test)]
     pub(crate) fn wait_for_delivery_for_test(&self) -> bool {
         self.inner
@@ -811,6 +999,10 @@ pub struct LoggerState {
     observability_rate_limiter: ObservabilityWorkerLogRateLimiter,
     backend_rate_limiter: BackendOutcomeLogRateLimiter,
     transport_rate_limiter: TransportOutcomeLogRateLimiter,
+    block_rate_limiter: BlockOutcomeLogRateLimiter,
+    pmem_rate_limiter: PmemOutcomeLogRateLimiter,
+    network_rate_limiter: NetworkOutcomeLogRateLimiter,
+    vsock_rate_limiter: VsockOutcomeLogRateLimiter,
     delivery_config: LoggerDeliveryConfig,
 }
 
@@ -831,6 +1023,10 @@ impl fmt::Debug for LoggerState {
             )
             .field("backend_rate_limiter", &self.backend_rate_limiter)
             .field("transport_rate_limiter", &self.transport_rate_limiter)
+            .field("block_rate_limiter", &self.block_rate_limiter)
+            .field("pmem_rate_limiter", &self.pmem_rate_limiter)
+            .field("network_rate_limiter", &self.network_rate_limiter)
+            .field("vsock_rate_limiter", &self.vsock_rate_limiter)
             .field("delivery_config", &self.delivery_config)
             .finish()
     }
@@ -875,6 +1071,10 @@ impl LoggerState {
             observability_rate_limiter: ObservabilityWorkerLogRateLimiter::default(),
             backend_rate_limiter: BackendOutcomeLogRateLimiter::default(),
             transport_rate_limiter: TransportOutcomeLogRateLimiter::default(),
+            block_rate_limiter: BlockOutcomeLogRateLimiter::default(),
+            pmem_rate_limiter: PmemOutcomeLogRateLimiter::default(),
+            network_rate_limiter: NetworkOutcomeLogRateLimiter::default(),
+            vsock_rate_limiter: VsockOutcomeLogRateLimiter::default(),
             delivery_config: LoggerDeliveryConfig::default(),
         }
     }
@@ -1176,6 +1376,10 @@ impl LoggerState {
                 metrics: self.metrics.clone(),
                 backend_rate_limiter: self.backend_rate_limiter.clone(),
                 transport_rate_limiter: self.transport_rate_limiter.clone(),
+                block_rate_limiter: self.block_rate_limiter.clone(),
+                pmem_rate_limiter: self.pmem_rate_limiter.clone(),
+                network_rate_limiter: self.network_rate_limiter.clone(),
+                vsock_rate_limiter: self.vsock_rate_limiter.clone(),
             }),
         }
     }
@@ -1269,6 +1473,47 @@ impl LoggerState {
     }
 }
 
+#[cfg(test)]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct LoggerTestCapture {
+    output: Arc<Mutex<Vec<u8>>>,
+}
+
+#[cfg(test)]
+impl LoggerTestCapture {
+    pub(crate) fn configured_guest_logger(&self) -> (LoggerState, GuestLogger) {
+        let mut state = LoggerState::default();
+        state.configure_test_writer(self.clone());
+        let logger = state.guest_logger();
+        (state, logger)
+    }
+
+    pub(crate) fn output(&self) -> String {
+        String::from_utf8(
+            self.output
+                .lock()
+                .expect("test logger output lock should succeed")
+                .clone(),
+        )
+        .expect("test logger output should be UTF-8")
+    }
+}
+
+#[cfg(test)]
+impl Write for LoggerTestCapture {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.output
+            .lock()
+            .expect("test logger output lock should succeed")
+            .extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 fn module_filter_allows(filter: Option<&str>, module_path: &str) -> bool {
     filter.is_none_or(|filter| module_path.starts_with(filter))
 }
@@ -1287,14 +1532,17 @@ mod tests {
 
     use super::delivery::WorkerObserver;
     use super::{
-        BackendOutcomeLogRateLimiter, BootTimerLogRateLimiter, GuestLogger, LogRateLimitDecision,
-        LogRateLimiterClock, LoggerAction, LoggerApiControlOutcome, LoggerApiResultOutcome,
-        LoggerApiRoute, LoggerApiWorkerOutcome, LoggerBackendOutcome, LoggerConfigError,
-        LoggerConfigInput, LoggerDeliveryConfig, LoggerDeviceKind, LoggerHttpMethod, LoggerLevel,
-        LoggerLifecycleOutcome, LoggerObservabilityOutcome, LoggerProcessSignalOutcome,
-        LoggerSnapshotOutcome, LoggerState, LoggerTransportOutcome,
-        ObservabilityWorkerLogRateLimiter, ProcessStartupOutcome, ProcessTerminalCategory,
-        SharedLoggerMetrics, TransportOutcomeLogRateLimiter,
+        BackendOutcomeLogRateLimiter, BlockOutcomeLogRateLimiter, BootTimerLogRateLimiter,
+        GuestLogger, LogRateLimitDecision, LogRateLimiterClock, LoggerAction,
+        LoggerApiControlOutcome, LoggerApiResultOutcome, LoggerApiRoute, LoggerApiWorkerOutcome,
+        LoggerBackendOutcome, LoggerBlockOutcome, LoggerConfigError, LoggerConfigInput,
+        LoggerDeliveryConfig, LoggerDeviceKind, LoggerHttpMethod, LoggerLevel,
+        LoggerLifecycleOutcome, LoggerNetworkOutcome, LoggerObservabilityOutcome,
+        LoggerPmemOutcome, LoggerProcessSignalOutcome, LoggerSnapshotOutcome, LoggerState,
+        LoggerTransportOutcome, LoggerVsockOutcome, NetworkOutcomeLogRateLimiter,
+        ObservabilityWorkerLogRateLimiter, PmemOutcomeLogRateLimiter, ProcessStartupOutcome,
+        ProcessTerminalCategory, SharedLoggerMetrics, TransportOutcomeLogRateLimiter,
+        VsockOutcomeLogRateLimiter,
     };
     use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
 
@@ -1641,7 +1889,7 @@ mod tests {
     }
 
     #[test]
-    fn guest_logger_uses_closed_backend_and_transport_shapes() {
+    fn guest_logger_uses_all_closed_guest_outcome_shapes() {
         let output = Arc::new(Mutex::new(Vec::new()));
         let mut state = LoggerState::default();
         state.configure_test_writer(SharedWriter(output.clone()));
@@ -1660,6 +1908,10 @@ mod tests {
             LoggerDeviceKind::Block,
         ));
         logger.log_transport(LoggerTransportOutcome::MmioRegistrationSucceeded);
+        logger.log_block(LoggerBlockOutcome::RequestSucceeded);
+        logger.log_pmem(LoggerPmemOutcome::FlushFailed);
+        logger.log_network(LoggerNetworkOutcome::MmdsRequestDetoured);
+        logger.log_vsock(LoggerVsockOutcome::HostConnectionPending);
         assert!(logger.wait_for_delivery_for_test());
 
         assert_eq!(
@@ -1670,6 +1922,10 @@ mod tests {
                 "level=Debug operation=virtual-timer outcome=activated\n",
                 "level=Info device-kind=block operation=device-activation outcome=succeeded\n",
                 "level=Debug operation=mmio-registration outcome=succeeded\n",
+                "level=Info device-kind=block operation=request outcome=succeeded\n",
+                "level=Error device-kind=pmem operation=flush outcome=failed\n",
+                "level=Info device-kind=network operation=mmds-request outcome=detoured\n",
+                "level=Debug device-kind=vsock operation=host-connection outcome=pending\n",
             )
         );
     }
@@ -1721,6 +1977,10 @@ mod tests {
         let mut state = LoggerState::with_shared_metrics(metrics.clone());
         state.backend_rate_limiter = BackendOutcomeLogRateLimiter::with_clock(clock.clone());
         state.transport_rate_limiter = TransportOutcomeLogRateLimiter::with_clock(clock.clone());
+        state.block_rate_limiter = BlockOutcomeLogRateLimiter::with_clock(clock.clone());
+        state.pmem_rate_limiter = PmemOutcomeLogRateLimiter::with_clock(clock.clone());
+        state.network_rate_limiter = NetworkOutcomeLogRateLimiter::with_clock(clock.clone());
+        state.vsock_rate_limiter = VsockOutcomeLogRateLimiter::with_clock(clock.clone());
         state.configure_test_writer(SharedWriter(output.clone()));
         state
             .configure(LoggerConfigInput::new().with_module("bangbang_runtime::device"))
@@ -1765,6 +2025,108 @@ mod tests {
     }
 
     #[test]
+    fn four_device_limiters_are_independent_and_filter_before_admission() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let metrics = SharedLoggerMetrics::default();
+        let clock = Arc::new(TestClock::default());
+        let mut state = LoggerState::with_shared_metrics(metrics.clone());
+        state.block_rate_limiter = BlockOutcomeLogRateLimiter::with_clock(clock.clone());
+        state.pmem_rate_limiter = PmemOutcomeLogRateLimiter::with_clock(clock.clone());
+        state.network_rate_limiter = NetworkOutcomeLogRateLimiter::with_clock(clock.clone());
+        state.vsock_rate_limiter = VsockOutcomeLogRateLimiter::with_clock(clock.clone());
+        state.configure_test_writer(SharedWriter(output.clone()));
+        state
+            .configure(LoggerConfigInput::new().with_module("bangbang_hvf::backend"))
+            .expect("backend-only filter should configure");
+
+        let filtered = state.guest_logger();
+        for _ in 0..20 {
+            filtered.log_block(LoggerBlockOutcome::RequestSucceeded);
+            filtered.log_pmem(LoggerPmemOutcome::FlushSucceeded);
+            filtered.log_network(LoggerNetworkOutcome::RxSucceeded);
+            filtered.log_vsock(LoggerVsockOutcome::RxSucceeded);
+        }
+
+        state
+            .configure(LoggerConfigInput::new().with_module("bangbang_runtime::device"))
+            .expect("device filter should configure");
+        let active = state.guest_logger();
+        for _ in 0..10 {
+            active.log_block(LoggerBlockOutcome::RequestSucceeded);
+            active.log_pmem(LoggerPmemOutcome::FlushSucceeded);
+            active.log_network(LoggerNetworkOutcome::RxSucceeded);
+            active.log_vsock(LoggerVsockOutcome::RxSucceeded);
+        }
+        active.log_block(LoggerBlockOutcome::RequestSucceeded);
+        active.log_pmem(LoggerPmemOutcome::FlushSucceeded);
+        active.log_network(LoggerNetworkOutcome::RxSucceeded);
+        active.log_vsock(LoggerVsockOutcome::RxSucceeded);
+        assert_eq!(metrics.rate_limited_log_count(), 4);
+
+        clock.set(500);
+        active.log_block(LoggerBlockOutcome::RequestSucceeded);
+        active.log_pmem(LoggerPmemOutcome::FlushSucceeded);
+        active.log_network(LoggerNetworkOutcome::RxSucceeded);
+        active.log_vsock(LoggerVsockOutcome::RxSucceeded);
+        assert!(active.wait_for_delivery_for_test());
+
+        let output = String::from_utf8(output.lock().expect("output lock should succeed").clone())
+            .expect("device logger output should be UTF-8");
+        for record in [
+            "device-kind=block operation=request outcome=succeeded\n",
+            "device-kind=pmem operation=flush outcome=succeeded\n",
+            "device-kind=network operation=rx outcome=succeeded\n",
+            "device-kind=vsock operation=rx outcome=succeeded\n",
+        ] {
+            assert_eq!(output.matches(record).count(), 11);
+        }
+        assert_eq!(
+            output
+                .matches("1 messages were suppressed due to rate limiting\n")
+                .count(),
+            4
+        );
+    }
+
+    #[test]
+    fn vsock_summary_uses_one_bounded_delivery_attempt() {
+        let gate = Arc::new(WriterGate::default());
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let metrics = SharedLoggerMetrics::default();
+        let mut state = LoggerState::with_shared_metrics(metrics.clone());
+        state.set_delivery_config_for_test(LoggerDeliveryConfig::for_test(
+            1,
+            Duration::from_millis(100),
+        ));
+        state.configure_test_writer(HeldRecordingWriter {
+            gate: gate.clone(),
+            output: output.clone(),
+        });
+        let logger = state.guest_logger();
+
+        logger.log_vsock_summary([
+            LoggerVsockOutcome::GuestConnectionDropped,
+            LoggerVsockOutcome::TxSucceeded,
+            LoggerVsockOutcome::ConnectionResetQueued,
+        ]);
+        gate.wait_until_entered();
+        assert_eq!(
+            metrics.missed_log_count(),
+            0,
+            "one summary must occupy only one producer queue slot"
+        );
+
+        gate.release();
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            *output.lock().expect("output lock should succeed"),
+            b"device-kind=vsock operation=guest-connection outcome=dropped\n\
+              device-kind=vsock operation=tx outcome=succeeded\n\
+              device-kind=vsock operation=connection-reset outcome=queued\n"
+        );
+    }
+
+    #[test]
     fn guest_logger_delivery_failure_is_observational_and_counted() {
         let metrics = SharedLoggerMetrics::default();
         let mut state = LoggerState::with_shared_metrics(metrics.clone());
@@ -1775,8 +2137,12 @@ mod tests {
         logger.log_transport(LoggerTransportOutcome::MmioAccessFailed(Some(
             LoggerDeviceKind::Vsock,
         )));
+        logger.log_block(LoggerBlockOutcome::RequestIoFailed);
+        logger.log_pmem(LoggerPmemOutcome::FlushFailed);
+        logger.log_network(LoggerNetworkOutcome::TxProviderFailed);
+        logger.log_vsock(LoggerVsockOutcome::TransportResetFailed);
         assert!(logger.wait_for_delivery_for_test());
-        assert_eq!(metrics.missed_log_count(), 2);
+        assert_eq!(metrics.missed_log_count(), 6);
     }
 
     #[test]
@@ -1846,7 +2212,11 @@ mod tests {
 
         logger.log_backend(LoggerBackendOutcome::VcpuRunFailed);
         logger.log_transport(LoggerTransportOutcome::MmioRegistrationFailed);
-        assert_eq!(metrics.missed_log_count(), 2);
+        logger.log_block(LoggerBlockOutcome::QueueDispatchFailed);
+        logger.log_pmem(LoggerPmemOutcome::QueueDispatchFailed);
+        logger.log_network(LoggerNetworkOutcome::QueueDispatchFailed);
+        logger.log_vsock(LoggerVsockOutcome::QueueDispatchFailed);
+        assert_eq!(metrics.missed_log_count(), 6);
     }
 
     #[test]
@@ -1854,6 +2224,10 @@ mod tests {
         let logger = GuestLogger::default();
         logger.log_backend(LoggerBackendOutcome::VcpuRunFailed);
         logger.log_transport(LoggerTransportOutcome::MmioRegistrationFailed);
+        logger.log_block(LoggerBlockOutcome::QueueDispatchFailed);
+        logger.log_pmem(LoggerPmemOutcome::QueueDispatchFailed);
+        logger.log_network(LoggerNetworkOutcome::QueueDispatchFailed);
+        logger.log_vsock(LoggerVsockOutcome::QueueDispatchFailed);
         assert!(logger.wait_for_delivery_for_test());
     }
 

--- a/crates/runtime/src/logger/event.rs
+++ b/crates/runtime/src/logger/event.rs
@@ -224,6 +224,363 @@ impl LoggerDeviceKind {
     }
 }
 
+/// Fixed, value-free block data-plane outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerBlockOutcome {
+    RequestSucceeded,
+    RequestUnsupported,
+    RequestParseFailed,
+    RequestIoFailed,
+    StatusWriteFailed,
+    QueueDispatchFailed,
+    QueueNotificationInactive,
+    QueueNotificationUnsupported,
+    RateLimiterThrottled,
+    RateLimiterResumed,
+    AsyncEngineThrottled,
+    AsyncEngineFailed,
+    VhostUserNotificationSucceeded,
+    VhostUserNotificationFailed,
+    VhostUserDisconnected,
+    VhostUserTerminal,
+    VhostUserConfigSucceeded,
+    VhostUserConfigFailed,
+    InterruptDeliveryFailed,
+}
+
+impl LoggerBlockOutcome {
+    pub const fn operation(self) -> &'static str {
+        match self {
+            Self::RequestSucceeded | Self::RequestUnsupported => "request",
+            Self::RequestParseFailed => "request-parse",
+            Self::RequestIoFailed => "request-io",
+            Self::StatusWriteFailed => "status-write",
+            Self::QueueDispatchFailed => "queue-dispatch",
+            Self::QueueNotificationInactive | Self::QueueNotificationUnsupported => {
+                "queue-notification"
+            }
+            Self::RateLimiterThrottled | Self::RateLimiterResumed => "rate-limiter",
+            Self::AsyncEngineThrottled | Self::AsyncEngineFailed => "async-engine",
+            Self::VhostUserNotificationSucceeded
+            | Self::VhostUserNotificationFailed
+            | Self::VhostUserDisconnected
+            | Self::VhostUserTerminal => "vhost-user-notification",
+            Self::VhostUserConfigSucceeded | Self::VhostUserConfigFailed => "vhost-user-config",
+            Self::InterruptDeliveryFailed => "interrupt-delivery",
+        }
+    }
+
+    pub const fn outcome(self) -> &'static str {
+        match self {
+            Self::RequestSucceeded
+            | Self::VhostUserNotificationSucceeded
+            | Self::VhostUserConfigSucceeded => "succeeded",
+            Self::RequestUnsupported | Self::QueueNotificationUnsupported => "unsupported",
+            Self::RequestParseFailed
+            | Self::RequestIoFailed
+            | Self::StatusWriteFailed
+            | Self::QueueDispatchFailed
+            | Self::AsyncEngineFailed
+            | Self::VhostUserNotificationFailed
+            | Self::VhostUserConfigFailed
+            | Self::InterruptDeliveryFailed => "failed",
+            Self::QueueNotificationInactive => "inactive",
+            Self::RateLimiterThrottled | Self::AsyncEngineThrottled => "throttled",
+            Self::RateLimiterResumed => "resumed",
+            Self::VhostUserDisconnected => "disconnected",
+            Self::VhostUserTerminal => "terminal",
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::RateLimiterThrottled | Self::RateLimiterResumed | Self::AsyncEngineThrottled => {
+                LoggerLevel::Debug
+            }
+            Self::RequestSucceeded
+            | Self::VhostUserNotificationSucceeded
+            | Self::VhostUserConfigSucceeded => LoggerLevel::Info,
+            Self::RequestUnsupported
+            | Self::QueueNotificationUnsupported
+            | Self::VhostUserDisconnected => LoggerLevel::Warn,
+            Self::RequestParseFailed
+            | Self::RequestIoFailed
+            | Self::StatusWriteFailed
+            | Self::QueueDispatchFailed
+            | Self::QueueNotificationInactive
+            | Self::AsyncEngineFailed
+            | Self::VhostUserNotificationFailed
+            | Self::VhostUserTerminal
+            | Self::VhostUserConfigFailed
+            | Self::InterruptDeliveryFailed => LoggerLevel::Error,
+        }
+    }
+}
+
+/// Fixed, value-free persistent-memory data-plane outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerPmemOutcome {
+    FlushSucceeded,
+    FlushFailed,
+    RequestParseFailed,
+    StatusWriteFailed,
+    QueueDispatchFailed,
+    QueueNotificationInactive,
+    QueueNotificationUnsupported,
+    RateLimiterThrottled,
+    RateLimiterResumed,
+    InterruptDeliveryFailed,
+}
+
+impl LoggerPmemOutcome {
+    pub const fn operation(self) -> &'static str {
+        match self {
+            Self::FlushSucceeded | Self::FlushFailed => "flush",
+            Self::RequestParseFailed => "request-parse",
+            Self::StatusWriteFailed => "status-write",
+            Self::QueueDispatchFailed => "queue-dispatch",
+            Self::QueueNotificationInactive | Self::QueueNotificationUnsupported => {
+                "queue-notification"
+            }
+            Self::RateLimiterThrottled | Self::RateLimiterResumed => "rate-limiter",
+            Self::InterruptDeliveryFailed => "interrupt-delivery",
+        }
+    }
+
+    pub const fn outcome(self) -> &'static str {
+        match self {
+            Self::FlushSucceeded => "succeeded",
+            Self::FlushFailed
+            | Self::RequestParseFailed
+            | Self::StatusWriteFailed
+            | Self::QueueDispatchFailed
+            | Self::InterruptDeliveryFailed => "failed",
+            Self::QueueNotificationInactive => "inactive",
+            Self::QueueNotificationUnsupported => "unsupported",
+            Self::RateLimiterThrottled => "throttled",
+            Self::RateLimiterResumed => "resumed",
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::RateLimiterThrottled | Self::RateLimiterResumed => LoggerLevel::Debug,
+            Self::FlushSucceeded => LoggerLevel::Info,
+            Self::QueueNotificationUnsupported => LoggerLevel::Warn,
+            Self::FlushFailed
+            | Self::RequestParseFailed
+            | Self::StatusWriteFailed
+            | Self::QueueDispatchFailed
+            | Self::QueueNotificationInactive
+            | Self::InterruptDeliveryFailed => LoggerLevel::Error,
+        }
+    }
+}
+
+/// Fixed, value-free network and MMDS data-plane outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerNetworkOutcome {
+    RxSucceeded,
+    RxBufferMalformed,
+    RxBufferTooSmall,
+    RxBufferUnavailable,
+    RxProviderFailed,
+    TxSucceeded,
+    TxFrameMalformed,
+    TxSpoofRejected,
+    TxProviderFailed,
+    QueueDispatchFailed,
+    QueueNotificationInactive,
+    QueueNotificationUnsupported,
+    RateLimiterThrottled,
+    RateLimiterResumed,
+    PacketProviderFailed,
+    PacketProviderPartial,
+    MmdsRequestDetoured,
+    MmdsTokenKeyRotated,
+    MmdsTokenKeyRotationFailed,
+    InterruptDeliveryFailed,
+}
+
+impl LoggerNetworkOutcome {
+    pub const fn operation(self) -> &'static str {
+        match self {
+            Self::RxSucceeded => "rx",
+            Self::RxBufferMalformed | Self::RxBufferTooSmall | Self::RxBufferUnavailable => {
+                "rx-buffer"
+            }
+            Self::RxProviderFailed => "rx-provider",
+            Self::TxSucceeded => "tx",
+            Self::TxFrameMalformed | Self::TxSpoofRejected => "tx-frame",
+            Self::TxProviderFailed => "tx-provider",
+            Self::QueueDispatchFailed => "queue-dispatch",
+            Self::QueueNotificationInactive | Self::QueueNotificationUnsupported => {
+                "queue-notification"
+            }
+            Self::RateLimiterThrottled | Self::RateLimiterResumed => "rate-limiter",
+            Self::PacketProviderFailed | Self::PacketProviderPartial => "packet-provider",
+            Self::MmdsRequestDetoured => "mmds-request",
+            Self::MmdsTokenKeyRotated | Self::MmdsTokenKeyRotationFailed => "mmds-token-key",
+            Self::InterruptDeliveryFailed => "interrupt-delivery",
+        }
+    }
+
+    pub const fn outcome(self) -> &'static str {
+        match self {
+            Self::RxSucceeded | Self::TxSucceeded => "succeeded",
+            Self::RxBufferMalformed | Self::TxFrameMalformed => "malformed",
+            Self::RxBufferTooSmall => "too-small",
+            Self::RxBufferUnavailable => "unavailable",
+            Self::RxProviderFailed
+            | Self::TxProviderFailed
+            | Self::QueueDispatchFailed
+            | Self::PacketProviderFailed
+            | Self::MmdsTokenKeyRotationFailed
+            | Self::InterruptDeliveryFailed => "failed",
+            Self::TxSpoofRejected => "spoof-rejected",
+            Self::QueueNotificationInactive => "inactive",
+            Self::QueueNotificationUnsupported => "unsupported",
+            Self::RateLimiterThrottled => "throttled",
+            Self::RateLimiterResumed => "resumed",
+            Self::PacketProviderPartial => "partial",
+            Self::MmdsRequestDetoured => "detoured",
+            Self::MmdsTokenKeyRotated => "rotated",
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::RxBufferUnavailable | Self::RateLimiterThrottled | Self::RateLimiterResumed => {
+                LoggerLevel::Debug
+            }
+            Self::RxSucceeded
+            | Self::TxSucceeded
+            | Self::MmdsRequestDetoured
+            | Self::MmdsTokenKeyRotated => LoggerLevel::Info,
+            Self::RxBufferTooSmall
+            | Self::TxSpoofRejected
+            | Self::QueueNotificationUnsupported
+            | Self::PacketProviderPartial => LoggerLevel::Warn,
+            Self::RxBufferMalformed
+            | Self::RxProviderFailed
+            | Self::TxFrameMalformed
+            | Self::TxProviderFailed
+            | Self::QueueDispatchFailed
+            | Self::QueueNotificationInactive
+            | Self::PacketProviderFailed
+            | Self::MmdsTokenKeyRotationFailed
+            | Self::InterruptDeliveryFailed => LoggerLevel::Error,
+        }
+    }
+}
+
+/// Fixed, value-free vsock queue and connection outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggerVsockOutcome {
+    RxSucceeded,
+    RxBufferMalformed,
+    RxBufferTooSmall,
+    TxSucceeded,
+    TxPacketMalformed,
+    QueueDispatchFailed,
+    QueueNotificationInactive,
+    QueueNotificationUnsupported,
+    HostConnectionAccepted,
+    HostConnectionCompleted,
+    HostConnectionPending,
+    HostConnectionDropped,
+    GuestConnectionRetained,
+    GuestConnectionForwarded,
+    GuestConnectionUpdated,
+    GuestConnectionClosed,
+    GuestConnectionIgnored,
+    GuestConnectionDropped,
+    ConnectionResetQueued,
+    ConnectionResetDropped,
+    TransportResetSucceeded,
+    TransportResetFailed,
+    InterruptDeliveryFailed,
+}
+
+impl LoggerVsockOutcome {
+    pub const fn operation(self) -> &'static str {
+        match self {
+            Self::RxSucceeded => "rx",
+            Self::RxBufferMalformed | Self::RxBufferTooSmall => "rx-buffer",
+            Self::TxSucceeded => "tx",
+            Self::TxPacketMalformed => "tx-packet",
+            Self::QueueDispatchFailed => "queue-dispatch",
+            Self::QueueNotificationInactive | Self::QueueNotificationUnsupported => {
+                "queue-notification"
+            }
+            Self::HostConnectionAccepted
+            | Self::HostConnectionCompleted
+            | Self::HostConnectionPending
+            | Self::HostConnectionDropped => "host-connection",
+            Self::GuestConnectionRetained
+            | Self::GuestConnectionForwarded
+            | Self::GuestConnectionUpdated
+            | Self::GuestConnectionClosed
+            | Self::GuestConnectionIgnored
+            | Self::GuestConnectionDropped => "guest-connection",
+            Self::ConnectionResetQueued | Self::ConnectionResetDropped => "connection-reset",
+            Self::TransportResetSucceeded | Self::TransportResetFailed => "transport-reset",
+            Self::InterruptDeliveryFailed => "interrupt-delivery",
+        }
+    }
+
+    pub const fn outcome(self) -> &'static str {
+        match self {
+            Self::RxSucceeded | Self::TxSucceeded | Self::TransportResetSucceeded => "succeeded",
+            Self::RxBufferMalformed | Self::TxPacketMalformed => "malformed",
+            Self::RxBufferTooSmall => "too-small",
+            Self::QueueDispatchFailed
+            | Self::TransportResetFailed
+            | Self::InterruptDeliveryFailed => "failed",
+            Self::QueueNotificationInactive => "inactive",
+            Self::QueueNotificationUnsupported => "unsupported",
+            Self::HostConnectionAccepted => "accepted",
+            Self::HostConnectionCompleted => "completed",
+            Self::HostConnectionPending => "pending",
+            Self::HostConnectionDropped | Self::GuestConnectionDropped => "dropped",
+            Self::GuestConnectionRetained => "retained",
+            Self::GuestConnectionForwarded => "forwarded",
+            Self::GuestConnectionUpdated => "updated",
+            Self::GuestConnectionClosed => "closed",
+            Self::GuestConnectionIgnored => "ignored",
+            Self::ConnectionResetQueued => "queued",
+            Self::ConnectionResetDropped => "dropped",
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::HostConnectionPending | Self::GuestConnectionIgnored => LoggerLevel::Debug,
+            Self::RxSucceeded
+            | Self::TxSucceeded
+            | Self::HostConnectionAccepted
+            | Self::HostConnectionCompleted
+            | Self::GuestConnectionRetained
+            | Self::GuestConnectionForwarded
+            | Self::GuestConnectionUpdated
+            | Self::GuestConnectionClosed
+            | Self::ConnectionResetQueued
+            | Self::TransportResetSucceeded => LoggerLevel::Info,
+            Self::RxBufferTooSmall
+            | Self::QueueNotificationUnsupported
+            | Self::HostConnectionDropped
+            | Self::GuestConnectionDropped
+            | Self::ConnectionResetDropped => LoggerLevel::Warn,
+            Self::RxBufferMalformed
+            | Self::TxPacketMalformed
+            | Self::QueueDispatchFailed
+            | Self::QueueNotificationInactive
+            | Self::TransportResetFailed
+            | Self::InterruptDeliveryFailed => LoggerLevel::Error,
+        }
+    }
+}
+
 /// Fixed, value-free backend outcomes observed before HVF errors are formatted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoggerBackendOutcome {
@@ -800,8 +1157,11 @@ pub(super) enum LoggerEvent {
         cpu_time_us: u64,
     },
     Backend(LoggerBackendOutcome),
+    Block(LoggerBlockOutcome),
     Lifecycle(LoggerLifecycleOutcome),
+    Network(LoggerNetworkOutcome),
     Observability(LoggerObservabilityOutcome),
+    Pmem(LoggerPmemOutcome),
     RateLimitRecovery {
         suppressed: u64,
     },
@@ -811,6 +1171,7 @@ pub(super) enum LoggerEvent {
     ProcessExit(ProcessTerminalCategory),
     Snapshot(LoggerSnapshotOutcome),
     Transport(LoggerTransportOutcome),
+    Vsock(LoggerVsockOutcome),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -921,6 +1282,14 @@ impl LogRecord {
                 encoder.push_str(" outcome=");
                 encoder.push_str(outcome.outcome());
             }
+            LoggerEvent::Block(outcome) => {
+                encode_fixed_device_outcome(
+                    &mut encoder,
+                    LoggerDeviceKind::Block,
+                    outcome.operation(),
+                    outcome.outcome(),
+                );
+            }
             LoggerEvent::Lifecycle(outcome) => {
                 if let Some(kind) = outcome.device_kind() {
                     encoder.push_str("device-kind=");
@@ -932,11 +1301,27 @@ impl LogRecord {
                 encoder.push_str(" outcome=");
                 encoder.push_str(outcome.outcome());
             }
+            LoggerEvent::Network(outcome) => {
+                encode_fixed_device_outcome(
+                    &mut encoder,
+                    LoggerDeviceKind::Network,
+                    outcome.operation(),
+                    outcome.outcome(),
+                );
+            }
             LoggerEvent::Observability(outcome) => {
                 encoder.push_str("operation=");
                 encoder.push_str(outcome.operation());
                 encoder.push_str(" outcome=");
                 encoder.push_str(outcome.outcome());
+            }
+            LoggerEvent::Pmem(outcome) => {
+                encode_fixed_device_outcome(
+                    &mut encoder,
+                    LoggerDeviceKind::Pmem,
+                    outcome.operation(),
+                    outcome.outcome(),
+                );
             }
             LoggerEvent::RateLimitRecovery { suppressed } => {
                 encoder.push_u64(suppressed);
@@ -974,6 +1359,14 @@ impl LogRecord {
                 encoder.push_str(" outcome=");
                 encoder.push_str(outcome.outcome());
             }
+            LoggerEvent::Vsock(outcome) => {
+                encode_fixed_device_outcome(
+                    &mut encoder,
+                    LoggerDeviceKind::Vsock,
+                    outcome.operation(),
+                    outcome.outcome(),
+                );
+            }
         }
 
         encoder.finish()
@@ -990,6 +1383,21 @@ impl LogRecord {
     pub(super) fn as_str(&self) -> &str {
         std::str::from_utf8(self.as_bytes()).unwrap_or("")
     }
+}
+
+fn encode_fixed_device_outcome(
+    encoder: &mut RecordEncoder,
+    kind: LoggerDeviceKind,
+    operation: &str,
+    outcome: &str,
+) {
+    encoder.push_str("device-kind=");
+    encoder.push_str(kind.as_str());
+    encoder.push_byte(b' ');
+    encoder.push_str("operation=");
+    encoder.push_str(operation);
+    encoder.push_str(" outcome=");
+    encoder.push_str(outcome);
 }
 
 /// Opaque, fixed panic records prepared before a panic hook can use them.
@@ -1068,33 +1476,74 @@ impl PanicLogRecords {
     }
 }
 
+const MAX_LOG_BATCH_RECORDS: usize = 11;
+
 #[derive(Debug)]
 pub(super) struct LogBatch {
-    first: LogRecord,
-    second: Option<LogRecord>,
+    records: [Option<LogRecord>; MAX_LOG_BATCH_RECORDS],
+    len: usize,
 }
 
 impl LogBatch {
-    pub(super) const fn one(record: LogRecord) -> Self {
+    pub(super) fn empty() -> Self {
         Self {
-            first: record,
-            second: None,
+            records: std::array::from_fn(|_| None),
+            len: 0,
         }
     }
 
-    pub(super) const fn two(first: LogRecord, second: LogRecord) -> Self {
-        Self {
-            first,
-            second: Some(second),
-        }
+    pub(super) fn one(record: LogRecord) -> Self {
+        let mut batch = Self::empty();
+        let inserted = batch.push(record);
+        debug_assert!(inserted);
+        batch
+    }
+
+    pub(super) fn two(first: LogRecord, second: LogRecord) -> Self {
+        let mut batch = Self::one(first);
+        let inserted = batch.push(second);
+        debug_assert!(inserted);
+        batch
+    }
+
+    pub(super) const fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     pub(super) const fn len(&self) -> usize {
-        if self.second.is_some() { 2 } else { 1 }
+        self.len
+    }
+
+    pub(super) fn push(&mut self, record: LogRecord) -> bool {
+        let Some(slot) = self.records.get_mut(self.len) else {
+            return false;
+        };
+        *slot = Some(record);
+        self.len += 1;
+        true
+    }
+
+    pub(super) fn prepend(&mut self, record: LogRecord) -> bool {
+        if self.len == self.records.len() {
+            return false;
+        }
+        let Some(active) = self.records.get_mut(..=self.len) else {
+            return false;
+        };
+        active.rotate_right(1);
+        let Some(slot) = active.first_mut() else {
+            return false;
+        };
+        *slot = Some(record);
+        self.len += 1;
+        true
     }
 
     pub(super) fn iter(&self) -> impl Iterator<Item = &LogRecord> {
-        std::iter::once(&self.first).chain(self.second.as_ref())
+        self.records
+            .iter()
+            .take(self.len)
+            .filter_map(Option::as_ref)
     }
 }
 
@@ -1260,11 +1709,12 @@ fn utf8_prefix_len(value: &str, maximum: usize) -> usize {
 mod tests {
     use super::{
         LogOrigin, LogRecord, LoggerAction, LoggerApiControlOutcome, LoggerApiResultOutcome,
-        LoggerApiRoute, LoggerApiWorkerOutcome, LoggerBackendOutcome, LoggerDeviceKind,
-        LoggerEvent, LoggerHttpMethod, LoggerLifecycleOutcome, LoggerObservabilityOutcome,
+        LoggerApiRoute, LoggerApiWorkerOutcome, LoggerBackendOutcome, LoggerBlockOutcome,
+        LoggerDeviceKind, LoggerEvent, LoggerHttpMethod, LoggerLifecycleOutcome,
+        LoggerNetworkOutcome, LoggerObservabilityOutcome, LoggerPmemOutcome,
         LoggerProcessSignalOutcome, LoggerSnapshotOutcome, LoggerTransportOutcome,
-        MAX_LOG_RECORD_BYTES, PanicLogRecords, ProcessStartupOutcome, ProcessTerminalCategory,
-        normalize_origin,
+        LoggerVsockOutcome, MAX_LOG_RECORD_BYTES, PanicLogRecords, ProcessStartupOutcome,
+        ProcessTerminalCategory, normalize_origin,
     };
     use crate::logger::LoggerLevel;
 
@@ -1696,6 +2146,494 @@ mod tests {
             ] {
                 assert!(!expected.contains(forbidden));
             }
+        }
+    }
+
+    #[test]
+    fn encodes_every_closed_block_outcome() {
+        let cases = [
+            (
+                LoggerBlockOutcome::RequestSucceeded,
+                LoggerLevel::Info,
+                "request",
+                "succeeded",
+            ),
+            (
+                LoggerBlockOutcome::RequestUnsupported,
+                LoggerLevel::Warn,
+                "request",
+                "unsupported",
+            ),
+            (
+                LoggerBlockOutcome::RequestParseFailed,
+                LoggerLevel::Error,
+                "request-parse",
+                "failed",
+            ),
+            (
+                LoggerBlockOutcome::RequestIoFailed,
+                LoggerLevel::Error,
+                "request-io",
+                "failed",
+            ),
+            (
+                LoggerBlockOutcome::StatusWriteFailed,
+                LoggerLevel::Error,
+                "status-write",
+                "failed",
+            ),
+            (
+                LoggerBlockOutcome::QueueDispatchFailed,
+                LoggerLevel::Error,
+                "queue-dispatch",
+                "failed",
+            ),
+            (
+                LoggerBlockOutcome::QueueNotificationInactive,
+                LoggerLevel::Error,
+                "queue-notification",
+                "inactive",
+            ),
+            (
+                LoggerBlockOutcome::QueueNotificationUnsupported,
+                LoggerLevel::Warn,
+                "queue-notification",
+                "unsupported",
+            ),
+            (
+                LoggerBlockOutcome::RateLimiterThrottled,
+                LoggerLevel::Debug,
+                "rate-limiter",
+                "throttled",
+            ),
+            (
+                LoggerBlockOutcome::RateLimiterResumed,
+                LoggerLevel::Debug,
+                "rate-limiter",
+                "resumed",
+            ),
+            (
+                LoggerBlockOutcome::AsyncEngineThrottled,
+                LoggerLevel::Debug,
+                "async-engine",
+                "throttled",
+            ),
+            (
+                LoggerBlockOutcome::AsyncEngineFailed,
+                LoggerLevel::Error,
+                "async-engine",
+                "failed",
+            ),
+            (
+                LoggerBlockOutcome::VhostUserNotificationSucceeded,
+                LoggerLevel::Info,
+                "vhost-user-notification",
+                "succeeded",
+            ),
+            (
+                LoggerBlockOutcome::VhostUserNotificationFailed,
+                LoggerLevel::Error,
+                "vhost-user-notification",
+                "failed",
+            ),
+            (
+                LoggerBlockOutcome::VhostUserDisconnected,
+                LoggerLevel::Warn,
+                "vhost-user-notification",
+                "disconnected",
+            ),
+            (
+                LoggerBlockOutcome::VhostUserTerminal,
+                LoggerLevel::Error,
+                "vhost-user-notification",
+                "terminal",
+            ),
+            (
+                LoggerBlockOutcome::VhostUserConfigSucceeded,
+                LoggerLevel::Info,
+                "vhost-user-config",
+                "succeeded",
+            ),
+            (
+                LoggerBlockOutcome::VhostUserConfigFailed,
+                LoggerLevel::Error,
+                "vhost-user-config",
+                "failed",
+            ),
+            (
+                LoggerBlockOutcome::InterruptDeliveryFailed,
+                LoggerLevel::Error,
+                "interrupt-delivery",
+                "failed",
+            ),
+        ];
+        for (outcome, level, operation, result) in cases {
+            assert_eq!(outcome.level(), level);
+            assert_closed_event(
+                LoggerEvent::Block(outcome),
+                level,
+                &format!("device-kind=block operation={operation} outcome={result}"),
+            );
+        }
+    }
+
+    #[test]
+    fn encodes_every_closed_pmem_outcome() {
+        let cases = [
+            (
+                LoggerPmemOutcome::FlushSucceeded,
+                LoggerLevel::Info,
+                "flush",
+                "succeeded",
+            ),
+            (
+                LoggerPmemOutcome::FlushFailed,
+                LoggerLevel::Error,
+                "flush",
+                "failed",
+            ),
+            (
+                LoggerPmemOutcome::RequestParseFailed,
+                LoggerLevel::Error,
+                "request-parse",
+                "failed",
+            ),
+            (
+                LoggerPmemOutcome::StatusWriteFailed,
+                LoggerLevel::Error,
+                "status-write",
+                "failed",
+            ),
+            (
+                LoggerPmemOutcome::QueueDispatchFailed,
+                LoggerLevel::Error,
+                "queue-dispatch",
+                "failed",
+            ),
+            (
+                LoggerPmemOutcome::QueueNotificationInactive,
+                LoggerLevel::Error,
+                "queue-notification",
+                "inactive",
+            ),
+            (
+                LoggerPmemOutcome::QueueNotificationUnsupported,
+                LoggerLevel::Warn,
+                "queue-notification",
+                "unsupported",
+            ),
+            (
+                LoggerPmemOutcome::RateLimiterThrottled,
+                LoggerLevel::Debug,
+                "rate-limiter",
+                "throttled",
+            ),
+            (
+                LoggerPmemOutcome::RateLimiterResumed,
+                LoggerLevel::Debug,
+                "rate-limiter",
+                "resumed",
+            ),
+            (
+                LoggerPmemOutcome::InterruptDeliveryFailed,
+                LoggerLevel::Error,
+                "interrupt-delivery",
+                "failed",
+            ),
+        ];
+        for (outcome, level, operation, result) in cases {
+            assert_eq!(outcome.level(), level);
+            assert_closed_event(
+                LoggerEvent::Pmem(outcome),
+                level,
+                &format!("device-kind=pmem operation={operation} outcome={result}"),
+            );
+        }
+    }
+
+    #[test]
+    fn encodes_every_closed_network_outcome() {
+        let cases = [
+            (
+                LoggerNetworkOutcome::RxSucceeded,
+                LoggerLevel::Info,
+                "rx",
+                "succeeded",
+            ),
+            (
+                LoggerNetworkOutcome::RxBufferMalformed,
+                LoggerLevel::Error,
+                "rx-buffer",
+                "malformed",
+            ),
+            (
+                LoggerNetworkOutcome::RxBufferTooSmall,
+                LoggerLevel::Warn,
+                "rx-buffer",
+                "too-small",
+            ),
+            (
+                LoggerNetworkOutcome::RxBufferUnavailable,
+                LoggerLevel::Debug,
+                "rx-buffer",
+                "unavailable",
+            ),
+            (
+                LoggerNetworkOutcome::RxProviderFailed,
+                LoggerLevel::Error,
+                "rx-provider",
+                "failed",
+            ),
+            (
+                LoggerNetworkOutcome::TxSucceeded,
+                LoggerLevel::Info,
+                "tx",
+                "succeeded",
+            ),
+            (
+                LoggerNetworkOutcome::TxFrameMalformed,
+                LoggerLevel::Error,
+                "tx-frame",
+                "malformed",
+            ),
+            (
+                LoggerNetworkOutcome::TxSpoofRejected,
+                LoggerLevel::Warn,
+                "tx-frame",
+                "spoof-rejected",
+            ),
+            (
+                LoggerNetworkOutcome::TxProviderFailed,
+                LoggerLevel::Error,
+                "tx-provider",
+                "failed",
+            ),
+            (
+                LoggerNetworkOutcome::QueueDispatchFailed,
+                LoggerLevel::Error,
+                "queue-dispatch",
+                "failed",
+            ),
+            (
+                LoggerNetworkOutcome::QueueNotificationInactive,
+                LoggerLevel::Error,
+                "queue-notification",
+                "inactive",
+            ),
+            (
+                LoggerNetworkOutcome::QueueNotificationUnsupported,
+                LoggerLevel::Warn,
+                "queue-notification",
+                "unsupported",
+            ),
+            (
+                LoggerNetworkOutcome::RateLimiterThrottled,
+                LoggerLevel::Debug,
+                "rate-limiter",
+                "throttled",
+            ),
+            (
+                LoggerNetworkOutcome::RateLimiterResumed,
+                LoggerLevel::Debug,
+                "rate-limiter",
+                "resumed",
+            ),
+            (
+                LoggerNetworkOutcome::PacketProviderFailed,
+                LoggerLevel::Error,
+                "packet-provider",
+                "failed",
+            ),
+            (
+                LoggerNetworkOutcome::PacketProviderPartial,
+                LoggerLevel::Warn,
+                "packet-provider",
+                "partial",
+            ),
+            (
+                LoggerNetworkOutcome::MmdsRequestDetoured,
+                LoggerLevel::Info,
+                "mmds-request",
+                "detoured",
+            ),
+            (
+                LoggerNetworkOutcome::MmdsTokenKeyRotated,
+                LoggerLevel::Info,
+                "mmds-token-key",
+                "rotated",
+            ),
+            (
+                LoggerNetworkOutcome::MmdsTokenKeyRotationFailed,
+                LoggerLevel::Error,
+                "mmds-token-key",
+                "failed",
+            ),
+            (
+                LoggerNetworkOutcome::InterruptDeliveryFailed,
+                LoggerLevel::Error,
+                "interrupt-delivery",
+                "failed",
+            ),
+        ];
+        for (outcome, level, operation, result) in cases {
+            assert_eq!(outcome.level(), level);
+            assert_closed_event(
+                LoggerEvent::Network(outcome),
+                level,
+                &format!("device-kind=network operation={operation} outcome={result}"),
+            );
+        }
+    }
+
+    #[test]
+    fn encodes_every_closed_vsock_outcome() {
+        let cases = [
+            (
+                LoggerVsockOutcome::RxSucceeded,
+                LoggerLevel::Info,
+                "rx",
+                "succeeded",
+            ),
+            (
+                LoggerVsockOutcome::RxBufferMalformed,
+                LoggerLevel::Error,
+                "rx-buffer",
+                "malformed",
+            ),
+            (
+                LoggerVsockOutcome::RxBufferTooSmall,
+                LoggerLevel::Warn,
+                "rx-buffer",
+                "too-small",
+            ),
+            (
+                LoggerVsockOutcome::TxSucceeded,
+                LoggerLevel::Info,
+                "tx",
+                "succeeded",
+            ),
+            (
+                LoggerVsockOutcome::TxPacketMalformed,
+                LoggerLevel::Error,
+                "tx-packet",
+                "malformed",
+            ),
+            (
+                LoggerVsockOutcome::QueueDispatchFailed,
+                LoggerLevel::Error,
+                "queue-dispatch",
+                "failed",
+            ),
+            (
+                LoggerVsockOutcome::QueueNotificationInactive,
+                LoggerLevel::Error,
+                "queue-notification",
+                "inactive",
+            ),
+            (
+                LoggerVsockOutcome::QueueNotificationUnsupported,
+                LoggerLevel::Warn,
+                "queue-notification",
+                "unsupported",
+            ),
+            (
+                LoggerVsockOutcome::HostConnectionAccepted,
+                LoggerLevel::Info,
+                "host-connection",
+                "accepted",
+            ),
+            (
+                LoggerVsockOutcome::HostConnectionCompleted,
+                LoggerLevel::Info,
+                "host-connection",
+                "completed",
+            ),
+            (
+                LoggerVsockOutcome::HostConnectionPending,
+                LoggerLevel::Debug,
+                "host-connection",
+                "pending",
+            ),
+            (
+                LoggerVsockOutcome::HostConnectionDropped,
+                LoggerLevel::Warn,
+                "host-connection",
+                "dropped",
+            ),
+            (
+                LoggerVsockOutcome::GuestConnectionRetained,
+                LoggerLevel::Info,
+                "guest-connection",
+                "retained",
+            ),
+            (
+                LoggerVsockOutcome::GuestConnectionForwarded,
+                LoggerLevel::Info,
+                "guest-connection",
+                "forwarded",
+            ),
+            (
+                LoggerVsockOutcome::GuestConnectionUpdated,
+                LoggerLevel::Info,
+                "guest-connection",
+                "updated",
+            ),
+            (
+                LoggerVsockOutcome::GuestConnectionClosed,
+                LoggerLevel::Info,
+                "guest-connection",
+                "closed",
+            ),
+            (
+                LoggerVsockOutcome::GuestConnectionIgnored,
+                LoggerLevel::Debug,
+                "guest-connection",
+                "ignored",
+            ),
+            (
+                LoggerVsockOutcome::GuestConnectionDropped,
+                LoggerLevel::Warn,
+                "guest-connection",
+                "dropped",
+            ),
+            (
+                LoggerVsockOutcome::ConnectionResetQueued,
+                LoggerLevel::Info,
+                "connection-reset",
+                "queued",
+            ),
+            (
+                LoggerVsockOutcome::ConnectionResetDropped,
+                LoggerLevel::Warn,
+                "connection-reset",
+                "dropped",
+            ),
+            (
+                LoggerVsockOutcome::TransportResetSucceeded,
+                LoggerLevel::Info,
+                "transport-reset",
+                "succeeded",
+            ),
+            (
+                LoggerVsockOutcome::TransportResetFailed,
+                LoggerLevel::Error,
+                "transport-reset",
+                "failed",
+            ),
+            (
+                LoggerVsockOutcome::InterruptDeliveryFailed,
+                LoggerLevel::Error,
+                "interrupt-delivery",
+                "failed",
+            ),
+        ];
+        for (outcome, level, operation, result) in cases {
+            assert_eq!(outcome.level(), level);
+            assert_closed_event(
+                LoggerEvent::Vsock(outcome),
+                level,
+                &format!("device-kind=vsock operation={operation} outcome={result}"),
+            );
         }
     }
 

--- a/crates/runtime/src/logger/rate_limiter.rs
+++ b/crates/runtime/src/logger/rate_limiter.rs
@@ -42,6 +42,10 @@ pub(super) enum LoggerRateLimitIdentity {
     ObservabilityWorker,
     BackendOutcome,
     TransportOutcome,
+    BlockOutcome,
+    PmemOutcome,
+    NetworkOutcome,
+    VsockOutcome,
 }
 
 impl LoggerRateLimitIdentity {
@@ -52,16 +56,24 @@ impl LoggerRateLimitIdentity {
             Self::ObservabilityWorker => 2,
             Self::BackendOutcome => 3,
             Self::TransportOutcome => 4,
+            Self::BlockOutcome => 5,
+            Self::PmemOutcome => 6,
+            Self::NetworkOutcome => 7,
+            Self::VsockOutcome => 8,
         }
     }
 }
 
-const LOGGER_RATE_LIMIT_IDENTITIES: [LoggerRateLimitIdentity; 5] = [
+const LOGGER_RATE_LIMIT_IDENTITIES: [LoggerRateLimitIdentity; 9] = [
     LoggerRateLimitIdentity::BootTimer,
     LoggerRateLimitIdentity::ApiRequest,
     LoggerRateLimitIdentity::ObservabilityWorker,
     LoggerRateLimitIdentity::BackendOutcome,
     LoggerRateLimitIdentity::TransportOutcome,
+    LoggerRateLimitIdentity::BlockOutcome,
+    LoggerRateLimitIdentity::PmemOutcome,
+    LoggerRateLimitIdentity::NetworkOutcome,
+    LoggerRateLimitIdentity::VsockOutcome,
 ];
 const LOGGER_RATE_LIMIT_IDENTITY_COUNT: usize = LOGGER_RATE_LIMIT_IDENTITIES.len();
 

--- a/crates/runtime/src/mmds.rs
+++ b/crates/runtime/src/mmds.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::{Map, Value};
 
+use crate::logger::GuestLogger;
 pub use crate::mmds_token::{
     MMDS_TOKEN_MAX_TTL_SECONDS, MMDS_TOKEN_MIN_TTL_SECONDS, MmdsTokenAuthority, MmdsTokenError,
 };
@@ -852,6 +853,10 @@ impl MmdsStateHandle {
         self.with(|state| state.config().cloned())
     }
 
+    pub fn attach_guest_logger(&self, logger: GuestLogger) -> Result<(), MmdsStateLockError> {
+        self.with_mut(|state| state.attach_guest_logger(logger))
+    }
+
     #[doc(hidden)]
     pub fn shares_state_with(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.state, &other.state)
@@ -896,6 +901,10 @@ impl MmdsState {
 
     pub fn config(&self) -> Option<&MmdsConfig> {
         self.config.as_ref()
+    }
+
+    pub fn attach_guest_logger(&mut self, logger: GuestLogger) {
+        self.token_authority.attach_guest_logger(logger);
     }
 
     pub const fn data_store_present(&self) -> bool {

--- a/crates/runtime/src/mmds_token.rs
+++ b/crates/runtime/src/mmds_token.rs
@@ -8,6 +8,8 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
 use zeroize::Zeroizing;
 
+use crate::logger::{GuestLogger, LoggerNetworkOutcome};
+
 pub const MMDS_TOKEN_MIN_TTL_SECONDS: u32 = 1;
 pub const MMDS_TOKEN_MAX_TTL_SECONDS: u32 = 21_600;
 
@@ -125,6 +127,7 @@ pub struct MmdsTokenAuthority {
     current_key: Option<Zeroizing<[u8; MMDS_TOKEN_KEY_BYTES]>>,
     additional_authenticated_data: Zeroizing<Vec<u8>>,
     num_encrypted_tokens: u32,
+    guest_logger: Option<GuestLogger>,
     clock: MmdsTokenClock,
     entropy: MmdsTokenEntropy,
     #[cfg(test)]
@@ -139,6 +142,7 @@ impl fmt::Debug for MmdsTokenAuthority {
             .field("current_key", &"[REDACTED]")
             .field("additional_authenticated_data", &"[REDACTED]")
             .field("num_encrypted_tokens", &self.num_encrypted_tokens)
+            .field("guest_logger_attached", &self.guest_logger.is_some())
             .field("clock", &"[REDACTED]")
             .field("entropy", &"[REDACTED]")
             .finish()
@@ -164,6 +168,7 @@ impl MmdsTokenAuthority {
             current_key: None,
             additional_authenticated_data,
             num_encrypted_tokens: 0,
+            guest_logger: None,
             clock: MmdsTokenClock::default(),
             entropy: MmdsTokenEntropy::default(),
             #[cfg(test)]
@@ -173,9 +178,31 @@ impl MmdsTokenAuthority {
         }
     }
 
+    pub fn attach_guest_logger(&mut self, logger: GuestLogger) {
+        self.guest_logger = Some(logger);
+    }
+
     pub fn generate_token(&mut self, ttl_seconds: u32) -> Result<String, MmdsTokenError> {
         validate_ttl(ttl_seconds)?;
         let now_millis = self.clock.now_millis()?;
+        let rotates_existing_key =
+            self.current_key.is_some() && self.num_encrypted_tokens == u32::MAX;
+        let result = self.generate_token_at(ttl_seconds, now_millis);
+        if rotates_existing_key && let Some(logger) = &self.guest_logger {
+            logger.log_network(if result.is_ok() {
+                LoggerNetworkOutcome::MmdsTokenKeyRotated
+            } else {
+                LoggerNetworkOutcome::MmdsTokenKeyRotationFailed
+            });
+        }
+        result
+    }
+
+    fn generate_token_at(
+        &mut self,
+        ttl_seconds: u32,
+        now_millis: u64,
+    ) -> Result<String, MmdsTokenError> {
         let expiry_millis = token_expiry_millis(now_millis, ttl_seconds);
         let needs_new_key = self.current_key.is_none() || self.num_encrypted_tokens == u32::MAX;
         let next_encrypted_tokens = if needs_new_key {
@@ -372,7 +399,28 @@ fn decode_token(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
     use super::*;
+    use crate::logger::LoggerState;
+
+    #[derive(Debug)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("MMDS logger output lock should succeed")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
 
     fn authority(instance_id: &str) -> MmdsTokenAuthority {
         MmdsTokenAuthority::with_manual_clock(instance_id, 1_000)
@@ -531,6 +579,51 @@ mod tests {
         assert_eq!(authority.num_encrypted_tokens, 1);
         assert!(!authority.is_valid(&old_token));
         assert!(authority.is_valid(&new_token));
+    }
+
+    #[test]
+    fn rotation_outcomes_are_logged_once_without_token_or_key_values() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let mut logger_state = LoggerState::default();
+        logger_state.configure_test_writer(SharedWriter(output.clone()));
+        let logger = logger_state.guest_logger();
+
+        let mut succeeded = authority("logged-success");
+        succeeded
+            .generate_token(60)
+            .expect("initial success token should generate");
+        succeeded.num_encrypted_tokens = u32::MAX;
+        succeeded.attach_guest_logger(logger.clone());
+        succeeded
+            .generate_token(60)
+            .expect("logged key rotation should succeed");
+
+        let mut failed = authority("logged-failure");
+        failed
+            .generate_token(60)
+            .expect("initial failure token should generate");
+        failed.num_encrypted_tokens = u32::MAX;
+        set_entropy_failure(&mut failed, 0);
+        failed.attach_guest_logger(logger.clone());
+        assert_eq!(
+            failed.generate_token(60),
+            Err(MmdsTokenError::RandomnessUnavailable)
+        );
+        assert!(logger.wait_for_delivery_for_test());
+
+        assert_eq!(
+            String::from_utf8(
+                output
+                    .lock()
+                    .expect("MMDS logger output lock should succeed")
+                    .clone(),
+            )
+            .expect("MMDS logger output should be UTF-8"),
+            concat!(
+                "device-kind=network operation=mmds-token-key outcome=rotated\n",
+                "device-kind=network operation=mmds-token-key outcome=failed\n",
+            )
+        );
     }
 
     #[test]

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
 
-use crate::logger::{GuestLogger, LoggerDeviceKind, LoggerTransportOutcome};
+use crate::logger::{GuestLogger, LoggerDeviceKind, LoggerNetworkOutcome, LoggerTransportOutcome};
 use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryRange,
 };
@@ -3621,6 +3621,25 @@ impl VirtioNetworkDevice {
         rx_source: &mut (impl VirtioNetworkRxPacketSource + ?Sized),
         now: Instant,
     ) -> Result<VirtioNetworkDeviceNotificationDispatch, VirtioNetworkDeviceNotificationError> {
+        let result = self.dispatch_drained_queue_notifications_with_packet_io_at_unobserved(
+            memory,
+            drained_notifications,
+            tx_sink,
+            rx_source,
+            now,
+        );
+        self.observe_notification_result(&result);
+        result
+    }
+
+    fn dispatch_drained_queue_notifications_with_packet_io_at_unobserved(
+        &mut self,
+        memory: &mut GuestMemory,
+        drained_notifications: Vec<usize>,
+        tx_sink: &mut (impl VirtioNetworkTxPacketSink + ?Sized),
+        rx_source: &mut (impl VirtioNetworkRxPacketSource + ?Sized),
+        now: Instant,
+    ) -> Result<VirtioNetworkDeviceNotificationDispatch, VirtioNetworkDeviceNotificationError> {
         let host_readiness = rx_source.host_readiness_hint();
         if drained_notifications.is_empty()
             && !self.has_pending_rate_limited_queue_work()
@@ -3770,6 +3789,149 @@ impl VirtioNetworkDevice {
             post_tx_rx_queue_dispatch,
         )
         .with_rate_limiter_events(rx_rate_limiter_event, tx_rate_limiter_event))
+    }
+
+    fn observe_notification_result(
+        &self,
+        result: &Result<
+            VirtioNetworkDeviceNotificationDispatch,
+            VirtioNetworkDeviceNotificationError,
+        >,
+    ) {
+        let Some(logger) = &self.guest_logger else {
+            return;
+        };
+        let mut observation = NetworkNotificationObservation::default();
+        match result {
+            Ok(dispatch) => observation.record_notification_dispatch(dispatch),
+            Err(VirtioNetworkDeviceNotificationError::Inactive { .. }) => {
+                observation.notification_inactive = true;
+            }
+            Err(VirtioNetworkDeviceNotificationError::UnsupportedQueue { .. }) => {
+                observation.notification_unsupported = true;
+            }
+            Err(source) => {
+                observation.queue_dispatch_failed = true;
+                if let Some(dispatch) = source.completed_initial_rx_dispatch() {
+                    observation.record_rx_dispatch(dispatch);
+                }
+                if let Some(dispatch) = source.completed_tx_dispatch() {
+                    observation.record_tx_dispatch(dispatch);
+                }
+                if let Some(dispatch) = source.completed_rx_dispatch() {
+                    observation.record_rx_dispatch(dispatch);
+                }
+            }
+        }
+        observation.log(logger);
+    }
+}
+
+#[derive(Debug, Default)]
+struct NetworkNotificationObservation {
+    rx_succeeded: bool,
+    rx_buffer_malformed: bool,
+    rx_buffer_too_small: bool,
+    rx_buffer_unavailable: bool,
+    rx_provider_failed: bool,
+    tx_succeeded: bool,
+    tx_frame_malformed: bool,
+    tx_spoof_rejected: bool,
+    tx_provider_failed: bool,
+    queue_dispatch_failed: bool,
+    notification_inactive: bool,
+    notification_unsupported: bool,
+    rate_limiter_throttled: bool,
+    rate_limiter_resumed: bool,
+    packet_provider_partial: bool,
+    mmds_request_detoured: bool,
+}
+
+impl NetworkNotificationObservation {
+    fn record_notification_dispatch(&mut self, dispatch: &VirtioNetworkDeviceNotificationDispatch) {
+        if let Some(rx) = dispatch.rx_queue_dispatch() {
+            self.record_rx_dispatch(rx);
+        }
+        if let Some(tx) = dispatch.tx_queue_dispatch() {
+            self.record_tx_dispatch(tx);
+        }
+        if let Some(rx) = dispatch.post_tx_rx_queue_dispatch() {
+            self.record_rx_dispatch(rx);
+        }
+        self.rate_limiter_resumed |=
+            dispatch.rx_rate_limiter_event() || dispatch.tx_rate_limiter_event();
+    }
+
+    fn record_rx_dispatch(&mut self, dispatch: &VirtioNetworkRxQueueDispatch) {
+        self.rx_succeeded |= dispatch.delivered_packets() != 0;
+        self.rx_buffer_malformed |= dispatch.buffer_parse_failures() != 0;
+        self.rx_buffer_too_small |= dispatch.buffer_too_small_failures() != 0;
+        self.rx_buffer_unavailable |= dispatch.no_available_buffers() != 0;
+        self.rx_provider_failed |= dispatch.source_failures() != 0;
+        self.rate_limiter_throttled |= dispatch.rate_limiter_throttled_packets() != 0;
+        self.record_backend_metrics(dispatch.backend_metrics());
+    }
+
+    fn record_tx_dispatch(&mut self, dispatch: &VirtioNetworkTxQueueDispatch) {
+        self.tx_succeeded |= dispatch.sink_successful_frames() != 0;
+        self.tx_frame_malformed |= dispatch.malformed_frames() != 0;
+        self.tx_provider_failed |= dispatch.sink_failures() != 0;
+        self.rate_limiter_throttled |= dispatch.rate_limiter_throttled_frames() != 0;
+        self.mmds_request_detoured |= dispatch.detoured_frames() != 0;
+        self.record_backend_metrics(dispatch.backend_metrics());
+    }
+
+    fn record_backend_metrics(&mut self, metrics: VirtioNetworkBackendMetrics) {
+        self.rx_provider_failed |= metrics.vmnet_read_fails() != 0;
+        self.tx_provider_failed |= metrics.vmnet_write_fails() != 0;
+        self.packet_provider_partial |=
+            metrics.vmnet_read_partial_batches() != 0 || metrics.vmnet_write_partial_batches() != 0;
+        self.tx_spoof_rejected |= metrics.tx_spoofed_mac_count() != 0;
+    }
+
+    fn outcomes(self) -> impl Iterator<Item = LoggerNetworkOutcome> {
+        [
+            self.queue_dispatch_failed
+                .then_some(LoggerNetworkOutcome::QueueDispatchFailed),
+            self.notification_inactive
+                .then_some(LoggerNetworkOutcome::QueueNotificationInactive),
+            self.notification_unsupported
+                .then_some(LoggerNetworkOutcome::QueueNotificationUnsupported),
+            self.rx_buffer_malformed
+                .then_some(LoggerNetworkOutcome::RxBufferMalformed),
+            self.rx_buffer_too_small
+                .then_some(LoggerNetworkOutcome::RxBufferTooSmall),
+            self.rx_provider_failed
+                .then_some(LoggerNetworkOutcome::RxProviderFailed),
+            self.tx_frame_malformed
+                .then_some(LoggerNetworkOutcome::TxFrameMalformed),
+            self.tx_spoof_rejected
+                .then_some(LoggerNetworkOutcome::TxSpoofRejected),
+            self.tx_provider_failed
+                .then_some(LoggerNetworkOutcome::TxProviderFailed),
+            self.packet_provider_partial
+                .then_some(LoggerNetworkOutcome::PacketProviderPartial),
+            self.rx_buffer_unavailable
+                .then_some(LoggerNetworkOutcome::RxBufferUnavailable),
+            self.rate_limiter_throttled
+                .then_some(LoggerNetworkOutcome::RateLimiterThrottled),
+            self.rate_limiter_resumed
+                .then_some(LoggerNetworkOutcome::RateLimiterResumed),
+            self.rx_succeeded
+                .then_some(LoggerNetworkOutcome::RxSucceeded),
+            self.tx_succeeded
+                .then_some(LoggerNetworkOutcome::TxSucceeded),
+            self.mmds_request_detoured
+                .then_some(LoggerNetworkOutcome::MmdsRequestDetoured),
+        ]
+        .into_iter()
+        .flatten()
+    }
+
+    fn log(self, logger: &GuestLogger) {
+        for outcome in self.outcomes() {
+            logger.log_network(outcome);
+        }
     }
 }
 
@@ -5398,20 +5560,14 @@ impl VirtioNetworkTxQueue {
             };
             let outcome = match preparation {
                 VirtioNetworkTxFramePreparation::Ready { frame, packet } => {
-                    let sink_error = match tx_sink.transmit_prepared_frame(memory, &frame, &packet)
+                    let sink_result = tx_sink.transmit_prepared_frame(memory, &frame, &packet);
+                    if matches!(sink_result, Ok(VirtioNetworkTxPacketDisposition::Detoured))
+                        && let (Some(limiter), Some(reservation)) =
+                            (rate_limiter.as_deref_mut(), reservation)
                     {
-                        Ok(VirtioNetworkTxPacketDisposition::Detoured) => {
-                            if let (Some(limiter), Some(reservation)) =
-                                (rate_limiter.as_deref_mut(), reservation)
-                            {
-                                limiter.restore(reservation);
-                            }
-                            None
-                        }
-                        Ok(VirtioNetworkTxPacketDisposition::Forwarded) => None,
-                        Err(source) => Some(source),
-                    };
-                    VirtioNetworkTxQueueDispatchOutcome::Ok { frame, sink_error }
+                        limiter.restore(reservation);
+                    }
+                    VirtioNetworkTxQueueDispatchOutcome::Ok { frame, sink_result }
                 }
                 VirtioNetworkTxFramePreparation::PacketError(source) => {
                     VirtioNetworkTxQueueDispatchOutcome::PacketPrepareError(source)
@@ -5680,7 +5836,7 @@ impl VirtioNetworkTxQueue {
                 dispatch.record(
                     VirtioNetworkTxQueueDispatchOutcome::Ok {
                         frame,
-                        sink_error: Some(source),
+                        sink_result: Err(source),
                     },
                     publication,
                 );
@@ -5702,7 +5858,7 @@ impl VirtioNetworkTxQueue {
                     dispatch.record(
                         VirtioNetworkTxQueueDispatchOutcome::Ok {
                             frame,
-                            sink_error: result.err(),
+                            sink_result: result,
                         },
                         publication,
                     );
@@ -5795,6 +5951,7 @@ pub struct VirtioNetworkTxQueueDispatch {
     parse_failures: usize,
     packet_prepare_failures: usize,
     sink_successful_frames: usize,
+    detoured_frames: usize,
     sink_failures: usize,
     sink_successful_bytes: u64,
     rate_limiter_throttled_frames: usize,
@@ -5823,6 +5980,7 @@ impl VirtioNetworkTxQueueDispatch {
             parse_failures: 0,
             packet_prepare_failures: 0,
             sink_successful_frames: 0,
+            detoured_frames: 0,
             sink_failures: 0,
             sink_successful_bytes: 0,
             rate_limiter_throttled_frames: 0,
@@ -5860,6 +6018,10 @@ impl VirtioNetworkTxQueueDispatch {
 
     pub const fn sink_successful_frames(&self) -> usize {
         self.sink_successful_frames
+    }
+
+    pub const fn detoured_frames(&self) -> usize {
+        self.detoured_frames
     }
 
     pub const fn sink_failures(&self) -> usize {
@@ -5918,19 +6080,22 @@ impl VirtioNetworkTxQueueDispatch {
         self.processed_frames += 1;
         self.needs_queue_interrupt |= publication.needs_queue_interrupt();
         match outcome {
-            VirtioNetworkTxQueueDispatchOutcome::Ok { frame, sink_error } => {
+            VirtioNetworkTxQueueDispatchOutcome::Ok { frame, sink_result } => {
                 self.successful_frames += 1;
-                match sink_error {
-                    Some(source) => {
+                match sink_result {
+                    Ok(disposition) => {
+                        self.sink_successful_frames += 1;
+                        if disposition == VirtioNetworkTxPacketDisposition::Detoured {
+                            self.detoured_frames += 1;
+                        }
+                        self.sink_successful_bytes =
+                            self.sink_successful_bytes.saturating_add(frame.frame_len());
+                    }
+                    Err(source) => {
                         self.sink_failures += 1;
                         if self.first_sink_failure.is_none() {
                             self.first_sink_failure = Some(source);
                         }
-                    }
-                    None => {
-                        self.sink_successful_frames += 1;
-                        self.sink_successful_bytes =
-                            self.sink_successful_bytes.saturating_add(frame.frame_len());
                     }
                 }
                 self.frames.push(frame);
@@ -5969,8 +6134,11 @@ impl VirtioNetworkTxQueueDispatch {
         result: Result<VirtioNetworkTxPacketDisposition, VirtioNetworkTxPacketSinkError>,
     ) {
         match result {
-            Ok(_) => {
+            Ok(disposition) => {
                 self.sink_successful_frames += 1;
+                if disposition == VirtioNetworkTxPacketDisposition::Detoured {
+                    self.detoured_frames += 1;
+                }
                 if let Some(frame) = self.frames.get(frame_index) {
                     self.sink_successful_bytes =
                         self.sink_successful_bytes.saturating_add(frame.frame_len());
@@ -6004,7 +6172,7 @@ impl VirtioNetworkTxQueueDispatch {
 enum VirtioNetworkTxQueueDispatchOutcome {
     Ok {
         frame: VirtioNetworkTxFrame,
-        sink_error: Option<VirtioNetworkTxPacketSinkError>,
+        sink_result: Result<VirtioNetworkTxPacketDisposition, VirtioNetworkTxPacketSinkError>,
     },
     ParseError(VirtioNetworkTxFrameParseError),
     PacketPrepareError(VirtioNetworkTxPacketPrepareError),
@@ -6410,6 +6578,13 @@ impl VirtioPciEndpoint<VirtioNetworkConfigSpace, VirtioNetworkDevice> {
             })
             .map_err(VirtioPciDeviceOperationError::Endpoint)?;
         let endpoint = work.drain_interrupt_intents();
+        if endpoint.is_err() {
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_network(LoggerNetworkOutcome::InterruptDeliveryFailed);
+                }
+            });
+        }
         VirtioPciDeviceOperationError::combine(dispatch, endpoint)
     }
 
@@ -6453,6 +6628,13 @@ impl VirtioPciEndpoint<VirtioNetworkConfigSpace, VirtioNetworkDevice> {
             })
             .map_err(VirtioPciDeviceOperationError::Endpoint)?;
         let endpoint = work.drain_interrupt_intents();
+        if endpoint.is_err() {
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_network(LoggerNetworkOutcome::InterruptDeliveryFailed);
+                }
+            });
+        }
         VirtioPciDeviceOperationError::combine(dispatch, endpoint)
     }
 }
@@ -8264,11 +8446,12 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use crate::interrupt::{DeviceInterruptKind, GuestInterruptLine};
+    use crate::logger::{LoggerNetworkOutcome, LoggerTestCapture};
     use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
     use crate::metrics::{NetworkInterfaceMetrics, SharedNetworkInterfaceMetrics};
     use crate::mmio::{
-        MmioAccess, MmioAccessBytes, MmioBus, MmioDispatchOutcome, MmioDispatcher, MmioOperation,
-        MmioRegion, MmioRegionId,
+        MmioAccess, MmioAccessBytes, MmioBus, MmioDispatchOutcome, MmioDispatcher, MmioHandler,
+        MmioOperation, MmioRegion, MmioRegionId,
     };
     use crate::snapshot_device_v2::{SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind};
     use crate::snapshot_network_v2_11::{
@@ -13158,6 +13341,9 @@ mod tests {
         let mut memory = tx_frame_memory();
         let mut device = VirtioNetworkDevice::new();
         let mut sink = RecordingTxPacketSink::default();
+        let capture = LoggerTestCapture::default();
+        let (_logger_state, logger) = capture.configured_guest_logger();
+        VirtioMmioDeviceActivationHandler::attach_guest_logger(&mut device, logger.clone());
 
         let error = device
             .dispatch_drained_queue_notifications_with_tx_sink(
@@ -13179,6 +13365,55 @@ mod tests {
         assert!(error.completed_tx_dispatch().is_none());
         assert!(std::error::Error::source(&error).is_none());
         assert_eq!(sink.calls, 0);
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture.output(),
+            "device-kind=network operation=queue-notification outcome=inactive\n"
+        );
+    }
+
+    #[test]
+    fn network_logger_summary_is_failure_first_and_deduplicated() {
+        let observation = super::NetworkNotificationObservation {
+            rx_succeeded: true,
+            rx_buffer_malformed: true,
+            rx_buffer_too_small: true,
+            rx_buffer_unavailable: true,
+            rx_provider_failed: true,
+            tx_succeeded: true,
+            tx_frame_malformed: true,
+            tx_spoof_rejected: true,
+            tx_provider_failed: true,
+            queue_dispatch_failed: true,
+            notification_inactive: true,
+            notification_unsupported: true,
+            rate_limiter_throttled: true,
+            rate_limiter_resumed: true,
+            packet_provider_partial: true,
+            mmds_request_detoured: true,
+        };
+
+        assert_eq!(
+            observation.outcomes().collect::<Vec<_>>(),
+            vec![
+                LoggerNetworkOutcome::QueueDispatchFailed,
+                LoggerNetworkOutcome::QueueNotificationInactive,
+                LoggerNetworkOutcome::QueueNotificationUnsupported,
+                LoggerNetworkOutcome::RxBufferMalformed,
+                LoggerNetworkOutcome::RxBufferTooSmall,
+                LoggerNetworkOutcome::RxProviderFailed,
+                LoggerNetworkOutcome::TxFrameMalformed,
+                LoggerNetworkOutcome::TxSpoofRejected,
+                LoggerNetworkOutcome::TxProviderFailed,
+                LoggerNetworkOutcome::PacketProviderPartial,
+                LoggerNetworkOutcome::RxBufferUnavailable,
+                LoggerNetworkOutcome::RateLimiterThrottled,
+                LoggerNetworkOutcome::RateLimiterResumed,
+                LoggerNetworkOutcome::RxSucceeded,
+                LoggerNetworkOutcome::TxSucceeded,
+                LoggerNetworkOutcome::MmdsRequestDetoured,
+            ]
+        );
     }
 
     #[test]
@@ -14800,6 +15035,9 @@ mod tests {
 
         configure_network_handler_queues(&mut handler);
         activate_network_handler(&mut handler);
+        let capture = LoggerTestCapture::default();
+        let (_logger_state, logger) = capture.configured_guest_logger();
+        handler.attach_guest_logger(logger.clone());
         write_two_tx_frames(&mut memory);
         let initial_limiter = handler
             .activation_handler()
@@ -14823,6 +15061,7 @@ mod tests {
             .expect("TX dispatch should be present");
         assert_eq!(dispatch.processed_frames(), 2);
         assert_eq!(dispatch.sink_successful_frames(), 2);
+        assert_eq!(dispatch.detoured_frames(), 2);
         assert_eq!(dispatch.rate_limiter_throttled_frames(), 0);
         assert_eq!(sink.calls, 2);
         assert_eq!(read_tx_used_index(&memory), 2);
@@ -14834,6 +15073,14 @@ mod tests {
             &initial_limiter
         );
         assert!(!handler.has_pending_network_queue_work());
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture.output(),
+            concat!(
+                "device-kind=network operation=tx outcome=succeeded\n",
+                "device-kind=network operation=mmds-request outcome=detoured\n",
+            )
+        );
     }
 
     #[test]

--- a/crates/runtime/src/pmem.rs
+++ b/crates/runtime/src/pmem.rs
@@ -17,7 +17,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
-use crate::logger::{GuestLogger, LoggerDeviceKind, LoggerTransportOutcome};
+use crate::logger::{GuestLogger, LoggerDeviceKind, LoggerPmemOutcome, LoggerTransportOutcome};
 use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryLayout,
     GuestMemoryRange, aarch64,
@@ -1433,6 +1433,23 @@ impl VirtioPmemDevice {
         flush: &mut impl FnMut() -> VirtioPmemFlushStatus,
         now: Instant,
     ) -> Result<VirtioPmemDeviceNotificationDispatch, VirtioPmemDeviceNotificationError> {
+        let result = self.dispatch_drained_queue_notifications_at_unobserved(
+            memory,
+            drained_notifications,
+            flush,
+            now,
+        );
+        self.observe_notification_result(&result);
+        result
+    }
+
+    fn dispatch_drained_queue_notifications_at_unobserved(
+        &mut self,
+        memory: &mut GuestMemory,
+        drained_notifications: Vec<usize>,
+        flush: &mut impl FnMut() -> VirtioPmemFlushStatus,
+        now: Instant,
+    ) -> Result<VirtioPmemDeviceNotificationDispatch, VirtioPmemDeviceNotificationError> {
         if drained_notifications.is_empty() && !self.pending_rate_limited_queue {
             return Ok(VirtioPmemDeviceNotificationDispatch::new(
                 drained_notifications,
@@ -1525,6 +1542,32 @@ impl VirtioPmemDevice {
         }
     }
 
+    fn observe_notification_result(
+        &self,
+        result: &Result<VirtioPmemDeviceNotificationDispatch, VirtioPmemDeviceNotificationError>,
+    ) {
+        let Some(logger) = &self.guest_logger else {
+            return;
+        };
+        match result {
+            Ok(dispatch) => {
+                if let Some(queue) = dispatch.queue_dispatch() {
+                    observe_pmem_queue_dispatch(logger, queue);
+                }
+            }
+            Err(VirtioPmemDeviceNotificationError::Inactive { .. }) => {
+                logger.log_pmem(LoggerPmemOutcome::QueueNotificationInactive);
+            }
+            Err(VirtioPmemDeviceNotificationError::UnsupportedQueue { .. }) => {
+                logger.log_pmem(LoggerPmemOutcome::QueueNotificationUnsupported);
+            }
+            Err(VirtioPmemDeviceNotificationError::QueueDispatch { source, .. }) => {
+                logger.log_pmem(LoggerPmemOutcome::QueueDispatchFailed);
+                observe_pmem_queue_dispatch(logger, source.completed_dispatch());
+            }
+        }
+    }
+
     pub fn activate_pmem(
         &mut self,
         activation: VirtioMmioDeviceActivation<'_>,
@@ -1557,6 +1600,24 @@ impl VirtioPmemDevice {
         self.active_queue = None;
         self.pending_rate_limited_queue = false;
     }
+}
+
+fn observe_pmem_queue_dispatch(logger: &GuestLogger, dispatch: &VirtioPmemQueueDispatch) {
+    for outcome in pmem_queue_outcomes(dispatch).into_iter().flatten() {
+        logger.log_pmem(outcome);
+    }
+}
+
+fn pmem_queue_outcomes(dispatch: &VirtioPmemQueueDispatch) -> [Option<LoggerPmemOutcome>; 6] {
+    [
+        (dispatch.failed_flushes() != 0).then_some(LoggerPmemOutcome::FlushFailed),
+        (dispatch.parse_failures() != 0).then_some(LoggerPmemOutcome::RequestParseFailed),
+        (dispatch.status_write_failures() != 0).then_some(LoggerPmemOutcome::StatusWriteFailed),
+        (dispatch.rate_limiter_throttled_events() != 0)
+            .then_some(LoggerPmemOutcome::RateLimiterThrottled),
+        (dispatch.rate_limiter_events() != 0).then_some(LoggerPmemOutcome::RateLimiterResumed),
+        (dispatch.successful_flushes() != 0).then_some(LoggerPmemOutcome::FlushSucceeded),
+    ]
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1724,6 +1785,13 @@ impl VirtioPciEndpoint<VirtioPmemConfigSpace, VirtioPmemDevice> {
             })
             .map_err(VirtioPciDeviceOperationError::Endpoint)?;
         let endpoint = work.drain_interrupt_intents();
+        if endpoint.is_err() {
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_pmem(LoggerPmemOutcome::InterruptDeliveryFailed);
+                }
+            });
+        }
         VirtioPciDeviceOperationError::combine(dispatch, endpoint)
     }
 }
@@ -5103,6 +5171,7 @@ mod tests {
 
     use super::*;
 
+    use crate::logger::{LoggerPmemOutcome, LoggerTestCapture};
     use crate::memory::{GuestAddress, GuestMemoryLayout, GuestMemoryRange, aarch64};
     use crate::metrics::{
         PmemDeviceMetrics, PmemDeviceMetricsByDevice, SharedPmemDeviceMetrics,
@@ -5441,6 +5510,65 @@ mod tests {
         ])
         .expect("test layout should be valid");
         GuestMemory::allocate(&layout).expect("test guest memory should allocate")
+    }
+
+    #[test]
+    fn pmem_notification_logger_preserves_inactive_result_and_redacts_metadata() {
+        let capture = LoggerTestCapture::default();
+        let (_logger_state, logger) = capture.configured_guest_logger();
+        let mut device = VirtioPmemDevice::new();
+        VirtioMmioDeviceActivationHandler::attach_guest_logger(&mut device, logger.clone());
+        let mut memory = request_memory();
+        let mut flush = || VirtioPmemFlushStatus::Success;
+
+        let error = device
+            .dispatch_drained_queue_notifications_at(
+                &mut memory,
+                vec![0],
+                &mut flush,
+                Instant::now(),
+            )
+            .expect_err("inactive pmem notification should remain an error");
+
+        assert!(matches!(
+            error,
+            VirtioPmemDeviceNotificationError::Inactive { .. }
+        ));
+        assert_eq!(error.drained_notifications(), &[0]);
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture.output(),
+            "device-kind=pmem operation=queue-notification outcome=inactive\n"
+        );
+    }
+
+    #[test]
+    fn pmem_logger_summary_is_failure_first_and_deduplicated() {
+        let dispatch = VirtioPmemQueueDispatch {
+            processed_requests: 12,
+            successful_flushes: 2,
+            failed_flushes: 2,
+            parse_failures: 2,
+            status_write_failures: 2,
+            rate_limiter_throttled_events: 2,
+            rate_limiter_events: 2,
+            ..VirtioPmemQueueDispatch::default()
+        };
+
+        assert_eq!(
+            super::pmem_queue_outcomes(&dispatch)
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>(),
+            vec![
+                LoggerPmemOutcome::FlushFailed,
+                LoggerPmemOutcome::RequestParseFailed,
+                LoggerPmemOutcome::StatusWriteFailed,
+                LoggerPmemOutcome::RateLimiterThrottled,
+                LoggerPmemOutcome::RateLimiterResumed,
+                LoggerPmemOutcome::FlushSucceeded,
+            ]
+        );
     }
 
     fn write_request_type(memory: &mut GuestMemory, request_type: u32) {

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use crate::interrupt::GuestInterruptLine;
+use crate::logger::GuestLogger;
 use crate::memory::{GuestMemory, GuestMemoryRange};
 use crate::message_interrupt::GuestMessageInterruptRegistry;
 use crate::mmio::{MmioRegion, MmioRegionId};
@@ -212,6 +213,45 @@ impl PreparedSnapshotV2VsockPciState {
         region_id: MmioRegionId,
         messages: GuestMessageInterruptRegistry,
     ) -> Result<PreparedSnapshotV2VsockPciEndpoint, SnapshotV2VsockPciEndpointError> {
+        self.into_pci_endpoint_with_optional_guest_logger(
+            config,
+            destination_memory,
+            resource,
+            region_id,
+            messages,
+            None,
+        )
+    }
+
+    #[doc(hidden)]
+    pub fn into_pci_endpoint_with_guest_logger(
+        self,
+        config: &VsockConfig,
+        destination_memory: &GuestMemory,
+        resource: &mut VirtioVsockReconstructionResource,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+        guest_logger: GuestLogger,
+    ) -> Result<PreparedSnapshotV2VsockPciEndpoint, SnapshotV2VsockPciEndpointError> {
+        self.into_pci_endpoint_with_optional_guest_logger(
+            config,
+            destination_memory,
+            resource,
+            region_id,
+            messages,
+            Some(guest_logger),
+        )
+    }
+
+    fn into_pci_endpoint_with_optional_guest_logger(
+        self,
+        config: &VsockConfig,
+        destination_memory: &GuestMemory,
+        resource: &mut VirtioVsockReconstructionResource,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+        guest_logger: Option<GuestLogger>,
+    ) -> Result<PreparedSnapshotV2VsockPciEndpoint, SnapshotV2VsockPciEndpointError> {
         if resource.captured_selector() != self.capture.device().backend_selector()
             || resource.destination_selector().path() != config.uds_path()
             || self.capture.device().guest_cid() != u64::from(config.guest_cid())
@@ -228,9 +268,15 @@ impl PreparedSnapshotV2VsockPciState {
             capture,
         } = self;
         let retained = capture.transport().clone();
-        let prepared = capture
-            .reconstruct_snapshot_device(destination_memory, resource)
-            .map_err(SnapshotV2VsockPciEndpointError::Device)?;
+        let prepared = match guest_logger {
+            Some(guest_logger) => capture.reconstruct_snapshot_device_with_guest_logger(
+                destination_memory,
+                resource,
+                guest_logger,
+            ),
+            None => capture.reconstruct_snapshot_device(destination_memory, resource),
+        }
+        .map_err(SnapshotV2VsockPciEndpointError::Device)?;
         let activation_is_active = prepared.device().is_activated();
         let (guest_cid, uds_path, config_space, device) = prepared.into_parts();
         let device_type = VirtioDeviceType::new(VIRTIO_VSOCK_DEVICE_ID)

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -47,6 +47,7 @@ use crate::fdt::{
     write_arm64_fdt_with_pci,
 };
 use crate::interrupt::GuestInterruptLine;
+use crate::logger::{GuestLogger, LoggerNetworkOutcome};
 use crate::machine::MachineConfig;
 use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryAllocationError,
@@ -2305,6 +2306,21 @@ pub enum Arm64BootVsockNotificationOutcome {
 }
 
 impl Arm64BootVsockNotificationOutcome {
+    /// Emits the closed device-owned summary after transport interrupt handling.
+    pub fn observe_with_guest_logger(&self, logger: &GuestLogger) {
+        match self {
+            Self::Dispatched(dispatch) => {
+                let result: Result<_, &VirtioVsockDeviceNotificationError> = Ok(dispatch.as_ref());
+                super::vsock::observe_vsock_notification_result(logger, result);
+            }
+            Self::DispatchFailed(error) => {
+                let result: Result<&VirtioVsockDeviceNotificationDispatch, _> = Err(error);
+                super::vsock::observe_vsock_notification_result(logger, result);
+            }
+            Self::HandlerLookupFailed(_) => {}
+        }
+    }
+
     pub fn needs_queue_interrupt(&self) -> bool {
         match self {
             Self::Dispatched(dispatch) => dispatch.needs_queue_interrupt(),
@@ -3780,6 +3796,9 @@ impl Arm64BootRuntimeResources {
                                 }
                             }
                             Err(source) => {
+                                mmio_dispatcher
+                                    .guest_logger()
+                                    .log_network(LoggerNetworkOutcome::PacketProviderFailed);
                                 Arm64BootNetworkNotificationOutcome::PacketIoProviderFailed(source)
                             }
                         }

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -21,6 +21,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::logger::{GuestLogger, LoggerVsockOutcome};
 use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryRange,
 };
@@ -7566,6 +7567,29 @@ impl VirtioVsockMmioCaptureState {
         memory: &GuestMemory,
         resource: &mut VirtioVsockReconstructionResource,
     ) -> Result<PreparedVsockDevice, VirtioVsockReconstructionError> {
+        self.reconstruct_snapshot_device_with_optional_guest_logger(memory, resource, None)
+    }
+
+    #[doc(hidden)]
+    pub fn reconstruct_snapshot_device_with_guest_logger(
+        &self,
+        memory: &GuestMemory,
+        resource: &mut VirtioVsockReconstructionResource,
+        guest_logger: GuestLogger,
+    ) -> Result<PreparedVsockDevice, VirtioVsockReconstructionError> {
+        self.reconstruct_snapshot_device_with_optional_guest_logger(
+            memory,
+            resource,
+            Some(guest_logger),
+        )
+    }
+
+    fn reconstruct_snapshot_device_with_optional_guest_logger(
+        &self,
+        memory: &GuestMemory,
+        resource: &mut VirtioVsockReconstructionResource,
+        guest_logger: Option<GuestLogger>,
+    ) -> Result<PreparedVsockDevice, VirtioVsockReconstructionError> {
         let queues = vsock_transport_queue_slice(self.transport.queues())
             .map_err(VirtioVsockReconstructionError::Capture)?;
         reconstruct_vsock_snapshot_device(
@@ -7575,6 +7599,7 @@ impl VirtioVsockMmioCaptureState {
             self.transport.is_device_activated(),
             memory,
             resource,
+            guest_logger,
         )
     }
 
@@ -7583,7 +7608,34 @@ impl VirtioVsockMmioCaptureState {
         memory: &GuestMemory,
         resource: &mut VirtioVsockReconstructionResource,
     ) -> Result<VirtioVsockMmioHandler, VirtioVsockReconstructionError> {
-        let prepared = self.reconstruct_snapshot_device(memory, resource)?;
+        self.reconstruct_snapshot_handler_with_optional_guest_logger(memory, resource, None)
+    }
+
+    #[doc(hidden)]
+    pub fn reconstruct_snapshot_handler_with_guest_logger(
+        &self,
+        memory: &GuestMemory,
+        resource: &mut VirtioVsockReconstructionResource,
+        guest_logger: GuestLogger,
+    ) -> Result<VirtioVsockMmioHandler, VirtioVsockReconstructionError> {
+        self.reconstruct_snapshot_handler_with_optional_guest_logger(
+            memory,
+            resource,
+            Some(guest_logger),
+        )
+    }
+
+    fn reconstruct_snapshot_handler_with_optional_guest_logger(
+        &self,
+        memory: &GuestMemory,
+        resource: &mut VirtioVsockReconstructionResource,
+        guest_logger: Option<GuestLogger>,
+    ) -> Result<VirtioVsockMmioHandler, VirtioVsockReconstructionError> {
+        let prepared = self.reconstruct_snapshot_device_with_optional_guest_logger(
+            memory,
+            resource,
+            guest_logger,
+        )?;
         let (_, _, config_space, device) = prepared.into_parts();
         let activation_is_active = device.is_activated();
         let mut handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
@@ -7659,6 +7711,29 @@ impl VirtioVsockPciCaptureState {
         memory: &GuestMemory,
         resource: &mut VirtioVsockReconstructionResource,
     ) -> Result<PreparedVsockDevice, VirtioVsockReconstructionError> {
+        self.reconstruct_snapshot_device_with_optional_guest_logger(memory, resource, None)
+    }
+
+    #[doc(hidden)]
+    pub fn reconstruct_snapshot_device_with_guest_logger(
+        &self,
+        memory: &GuestMemory,
+        resource: &mut VirtioVsockReconstructionResource,
+        guest_logger: GuestLogger,
+    ) -> Result<PreparedVsockDevice, VirtioVsockReconstructionError> {
+        self.reconstruct_snapshot_device_with_optional_guest_logger(
+            memory,
+            resource,
+            Some(guest_logger),
+        )
+    }
+
+    fn reconstruct_snapshot_device_with_optional_guest_logger(
+        &self,
+        memory: &GuestMemory,
+        resource: &mut VirtioVsockReconstructionResource,
+        guest_logger: Option<GuestLogger>,
+    ) -> Result<PreparedVsockDevice, VirtioVsockReconstructionError> {
         let queues = vsock_transport_queues(self.transport.queues())
             .map_err(VirtioVsockReconstructionError::Capture)?;
         reconstruct_vsock_snapshot_device(
@@ -7668,6 +7743,7 @@ impl VirtioVsockPciCaptureState {
             self.transport.is_device_activated(),
             memory,
             resource,
+            guest_logger,
         )
     }
 }
@@ -8219,6 +8295,7 @@ fn reconstruct_vsock_snapshot_device(
     transport_activated: bool,
     memory: &GuestMemory,
     resource: &mut VirtioVsockReconstructionResource,
+    guest_logger: Option<GuestLogger>,
 ) -> Result<PreparedVsockDevice, VirtioVsockReconstructionError> {
     validate_vsock_capture_state(state, device_registers, queues, transport_activated, memory)
         .map_err(VirtioVsockReconstructionError::Capture)?;
@@ -8285,6 +8362,7 @@ fn reconstruct_vsock_snapshot_device(
     let (owner, guest_connector) =
         VsockHostSocketOwner::from_prepared_supplied(&uds_path, listener);
     let mut device = VirtioVsockDevice::with_host_socket_owner(guest_cid, owner);
+    device.guest_logger = guest_logger;
     device.guest_connector = guest_connector;
     device.host_connections =
         VsockHostConnectionTable::from_local_port_cursor(state.host_local_port_cursor());
@@ -8417,6 +8495,7 @@ impl VirtioVsockPendingRxPacket {
 #[derive(Debug)]
 pub struct VirtioVsockDevice {
     capture_owner_identity: Arc<()>,
+    guest_logger: Option<GuestLogger>,
     guest_cid: u32,
     active_rx_queue: Option<VirtioVsockRxQueue>,
     active_tx_queue: Option<VirtioVsockTxQueue>,
@@ -8441,6 +8520,7 @@ impl VirtioVsockDevice {
     fn with_guest_cid(guest_cid: u32) -> Self {
         Self {
             capture_owner_identity: Arc::new(()),
+            guest_logger: None,
             guest_cid,
             active_rx_queue: None,
             active_tx_queue: None,
@@ -8977,6 +9057,28 @@ impl VirtioVsockDevice {
         &mut self,
         memory: &mut GuestMemory,
     ) -> Result<VirtioVsockTransportResetAttempt, VirtioVsockTransportResetError> {
+        let result = self.prepare_transport_reset_unobserved(memory);
+        if let Some(logger) = &self.guest_logger {
+            match &result {
+                Ok(VirtioVsockTransportResetAttempt::Published(_)) => {
+                    logger.log_vsock(LoggerVsockOutcome::TransportResetSucceeded);
+                }
+                Ok(VirtioVsockTransportResetAttempt::QueueEmpty) | Err(_) => {
+                    logger.log_vsock(LoggerVsockOutcome::TransportResetFailed);
+                }
+                Ok(
+                    VirtioVsockTransportResetAttempt::Inactive
+                    | VirtioVsockTransportResetAttempt::AlreadyPending,
+                ) => {}
+            }
+        }
+        result
+    }
+
+    fn prepare_transport_reset_unobserved(
+        &mut self,
+        memory: &mut GuestMemory,
+    ) -> Result<VirtioVsockTransportResetAttempt, VirtioVsockTransportResetError> {
         if !self.is_activated() {
             return Ok(VirtioVsockTransportResetAttempt::Inactive);
         }
@@ -8995,12 +9097,20 @@ impl VirtioVsockDevice {
     }
 
     fn signal_restored_transport_reset(&mut self) -> VirtioVsockRestoredTransportResetSignal {
-        if !self.is_activated() {
-            return VirtioVsockRestoredTransportResetSignal::Inactive;
+        let already_pending = self.pending_event_ack;
+        let signal = if self.is_activated() {
+            self.pending_event_ack = true;
+            VirtioVsockRestoredTransportResetSignal::Signaled
+        } else {
+            VirtioVsockRestoredTransportResetSignal::Inactive
+        };
+        if !already_pending
+            && matches!(signal, VirtioVsockRestoredTransportResetSignal::Signaled)
+            && let Some(logger) = &self.guest_logger
+        {
+            logger.log_vsock(LoggerVsockOutcome::TransportResetSucceeded);
         }
-
-        self.pending_event_ack = true;
-        VirtioVsockRestoredTransportResetSignal::Signaled
+        signal
     }
 
     pub fn reset(&mut self) {
@@ -9863,10 +9973,16 @@ impl VirtioVsockDevice {
         memory: &mut GuestMemory,
         drained_notifications: Vec<usize>,
     ) -> Result<VirtioVsockDeviceNotificationDispatch, VirtioVsockDeviceNotificationError> {
-        self.dispatch_drained_queue_notifications_at(memory, drained_notifications, Instant::now())
+        let result = self.dispatch_drained_queue_notifications_at_unobserved(
+            memory,
+            drained_notifications,
+            Instant::now(),
+        );
+        self.observe_notification_result(&result);
+        result
     }
 
-    fn dispatch_drained_queue_notifications_at(
+    fn dispatch_drained_queue_notifications_at_unobserved(
         &mut self,
         memory: &mut GuestMemory,
         drained_notifications: Vec<usize>,
@@ -9942,9 +10058,15 @@ impl VirtioVsockDevice {
                     (Some(dispatch), guest_tx_control_dispatch)
                 }
                 Err(source) => {
-                    return Err(VirtioVsockDeviceNotificationError::TxQueueDispatch {
+                    let partial_dispatch = VirtioVsockDeviceNotificationDispatch::new(
                         drained_notifications,
-                        completed_rx_dispatch: None,
+                        host_request_dispatch,
+                        VirtioVsockGuestTxControlDispatch::empty(),
+                        None,
+                        None,
+                    );
+                    return Err(VirtioVsockDeviceNotificationError::TxQueueDispatch {
+                        partial_dispatch: Box::new(partial_dispatch),
                         source,
                     });
                 }
@@ -9958,9 +10080,15 @@ impl VirtioVsockDevice {
             match self.dispatch_pending_rx_packets(memory, now) {
                 Ok(dispatch) => Some(dispatch),
                 Err(source) => {
-                    return Err(VirtioVsockDeviceNotificationError::RxQueueDispatch {
+                    let partial_dispatch = VirtioVsockDeviceNotificationDispatch::new(
                         drained_notifications,
-                        completed_tx_dispatch: tx_queue_dispatch.map(Box::new),
+                        host_request_dispatch,
+                        guest_tx_control_dispatch,
+                        None,
+                        tx_queue_dispatch,
+                    );
+                    return Err(VirtioVsockDeviceNotificationError::RxQueueDispatch {
+                        partial_dispatch: Box::new(partial_dispatch),
                         source,
                     });
                 }
@@ -9976,6 +10104,15 @@ impl VirtioVsockDevice {
             rx_queue_dispatch,
             tx_queue_dispatch,
         ))
+    }
+
+    fn observe_notification_result(
+        &self,
+        result: &Result<VirtioVsockDeviceNotificationDispatch, VirtioVsockDeviceNotificationError>,
+    ) {
+        if let Some(logger) = &self.guest_logger {
+            VsockNotificationObservation::from_result(result).emit(logger);
+        }
     }
 }
 
@@ -10221,6 +10358,251 @@ impl VirtioVsockDeviceNotificationDispatch {
                 .as_ref()
                 .is_some_and(VirtioVsockRxQueueDispatch::needs_queue_interrupt)
     }
+}
+
+#[derive(Debug, Default)]
+struct VsockNotificationObservation {
+    rx_succeeded: bool,
+    rx_buffer_malformed: bool,
+    rx_buffer_too_small: bool,
+    tx_succeeded: bool,
+    tx_packet_malformed: bool,
+    queue_dispatch_failed: bool,
+    queue_notification_inactive: bool,
+    queue_notification_unsupported: bool,
+    host_connection_accepted: bool,
+    host_connection_completed: bool,
+    host_connection_pending: bool,
+    host_connection_dropped: bool,
+    guest_connection_retained: bool,
+    guest_connection_forwarded: bool,
+    guest_connection_updated: bool,
+    guest_connection_closed: bool,
+    guest_connection_ignored: bool,
+    guest_connection_dropped: bool,
+    connection_reset_queued: bool,
+    connection_reset_dropped: bool,
+}
+
+impl VsockNotificationObservation {
+    fn from_result(
+        result: &Result<VirtioVsockDeviceNotificationDispatch, VirtioVsockDeviceNotificationError>,
+    ) -> Self {
+        Self::from_result_ref(result.as_ref())
+    }
+
+    fn from_result_ref(
+        result: Result<&VirtioVsockDeviceNotificationDispatch, &VirtioVsockDeviceNotificationError>,
+    ) -> Self {
+        let mut observation = Self::default();
+        match result {
+            Ok(dispatch) => observation.ingest_dispatch(dispatch),
+            Err(error) => {
+                match error {
+                    VirtioVsockDeviceNotificationError::Inactive { .. } => {
+                        observation.queue_notification_inactive = true;
+                    }
+                    VirtioVsockDeviceNotificationError::UnsupportedQueue { .. } => {
+                        observation.queue_notification_unsupported = true;
+                    }
+                    VirtioVsockDeviceNotificationError::TxQueueDispatch {
+                        partial_dispatch,
+                        ..
+                    }
+                    | VirtioVsockDeviceNotificationError::RxQueueDispatch {
+                        partial_dispatch,
+                        ..
+                    } => {
+                        observation.queue_dispatch_failed = true;
+                        observation.ingest_dispatch(partial_dispatch);
+                    }
+                }
+                if let Some(dispatch) = error.completed_rx_dispatch() {
+                    observation.ingest_rx(dispatch);
+                }
+                if let Some(dispatch) = error.completed_tx_dispatch() {
+                    observation.ingest_tx(dispatch);
+                }
+            }
+        }
+        observation
+    }
+
+    fn ingest_dispatch(&mut self, dispatch: &VirtioVsockDeviceNotificationDispatch) {
+        if let Some(rx) = dispatch.rx_queue_dispatch() {
+            self.ingest_rx(rx);
+        }
+        if let Some(tx) = dispatch.tx_queue_dispatch() {
+            self.ingest_tx(tx);
+        }
+
+        self.ingest_host_request(dispatch.host_request_dispatch());
+        self.ingest_guest_tx_control(&VirtioVsockGuestTxControlDispatch::new(
+            *dispatch.guest_response_dispatch(),
+            *dispatch.guest_request_dispatch(),
+            *dispatch.guest_rw_dispatch(),
+            *dispatch.guest_credit_dispatch(),
+            *dispatch.guest_rst_dispatch(),
+            *dispatch.guest_shutdown_dispatch(),
+            *dispatch.guest_reset_dispatch(),
+        ));
+    }
+
+    fn ingest_host_request(&mut self, host: &VirtioVsockHostRequestDispatch) {
+        self.host_connection_accepted |= host.accepted_connections() > 0;
+        self.host_connection_completed |= host.completed_requests() > 0;
+        self.host_connection_pending |= host.pending_connections() > 0;
+        self.host_connection_dropped |= host.dropped_connections() > 0;
+    }
+
+    fn ingest_guest_tx_control(&mut self, dispatch: &VirtioVsockGuestTxControlDispatch) {
+        let response = &dispatch.response_dispatch;
+        self.guest_connection_retained |= response.acknowledged_responses() > 0;
+        self.guest_connection_ignored |= response.ignored_responses() > 0;
+        self.guest_connection_dropped |= response.dropped_connections() > 0;
+
+        let request = &dispatch.request_dispatch;
+        self.guest_connection_retained |= request.retained_requests() > 0;
+        self.guest_connection_ignored |= request.ignored_requests() > 0;
+        self.guest_connection_dropped |= request.dropped_requests() > 0;
+
+        let rw = &dispatch.rw_dispatch;
+        self.guest_connection_forwarded |= rw.forwarded_packets() > 0;
+        self.guest_connection_ignored |= rw.ignored_packets() > 0;
+        self.guest_connection_dropped |= rw.dropped_connections() > 0;
+
+        let credit = &dispatch.credit_dispatch;
+        self.guest_connection_updated |= credit.update_packets() > 0 || credit.queued_updates() > 0;
+        self.guest_connection_ignored |= credit.ignored_packets() > 0;
+
+        let rst = &dispatch.guest_rst_dispatch;
+        self.guest_connection_closed |=
+            rst.closed_host_connections() > 0 || rst.closed_guest_connections() > 0;
+        self.guest_connection_ignored |= rst.ignored_packets() > 0;
+
+        let shutdown = &dispatch.guest_shutdown_dispatch;
+        self.guest_connection_updated |=
+            shutdown.updated_host_connections() > 0 || shutdown.updated_guest_connections() > 0;
+        self.guest_connection_closed |=
+            shutdown.closed_host_connections() > 0 || shutdown.closed_guest_connections() > 0;
+        self.guest_connection_ignored |= shutdown.ignored_packets() > 0;
+        self.connection_reset_queued |= shutdown.queued_resets() > 0;
+        self.connection_reset_dropped |= shutdown.dropped_resets() > 0;
+
+        let reset = &dispatch.reset_dispatch;
+        self.connection_reset_queued |= reset.queued_resets() > 0;
+        self.connection_reset_dropped |= reset.dropped_resets() > 0;
+    }
+
+    fn ingest_rx(&mut self, dispatch: &VirtioVsockRxQueueDispatch) {
+        let delivered = dispatch.delivered_requests()
+            + dispatch.delivered_responses()
+            + dispatch.delivered_reset_packets()
+            + dispatch.delivered_shutdown_packets()
+            + dispatch.delivered_credit_requests()
+            + dispatch.delivered_credit_updates()
+            + dispatch.delivered_host_rw_packets();
+        self.rx_succeeded |= delivered > 0;
+        self.rx_buffer_malformed |= dispatch.buffer_parse_failures() > 0;
+        self.rx_buffer_too_small |= dispatch.buffer_too_small_failures() > 0;
+    }
+
+    fn ingest_tx(&mut self, dispatch: &VirtioVsockTxQueueDispatch) {
+        self.tx_succeeded |= dispatch.successful_packets() > 0;
+        self.tx_packet_malformed |= dispatch.parse_failures() > 0;
+    }
+
+    fn outcomes(self) -> impl Iterator<Item = LoggerVsockOutcome> {
+        [
+            (
+                self.rx_buffer_malformed,
+                LoggerVsockOutcome::RxBufferMalformed,
+            ),
+            (
+                self.rx_buffer_too_small,
+                LoggerVsockOutcome::RxBufferTooSmall,
+            ),
+            (
+                self.tx_packet_malformed,
+                LoggerVsockOutcome::TxPacketMalformed,
+            ),
+            (
+                self.queue_dispatch_failed,
+                LoggerVsockOutcome::QueueDispatchFailed,
+            ),
+            (
+                self.queue_notification_inactive,
+                LoggerVsockOutcome::QueueNotificationInactive,
+            ),
+            (
+                self.queue_notification_unsupported,
+                LoggerVsockOutcome::QueueNotificationUnsupported,
+            ),
+            (
+                self.host_connection_dropped,
+                LoggerVsockOutcome::HostConnectionDropped,
+            ),
+            (
+                self.guest_connection_dropped,
+                LoggerVsockOutcome::GuestConnectionDropped,
+            ),
+            (
+                self.connection_reset_dropped,
+                LoggerVsockOutcome::ConnectionResetDropped,
+            ),
+            (self.rx_succeeded, LoggerVsockOutcome::RxSucceeded),
+            (self.tx_succeeded, LoggerVsockOutcome::TxSucceeded),
+            (
+                self.host_connection_accepted,
+                LoggerVsockOutcome::HostConnectionAccepted,
+            ),
+            (
+                self.host_connection_completed,
+                LoggerVsockOutcome::HostConnectionCompleted,
+            ),
+            (
+                self.host_connection_pending,
+                LoggerVsockOutcome::HostConnectionPending,
+            ),
+            (
+                self.guest_connection_retained,
+                LoggerVsockOutcome::GuestConnectionRetained,
+            ),
+            (
+                self.guest_connection_forwarded,
+                LoggerVsockOutcome::GuestConnectionForwarded,
+            ),
+            (
+                self.guest_connection_updated,
+                LoggerVsockOutcome::GuestConnectionUpdated,
+            ),
+            (
+                self.guest_connection_closed,
+                LoggerVsockOutcome::GuestConnectionClosed,
+            ),
+            (
+                self.guest_connection_ignored,
+                LoggerVsockOutcome::GuestConnectionIgnored,
+            ),
+            (
+                self.connection_reset_queued,
+                LoggerVsockOutcome::ConnectionResetQueued,
+            ),
+        ]
+        .into_iter()
+        .filter_map(|(observed, outcome)| observed.then_some(outcome))
+    }
+
+    fn emit(self, logger: &GuestLogger) {
+        logger.log_vsock_summary(self.outcomes());
+    }
+}
+
+pub(crate) fn observe_vsock_notification_result(
+    logger: &GuestLogger,
+    result: Result<&VirtioVsockDeviceNotificationDispatch, &VirtioVsockDeviceNotificationError>,
+) {
+    VsockNotificationObservation::from_result_ref(result).emit(logger);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10683,13 +11065,11 @@ pub enum VirtioVsockDeviceNotificationError {
         queue_index: usize,
     },
     TxQueueDispatch {
-        drained_notifications: Vec<usize>,
-        completed_rx_dispatch: Option<Box<VirtioVsockRxQueueDispatch>>,
+        partial_dispatch: Box<VirtioVsockDeviceNotificationDispatch>,
         source: VirtioVsockTxQueueDispatchError,
     },
     RxQueueDispatch {
-        drained_notifications: Vec<usize>,
-        completed_tx_dispatch: Option<Box<VirtioVsockTxQueueDispatch>>,
+        partial_dispatch: Box<VirtioVsockDeviceNotificationDispatch>,
         source: VirtioVsockRxQueueDispatchError,
     },
 }
@@ -10703,15 +11083,13 @@ impl VirtioVsockDeviceNotificationError {
             | Self::UnsupportedQueue {
                 drained_notifications,
                 ..
-            }
-            | Self::TxQueueDispatch {
-                drained_notifications,
-                ..
+            } => drained_notifications,
+            Self::TxQueueDispatch {
+                partial_dispatch, ..
             }
             | Self::RxQueueDispatch {
-                drained_notifications,
-                ..
-            } => drained_notifications,
+                partial_dispatch, ..
+            } => partial_dispatch.drained_notifications(),
         }
     }
 
@@ -10719,12 +11097,8 @@ impl VirtioVsockDeviceNotificationError {
         match self {
             Self::TxQueueDispatch { source, .. } => source.completed_dispatch(),
             Self::RxQueueDispatch {
-                completed_tx_dispatch,
-                ..
-            } => match completed_tx_dispatch {
-                Some(dispatch) => Some(dispatch),
-                None => None,
-            },
+                partial_dispatch, ..
+            } => partial_dispatch.tx_queue_dispatch(),
             Self::Inactive { .. } | Self::UnsupportedQueue { .. } => None,
         }
     }
@@ -10733,12 +11107,8 @@ impl VirtioVsockDeviceNotificationError {
         match self {
             Self::RxQueueDispatch { source, .. } => source.completed_dispatch(),
             Self::TxQueueDispatch {
-                completed_rx_dispatch,
-                ..
-            } => match completed_rx_dispatch {
-                Some(dispatch) => Some(dispatch),
-                None => None,
-            },
+                partial_dispatch, ..
+            } => partial_dispatch.rx_queue_dispatch(),
             Self::Inactive { .. } | Self::UnsupportedQueue { .. } => None,
         }
     }
@@ -10877,7 +11247,7 @@ impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioVsockD
         let drained_notifications = self.take_pending_queue_notifications();
         let dispatch = self
             .activation_handler_mut()
-            .dispatch_drained_queue_notifications_at(memory, drained_notifications, now);
+            .dispatch_drained_queue_notifications_at_unobserved(memory, drained_notifications, now);
         let (rx_interrupt, tx_interrupt) = match &dispatch {
             Ok(dispatch) => (
                 dispatch
@@ -10924,6 +11294,10 @@ fn virtio_feature_enabled(features: u64, feature: u32) -> bool {
 }
 
 impl VirtioMmioDeviceActivationHandler for VirtioVsockDevice {
+    fn attach_guest_logger(&mut self, logger: GuestLogger) {
+        self.guest_logger = Some(logger);
+    }
+
     fn activate(
         &mut self,
         activation: VirtioMmioDeviceActivation<'_>,
@@ -11034,6 +11408,11 @@ impl VirtioPciEndpoint<VirtioVsockConfigSpace, VirtioVsockDevice> {
         let endpoint = work.drain_interrupt_intents();
         if signal_required && endpoint.is_err() {
             metrics.record_event_queue_signal_failure();
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_vsock(LoggerVsockOutcome::InterruptDeliveryFailed);
+                }
+            });
         }
         VirtioPciDeviceOperationError::combine(attempt, endpoint)
     }
@@ -11066,6 +11445,11 @@ impl VirtioPciEndpoint<VirtioVsockConfigSpace, VirtioVsockDevice> {
         let endpoint = work.drain_interrupt_intents();
         if signal.needs_queue_interrupt() && endpoint.is_err() {
             metrics.record_event_queue_signal_failure();
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_vsock(LoggerVsockOutcome::InterruptDeliveryFailed);
+                }
+            });
         }
         let device: Result<_, std::convert::Infallible> = Ok(signal);
         VirtioPciDeviceOperationError::combine(device, endpoint)
@@ -11088,11 +11472,13 @@ impl VirtioPciEndpoint<VirtioVsockConfigSpace, VirtioVsockDevice> {
             .with_core_mut(|core| {
                 let drained_notifications =
                     core.queue_notifications.take_pending_queue_notifications();
-                let dispatch = core.activation.dispatch_drained_queue_notifications_at(
-                    memory,
-                    drained_notifications,
-                    Instant::now(),
-                );
+                let dispatch = core
+                    .activation
+                    .dispatch_drained_queue_notifications_at_unobserved(
+                        memory,
+                        drained_notifications,
+                        Instant::now(),
+                    );
                 let (rx_interrupt, tx_interrupt) = match &dispatch {
                     Ok(dispatch) => (
                         dispatch
@@ -11124,7 +11510,16 @@ impl VirtioPciEndpoint<VirtioVsockConfigSpace, VirtioVsockDevice> {
                 dispatch
             })
             .map_err(VirtioPciDeviceOperationError::Endpoint)?;
-        VirtioPciDeviceOperationError::combine(dispatch, work.drain_interrupt_intents())
+        let endpoint = work.drain_interrupt_intents();
+        if endpoint.is_err() {
+            let _ = work.with_core_mut(|core| {
+                if let Some(logger) = &core.activation.guest_logger {
+                    logger.log_vsock(LoggerVsockOutcome::InterruptDeliveryFailed);
+                }
+            });
+        }
+        let _ = work.with_core_mut(|core| core.activation.observe_notification_result(&dispatch));
+        VirtioPciDeviceOperationError::combine(dispatch, endpoint)
     }
 
     pub fn host_wakeup(
@@ -11548,11 +11943,12 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use crate::interrupt::DeviceInterruptKind;
+    use crate::logger::{LoggerTestCapture, LoggerVsockOutcome};
     use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
     use crate::metrics::{SharedVsockDeviceMetrics, VsockDeviceMetrics};
     use crate::mmio::{
-        MmioAccess, MmioAccessBytes, MmioBus, MmioDispatchOutcome, MmioDispatcher, MmioOperation,
-        MmioRegionId,
+        MmioAccess, MmioAccessBytes, MmioBus, MmioDispatchOutcome, MmioDispatcher, MmioHandler,
+        MmioOperation, MmioRegionId,
     };
     use crate::snapshot::{SnapshotVsockOverride, resolve_snapshot_vsock_selectors};
     use crate::virtio_mmio::{
@@ -18597,7 +18993,14 @@ mod tests {
         assert_eq!(read_interrupt_status(&inactive), 0);
 
         activate_vsock_handler(&mut inactive);
+        let capture = LoggerTestCapture::default();
+        let (_logger_state, logger) = capture.configured_guest_logger();
+        inactive.attach_guest_logger(logger.clone());
         assert!(!inactive.activation_handler().pending_event_ack());
+        assert_eq!(
+            inactive.signal_restored_vsock_transport_reset(),
+            super::VirtioVsockRestoredTransportResetSignal::Signaled
+        );
         assert_eq!(
             inactive.signal_restored_vsock_transport_reset(),
             super::VirtioVsockRestoredTransportResetSignal::Signaled
@@ -18626,6 +19029,15 @@ mod tests {
             .expect("ordinary reset should succeed");
         assert!(!inactive.activation_handler().pending_event_ack());
         assert!(!inactive.activation_handler().is_activated());
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture
+                .output()
+                .matches("device-kind=vsock operation=transport-reset outcome=succeeded\n")
+                .count(),
+            2,
+            "one record should be emitted for each false-to-true reset gate transition"
+        );
     }
 
     #[test]
@@ -18951,6 +19363,9 @@ mod tests {
     fn virtio_vsock_notifications_reject_inactive_device_with_drained_metadata() {
         let mut memory = vsock_tx_memory();
         let mut device = VirtioVsockDevice::new();
+        let capture = LoggerTestCapture::default();
+        let (_logger_state, logger) = capture.configured_guest_logger();
+        VirtioMmioDeviceActivationHandler::attach_guest_logger(&mut device, logger.clone());
 
         let error = device
             .dispatch_drained_queue_notifications(&mut memory, vec![VIRTIO_VSOCK_EVENT_QUEUE_INDEX])
@@ -18971,6 +19386,145 @@ mod tests {
         assert!(error.completed_tx_dispatch().is_none());
         assert!(error.completed_rx_dispatch().is_none());
         assert!(error.source().is_none());
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture.output(),
+            "device-kind=vsock operation=queue-notification outcome=inactive\n"
+        );
+    }
+
+    #[test]
+    fn vsock_logger_summary_is_failure_first_and_deduplicated() {
+        let observation = super::VsockNotificationObservation {
+            rx_succeeded: true,
+            rx_buffer_malformed: true,
+            rx_buffer_too_small: true,
+            tx_succeeded: true,
+            tx_packet_malformed: true,
+            queue_dispatch_failed: true,
+            queue_notification_inactive: true,
+            queue_notification_unsupported: true,
+            host_connection_accepted: true,
+            host_connection_completed: true,
+            host_connection_pending: true,
+            host_connection_dropped: true,
+            guest_connection_retained: true,
+            guest_connection_forwarded: true,
+            guest_connection_updated: true,
+            guest_connection_closed: true,
+            guest_connection_ignored: true,
+            guest_connection_dropped: true,
+            connection_reset_queued: true,
+            connection_reset_dropped: true,
+        };
+
+        assert_eq!(
+            observation.outcomes().collect::<Vec<_>>(),
+            vec![
+                LoggerVsockOutcome::RxBufferMalformed,
+                LoggerVsockOutcome::RxBufferTooSmall,
+                LoggerVsockOutcome::TxPacketMalformed,
+                LoggerVsockOutcome::QueueDispatchFailed,
+                LoggerVsockOutcome::QueueNotificationInactive,
+                LoggerVsockOutcome::QueueNotificationUnsupported,
+                LoggerVsockOutcome::HostConnectionDropped,
+                LoggerVsockOutcome::GuestConnectionDropped,
+                LoggerVsockOutcome::ConnectionResetDropped,
+                LoggerVsockOutcome::RxSucceeded,
+                LoggerVsockOutcome::TxSucceeded,
+                LoggerVsockOutcome::HostConnectionAccepted,
+                LoggerVsockOutcome::HostConnectionCompleted,
+                LoggerVsockOutcome::HostConnectionPending,
+                LoggerVsockOutcome::GuestConnectionRetained,
+                LoggerVsockOutcome::GuestConnectionForwarded,
+                LoggerVsockOutcome::GuestConnectionUpdated,
+                LoggerVsockOutcome::GuestConnectionClosed,
+                LoggerVsockOutcome::GuestConnectionIgnored,
+                LoggerVsockOutcome::ConnectionResetQueued,
+            ]
+        );
+    }
+
+    #[test]
+    fn vsock_logger_preserves_host_and_guest_outcomes_before_rx_failure() {
+        let mut host_request_dispatch = super::VirtioVsockHostRequestDispatch::new();
+        host_request_dispatch.accepted_connections = 1;
+        let mut guest_tx_control_dispatch = super::VirtioVsockGuestTxControlDispatch::empty();
+        guest_tx_control_dispatch
+            .response_dispatch
+            .acknowledged_responses = 1;
+        let partial_dispatch = super::VirtioVsockDeviceNotificationDispatch::new(
+            vec![VIRTIO_VSOCK_RX_QUEUE_INDEX],
+            host_request_dispatch,
+            guest_tx_control_dispatch,
+            None,
+            None,
+        );
+        let result = Err(super::VirtioVsockDeviceNotificationError::RxQueueDispatch {
+            partial_dispatch: Box::new(partial_dispatch),
+            source: VirtioVsockRxQueueDispatchError::EmptyDescriptorChain {
+                completed_dispatch: Box::new(super::VirtioVsockRxQueueDispatch::new()),
+            },
+        });
+
+        assert_eq!(
+            super::VsockNotificationObservation::from_result(&result)
+                .outcomes()
+                .collect::<Vec<_>>(),
+            vec![
+                LoggerVsockOutcome::QueueDispatchFailed,
+                LoggerVsockOutcome::HostConnectionAccepted,
+                LoggerVsockOutcome::GuestConnectionRetained,
+            ]
+        );
+    }
+
+    #[test]
+    fn vsock_mmio_defers_summary_until_transport_observes_the_result() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
+        let capture = LoggerTestCapture::default();
+        let (_logger_state, logger) = capture.configured_guest_logger();
+        VirtioMmioDeviceActivationHandler::attach_guest_logger(
+            handler.activation_handler_mut(),
+            logger.clone(),
+        );
+
+        activate_vsock_handler(&mut handler);
+        write_vsock_packet_header(
+            &mut memory,
+            TEST_VSOCK_HEADER,
+            guest_rw_tx_packet(42, 52, 4000).header(),
+        );
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
+
+        let result = handler.dispatch_vsock_queue_notifications(&mut memory);
+        assert!(result.is_ok(), "orphan guest RW should dispatch");
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture.output(),
+            "",
+            "device summary must remain deferred while the transport owns interrupt handling"
+        );
+
+        super::observe_vsock_notification_result(&logger, result.as_ref());
+        assert!(logger.wait_for_delivery_for_test());
+        assert_eq!(
+            capture.output(),
+            "device-kind=vsock operation=guest-connection outcome=dropped\n\
+             device-kind=vsock operation=tx outcome=succeeded\n\
+             device-kind=vsock operation=connection-reset outcome=queued\n"
+        );
     }
 
     #[test]

--- a/docs/security.md
+++ b/docs/security.md
@@ -2904,7 +2904,9 @@ Guest-triggerable backend and generic transport records use a separate
 cloneable `GuestLogger` capability with no writer, configuration mutation,
 arbitrary formatting, receipt, retry, sleep, or wait surface. Its immutable
 producer snapshot shares the controller's sole worker and the independent
-`logger-rate.backend.outcome` and `logger-rate.transport.outcome` states.
+`logger-rate.backend.outcome`, `logger-rate.transport.outcome`,
+`logger-rate.block.outcome`, `logger-rate.pmem.outcome`,
+`logger-rate.network.outcome`, and `logger-rate.vsock.outcome` states.
 Normal and native-v2 assembly install the capability before HVF and MMIO/PCI
 publication, and run-loop adapter traits require explicit logger forwarding so
 a wrapper cannot silently substitute an inert capability. Repeating successful
@@ -2914,6 +2916,25 @@ remains visible in exact metrics and is logged only at debug level. The last
 typed owner selects only a closed operation, outcome, and optional device kind
 before raw errors, addresses, registers, queue indexes, identifiers, or guest
 values can cross a formatting boundary.
+
+Block, pmem, network/MMDS, and vsock observers operate on completed typed
+notification summaries shared by MMIO and product PCI. They emit at most one
+fixed record for each nonzero category, with failures admitted before
+successes, so guest-controlled request, packet, descriptor, connection, and
+byte volume cannot multiply formatting work. Vsock's higher-cardinality
+summary uses one fixed-capacity producer batch only after MMIO or product-PCI
+interrupt handling completes, keeping logger scheduling outside the
+device-to-guest publication window. Packet-provider acquisition and HVF
+interrupt delivery use narrow fixed supplements. MMDS token-key records are
+emitted only for the transactional rollover boundary; token, key, nonce,
+instance, interface, socket, port, path, packet, and guest values are never
+fields.
+
+Production-bundle coverage routes representative records from all four classes
+through a separately granted write-only logger descriptor, replaces its source
+pathname after launcher adoption, and verifies that records follow the opened
+object while all grant, backing, socket, interface, and guest selectors remain
+absent.
 
 If failed HVF teardown requires intentionally retaining mapped memory for host
 safety, Bangbang first replaces the retained GuestMemory logger with an inert

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1528,8 +1528,8 @@ command never creates, carries forward, or rewrites semantic classes in
 `logger-producer-audit.json`; missing or stale mappings require human review.
 The class policy and safe-field boundary are documented in the
 [logger producer contract](../compat/firecracker/v1.16.0/logger-contract.md).
-The current overlay has exactly 15 implemented, nine planned, and seven
-not-applicable classes, representing 182 implemented, 224 planned, and 62
+The current overlay has exactly 19 implemented, five planned, and seven
+not-applicable classes, representing 312 implemented, 94 planned, and 62
 not-applicable source mappings. The remaining planned classes are all owned by
 #1809.
 
@@ -1554,6 +1554,18 @@ throttling, and unchanged functional results. The signed production bundle
 asserts representative transport publication and HVF guest-exit records from a
 real Apple Silicon session, while the entropy snapshot continuation proves
 normal throttling cannot split the default logger/serial guest marker.
+
+Storage, network/MMDS, and vsock logger coverage exhaustively checks each
+closed event and level, independent class limiter identities, batch-level
+deduplication, deferred vsock publication after transport interrupt handling,
+partial queue results, provider and interrupt supplements, MMDS detours,
+transactional key-rotation success/failure, redaction, and unchanged
+functional results. Signed Apple Silicon coverage exercises block
+data-plane outcomes through both MMIO and product PCI. The contained production
+bundle reuses its product-PCI aggregate-storage and MMDS workloads plus its MMIO
+vsock workload to prove block, pmem, network, and vsock records reach an exact
+write-only logger grant without following pathname replacement or exposing
+backing paths, grant references, sockets, MAC addresses, or guest payloads.
 
 The final parent gate is:
 

--- a/tools/firecracker-capability-audit/src/logger_model.rs
+++ b/tools/firecracker-capability-audit/src/logger_model.rs
@@ -265,11 +265,14 @@ pub enum LoggerCompiledEvent {
     ApiRequest,
     ApiResult,
     Backend,
+    Block,
     InstanceStart,
     FlushMetrics,
     BootTime,
     Lifecycle,
     Observability,
+    Network,
+    Pmem,
     RateLimitRecovery,
     ProcessStartup,
     ProcessPanic,
@@ -277,6 +280,7 @@ pub enum LoggerCompiledEvent {
     ProcessSignal,
     Snapshot,
     Transport,
+    Vsock,
 }
 
 /// Human-owned policy and evidence for one coherent semantic producer class.

--- a/tools/firecracker-capability-audit/src/logger_validate.rs
+++ b/tools/firecracker-capability-audit/src/logger_validate.rs
@@ -685,6 +685,7 @@ fn validate_compiled_event_set(classes: &[LoggerProducerClass], errors: &mut Vec
         (LoggerCompiledEvent::ApiRequest, "logger.api.request"),
         (LoggerCompiledEvent::ApiResult, "logger.api.result"),
         (LoggerCompiledEvent::Backend, "logger.backend.outcome"),
+        (LoggerCompiledEvent::Block, "logger.block.outcome"),
         (LoggerCompiledEvent::InstanceStart, "logger.api.result"),
         (LoggerCompiledEvent::FlushMetrics, "logger.api.result"),
         (LoggerCompiledEvent::BootTime, "logger.boot.time"),
@@ -693,6 +694,8 @@ fn validate_compiled_event_set(classes: &[LoggerProducerClass], errors: &mut Vec
             LoggerCompiledEvent::Observability,
             "logger.observability.outcome",
         ),
+        (LoggerCompiledEvent::Network, "logger.network.outcome"),
+        (LoggerCompiledEvent::Pmem, "logger.pmem.outcome"),
         (
             LoggerCompiledEvent::RateLimitRecovery,
             "logger.limiter.recovery",
@@ -709,6 +712,7 @@ fn validate_compiled_event_set(classes: &[LoggerProducerClass], errors: &mut Vec
         ),
         (LoggerCompiledEvent::Snapshot, "logger.snapshot.outcome"),
         (LoggerCompiledEvent::Transport, "logger.transport.outcome"),
+        (LoggerCompiledEvent::Vsock, "logger.vsock.outcome"),
     ]);
     let actual = classes
         .iter()

--- a/tools/firecracker-capability-audit/tests/checked_inventory.rs
+++ b/tools/firecracker-capability-audit/tests/checked_inventory.rs
@@ -113,7 +113,11 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             LoggerClassDisposition::Planned,
             28,
         ),
-        ("logger.block.outcome", LoggerClassDisposition::Planned, 34),
+        (
+            "logger.block.outcome",
+            LoggerClassDisposition::Implemented,
+            34,
+        ),
         ("logger.boot.time", LoggerClassDisposition::Implemented, 1),
         (
             "logger.entropy.outcome",
@@ -137,7 +141,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
         ),
         (
             "logger.network.outcome",
-            LoggerClassDisposition::Planned,
+            LoggerClassDisposition::Implemented,
             26,
         ),
         (
@@ -180,7 +184,11 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             LoggerClassDisposition::Implemented,
             4,
         ),
-        ("logger.pmem.outcome", LoggerClassDisposition::Planned, 18),
+        (
+            "logger.pmem.outcome",
+            LoggerClassDisposition::Implemented,
+            18,
+        ),
         (
             "logger.process-signal.outcome",
             LoggerClassDisposition::Implemented,
@@ -217,7 +225,11 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             LoggerClassDisposition::Implemented,
             74,
         ),
-        ("logger.vsock.outcome", LoggerClassDisposition::Planned, 52),
+        (
+            "logger.vsock.outcome",
+            LoggerClassDisposition::Implemented,
+            52,
+        ),
     ];
     const LOGGER_CAPABILITIES: [&str; 11] = [
         "api-operation:PUT /logger",
@@ -308,7 +320,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             .iter()
             .filter(|class| class.disposition == LoggerClassDisposition::Implemented)
             .count(),
-        15
+        19
     );
     assert_eq!(
         audit
@@ -316,7 +328,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             .iter()
             .filter(|class| class.disposition == LoggerClassDisposition::Planned)
             .count(),
-        9
+        5
     );
     assert_eq!(
         audit
@@ -342,8 +354,8 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
     assert_eq!(
         mapped_dispositions,
         BTreeMap::from([
-            (LoggerClassDisposition::Implemented, 182),
-            (LoggerClassDisposition::Planned, 224),
+            (LoggerClassDisposition::Implemented, 312),
+            (LoggerClassDisposition::Planned, 94),
             (LoggerClassDisposition::NotApplicable, 62),
         ])
     );
@@ -359,7 +371,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             *counts.entry(issue).or_insert(0_usize) += 1;
             counts
         });
-    assert_eq!(planned_owners, BTreeMap::from([("#1809", 9)]));
+    assert_eq!(planned_owners, BTreeMap::from([("#1809", 5)]));
 
     let compiled_events = audit
         .classes
@@ -374,11 +386,14 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             LoggerCompiledEvent::ApiRequest,
             LoggerCompiledEvent::ApiResult,
             LoggerCompiledEvent::Backend,
+            LoggerCompiledEvent::Block,
             LoggerCompiledEvent::InstanceStart,
             LoggerCompiledEvent::FlushMetrics,
             LoggerCompiledEvent::BootTime,
             LoggerCompiledEvent::Lifecycle,
+            LoggerCompiledEvent::Network,
             LoggerCompiledEvent::Observability,
+            LoggerCompiledEvent::Pmem,
             LoggerCompiledEvent::RateLimitRecovery,
             LoggerCompiledEvent::ProcessStartup,
             LoggerCompiledEvent::ProcessPanic,
@@ -386,6 +401,7 @@ fn checked_logger_producer_audit_is_complete_and_stable() {
             LoggerCompiledEvent::ProcessSignal,
             LoggerCompiledEvent::Snapshot,
             LoggerCompiledEvent::Transport,
+            LoggerCompiledEvent::Vsock,
         ])
     );
     let planned_with_compiled_events = audit


### PR DESCRIPTION
## Summary

- add closed, redacted block, pmem, network/MMDS, and vsock outcome families with independent guest-safe limiter identities
- observe typed MMIO and product-PCI device results, MMDS token-key rotation, provider failures, and interrupt-delivery failures without changing functional results
- certify deterministic and signed reachability, output-grant identity, redaction, and the updated Firecracker v1.16.0 audit inventory

## Scope exclusions

- balloon, memory-hotplug, serial, entropy, and time/identity outcomes remain in parent delivery #1809 for the next slice
- aggregate logger certification owned by #1810 is not claimed here

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-runtime --lib --all-features --locked`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1815

Parent: #1809
