### PR TITLE
test: check Firecracker metrics schema authority

### DIFF
--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -26,14 +26,19 @@ For commands and test-layer selection, see the
 - [`logger-producer-audit.json`](logger-producer-audit.json) is human-owned. It
   maps every logger invocation explicitly to one closed semantic class and its
   reviewed delivery, limiter, disposition, owner, and evidence policy.
+- [`metrics-schema.json`](metrics-schema.json) is one strict authority envelope.
+  Its `source` projection is machine-derived from the pinned Rust serializers
+  and Python fixture; its policy profiles and exact field mappings are
+  human-owned and never regenerated.
 - Contract Markdown files are human-owned evidence ledgers. They define a
   selected capability family, its exact supported or excluded boundary, and
   the implementation and validation evidence for its dispositions.
 
-Regeneration may create a candidate source manifest. It must never create or
-rewrite capability dispositions, owners, evidence references, delivery issues,
-or Challenge results. A generated identity change must instead surface as a
-missing or stale overlay for review.
+Regeneration may create a candidate source manifest or machine-owned source
+projection. It must never create or rewrite capability dispositions, owners,
+evidence references, delivery issues, policy mappings, or Challenge results. A
+generated identity change must instead surface as missing or stale human policy
+for review.
 
 Stable source IDs use `<kind>:<upstream-key>`. Semantic IDs use
 `semantic.<namespace>:<slug>`. IDs are scoped to this immutable baseline; a
@@ -65,6 +70,7 @@ reviewed delta.
 | [Snapshot Wave 6](snapshot-wave6-contract.md) | Exact 70-row load, artifact, version, device, tool, time/identity, portability, and downstream-owner certification |
 | [Observability, tools, and specification](observability-tools-specification-contract.md) | Exact Wave 7 ownership, core API certification, x86 CPUID/MSR platform exclusions, and retained downstream handoffs |
 | [Logger producers](logger-contract.md) | Certified 11-row logger aggregate with exact 468-invocation source closure, 24 implemented classes, 7 exact platform/developer exclusions, no planned producer classes, safe fields, and bounded default-stdout admission/forwarding policy |
+| [Metrics schema](metrics-contract.md) | Exact 24-root/243-static-field arm64 line shape, 24/29/5 configured dynamic families, source fingerprints, closed units/reset/aggregation policy, and truthful #1822/#1788/#1789 producer handoffs |
 
 ## Dispositions
 
@@ -131,6 +137,7 @@ full evidence and Challenge gate.
 Validate the checked inventory, compare or regenerate candidates, and run the
 normal repository checks using
 [Testing Guide](../../../docs/testing.md#firecracker-capability-inventory).
-Review candidate identity changes before updating either machine-owned
-manifest. Never use regeneration to alter `capabilities.json` or
-`logger-producer-audit.json`.
+Review candidate identity changes before updating a machine-owned projection.
+Never use regeneration to alter `capabilities.json`,
+`logger-producer-audit.json`, or the human policy projections in
+`metrics-schema.json`.

--- a/compat/firecracker/v1.16.0/metrics-contract.md
+++ b/compat/firecracker/v1.16.0/metrics-contract.md
@@ -1,0 +1,194 @@
+# Firecracker v1.16.0 Metrics Schema Contract
+
+This contract defines the checked public metrics-line authority used by
+Bangbang for the pinned Firecracker v1.16.0 arm64 target. It separates schema
+presence from producer completion. The machine-readable authority is
+[`metrics-schema.json`](metrics-schema.json); this document explains how to
+interpret and update it.
+
+## Authority Boundary
+
+`metrics-schema.json` is one strict envelope with two ownership domains:
+
+- `source` is machine-derived from the pinned Rust serializers and
+  `tests/host_tools/fcmetrics.py`. It owns inputs and Git blobs, exact roots,
+  scalar paths, JSON type, reset primitive, architecture, configured-root
+  grammar, source anchors, and normalized SHA-256 fingerprints.
+- `policy_profiles` and `field_policies` are reviewed Bangbang policy. Together
+  they attach one closed unit, aggregation rule, producer owner/disposition,
+  delivery issue, rationale, and eventual implementation/validation evidence
+  to every source field.
+
+The policy mapping is an exact bijection over the source fields. Policy cannot
+create or remove schema identities, and source regeneration cannot manufacture
+or overwrite policy. A field being required in every line does not mean its
+producer is implemented; a required numeric neutral value remains distinct
+from an evidence-backed producer.
+
+This authority-only delivery leaves all producer profiles nonterminal. #1822
+owns canonical line construction and timestamp publication, #1788 owns API,
+process, logger, signal, boot, and lifecycle producers, and #1789 owns device,
+MMDS, vCPU, time/device, configured-key, and retained-neutral producers. #1823
+owns the final #1787 API/schema certification. `corpus:metrics` and the
+cross-producer aggregate semantic remain #1790-owned.
+
+## Exact Arm64 Shape
+
+Every scalar is JSON `number`. Every static property is required and every
+object rejects additional properties. The 24 static roots occur in pinned Rust
+serialization order:
+
+1. `utc_timestamp_ms`
+2. `api_server`
+3. `balloon`
+4. `block`
+5. `deprecated_api`
+6. `get_api_requests`
+7. `i8042`
+8. `rtc`
+9. `uart`
+10. `latencies_us`
+11. `logger`
+12. `mmds`
+13. `net`
+14. `patch_api_requests`
+15. `put_api_requests`
+16. `seccomp`
+17. `vcpu`
+18. `vmm`
+19. `signals`
+20. `vsock`
+21. `entropy`
+22. `pmem`
+23. `interrupts`
+24. `memory_hotplug`
+
+Those roots contain exactly 243 scalar paths. `i8042` is retained by the common
+legacy serializer on arm64 and must not be removed merely because its useful
+PIO device mechanism is x86-oriented. Arm64 additionally serializes `rtc`;
+this is an addition, not an `i8042` replacement.
+
+The upstream fixture's dictionary insertion order is not the wire order: it
+adds `rtc` after constructing the base dictionary. The authority therefore
+uses the parsed Rust root/flatten order while requiring exact set equality with
+the strict fixture.
+
+## Configured Dynamic Roots
+
+The canonical schema has exactly three configured dynamic families:
+
+| Fixture rule | Concrete pinned producer template | Scalar fields | Cardinality |
+| --- | --- | ---: | --- |
+| `block_*` | `block_{drive_id}` | 24 | one object per configured ordinary block device |
+| `net_*` | `net_{iface_id}` | 29 | one object per configured network interface |
+| `vhost_user_*` | `vhost_user_block_{drive_id}` | 5 | one object per configured vhost-user block device |
+
+Block and network also retain their required aggregate `block` and `net` roots
+when no device is configured. Their configured entries precede the aggregate
+in the pinned serializer and use ordered maps. Vhost-user has no aggregate
+root. The generic serializer prepends `vhost_user_` to the module name; the
+pinned block constructor supplies `block_{drive_id}`. A vhost-user block is not
+also entered into the ordinary block metrics map and must not produce a second
+`block_{drive_id}` object.
+
+Dynamic suffixes come only from validated configuration identifiers. Runtime
+serialization may iterate only the bounded device registries owned by the
+configuration model; it must not discover untrusted host paths, guest data, or
+unbounded keys while writing a line.
+
+Pinned Rust also formats `pmem_{pmem_id}`, while the strict v1.16.0 fixture has
+no `pmem_` prefix branch and would reject such an extra root. The source
+authority retains this as the explicit
+`producer-only:pmem_{pmem_id}` reconciliation. It is not a fourth canonical
+dynamic family. A later compatibility-policy change must update the strict
+extension boundary deliberately rather than silently admitting the producer
+extra.
+
+## Value, Unit, and Aggregation Semantics
+
+`SharedIncMetric` fields are interval values. Pinned Firecracker computes the
+delta from its previous atomic and advances that previous value when field
+serialization succeeds. `SharedStoreMetric` fields are current persistent
+values and do not reset per line. `utc_timestamp_ms` is a fresh publication
+attempt timestamp in milliseconds since the Unix epoch; the upstream fixture
+requires it to be plausible within one second.
+
+The closed units are counts, bytes, microseconds, and Unix-epoch milliseconds.
+Byte fields include names containing `bytes` and balloon's
+`free_page_report_freed` and `free_page_hint_freed`, which add descriptor byte
+lengths. Latency roots, `_us` fields, and `min_us`/`max_us`/`sum_us` leaves use
+microseconds. All remaining fields use counts.
+
+Nested latency aggregates identify minimum, maximum, and sum semantics. Static
+block, network, and pmem roots are sums across configured devices for their
+ordinary fields. Pinned block/network aggregate construction adds latency
+`sum_us` but leaves aggregate `min_us` and `max_us` at zero; the authority
+records that behavior explicitly instead of describing those zeros as valid
+cross-device extrema. Dynamic per-device latency objects retain their own
+minimum/maximum/sum meaning.
+
+The arm64 schema keeps the i8042 fields and the x86-only vCPU PIO and KVM-clock
+fields as required numeric neutral values. Their `platform-zero` producer
+disposition is not an implementation claim; #1789 retains the terminal evidence
+responsibility. Other process and device fields remain `planned` until their
+owner slices provide exact production and validation evidence.
+
+## Bangbang Publication Rules for the Next Slice
+
+The checked shape is strict. Canonical Firecracker lines cannot retain public
+Bangbang-only fields such as `vmm.metrics_flush_count` or string-valued status
+extensions. Any extension needs a separately versioned and tested boundary;
+silently appending it to the pinned line is incompatible with
+`additionalProperties: false`.
+
+`GET /vm/config` continues to omit active metrics output configuration, as does
+the pinned Firecracker full-configuration projection. Output sink ownership and
+path redaction remain governed by the existing direct/contained process
+contract.
+
+Bangbang uses a stronger publication transaction than pinned Firecracker. One
+flush attempt must snapshot all producers before serialization. Interval values
+are computed from the last completely successful publication, and that
+baseline advances only after the entire newline-terminated line is accepted.
+A failed write retains the baseline and replays the interval. If a writer
+exposed a prefix before returning failure, observers may see an ambiguous
+partial attempt followed by an at-least-once replay; the contract does not
+claim durable or exactly-once output.
+
+Initial, periodic, explicit, and terminal flush paths must share that immutable
+attempt transaction. Producer events arriving after the snapshot belong to a
+later attempt. No individual producer may reset independently during
+collection.
+
+## Validation and Regeneration
+
+Ordinary delivery validation is self-contained:
+
+```sh
+cargo test -p bangbang-firecracker-capability-audit --test metrics_schema --locked
+cargo run -p bangbang-firecracker-capability-audit --locked -- validate
+```
+
+With an explicit clean sibling at the pinned commit, compare every source
+identity, Git blob, root/path/template, type/reset fact, architecture rule, and
+fingerprint:
+
+```sh
+cargo run -p bangbang-firecracker-capability-audit --locked -- compare \
+  --firecracker /path/to/firecracker
+```
+
+Regeneration can emit only a source candidate at a new explicit path:
+
+```sh
+cargo run -p bangbang-firecracker-capability-audit --locked -- \
+  regenerate-metrics-schema-source \
+  --firecracker /path/to/firecracker \
+  --output codex-work/tmp/metrics-schema-source.candidate.json
+```
+
+The destination must not exist and cannot directly, lexically, or through a
+symlink alias any checked inventory file. Review exact source changes, then
+manually reconcile them with human policy. Never copy old policy onto a changed
+identity without reviewing its unit, reset, aggregation, architecture,
+cardinality, producer owner, disposition, rationale, and evidence.

--- a/compat/firecracker/v1.16.0/metrics-schema.json
+++ b/compat/firecracker/v1.16.0/metrics-schema.json
@@ -1,0 +1,8646 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "version": "1.16.0",
+    "commit": "d83d72b710361a10294480131377b1b00b163af8",
+    "target": "aarch64-macos-hvf"
+  },
+  "generator_version": 1,
+  "source": {
+    "inputs": [
+      {
+        "path": "src/vmm/src/devices/legacy/i8042.rs",
+        "git_blob": "2f1b6b95c1d553ff4f56fb3aea48a03d38a22255",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/legacy/mod.rs",
+        "git_blob": "9804625cf0952cc5939bb81dde2bbd302ca2cab5",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/legacy/rtc_pl031.rs",
+        "git_blob": "96b1134eb1c6d39128cdcc037582cb775d2f3a5d",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/legacy/serial.rs",
+        "git_blob": "e38480179de107a3d6c27066fd9e93b8c3b2b043",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+        "git_blob": "66e33ac1799fb961d184afb581213ec6a24ec4c5",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/virtio/block/vhost_user/device.rs",
+        "git_blob": "7df600722ab95ea85360712e5737b54f870f1fc5",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+        "git_blob": "0abe2a5896374c36810b51376456b3a4b57e82fa",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+        "git_blob": "d69255d44ec5b62417954350b3043a61821aba98",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+        "git_blob": "74e6f7ae4e186829f6c9e8bb9d32282ba62576a6",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+        "git_blob": "8aaae2f041e020d495758612585865ecf7a39a59",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/virtio/rng/metrics.rs",
+        "git_blob": "e02f5ce8cc44cd97ea45fef26beb59e807606853",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/virtio/vhost_user_metrics.rs",
+        "git_blob": "bb7f03b30a679f1a3af5f3e7e8332db35a238c6e",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+        "git_blob": "d626d5dca3447989207bdc86543fe3e7659a1b7a",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "src/vmm/src/logger/metrics.rs",
+        "git_blob": "ca96fe8b5b320f355a4f1ee1ff3be6793d4c194e",
+        "extractor": "rust-metrics-schema-v1"
+      },
+      {
+        "path": "tests/host_tools/fcmetrics.py",
+        "git_blob": "c9685b21f608c676d991d8074db6868f5fd3a0ba",
+        "extractor": "python-metrics-schema-v1"
+      }
+    ],
+    "counts": {
+      "static_roots": 24,
+      "static_fields": 243,
+      "dynamic_families": 3,
+      "block_dynamic_fields": 24,
+      "net_dynamic_fields": 29,
+      "vhost_user_dynamic_fields": 5
+    },
+    "static_roots": [
+      {
+        "name": "utc_timestamp_ms",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.utc_timestamp_ms",
+          "line": 909,
+          "column": 5,
+          "fingerprint": "sha256:a8088d797d9be5c522c244cf99aebd8658952d5f101a5a9fa3d20893f3949a95"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "api_server",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.api_server",
+          "line": 910,
+          "column": 5,
+          "fingerprint": "sha256:beb0d02111a0391be7e6a9f150a8a7b6e1df5f4bd710265556d6b69ac55ad05c"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "balloon",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "serialize-root:balloon",
+          "line": 47,
+          "column": 9,
+          "fingerprint": "sha256:e3ac05c351cd0a6bf17d87f891f5e5b20f32b2655ba2677cec074dfcbccf4e40"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "block",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "aggregate",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "serialize-root:block",
+          "line": 139,
+          "column": 9,
+          "fingerprint": "sha256:cf0ad1be45cb6ece1d660b131a9ec120294d98a3a06b03b95b47f20095fbd2bd"
+        },
+        "aggregation_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics::aggregate",
+          "line": 199,
+          "column": 5,
+          "fingerprint": "sha256:222721167e72f306ebf6b0752c670a7bab35c83c584c74005bab9b58174ea4c3"
+        }
+      },
+      {
+        "name": "deprecated_api",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.deprecated_api",
+          "line": 918,
+          "column": 5,
+          "fingerprint": "sha256:7330b1ae9fd50a65cae8a902d15db5b611889b4aa1308ec77d4f6da6df66f2af"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "get_api_requests",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.get_api_requests",
+          "line": 920,
+          "column": 5,
+          "fingerprint": "sha256:1196ba3e2f71fb566ff79dd7df44dd70762ea0f1656b663fa8c8adb8b4f7388b"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "i8042",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/mod.rs",
+          "symbol": "serialize-root:i8042",
+          "line": 68,
+          "column": 9,
+          "fingerprint": "sha256:bef8c40dee770c9c9ca18e3eac3c75b7209a99ec0e8483629082417697f70f32"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "rtc",
+        "architecture": "arm64",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/mod.rs",
+          "symbol": "serialize-root:rtc",
+          "line": 70,
+          "column": 9,
+          "fingerprint": "sha256:56849b1a6b12e30e4a81542d2d1baccd11c37df7edf56ec9fc80028107fe2577"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "uart",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/mod.rs",
+          "symbol": "serialize-root:uart",
+          "line": 71,
+          "column": 9,
+          "fingerprint": "sha256:b3b043fe6ccfc7f265a0a9e9a873cab6bd02bec04302e015620487f8c24632eb"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "latencies_us",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.latencies_us",
+          "line": 925,
+          "column": 5,
+          "fingerprint": "sha256:38f5824f47719dcbe01a119c624b691453a791311f09ac31ced49444704a6d0b"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "logger",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.logger",
+          "line": 927,
+          "column": 5,
+          "fingerprint": "sha256:057cddcfc28eb010cfb92133b722ff66520ebb1209343a596918fce6406b36f7"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "mmds",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.mmds",
+          "line": 929,
+          "column": 5,
+          "fingerprint": "sha256:04c603f0282389c8f851d5856a4517118be5215017687e809d96b6ffe5ccf510"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "net",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "aggregate",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "serialize-root:net",
+          "line": 141,
+          "column": 9,
+          "fingerprint": "sha256:c78b93d2f9e70942cb9214a97814715d55b07a407bd9c0b9766edb84bb7a05d9"
+        },
+        "aggregation_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics::aggregate",
+          "line": 213,
+          "column": 5,
+          "fingerprint": "sha256:65080357aa90a03cf0614d5557d37504f76fc564466dabeadda77a9d5aeacbdc"
+        }
+      },
+      {
+        "name": "patch_api_requests",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.patch_api_requests",
+          "line": 934,
+          "column": 5,
+          "fingerprint": "sha256:7e5939a4f1b9b2418b44ae3ac1f031c387934357b71cf61f9e53023b77face02"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "put_api_requests",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.put_api_requests",
+          "line": 936,
+          "column": 5,
+          "fingerprint": "sha256:d9c6bcd33f0ffde9b602963caf52f994cf109b318cd4a23d658e16b867c614c8"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "seccomp",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.seccomp",
+          "line": 938,
+          "column": 5,
+          "fingerprint": "sha256:a1e2a1b3993510c6e7d23af1fdcf059256142c892404b9c2314413542e483c49"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "vcpu",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.vcpu",
+          "line": 940,
+          "column": 5,
+          "fingerprint": "sha256:26b2b2dca2ef45b8949dd312c5d018db93ba6fe0e5905bd0feff60c5f330840c"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "vmm",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.vmm",
+          "line": 942,
+          "column": 5,
+          "fingerprint": "sha256:87e30fa66c04418a71bd0caf9e1578daf7cef96f4777d1867cd7f6bcaad17cfd"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "signals",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.signals",
+          "line": 944,
+          "column": 5,
+          "fingerprint": "sha256:5cc58b7df185958326dbe2e3aa485c5691cc067303bc117f35fac158130ee431"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "vsock",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "serialize-root:vsock",
+          "line": 50,
+          "column": 9,
+          "fingerprint": "sha256:ee323a278cd8069e806443972e5c2d89ec8e8eb42fe7ce903e52f9aad35482da"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "entropy",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/rng/metrics.rs",
+          "symbol": "serialize-root:entropy",
+          "line": 47,
+          "column": 9,
+          "fingerprint": "sha256:4f0eb58e444c5c9f09e2cce2329b91f96b78d7d7b4996f69a41129364b5aeaa4"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "pmem",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "aggregate",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+          "symbol": "serialize-root:pmem",
+          "line": 139,
+          "column": 9,
+          "fingerprint": "sha256:4d0a7d3ce265bef80ea4f4e85d371f2be23f982879cc0a89e9989257b56cb9ed"
+        },
+        "aggregation_anchor": {
+          "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+          "symbol": "PmemMetrics::aggregate",
+          "line": 168,
+          "column": 5,
+          "fingerprint": "sha256:27de1ebd830e3b18b8efa58440430f8ae71fb57ac1b3dad59140e9ebb5edee03"
+        }
+      },
+      {
+        "name": "interrupts",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.interrupts",
+          "line": 958,
+          "column": 5,
+          "fingerprint": "sha256:66e9330b8fa79ae7f637be55b451bbe4b7b8817150acbb730622db97ff21e24f"
+        },
+        "aggregation_anchor": null
+      },
+      {
+        "name": "memory_hotplug",
+        "architecture": "all",
+        "schema_disposition": "required-static",
+        "cardinality": "singleton",
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "serialize-root:memory_hotplug",
+          "line": 36,
+          "column": 9,
+          "fingerprint": "sha256:482094038d9e8356dbe6d421a7189827570b6d354f9b731df1fbae7685a77932"
+        },
+        "aggregation_anchor": null
+      }
+    ],
+    "fields": [
+      {
+        "ordinal": 0,
+        "id": "static:utc_timestamp_ms",
+        "path": "utc_timestamp_ms",
+        "json_type": "number",
+        "value_kind": "attempt-timestamp",
+        "rust_type": "SerializeToUtcTimestampMs",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:utc_timestamp_ms",
+          "line": 132,
+          "column": 9,
+          "fingerprint": "sha256:48676e739677950c349825d7d4c47d899c87c114f24fa13be238fe7515d91a4a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "FirecrackerMetrics.utc_timestamp_ms",
+          "line": 909,
+          "column": 5,
+          "fingerprint": "sha256:a8088d797d9be5c522c244cf99aebd8658952d5f101a5a9fa3d20893f3949a95"
+        }
+      },
+      {
+        "ordinal": 1,
+        "id": "static:api_server.process_startup_time_us",
+        "path": "api_server.process_startup_time_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:process_startup_time_us",
+          "line": 134,
+          "column": 13,
+          "fingerprint": "sha256:ec9bcde7a4df83277a18760eb274f115f561322bfc14ee43caf9f504da9a52f3"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "ApiServerMetrics.process_startup_time_us",
+          "line": 338,
+          "column": 5,
+          "fingerprint": "sha256:345665c9a45c1466762a1b98b18b698c60b0d8fe3f6fa3905b94611a1f6b5ac6"
+        }
+      },
+      {
+        "ordinal": 2,
+        "id": "static:api_server.process_startup_time_cpu_us",
+        "path": "api_server.process_startup_time_cpu_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:process_startup_time_cpu_us",
+          "line": 135,
+          "column": 13,
+          "fingerprint": "sha256:a8739d2b5e08d456650379f99c2617c0927342c98ea2c295f69c6d012bf1e999"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "ApiServerMetrics.process_startup_time_cpu_us",
+          "line": 340,
+          "column": 5,
+          "fingerprint": "sha256:51ad9acf6896a05be5fdd0aff4cafc7f579641707092e03d73b0092ccbc9270a"
+        }
+      },
+      {
+        "ordinal": 3,
+        "id": "static:balloon.activate_fails",
+        "path": "balloon.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 138,
+          "column": 13,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.activate_fails",
+          "line": 54,
+          "column": 5,
+          "fingerprint": "sha256:9607fa3834b17fc6a720652518f74868d60c2d7e238170b31b239317d51f50b2"
+        }
+      },
+      {
+        "ordinal": 4,
+        "id": "static:balloon.inflate_count",
+        "path": "balloon.inflate_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:inflate_count",
+          "line": 139,
+          "column": 13,
+          "fingerprint": "sha256:1d2a43ff009b47498aa0ef3cbefa0dfb9b4b0378ca7a6392ec9ea410df98aacf"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.inflate_count",
+          "line": 56,
+          "column": 5,
+          "fingerprint": "sha256:7c874f9084f04e3649779efed75f269b0477224ce05578901b5ce5ddb72bc63b"
+        }
+      },
+      {
+        "ordinal": 5,
+        "id": "static:balloon.stats_updates_count",
+        "path": "balloon.stats_updates_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:stats_updates_count",
+          "line": 140,
+          "column": 13,
+          "fingerprint": "sha256:51edd4762940d16540c82b87e2f64e25a4375cb9f1f691505278b13eff1c95d9"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.stats_updates_count",
+          "line": 59,
+          "column": 5,
+          "fingerprint": "sha256:be252527b6a8bc81396a8c93dee978ee7555740aa6157e1d9ced2b00197acbea"
+        }
+      },
+      {
+        "ordinal": 6,
+        "id": "static:balloon.stats_update_fails",
+        "path": "balloon.stats_update_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:stats_update_fails",
+          "line": 141,
+          "column": 13,
+          "fingerprint": "sha256:fed1cd2af06083ca834f8c4b1011346cd6ccc3af09b3ea69639c324bed26e5af"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.stats_update_fails",
+          "line": 61,
+          "column": 5,
+          "fingerprint": "sha256:a0c61ffbf8267c38c8fa482e6e49718151b6aea23a6e8a1794ba16725f73b9d5"
+        }
+      },
+      {
+        "ordinal": 7,
+        "id": "static:balloon.deflate_count",
+        "path": "balloon.deflate_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:deflate_count",
+          "line": 142,
+          "column": 13,
+          "fingerprint": "sha256:3981acbbad8de8728c825075e27ab32b8cc8baa14828f4dc2db6cd2b1da43c0d"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.deflate_count",
+          "line": 62,
+          "column": 5,
+          "fingerprint": "sha256:f26d14d68ec4ae727714a082d0e877e977cb21f7dc866210124cfcc9ebceb2ff"
+        }
+      },
+      {
+        "ordinal": 8,
+        "id": "static:balloon.event_fails",
+        "path": "balloon.event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:event_fails",
+          "line": 143,
+          "column": 13,
+          "fingerprint": "sha256:af808eac4d6aeffe1c5fc8f67a3a735f7f571acf68499b409872222ff7292154"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.event_fails",
+          "line": 64,
+          "column": 5,
+          "fingerprint": "sha256:4322ffbc41b5917654730863d74b4b247b8021a80b21052cbe781e8fc99b3551"
+        }
+      },
+      {
+        "ordinal": 9,
+        "id": "static:balloon.free_page_report_count",
+        "path": "balloon.free_page_report_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:free_page_report_count",
+          "line": 144,
+          "column": 13,
+          "fingerprint": "sha256:2d2b1d14adeaff9483672f6374b1f50e40a665cceadbe15eaf16c458e5d85d0f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.free_page_report_count",
+          "line": 66,
+          "column": 5,
+          "fingerprint": "sha256:a939319b8f2968515aa5efb501c3bf10566aceb459852d0a0a6165c52829002f"
+        }
+      },
+      {
+        "ordinal": 10,
+        "id": "static:balloon.free_page_report_freed",
+        "path": "balloon.free_page_report_freed",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:free_page_report_freed",
+          "line": 145,
+          "column": 13,
+          "fingerprint": "sha256:44da7d4fdda31d51c8a27fc00d1b004116e5c3879db22401724d537d7b7533f8"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.free_page_report_freed",
+          "line": 68,
+          "column": 5,
+          "fingerprint": "sha256:c1aa046c026e243c93c794058d8600dddc300459c58a397167c910b9b51c2b4b"
+        }
+      },
+      {
+        "ordinal": 11,
+        "id": "static:balloon.free_page_report_fails",
+        "path": "balloon.free_page_report_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:free_page_report_fails",
+          "line": 146,
+          "column": 13,
+          "fingerprint": "sha256:d644ecc17dca246a4f05ea226d16f1ea957312385dce8ecd10e0ab3a5974fc07"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.free_page_report_fails",
+          "line": 70,
+          "column": 5,
+          "fingerprint": "sha256:1bda50c9bac544105a501f8d5fd8e4f76a568c4cfe8a274c2ff03f96849725f8"
+        }
+      },
+      {
+        "ordinal": 12,
+        "id": "static:balloon.free_page_hint_count",
+        "path": "balloon.free_page_hint_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:free_page_hint_count",
+          "line": 147,
+          "column": 13,
+          "fingerprint": "sha256:d59ae69243534f751d279fa1b20f315fcdd0a523f394fc5c630302bbc2eb4d81"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.free_page_hint_count",
+          "line": 72,
+          "column": 5,
+          "fingerprint": "sha256:2e6b70d11006c982f4179854036b5b68fc765934ca32673920f9400129718aac"
+        }
+      },
+      {
+        "ordinal": 13,
+        "id": "static:balloon.free_page_hint_freed",
+        "path": "balloon.free_page_hint_freed",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:free_page_hint_freed",
+          "line": 148,
+          "column": 13,
+          "fingerprint": "sha256:3f12385af52497627047bd7d00ae77365885ffc3a0e91d17ed5dbb151f47ad66"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.free_page_hint_freed",
+          "line": 74,
+          "column": 5,
+          "fingerprint": "sha256:4bd03064a504c8089bc3b966273c8d9c275bb051a617083e8e15cfc5e4112b92"
+        }
+      },
+      {
+        "ordinal": 14,
+        "id": "static:balloon.free_page_hint_fails",
+        "path": "balloon.free_page_hint_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:free_page_hint_fails",
+          "line": 149,
+          "column": 13,
+          "fingerprint": "sha256:bd6bb34b2b6a390c7769f45289deb228836c0dc72bc5fdbf726e5f537f0aea5e"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/balloon/metrics.rs",
+          "symbol": "BalloonDeviceMetrics.free_page_hint_fails",
+          "line": 76,
+          "column": 5,
+          "fingerprint": "sha256:f27775487c289f3ed294bf077473b9c4b7fd1632e87e13c1979a4080cde5d47a"
+        }
+      },
+      {
+        "ordinal": 15,
+        "id": "static:block.activate_fails",
+        "path": "block.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 81,
+          "column": 9,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.activate_fails",
+          "line": 146,
+          "column": 5,
+          "fingerprint": "sha256:d0faa9177e126ccc4c117fd3f17b242ab2e64d29fdcba624c3fe648776c73140"
+        }
+      },
+      {
+        "ordinal": 16,
+        "id": "static:block.cfg_fails",
+        "path": "block.cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:cfg_fails",
+          "line": 82,
+          "column": 9,
+          "fingerprint": "sha256:ddf6ccea8ce5f2e735df611b679382a9746297209cd37172297a36975bfbc8e4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.cfg_fails",
+          "line": 148,
+          "column": 5,
+          "fingerprint": "sha256:1d20e600e190b9ccc33a8d36276aae832d3cea2dfef5a744b6d6758023eae958"
+        }
+      },
+      {
+        "ordinal": 17,
+        "id": "static:block.no_avail_buffer",
+        "path": "block.no_avail_buffer",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:no_avail_buffer",
+          "line": 83,
+          "column": 9,
+          "fingerprint": "sha256:c4b08df3e09e11ff716de2102c61a0f5c57431ba2e95d7c1e738cc51cddcf756"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.no_avail_buffer",
+          "line": 150,
+          "column": 5,
+          "fingerprint": "sha256:82ab57968af118789495b487c180ce9d4c4e335935f07f4248794b507703568b"
+        }
+      },
+      {
+        "ordinal": 18,
+        "id": "static:block.event_fails",
+        "path": "block.event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:event_fails",
+          "line": 84,
+          "column": 9,
+          "fingerprint": "sha256:af808eac4d6aeffe1c5fc8f67a3a735f7f571acf68499b409872222ff7292154"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.event_fails",
+          "line": 152,
+          "column": 5,
+          "fingerprint": "sha256:b2cae36491b21ff690c614dd823553ad87145b80eb9519028c3b998b79daf3e8"
+        }
+      },
+      {
+        "ordinal": 19,
+        "id": "static:block.execute_fails",
+        "path": "block.execute_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:execute_fails",
+          "line": 85,
+          "column": 9,
+          "fingerprint": "sha256:209e2f3512f8ec0a84f3f5f6bc10d2e2a8173d0878a0ea3a571ed1ebb3108e3c"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.execute_fails",
+          "line": 154,
+          "column": 5,
+          "fingerprint": "sha256:6787fe87623831b31ccfc6c5a51ea854eded031ddc658e9488d0b0169de4122b"
+        }
+      },
+      {
+        "ordinal": 20,
+        "id": "static:block.invalid_reqs_count",
+        "path": "block.invalid_reqs_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:invalid_reqs_count",
+          "line": 86,
+          "column": 9,
+          "fingerprint": "sha256:d798ca023381f26d428427ba184a8940e43641639420310b5d73528be3bbf6e2"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.invalid_reqs_count",
+          "line": 156,
+          "column": 5,
+          "fingerprint": "sha256:a2493b4f93bda4bad7e5a6d8b0bf5aadfc564b08501261e6be1b4600a9dca5d5"
+        }
+      },
+      {
+        "ordinal": 21,
+        "id": "static:block.flush_count",
+        "path": "block.flush_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:flush_count",
+          "line": 87,
+          "column": 9,
+          "fingerprint": "sha256:a8a330c6ee94d8e4311bc3860de7734d800835f8de6828bf24df1eb5688ff36a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.flush_count",
+          "line": 158,
+          "column": 5,
+          "fingerprint": "sha256:f72c48ebd323479198987ff23457027a734f5b97f9bbbac7d8f92c1085fabb6f"
+        }
+      },
+      {
+        "ordinal": 22,
+        "id": "static:block.queue_event_count",
+        "path": "block.queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:queue_event_count",
+          "line": 88,
+          "column": 9,
+          "fingerprint": "sha256:c6df276e377d4594d51232bd6a88d40ff9de98fdc8d957cd6551951b7f7a5828"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.queue_event_count",
+          "line": 160,
+          "column": 5,
+          "fingerprint": "sha256:f33bc18df961dfabb65cb649e7796d13b6ab450146a8ae7387344a070e6a0a85"
+        }
+      },
+      {
+        "ordinal": 23,
+        "id": "static:block.rate_limiter_event_count",
+        "path": "block.rate_limiter_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rate_limiter_event_count",
+          "line": 89,
+          "column": 9,
+          "fingerprint": "sha256:47bbc1808028b853194b35f7b105b7654a31703035c2f5c679a5b99d53ad6ffb"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.rate_limiter_event_count",
+          "line": 162,
+          "column": 5,
+          "fingerprint": "sha256:05c66851865d4fccf91d80966f8fe720b0581ec2ffbde255e1a5bf35ade902ea"
+        }
+      },
+      {
+        "ordinal": 24,
+        "id": "static:block.update_count",
+        "path": "block.update_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:update_count",
+          "line": 90,
+          "column": 9,
+          "fingerprint": "sha256:9d2a199e953e7c1e22b6a2953f04fdc7ad8def493b42934187299b30fb187da0"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.update_count",
+          "line": 164,
+          "column": 5,
+          "fingerprint": "sha256:c2186ce2966221c59caf039f7cd3db9f13e8f53e2f15df3f6ed82df5760518bb"
+        }
+      },
+      {
+        "ordinal": 25,
+        "id": "static:block.update_fails",
+        "path": "block.update_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:update_fails",
+          "line": 91,
+          "column": 9,
+          "fingerprint": "sha256:15b8632ec5ff761f4b751b37a79175de601b0a5cdd7eec811563b7097cace668"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.update_fails",
+          "line": 166,
+          "column": 5,
+          "fingerprint": "sha256:0ba36387296cd931e6736c198fe0ee789c03dd6bc6e82e6a480be82f6f9d91ab"
+        }
+      },
+      {
+        "ordinal": 26,
+        "id": "static:block.read_bytes",
+        "path": "block.read_bytes",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:read_bytes",
+          "line": 92,
+          "column": 9,
+          "fingerprint": "sha256:7e06cfe49ff3038a98ca232f81f6b9e7c44341255894e0fdbdd7ab97220b13d1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.read_bytes",
+          "line": 168,
+          "column": 5,
+          "fingerprint": "sha256:801deaf8f2e1ba22d2efe02c1b6c6bd98df3dd435ddbcbeffaad918bdf6f5c72"
+        }
+      },
+      {
+        "ordinal": 27,
+        "id": "static:block.write_bytes",
+        "path": "block.write_bytes",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:write_bytes",
+          "line": 93,
+          "column": 9,
+          "fingerprint": "sha256:7be0557d1e6667c17fdfe20bcc81bd46013e7c21a7593dad113caf638be4478c"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.write_bytes",
+          "line": 170,
+          "column": 5,
+          "fingerprint": "sha256:80d193d5a92fb41dfce38f0ae5521d3ae2caf1edf4e8859e427add1d3030fcd1"
+        }
+      },
+      {
+        "ordinal": 28,
+        "id": "static:block.read_count",
+        "path": "block.read_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:read_count",
+          "line": 94,
+          "column": 9,
+          "fingerprint": "sha256:09641191fe5b775bd1dd08d371e0b6a19143d773caf878393622201345daa079"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.read_count",
+          "line": 172,
+          "column": 5,
+          "fingerprint": "sha256:79163b58c88514ac86dba38a7ad8294db1847e727176b97fa6719be4d12cf8d1"
+        }
+      },
+      {
+        "ordinal": 29,
+        "id": "static:block.write_count",
+        "path": "block.write_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:write_count",
+          "line": 95,
+          "column": 9,
+          "fingerprint": "sha256:d939c3af59febd992a3fdde689ad5aba7e0340fda909f165315d2e87f42de2d3"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.write_count",
+          "line": 174,
+          "column": 5,
+          "fingerprint": "sha256:bc6d9f11dac49eaf3ec0b1480e18ceee95edf36ef31f5b8104c64469b51e8891"
+        }
+      },
+      {
+        "ordinal": 30,
+        "id": "static:block.read_agg.min_us",
+        "path": "block.read_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 31,
+        "id": "static:block.read_agg.max_us",
+        "path": "block.read_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 32,
+        "id": "static:block.read_agg.sum_us",
+        "path": "block.read_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 33,
+        "id": "static:block.write_agg.min_us",
+        "path": "block.write_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 34,
+        "id": "static:block.write_agg.max_us",
+        "path": "block.write_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 35,
+        "id": "static:block.write_agg.sum_us",
+        "path": "block.write_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 36,
+        "id": "static:block.rate_limiter_throttled_events",
+        "path": "block.rate_limiter_throttled_events",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rate_limiter_throttled_events",
+          "line": 96,
+          "column": 9,
+          "fingerprint": "sha256:a15942a55baf426c576a5a146cff20f181c315fabca034a0dbeb98abef1e9bf7"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.rate_limiter_throttled_events",
+          "line": 180,
+          "column": 5,
+          "fingerprint": "sha256:d0998ad739889c77941fe8303509ce9dfead9eeb0b47c13d079522c6009c497c"
+        }
+      },
+      {
+        "ordinal": 37,
+        "id": "static:block.io_engine_throttled_events",
+        "path": "block.io_engine_throttled_events",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:io_engine_throttled_events",
+          "line": 97,
+          "column": 9,
+          "fingerprint": "sha256:4615461f13d46073a770c82470854ab11c2b963f40ec4a6ea27d65691370de72"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.io_engine_throttled_events",
+          "line": 182,
+          "column": 5,
+          "fingerprint": "sha256:51416d04714863c489413854646dfb2a68fbb7c77db5647b33199e7fae51a8f3"
+        }
+      },
+      {
+        "ordinal": 38,
+        "id": "static:block.remaining_reqs_count",
+        "path": "block.remaining_reqs_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:remaining_reqs_count",
+          "line": 98,
+          "column": 9,
+          "fingerprint": "sha256:953e457ec5d6c18efeec153e392bf9ffc25995ad7c4368735c04a72c6e7525ec"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.remaining_reqs_count",
+          "line": 185,
+          "column": 5,
+          "fingerprint": "sha256:ac49fc1d30bd49114a7160fd161e62859ebb42d3e6c2d4f946ba8ebee15c3cca"
+        }
+      },
+      {
+        "ordinal": 39,
+        "id": "static:deprecated_api.deprecated_http_api_calls",
+        "path": "deprecated_api.deprecated_http_api_calls",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:deprecated_http_api_calls",
+          "line": 153,
+          "column": 13,
+          "fingerprint": "sha256:b88de1a8eb557426e71eb0a54d2bbab3a280811682fc510a5f28cd60e4f91fee"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "DeprecatedApiMetrics.deprecated_http_api_calls",
+          "line": 521,
+          "column": 5,
+          "fingerprint": "sha256:5a6132a411d7ca89c096948c6c99d4391171d56e0b22d524134c1351112c54fd"
+        }
+      },
+      {
+        "ordinal": 40,
+        "id": "static:get_api_requests.instance_info_count",
+        "path": "get_api_requests.instance_info_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:instance_info_count",
+          "line": 156,
+          "column": 13,
+          "fingerprint": "sha256:67a9262c0b9f0f676573f876ed9a6706bdb6d694b210b3e768a28765d4c6d8aa"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "GetRequestsMetrics.instance_info_count",
+          "line": 356,
+          "column": 5,
+          "fingerprint": "sha256:76f8ba24ba679643a12c60999bbffae42e4ea7e8941b69ff6758e0689f445539"
+        }
+      },
+      {
+        "ordinal": 41,
+        "id": "static:get_api_requests.machine_cfg_count",
+        "path": "get_api_requests.machine_cfg_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:machine_cfg_count",
+          "line": 157,
+          "column": 13,
+          "fingerprint": "sha256:2c6e1febb1b5d5613ca735a2d94dbca42be2454ee845a213e5b61300ccf74fc1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "GetRequestsMetrics.machine_cfg_count",
+          "line": 358,
+          "column": 5,
+          "fingerprint": "sha256:579f8f5710af8991e7cc45f0846d59eb79726c8956ac51cc9f8a1d146cd9e343"
+        }
+      },
+      {
+        "ordinal": 42,
+        "id": "static:get_api_requests.mmds_count",
+        "path": "get_api_requests.mmds_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:mmds_count",
+          "line": 158,
+          "column": 13,
+          "fingerprint": "sha256:1f61d179a7146d9082f827ad20da776b1cad30fb6fc6985af57bd4c13ef3238b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "GetRequestsMetrics.mmds_count",
+          "line": 360,
+          "column": 5,
+          "fingerprint": "sha256:ed409cea6360754c494306921b6fad7dbf0862948f4deebd58c4bb172e88409c"
+        }
+      },
+      {
+        "ordinal": 43,
+        "id": "static:get_api_requests.vmm_version_count",
+        "path": "get_api_requests.vmm_version_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:vmm_version_count",
+          "line": 159,
+          "column": 13,
+          "fingerprint": "sha256:9191b3fe58cb0120270df82f9f7b9e036219376d18ad396ace1410c3c08bd243"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "GetRequestsMetrics.vmm_version_count",
+          "line": 362,
+          "column": 5,
+          "fingerprint": "sha256:766068de924ea25682a08d7340991092c15314e3da3a4c259ea074a52c39fdb3"
+        }
+      },
+      {
+        "ordinal": 44,
+        "id": "static:get_api_requests.hotplug_memory_count",
+        "path": "get_api_requests.hotplug_memory_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:hotplug_memory_count",
+          "line": 160,
+          "column": 13,
+          "fingerprint": "sha256:0068a9a1854fa6ffd4f1b781aec1736dbcc908094110fb882d5624eb8deb54db"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "GetRequestsMetrics.hotplug_memory_count",
+          "line": 364,
+          "column": 5,
+          "fingerprint": "sha256:c3531c6378f833f0ecd1b40006b9e1d78ba600cd4538801ca17caacceccc7bb9"
+        }
+      },
+      {
+        "ordinal": 45,
+        "id": "static:i8042.error_count",
+        "path": "i8042.error_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:error_count",
+          "line": 163,
+          "column": 13,
+          "fingerprint": "sha256:1dc4c12d3fcb7ebc8cd65131d509b88762c958462e55e73fe0c0c9723af4f09b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/i8042.rs",
+          "symbol": "I8042DeviceMetrics.error_count",
+          "line": 32,
+          "column": 5,
+          "fingerprint": "sha256:b23a6473d255628555bd521afce01bf3cbd01b2034ba1a0b2b2262619885c1e3"
+        }
+      },
+      {
+        "ordinal": 46,
+        "id": "static:i8042.missed_read_count",
+        "path": "i8042.missed_read_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:missed_read_count",
+          "line": 164,
+          "column": 13,
+          "fingerprint": "sha256:cc48cb94b6ef193a2063bea802c34f2989671c5778408861bd35c2cbbf35ca93"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/i8042.rs",
+          "symbol": "I8042DeviceMetrics.missed_read_count",
+          "line": 34,
+          "column": 5,
+          "fingerprint": "sha256:9d7d83b915d86baf95d430973de41e2169d60b9f553f1c4ba0e51dcdc881fce5"
+        }
+      },
+      {
+        "ordinal": 47,
+        "id": "static:i8042.missed_write_count",
+        "path": "i8042.missed_write_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:missed_write_count",
+          "line": 165,
+          "column": 13,
+          "fingerprint": "sha256:4f0042919f0929def5e02d7bd3a2257cc0db7f59aaaddee44c05a615453d7a72"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/i8042.rs",
+          "symbol": "I8042DeviceMetrics.missed_write_count",
+          "line": 36,
+          "column": 5,
+          "fingerprint": "sha256:57d3ae3fa2f4e3664f6528c858da72420ad674e97e170526b22f9f04bd13bf45"
+        }
+      },
+      {
+        "ordinal": 48,
+        "id": "static:i8042.read_count",
+        "path": "i8042.read_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:read_count",
+          "line": 166,
+          "column": 13,
+          "fingerprint": "sha256:09641191fe5b775bd1dd08d371e0b6a19143d773caf878393622201345daa079"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/i8042.rs",
+          "symbol": "I8042DeviceMetrics.read_count",
+          "line": 38,
+          "column": 5,
+          "fingerprint": "sha256:31f2dce92e9df744310e75a4f870284801106f7c027a9687c84bcb53b49d24e5"
+        }
+      },
+      {
+        "ordinal": 49,
+        "id": "static:i8042.reset_count",
+        "path": "i8042.reset_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:reset_count",
+          "line": 167,
+          "column": 13,
+          "fingerprint": "sha256:b41f51e1ead0b12cafc61c8908f04fc60b1d5cce329db8d8efd65991caac6b4c"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/i8042.rs",
+          "symbol": "I8042DeviceMetrics.reset_count",
+          "line": 40,
+          "column": 5,
+          "fingerprint": "sha256:5fb753bd5add5e1bc07f9a7eadef64e1cbebc2fa07f8ce6611bc64f62ea9627a"
+        }
+      },
+      {
+        "ordinal": 50,
+        "id": "static:i8042.write_count",
+        "path": "i8042.write_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:write_count",
+          "line": 168,
+          "column": 13,
+          "fingerprint": "sha256:d939c3af59febd992a3fdde689ad5aba7e0340fda909f165315d2e87f42de2d3"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/i8042.rs",
+          "symbol": "I8042DeviceMetrics.write_count",
+          "line": 42,
+          "column": 5,
+          "fingerprint": "sha256:b74c2fb2d5f221ce3fe5baca217798b315a2edc7f9113dedc3e09b99d031c7f4"
+        }
+      },
+      {
+        "ordinal": 51,
+        "id": "static:rtc.error_count",
+        "path": "rtc.error_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:error_count",
+          "line": 356,
+          "column": 13,
+          "fingerprint": "sha256:1dc4c12d3fcb7ebc8cd65131d509b88762c958462e55e73fe0c0c9723af4f09b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/rtc_pl031.rs",
+          "symbol": "RTCDeviceMetrics.error_count",
+          "line": 15,
+          "column": 5,
+          "fingerprint": "sha256:47720466aa4ff15bc69cb2e9191f3edae355d0abb5205f89766affd1952455b5"
+        }
+      },
+      {
+        "ordinal": 52,
+        "id": "static:rtc.missed_read_count",
+        "path": "rtc.missed_read_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:missed_read_count",
+          "line": 357,
+          "column": 13,
+          "fingerprint": "sha256:cc48cb94b6ef193a2063bea802c34f2989671c5778408861bd35c2cbbf35ca93"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/rtc_pl031.rs",
+          "symbol": "RTCDeviceMetrics.missed_read_count",
+          "line": 17,
+          "column": 5,
+          "fingerprint": "sha256:eafbd0df6a4cb4765d2f063c597602b2c9d734e3621505b4c1e8a36263dc0761"
+        }
+      },
+      {
+        "ordinal": 53,
+        "id": "static:rtc.missed_write_count",
+        "path": "rtc.missed_write_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:missed_write_count",
+          "line": 358,
+          "column": 13,
+          "fingerprint": "sha256:4f0042919f0929def5e02d7bd3a2257cc0db7f59aaaddee44c05a615453d7a72"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/rtc_pl031.rs",
+          "symbol": "RTCDeviceMetrics.missed_write_count",
+          "line": 19,
+          "column": 5,
+          "fingerprint": "sha256:02ffa42182949ff03b897339d97deee7a3c43a71737cd8bb887c92271ffb0518"
+        }
+      },
+      {
+        "ordinal": 54,
+        "id": "static:uart.error_count",
+        "path": "uart.error_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:error_count",
+          "line": 265,
+          "column": 13,
+          "fingerprint": "sha256:1dc4c12d3fcb7ebc8cd65131d509b88762c958462e55e73fe0c0c9723af4f09b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/serial.rs",
+          "symbol": "SerialDeviceMetrics.error_count",
+          "line": 32,
+          "column": 5,
+          "fingerprint": "sha256:7554e586d8e1e53ed3f9632515446d1c62889b5bc4c4c589b65bbcb9b2d7850b"
+        }
+      },
+      {
+        "ordinal": 55,
+        "id": "static:uart.flush_count",
+        "path": "uart.flush_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:flush_count",
+          "line": 266,
+          "column": 13,
+          "fingerprint": "sha256:a8a330c6ee94d8e4311bc3860de7734d800835f8de6828bf24df1eb5688ff36a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/serial.rs",
+          "symbol": "SerialDeviceMetrics.flush_count",
+          "line": 34,
+          "column": 5,
+          "fingerprint": "sha256:2609217a5b63caf33b64eb674ab7374aa7e984ace6d5039252e0cb7447e3b62f"
+        }
+      },
+      {
+        "ordinal": 56,
+        "id": "static:uart.missed_read_count",
+        "path": "uart.missed_read_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:missed_read_count",
+          "line": 267,
+          "column": 13,
+          "fingerprint": "sha256:cc48cb94b6ef193a2063bea802c34f2989671c5778408861bd35c2cbbf35ca93"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/serial.rs",
+          "symbol": "SerialDeviceMetrics.missed_read_count",
+          "line": 36,
+          "column": 5,
+          "fingerprint": "sha256:fab47b75840a8ba2e760597b91ce35a85f8a7a0e51e05c1c0f6989db8b4f82ba"
+        }
+      },
+      {
+        "ordinal": 57,
+        "id": "static:uart.missed_write_count",
+        "path": "uart.missed_write_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:missed_write_count",
+          "line": 268,
+          "column": 13,
+          "fingerprint": "sha256:4f0042919f0929def5e02d7bd3a2257cc0db7f59aaaddee44c05a615453d7a72"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/serial.rs",
+          "symbol": "SerialDeviceMetrics.missed_write_count",
+          "line": 38,
+          "column": 5,
+          "fingerprint": "sha256:8681b12da7ceefa1b18b48dc4ac5207a6347dbb0f5431157bcc244f346f3ae65"
+        }
+      },
+      {
+        "ordinal": 58,
+        "id": "static:uart.read_count",
+        "path": "uart.read_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:read_count",
+          "line": 269,
+          "column": 13,
+          "fingerprint": "sha256:09641191fe5b775bd1dd08d371e0b6a19143d773caf878393622201345daa079"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/serial.rs",
+          "symbol": "SerialDeviceMetrics.read_count",
+          "line": 40,
+          "column": 5,
+          "fingerprint": "sha256:1a2b27ffa0f33528ba60dbbfbf7267a33c7932307fec944e0dd6f43150bb2459"
+        }
+      },
+      {
+        "ordinal": 59,
+        "id": "static:uart.write_count",
+        "path": "uart.write_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:write_count",
+          "line": 270,
+          "column": 13,
+          "fingerprint": "sha256:d939c3af59febd992a3fdde689ad5aba7e0340fda909f165315d2e87f42de2d3"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/serial.rs",
+          "symbol": "SerialDeviceMetrics.write_count",
+          "line": 42,
+          "column": 5,
+          "fingerprint": "sha256:6bee024aa1e26b0171972b40e67d976f8be0c52efbfa33fd08c9b0effc47a517"
+        }
+      },
+      {
+        "ordinal": 60,
+        "id": "static:uart.rate_limiter_dropped_bytes",
+        "path": "uart.rate_limiter_dropped_bytes",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rate_limiter_dropped_bytes",
+          "line": 271,
+          "column": 13,
+          "fingerprint": "sha256:f606347176cc6608d9573f45a79f5d2206f24cd0413ef8fc73d90e28052ff80a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/legacy/serial.rs",
+          "symbol": "SerialDeviceMetrics.rate_limiter_dropped_bytes",
+          "line": 44,
+          "column": 5,
+          "fingerprint": "sha256:55e3beef43782bb9039a0e256e3cb0f1540261f920992fc18f31851c8618a444"
+        }
+      },
+      {
+        "ordinal": 61,
+        "id": "static:latencies_us.full_create_snapshot",
+        "path": "latencies_us.full_create_snapshot",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:full_create_snapshot",
+          "line": 171,
+          "column": 13,
+          "fingerprint": "sha256:64625bc0dfad60267407a3c2160d9dce983ca786d65cb0b59b8f36a07f2547a1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.full_create_snapshot",
+          "line": 618,
+          "column": 5,
+          "fingerprint": "sha256:3e8ca7fc1d7c7cda22767fca3a51c93fe5cae356a58ee582305096376b186ed3"
+        }
+      },
+      {
+        "ordinal": 62,
+        "id": "static:latencies_us.diff_create_snapshot",
+        "path": "latencies_us.diff_create_snapshot",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:diff_create_snapshot",
+          "line": 172,
+          "column": 13,
+          "fingerprint": "sha256:eb280f238dcc7564163b217d7f346fd06448344a969b024ca3bfcdda52398aa6"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.diff_create_snapshot",
+          "line": 620,
+          "column": 5,
+          "fingerprint": "sha256:f38b971101a0e4389bc49b9088eae26707914df16e78dc687f698f54df175375"
+        }
+      },
+      {
+        "ordinal": 63,
+        "id": "static:latencies_us.load_snapshot",
+        "path": "latencies_us.load_snapshot",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:load_snapshot",
+          "line": 173,
+          "column": 13,
+          "fingerprint": "sha256:bb08e18482bb46f1aa9cc4998dae6ec2fcd351b5e1c27c39291e6be23280d483"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.load_snapshot",
+          "line": 622,
+          "column": 5,
+          "fingerprint": "sha256:b2c821897dbeb7d8b77e9da04b75646b1abad0f809958fda14f85218ea49ec5f"
+        }
+      },
+      {
+        "ordinal": 64,
+        "id": "static:latencies_us.pause_vm",
+        "path": "latencies_us.pause_vm",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:pause_vm",
+          "line": 174,
+          "column": 13,
+          "fingerprint": "sha256:72675534aebcd49eb6318772e7c6d4652399ee5cc1a68c92ef50b6b3db07472f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.pause_vm",
+          "line": 624,
+          "column": 5,
+          "fingerprint": "sha256:cb4a3d608e111ba0568e1a608933dadb7f00fe4771ab9563fe09e684b3c910aa"
+        }
+      },
+      {
+        "ordinal": 65,
+        "id": "static:latencies_us.resume_vm",
+        "path": "latencies_us.resume_vm",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:resume_vm",
+          "line": 175,
+          "column": 13,
+          "fingerprint": "sha256:e95314029d09089f76e8c9a72124b29b628691dec6cacebdc4440ac23ee47c09"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.resume_vm",
+          "line": 626,
+          "column": 5,
+          "fingerprint": "sha256:6ca3ca5c9187e62e1c1704efa7404368119aeae2602a98433d149e9efafe07e3"
+        }
+      },
+      {
+        "ordinal": 66,
+        "id": "static:latencies_us.vmm_full_create_snapshot",
+        "path": "latencies_us.vmm_full_create_snapshot",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:vmm_full_create_snapshot",
+          "line": 176,
+          "column": 13,
+          "fingerprint": "sha256:14efe2237d17c41b731155bc7dcffee9c213182ecbfbfe3f723545edb1a1b95f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.vmm_full_create_snapshot",
+          "line": 628,
+          "column": 5,
+          "fingerprint": "sha256:b4c5a8bc8ef16554349e68d2a2fc465a508ab63cdee4dd1b852337a71898b565"
+        }
+      },
+      {
+        "ordinal": 67,
+        "id": "static:latencies_us.vmm_diff_create_snapshot",
+        "path": "latencies_us.vmm_diff_create_snapshot",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:vmm_diff_create_snapshot",
+          "line": 177,
+          "column": 13,
+          "fingerprint": "sha256:a525b40102e56eaa1bff325594769d0f4ad92122069b3733a2aea3a32a2d5016"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.vmm_diff_create_snapshot",
+          "line": 630,
+          "column": 5,
+          "fingerprint": "sha256:2be263baceb4860ca2593a3423fd9c8ea9330393e4d1877f5dfd3beab0f27573"
+        }
+      },
+      {
+        "ordinal": 68,
+        "id": "static:latencies_us.vmm_load_snapshot",
+        "path": "latencies_us.vmm_load_snapshot",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:vmm_load_snapshot",
+          "line": 178,
+          "column": 13,
+          "fingerprint": "sha256:f79a55457292c76747ddab9e9006c22e2e6a70040bb333ec151e48bfb148e733"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.vmm_load_snapshot",
+          "line": 632,
+          "column": 5,
+          "fingerprint": "sha256:a7583c4f0743a7abd35a7bcda633c65dbd96b935c7488092e80d88dacf7e5cd9"
+        }
+      },
+      {
+        "ordinal": 69,
+        "id": "static:latencies_us.vmm_pause_vm",
+        "path": "latencies_us.vmm_pause_vm",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:vmm_pause_vm",
+          "line": 179,
+          "column": 13,
+          "fingerprint": "sha256:83bddaf20e1226a67f3b5842914de14ab10eb60ce5db08271d33072c4d7f9ca4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.vmm_pause_vm",
+          "line": 634,
+          "column": 5,
+          "fingerprint": "sha256:42904df195987f21f7c61cc502874a4c5177c1afd8169e3478f2fbd8ca221e74"
+        }
+      },
+      {
+        "ordinal": 70,
+        "id": "static:latencies_us.vmm_resume_vm",
+        "path": "latencies_us.vmm_resume_vm",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:vmm_resume_vm",
+          "line": 180,
+          "column": 13,
+          "fingerprint": "sha256:397c3e8c555a42484078380753cccd6a24fb6de701d680b8bbb184f3e5f064a7"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PerformanceMetrics.vmm_resume_vm",
+          "line": 636,
+          "column": 5,
+          "fingerprint": "sha256:e4620c0de702381e90d4691a1bb300c707d2291aa0be67d809020a2b7ed41a13"
+        }
+      },
+      {
+        "ordinal": 71,
+        "id": "static:logger.missed_metrics_count",
+        "path": "logger.missed_metrics_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:missed_metrics_count",
+          "line": 183,
+          "column": 13,
+          "fingerprint": "sha256:d918070368e47bb80f1350bbb9aef4bab979b1001196364fbafd4b5c952f6b13"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LoggerSystemMetrics.missed_metrics_count",
+          "line": 536,
+          "column": 5,
+          "fingerprint": "sha256:83920406104148b13827be0aac02c3a09f36326aad5f6b0e5fe0f22017907b37"
+        }
+      },
+      {
+        "ordinal": 72,
+        "id": "static:logger.metrics_fails",
+        "path": "logger.metrics_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:metrics_fails",
+          "line": 184,
+          "column": 13,
+          "fingerprint": "sha256:8164283cbc3e076ab27a924b0b68c4a40443c6fb8a0dc17d7d292a7b1546cbdd"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LoggerSystemMetrics.metrics_fails",
+          "line": 538,
+          "column": 5,
+          "fingerprint": "sha256:dfe8602e8eae067d3d159205b392e45c0f34007969285782a098d6a36da83645"
+        }
+      },
+      {
+        "ordinal": 73,
+        "id": "static:logger.missed_log_count",
+        "path": "logger.missed_log_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:missed_log_count",
+          "line": 185,
+          "column": 13,
+          "fingerprint": "sha256:8abed89481595d64f9cfa3c94f88f37a0f22465a5cc4abf171871286b7e48a79"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LoggerSystemMetrics.missed_log_count",
+          "line": 540,
+          "column": 5,
+          "fingerprint": "sha256:641b9f702d24e0d4392744d08b3fe0434171735b909ebc785ab880896e03de0d"
+        }
+      },
+      {
+        "ordinal": 74,
+        "id": "static:logger.rate_limited_log_count",
+        "path": "logger.rate_limited_log_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rate_limited_log_count",
+          "line": 186,
+          "column": 13,
+          "fingerprint": "sha256:19e51332be0a29ae92922a5a349811e72b39c7a4b47420f47c2ded1161842a38"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LoggerSystemMetrics.rate_limited_log_count",
+          "line": 542,
+          "column": 5,
+          "fingerprint": "sha256:c81b95d3d4709a17371edc1df4f97105d37ca9c60672892bfd64f754da3711c6"
+        }
+      },
+      {
+        "ordinal": 75,
+        "id": "static:mmds.rx_accepted",
+        "path": "mmds.rx_accepted",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_accepted",
+          "line": 189,
+          "column": 13,
+          "fingerprint": "sha256:ef82d25b5c8f9309412ccf81e5e2fb3b9d0f387d2eeda5f10b5da8268df3d617"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.rx_accepted",
+          "line": 560,
+          "column": 5,
+          "fingerprint": "sha256:3fa4558cf04ac938ada45b657d775db6f24e340d2d8d4d533deb30753339bca0"
+        }
+      },
+      {
+        "ordinal": 76,
+        "id": "static:mmds.rx_accepted_err",
+        "path": "mmds.rx_accepted_err",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_accepted_err",
+          "line": 190,
+          "column": 13,
+          "fingerprint": "sha256:da19360d91639bb5c42e9e3a3ae31b1b7b7ac9b9f2001b32ca1e906d8c1ed9ab"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.rx_accepted_err",
+          "line": 562,
+          "column": 5,
+          "fingerprint": "sha256:ec304e603aa9d9cd8a10e7372508296b3bc92baab1427f53a5db5b35591a11c4"
+        }
+      },
+      {
+        "ordinal": 77,
+        "id": "static:mmds.rx_accepted_unusual",
+        "path": "mmds.rx_accepted_unusual",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_accepted_unusual",
+          "line": 191,
+          "column": 13,
+          "fingerprint": "sha256:d43def7eff308553bffe24e770f1cfedb2e1ecea616529f60d666f81689fef79"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.rx_accepted_unusual",
+          "line": 564,
+          "column": 5,
+          "fingerprint": "sha256:d3fcb9032ed06145ffcd9d9dfc59c7eac8a184a32f33a79ceaeddf27a024b5a6"
+        }
+      },
+      {
+        "ordinal": 78,
+        "id": "static:mmds.rx_bad_eth",
+        "path": "mmds.rx_bad_eth",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_bad_eth",
+          "line": 192,
+          "column": 13,
+          "fingerprint": "sha256:4a6dd7e03a652c5ad8ac31ae58b7b392869db7c1ff366a878dfafbe1755021e6"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.rx_bad_eth",
+          "line": 566,
+          "column": 5,
+          "fingerprint": "sha256:830c344efba9f190da7331d7b81019d7a6d50972abfd655b5843bbfec12ae907"
+        }
+      },
+      {
+        "ordinal": 79,
+        "id": "static:mmds.rx_invalid_token",
+        "path": "mmds.rx_invalid_token",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_invalid_token",
+          "line": 193,
+          "column": 13,
+          "fingerprint": "sha256:79120761ee83dd6100065e966d96d38f4e247187074a60c4ceed05320921a8dc"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.rx_invalid_token",
+          "line": 568,
+          "column": 5,
+          "fingerprint": "sha256:80ec77c3e4153c232fb48109183e1590026d4b7bc2b466405987bc04138510cb"
+        }
+      },
+      {
+        "ordinal": 80,
+        "id": "static:mmds.rx_no_token",
+        "path": "mmds.rx_no_token",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_no_token",
+          "line": 194,
+          "column": 13,
+          "fingerprint": "sha256:cca3c2a3ad2d7a7ac00275d4c13340cfdc496ae63e1ab965fed6225e488c02b6"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.rx_no_token",
+          "line": 570,
+          "column": 5,
+          "fingerprint": "sha256:25f51da451f4abe639d0087f49167be90574fc9ce741c23572329b79dbb5ab54"
+        }
+      },
+      {
+        "ordinal": 81,
+        "id": "static:mmds.rx_count",
+        "path": "mmds.rx_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_count",
+          "line": 195,
+          "column": 13,
+          "fingerprint": "sha256:36d9049dbbb004f3bbe78fb95dbed8dbb029c132944d070daf1900426e1d2050"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.rx_count",
+          "line": 572,
+          "column": 5,
+          "fingerprint": "sha256:2dcd56d8e2acd9b45de52a19ead75b077f6334dad88dcaff134afa2d14393ea2"
+        }
+      },
+      {
+        "ordinal": 82,
+        "id": "static:mmds.tx_bytes",
+        "path": "mmds.tx_bytes",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_bytes",
+          "line": 196,
+          "column": 13,
+          "fingerprint": "sha256:46901c57b256a666393ce5ae80eb2f25a4c681015fd49527d873f2c889a6850b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.tx_bytes",
+          "line": 574,
+          "column": 5,
+          "fingerprint": "sha256:18aba02b7aa18e6ef18d306111f3c2b80bbd26a7be030ba5d296f2cf798a8723"
+        }
+      },
+      {
+        "ordinal": 83,
+        "id": "static:mmds.tx_count",
+        "path": "mmds.tx_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_count",
+          "line": 197,
+          "column": 13,
+          "fingerprint": "sha256:4304fbf94751153c16613ef5fec5fad3e0c6b3441ae4e99cb5783c3e94011e1a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.tx_count",
+          "line": 576,
+          "column": 5,
+          "fingerprint": "sha256:be7dc86c93b48b490d5ccc1841bd6524417fff32498068b55b24819abfebe973"
+        }
+      },
+      {
+        "ordinal": 84,
+        "id": "static:mmds.tx_errors",
+        "path": "mmds.tx_errors",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_errors",
+          "line": 198,
+          "column": 13,
+          "fingerprint": "sha256:dc8e1b93643c18e3809b1e2634555e8739f5b5d842f5db4c2cf329ce59eeda87"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.tx_errors",
+          "line": 578,
+          "column": 5,
+          "fingerprint": "sha256:a95623290a427538840ed1a04f3461a2cc779e991487fa4471113fb17c8c23f0"
+        }
+      },
+      {
+        "ordinal": 85,
+        "id": "static:mmds.tx_frames",
+        "path": "mmds.tx_frames",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_frames",
+          "line": 199,
+          "column": 13,
+          "fingerprint": "sha256:689943ebc0d79b0ede1fb83eac2ca54689bc74f6a411790b009cfef03817bd40"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.tx_frames",
+          "line": 580,
+          "column": 5,
+          "fingerprint": "sha256:4a224e019fc90e508b6b5ff30c71f3aa10a5d4aba9680566712410bedcb85819"
+        }
+      },
+      {
+        "ordinal": 86,
+        "id": "static:mmds.connections_created",
+        "path": "mmds.connections_created",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:connections_created",
+          "line": 200,
+          "column": 13,
+          "fingerprint": "sha256:c35fe043311a29c360a56e642b19d4ed3182f1076002cdb83d51911f2c27baa6"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.connections_created",
+          "line": 582,
+          "column": 5,
+          "fingerprint": "sha256:ec0db1b0b92c1fb798d37bb78aa46ce9e5cba29884a4d8b368a13623e5e7c929"
+        }
+      },
+      {
+        "ordinal": 87,
+        "id": "static:mmds.connections_destroyed",
+        "path": "mmds.connections_destroyed",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:connections_destroyed",
+          "line": 201,
+          "column": 13,
+          "fingerprint": "sha256:f4df27ea46cb66d011bb0c70475ee883493f1ad9792827b221158a2edd90901b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "MmdsMetrics.connections_destroyed",
+          "line": 584,
+          "column": 5,
+          "fingerprint": "sha256:4482f6da5ead89056d425bf7ee993f1c8923808e725dae1bf960c66dcb6803c3"
+        }
+      },
+      {
+        "ordinal": 88,
+        "id": "static:net.activate_fails",
+        "path": "net.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 103,
+          "column": 9,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.activate_fails",
+          "line": 148,
+          "column": 5,
+          "fingerprint": "sha256:4c3e548ddc5a4eaad3c6d98b1dfa638213fdfcd53bd47e058f21b93bcb727367"
+        }
+      },
+      {
+        "ordinal": 89,
+        "id": "static:net.cfg_fails",
+        "path": "net.cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:cfg_fails",
+          "line": 104,
+          "column": 9,
+          "fingerprint": "sha256:ddf6ccea8ce5f2e735df611b679382a9746297209cd37172297a36975bfbc8e4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.cfg_fails",
+          "line": 150,
+          "column": 5,
+          "fingerprint": "sha256:5e05cb85492f765a5c64456f56250c084a72f7f829e852e0717dec7e261345b7"
+        }
+      },
+      {
+        "ordinal": 90,
+        "id": "static:net.mac_address_updates",
+        "path": "net.mac_address_updates",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:mac_address_updates",
+          "line": 105,
+          "column": 9,
+          "fingerprint": "sha256:95d906e3e8d950e4d3c1d18716a674bf61654de2303afd03923531115de1c772"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.mac_address_updates",
+          "line": 152,
+          "column": 5,
+          "fingerprint": "sha256:5092bdd9e6a47db4d343cbbf09437fa848eabb1cf4055fe8dc682d71861614ad"
+        }
+      },
+      {
+        "ordinal": 91,
+        "id": "static:net.no_rx_avail_buffer",
+        "path": "net.no_rx_avail_buffer",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:no_rx_avail_buffer",
+          "line": 106,
+          "column": 9,
+          "fingerprint": "sha256:6738401c387cd7e84a29ec5978cb7b0e46bf30257107721d7055b27953293660"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.no_rx_avail_buffer",
+          "line": 154,
+          "column": 5,
+          "fingerprint": "sha256:9077195cdb13b22b15bcef08e359de180887dcd805972a75986c5dff2ef8132c"
+        }
+      },
+      {
+        "ordinal": 92,
+        "id": "static:net.no_tx_avail_buffer",
+        "path": "net.no_tx_avail_buffer",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:no_tx_avail_buffer",
+          "line": 107,
+          "column": 9,
+          "fingerprint": "sha256:21018758c80bcefab937a1d5a01f89140147d5f1529e74a9912b681c60c51537"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.no_tx_avail_buffer",
+          "line": 156,
+          "column": 5,
+          "fingerprint": "sha256:e96ea3b15f3959a47b4c30831818b904c8d2a13d72bfda2ac719622aed33917e"
+        }
+      },
+      {
+        "ordinal": 93,
+        "id": "static:net.event_fails",
+        "path": "net.event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:event_fails",
+          "line": 108,
+          "column": 9,
+          "fingerprint": "sha256:af808eac4d6aeffe1c5fc8f67a3a735f7f571acf68499b409872222ff7292154"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.event_fails",
+          "line": 158,
+          "column": 5,
+          "fingerprint": "sha256:c4a4a9a987f863119612bc3c228280310185d2d08e7e8ec3fe4c53cc665e58cc"
+        }
+      },
+      {
+        "ordinal": 94,
+        "id": "static:net.rx_queue_event_count",
+        "path": "net.rx_queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_queue_event_count",
+          "line": 109,
+          "column": 9,
+          "fingerprint": "sha256:f60ad03226f86eb2e874f9b9dd39208b066e0a705d682adcb576f6f34dd7d48a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_queue_event_count",
+          "line": 160,
+          "column": 5,
+          "fingerprint": "sha256:c4bbd22125da5c390344c321540faaeef83c679f7dd7e185216e055b2167ac38"
+        }
+      },
+      {
+        "ordinal": 95,
+        "id": "static:net.rx_event_rate_limiter_count",
+        "path": "net.rx_event_rate_limiter_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_event_rate_limiter_count",
+          "line": 110,
+          "column": 9,
+          "fingerprint": "sha256:799a5aef6283bef8ba0c2b60d58f83bac4bcb8547c3069be28cc3d3e95dff93a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_event_rate_limiter_count",
+          "line": 162,
+          "column": 5,
+          "fingerprint": "sha256:e381a0258e951f1610f78cd5dc12b515197372ed8665b798d8d438375f79dc74"
+        }
+      },
+      {
+        "ordinal": 96,
+        "id": "static:net.rx_rate_limiter_throttled",
+        "path": "net.rx_rate_limiter_throttled",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_rate_limiter_throttled",
+          "line": 111,
+          "column": 9,
+          "fingerprint": "sha256:0030f620c284c6dc8b3f9c8febb41d47787a11508dd0b50daab16f4d6cd9cb7f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_rate_limiter_throttled",
+          "line": 164,
+          "column": 5,
+          "fingerprint": "sha256:d927062707df0beb9a09cc8250d0718a6da52e70866bfa594cfab33f13106434"
+        }
+      },
+      {
+        "ordinal": 97,
+        "id": "static:net.rx_tap_event_count",
+        "path": "net.rx_tap_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_tap_event_count",
+          "line": 112,
+          "column": 9,
+          "fingerprint": "sha256:18c8effb36b14efaa7bb5e035c53c36161d5a3ee06856ac599ed2e60b117db8d"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_tap_event_count",
+          "line": 166,
+          "column": 5,
+          "fingerprint": "sha256:8cfc6f47b123ae2317028fc3296bc29098cda61bd9f61caa007403368039a1a4"
+        }
+      },
+      {
+        "ordinal": 98,
+        "id": "static:net.rx_bytes_count",
+        "path": "net.rx_bytes_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_bytes_count",
+          "line": 113,
+          "column": 9,
+          "fingerprint": "sha256:c46e1d8621e8290212400a1d437a94ea08474454c79bc3377e14fdbedbdc5ae5"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_bytes_count",
+          "line": 168,
+          "column": 5,
+          "fingerprint": "sha256:7933a7942857d10b360f152c4feb84b8ec8c26ab4f8886fa2569d22b7bd34082"
+        }
+      },
+      {
+        "ordinal": 99,
+        "id": "static:net.rx_packets_count",
+        "path": "net.rx_packets_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_packets_count",
+          "line": 114,
+          "column": 9,
+          "fingerprint": "sha256:f56f99b197b295d3734cf636eda998f16acc39da1e996bf2fc668d912f0054f2"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_packets_count",
+          "line": 170,
+          "column": 5,
+          "fingerprint": "sha256:326d18233e88330c95e7a97709fe08fb60e60fab340ca85b57a603796265ba9a"
+        }
+      },
+      {
+        "ordinal": 100,
+        "id": "static:net.rx_fails",
+        "path": "net.rx_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_fails",
+          "line": 115,
+          "column": 9,
+          "fingerprint": "sha256:6eeb534e1d15391f3099081d2d8f489f88a3166fecdbba8eb715289b4ecf4d32"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_fails",
+          "line": 172,
+          "column": 5,
+          "fingerprint": "sha256:96979263c732a9c6ac83505333edc501206e111a0f8b916a0a857c88fbcc047a"
+        }
+      },
+      {
+        "ordinal": 101,
+        "id": "static:net.rx_count",
+        "path": "net.rx_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_count",
+          "line": 116,
+          "column": 9,
+          "fingerprint": "sha256:36d9049dbbb004f3bbe78fb95dbed8dbb029c132944d070daf1900426e1d2050"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_count",
+          "line": 174,
+          "column": 5,
+          "fingerprint": "sha256:5af94b008165c9f9b70e124f234df0ac70a859b6afd068b9df2517600f08b9f7"
+        }
+      },
+      {
+        "ordinal": 102,
+        "id": "static:net.tap_read_fails",
+        "path": "net.tap_read_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tap_read_fails",
+          "line": 117,
+          "column": 9,
+          "fingerprint": "sha256:269a963df8d8bd382657c33b60ff3b826a5403aa8296375f660e2b8495ff807d"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tap_read_fails",
+          "line": 176,
+          "column": 5,
+          "fingerprint": "sha256:90c4654d5643f70e2f7b1a687592c9b283f4357ec9423f026ba9768e9e43860e"
+        }
+      },
+      {
+        "ordinal": 103,
+        "id": "static:net.tap_write_fails",
+        "path": "net.tap_write_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tap_write_fails",
+          "line": 118,
+          "column": 9,
+          "fingerprint": "sha256:256f300abd6629a78404e26d8278419fc40069db495250973ad717616faaf46b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tap_write_fails",
+          "line": 178,
+          "column": 5,
+          "fingerprint": "sha256:c85a7f4267f8a5fd1f8f0fa141e0a888270c0658e8ad2dc48f2ded9c1601dfba"
+        }
+      },
+      {
+        "ordinal": 104,
+        "id": "static:net.tap_write_agg.min_us",
+        "path": "net.tap_write_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 105,
+        "id": "static:net.tap_write_agg.max_us",
+        "path": "net.tap_write_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 106,
+        "id": "static:net.tap_write_agg.sum_us",
+        "path": "net.tap_write_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 107,
+        "id": "static:net.tx_bytes_count",
+        "path": "net.tx_bytes_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_bytes_count",
+          "line": 119,
+          "column": 9,
+          "fingerprint": "sha256:cd470e94bc651b5d8eeb47c9238b775be646265969d1841a733c85d50ce3b1d1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_bytes_count",
+          "line": 182,
+          "column": 5,
+          "fingerprint": "sha256:75fda4340f29f55e844856e8025dd45926da7be3c6f496799231af77fc11a3fc"
+        }
+      },
+      {
+        "ordinal": 108,
+        "id": "static:net.tx_malformed_frames",
+        "path": "net.tx_malformed_frames",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_malformed_frames",
+          "line": 120,
+          "column": 9,
+          "fingerprint": "sha256:376ac52ee5e4eca5e7b4f851c5b4aa106565f75d31ad72cfd1b06af98d987594"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_malformed_frames",
+          "line": 184,
+          "column": 5,
+          "fingerprint": "sha256:7d99fb7d430dbe3f84d49d6bdd4d206f1418e0fc3170a1e288310f0465c75887"
+        }
+      },
+      {
+        "ordinal": 109,
+        "id": "static:net.tx_fails",
+        "path": "net.tx_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_fails",
+          "line": 121,
+          "column": 9,
+          "fingerprint": "sha256:ba5d7d049060d3edffaacd40f7a3330ff35c3c9434a2a2a3fb0fe56387ab995b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_fails",
+          "line": 186,
+          "column": 5,
+          "fingerprint": "sha256:47ab1e31fceead4c0de7c72e06d97c13638ada2c8dacb6da47e6f015e9ccb3e3"
+        }
+      },
+      {
+        "ordinal": 110,
+        "id": "static:net.tx_count",
+        "path": "net.tx_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_count",
+          "line": 122,
+          "column": 9,
+          "fingerprint": "sha256:4304fbf94751153c16613ef5fec5fad3e0c6b3441ae4e99cb5783c3e94011e1a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_count",
+          "line": 188,
+          "column": 5,
+          "fingerprint": "sha256:300f2c1d82af9964d4beb581a1e7928384f50e818621cf9157bebc58054b8d75"
+        }
+      },
+      {
+        "ordinal": 111,
+        "id": "static:net.tx_packets_count",
+        "path": "net.tx_packets_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_packets_count",
+          "line": 123,
+          "column": 9,
+          "fingerprint": "sha256:8203eccfbd7be213263d324b3764df310788a1a386a9342c56778f2c07e5dec9"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_packets_count",
+          "line": 190,
+          "column": 5,
+          "fingerprint": "sha256:d19d3a52f3f85d63e1c4c9e814de0bf7ff36a5499c24fe870df21abff02c3b3a"
+        }
+      },
+      {
+        "ordinal": 112,
+        "id": "static:net.tx_queue_event_count",
+        "path": "net.tx_queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_queue_event_count",
+          "line": 124,
+          "column": 9,
+          "fingerprint": "sha256:3dd397e2fc51a3f3c1ce5c618515c56b160c75367dcf44dd9f15e608736f83c3"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_queue_event_count",
+          "line": 192,
+          "column": 5,
+          "fingerprint": "sha256:efee9a2b38f5122a6a2a88d3b2e8312c7e52d9d13089bd4af5ec14a7da9babb2"
+        }
+      },
+      {
+        "ordinal": 113,
+        "id": "static:net.tx_rate_limiter_event_count",
+        "path": "net.tx_rate_limiter_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_rate_limiter_event_count",
+          "line": 125,
+          "column": 9,
+          "fingerprint": "sha256:bdbf48711873943b7d761a3af82a754558db209b59b7a23c70c2bf63867af67a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_rate_limiter_event_count",
+          "line": 194,
+          "column": 5,
+          "fingerprint": "sha256:27dc7888ebe248dbb122a66ab637d0810771150734126b3306e8bd48d1353562"
+        }
+      },
+      {
+        "ordinal": 114,
+        "id": "static:net.tx_rate_limiter_throttled",
+        "path": "net.tx_rate_limiter_throttled",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_rate_limiter_throttled",
+          "line": 126,
+          "column": 9,
+          "fingerprint": "sha256:db0ef6c6709d5d4406a4caac80d9f90e026f9e9963d536d00f7b2f62c6160057"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_rate_limiter_throttled",
+          "line": 196,
+          "column": 5,
+          "fingerprint": "sha256:7e24af5cdd5b6ea076326a378ce86db8ddbe6baa9b74e9065444ba4db6caec06"
+        }
+      },
+      {
+        "ordinal": 115,
+        "id": "static:net.tx_spoofed_mac_count",
+        "path": "net.tx_spoofed_mac_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_spoofed_mac_count",
+          "line": 127,
+          "column": 9,
+          "fingerprint": "sha256:17d9c56a471e6170bd888751c46ae13db228420a7fc5adcda8b9b3dfbcc88c45"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_spoofed_mac_count",
+          "line": 198,
+          "column": 5,
+          "fingerprint": "sha256:3a0f6e8be2b1d5009679427c6073402bb2f1186cd8cf11fdda791b7fcff62777"
+        }
+      },
+      {
+        "ordinal": 116,
+        "id": "static:net.tx_remaining_reqs_count",
+        "path": "net.tx_remaining_reqs_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_remaining_reqs_count",
+          "line": 128,
+          "column": 9,
+          "fingerprint": "sha256:ded59fcdcfc1df8cb34e5d7ace1dc1594ac4bb8dfb9ad89b2c705f00efec05a9"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_remaining_reqs_count",
+          "line": 200,
+          "column": 5,
+          "fingerprint": "sha256:6e6d069191515892e2e907bab5ac9647f6ecfc4a7dd5bfd60b717425f29cac8b"
+        }
+      },
+      {
+        "ordinal": 117,
+        "id": "static:patch_api_requests.drive_count",
+        "path": "patch_api_requests.drive_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:drive_count",
+          "line": 205,
+          "column": 13,
+          "fingerprint": "sha256:b17002c3b063579afc609da22a51532c1c5daeee17b24c084ede6fd31505f48f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.drive_count",
+          "line": 473,
+          "column": 5,
+          "fingerprint": "sha256:71ea8d76d0ff391c02d5d5af91a681d4a0261715681fa91d6a9f4a33567e2db7"
+        }
+      },
+      {
+        "ordinal": 118,
+        "id": "static:patch_api_requests.drive_fails",
+        "path": "patch_api_requests.drive_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:drive_fails",
+          "line": 206,
+          "column": 13,
+          "fingerprint": "sha256:a278fa10d83e8b8e36318ece7d1c4197ba9b2cc74576c1cc92c7f6a348fd3787"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.drive_fails",
+          "line": 475,
+          "column": 5,
+          "fingerprint": "sha256:7c0ccb576e1f5699bfa2e6804db1442524dee08b2e9dacc043e38f6824ee0228"
+        }
+      },
+      {
+        "ordinal": 119,
+        "id": "static:patch_api_requests.network_count",
+        "path": "patch_api_requests.network_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:network_count",
+          "line": 207,
+          "column": 13,
+          "fingerprint": "sha256:be27a2468fea6813d771376c12735964db22a24401de7a5c61edf5235ea55bda"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.network_count",
+          "line": 477,
+          "column": 5,
+          "fingerprint": "sha256:05bd3dd255c3998b7dc54c2c142adb273ed8675738c2be8eb22b5159ff5d2ab3"
+        }
+      },
+      {
+        "ordinal": 120,
+        "id": "static:patch_api_requests.network_fails",
+        "path": "patch_api_requests.network_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:network_fails",
+          "line": 208,
+          "column": 13,
+          "fingerprint": "sha256:943c40e414468a3d0be4a8d29c139123e87a472d521c360e9d7b96462d3a8e77"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.network_fails",
+          "line": 479,
+          "column": 5,
+          "fingerprint": "sha256:e8278ea6ebed9e428e36dd5427104543cea177a96ba5bc554c592876f192fde7"
+        }
+      },
+      {
+        "ordinal": 121,
+        "id": "static:patch_api_requests.machine_cfg_count",
+        "path": "patch_api_requests.machine_cfg_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:machine_cfg_count",
+          "line": 209,
+          "column": 13,
+          "fingerprint": "sha256:2c6e1febb1b5d5613ca735a2d94dbca42be2454ee845a213e5b61300ccf74fc1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.machine_cfg_count",
+          "line": 481,
+          "column": 5,
+          "fingerprint": "sha256:cbff6ca850718576fc9c604b48572c4fbc22d4268f6634ab0262d5b59193a4f8"
+        }
+      },
+      {
+        "ordinal": 122,
+        "id": "static:patch_api_requests.machine_cfg_fails",
+        "path": "patch_api_requests.machine_cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:machine_cfg_fails",
+          "line": 210,
+          "column": 13,
+          "fingerprint": "sha256:a3b82ebf0aa3d3be4fde878d2c904eb5b5717743c60fe51875f05f53ac435346"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.machine_cfg_fails",
+          "line": 483,
+          "column": 5,
+          "fingerprint": "sha256:d82fae72cb46ff88b6fa23065954b70e252a834d26b99487e6794e8676b4580c"
+        }
+      },
+      {
+        "ordinal": 123,
+        "id": "static:patch_api_requests.mmds_count",
+        "path": "patch_api_requests.mmds_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:mmds_count",
+          "line": 211,
+          "column": 13,
+          "fingerprint": "sha256:1f61d179a7146d9082f827ad20da776b1cad30fb6fc6985af57bd4c13ef3238b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.mmds_count",
+          "line": 485,
+          "column": 5,
+          "fingerprint": "sha256:b44c6c9f581f9a05f191f5bdc26ca3930613c23c1676e0895748f8a76e4fccda"
+        }
+      },
+      {
+        "ordinal": 124,
+        "id": "static:patch_api_requests.mmds_fails",
+        "path": "patch_api_requests.mmds_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:mmds_fails",
+          "line": 212,
+          "column": 13,
+          "fingerprint": "sha256:11b983f9bbc5f88491d80ccb99a11336f72284b25e0bdba8484dcdac7d2bad87"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.mmds_fails",
+          "line": 487,
+          "column": 5,
+          "fingerprint": "sha256:b14e3e3008fc98e3adfdcdd443937347931673e300332cd59e235f1061a6680f"
+        }
+      },
+      {
+        "ordinal": 125,
+        "id": "static:patch_api_requests.hotplug_memory_count",
+        "path": "patch_api_requests.hotplug_memory_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:hotplug_memory_count",
+          "line": 213,
+          "column": 13,
+          "fingerprint": "sha256:0068a9a1854fa6ffd4f1b781aec1736dbcc908094110fb882d5624eb8deb54db"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.hotplug_memory_count",
+          "line": 489,
+          "column": 5,
+          "fingerprint": "sha256:4866620e920cec46758b80aa42c343034401438ec54a19d680c736e17e0b2786"
+        }
+      },
+      {
+        "ordinal": 126,
+        "id": "static:patch_api_requests.hotplug_memory_fails",
+        "path": "patch_api_requests.hotplug_memory_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:hotplug_memory_fails",
+          "line": 214,
+          "column": 13,
+          "fingerprint": "sha256:1aa2cacd9991faeeab3ba4ce07778cec13c5dcc4c713a96fed6980b62ba751b1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.hotplug_memory_fails",
+          "line": 491,
+          "column": 5,
+          "fingerprint": "sha256:5ee9a1c610255f1ec6cccb73d12c326f879b4d182f1bf7c7b0a2ecd2e4abdce4"
+        }
+      },
+      {
+        "ordinal": 127,
+        "id": "static:patch_api_requests.pmem_count",
+        "path": "patch_api_requests.pmem_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:pmem_count",
+          "line": 215,
+          "column": 13,
+          "fingerprint": "sha256:a7a6ad83a457d7e78ce74151ca46c70c45c6d6731f409d2bd70a773c19fa4d8f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.pmem_count",
+          "line": 493,
+          "column": 5,
+          "fingerprint": "sha256:ba50f5043e03eba5224ec2e8a41744ec42cb371b1669eece9eca6336f52fc0de"
+        }
+      },
+      {
+        "ordinal": 128,
+        "id": "static:patch_api_requests.pmem_fails",
+        "path": "patch_api_requests.pmem_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:pmem_fails",
+          "line": 216,
+          "column": 13,
+          "fingerprint": "sha256:2b7a959fce16e51c77d92b156b37471bbed2e7e42af95bf7e36cfdb1c47b4443"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PatchRequestsMetrics.pmem_fails",
+          "line": 495,
+          "column": 5,
+          "fingerprint": "sha256:ac8ffb2d502cc11584e42097afa3f9e1caf44950402a5a487c70ab55af1c3919"
+        }
+      },
+      {
+        "ordinal": 129,
+        "id": "static:put_api_requests.actions_count",
+        "path": "put_api_requests.actions_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:actions_count",
+          "line": 219,
+          "column": 13,
+          "fingerprint": "sha256:04a5fa1915e9dfaf1737a018da69c79e0d3bbaf53255fbf3d52c768abd9d5aa1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.actions_count",
+          "line": 383,
+          "column": 5,
+          "fingerprint": "sha256:28c3398a5174724cfd6edd7ba5a254fef65ff8319b419d555f48ba2ccd9a5052"
+        }
+      },
+      {
+        "ordinal": 130,
+        "id": "static:put_api_requests.actions_fails",
+        "path": "put_api_requests.actions_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:actions_fails",
+          "line": 220,
+          "column": 13,
+          "fingerprint": "sha256:2abbbc9b00b38a8b550da4b49a4492e7e4d6b9d7580f363ab360fcf99a42d5ec"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.actions_fails",
+          "line": 385,
+          "column": 5,
+          "fingerprint": "sha256:ce03e51c61409354079e1ba25354d05258d941c99f7cfc94b34cc4da832f8c79"
+        }
+      },
+      {
+        "ordinal": 131,
+        "id": "static:put_api_requests.boot_source_count",
+        "path": "put_api_requests.boot_source_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:boot_source_count",
+          "line": 221,
+          "column": 13,
+          "fingerprint": "sha256:04063a8f4da718dadadb6829487d1df82e7838f7e350279f10f67f878978c2a1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.boot_source_count",
+          "line": 387,
+          "column": 5,
+          "fingerprint": "sha256:60e2ce94ccbaa3f67162680aff8d2ebc1a57c1d8ff30deded9c8bc23b78328c6"
+        }
+      },
+      {
+        "ordinal": 132,
+        "id": "static:put_api_requests.boot_source_fails",
+        "path": "put_api_requests.boot_source_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:boot_source_fails",
+          "line": 222,
+          "column": 13,
+          "fingerprint": "sha256:245a036041d030383026a7f0d885085ae21c0e7e999d96390cb14d7058b545d6"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.boot_source_fails",
+          "line": 389,
+          "column": 5,
+          "fingerprint": "sha256:520fe31e4a3b5b189cc33a7f878443ec1cc89bd0216741e81e2657a17a538a44"
+        }
+      },
+      {
+        "ordinal": 133,
+        "id": "static:put_api_requests.drive_count",
+        "path": "put_api_requests.drive_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:drive_count",
+          "line": 223,
+          "column": 13,
+          "fingerprint": "sha256:b17002c3b063579afc609da22a51532c1c5daeee17b24c084ede6fd31505f48f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.drive_count",
+          "line": 391,
+          "column": 5,
+          "fingerprint": "sha256:948146e3d57ca4c9d8fb6b2075deb474fc8de001a97b1f69d69fd5c0b63bef12"
+        }
+      },
+      {
+        "ordinal": 134,
+        "id": "static:put_api_requests.drive_fails",
+        "path": "put_api_requests.drive_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:drive_fails",
+          "line": 224,
+          "column": 13,
+          "fingerprint": "sha256:a278fa10d83e8b8e36318ece7d1c4197ba9b2cc74576c1cc92c7f6a348fd3787"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.drive_fails",
+          "line": 393,
+          "column": 5,
+          "fingerprint": "sha256:9432660bf536bcdc1be544f827ca66724b5b256609334cad07b0b6108b10781d"
+        }
+      },
+      {
+        "ordinal": 135,
+        "id": "static:put_api_requests.logger_count",
+        "path": "put_api_requests.logger_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:logger_count",
+          "line": 225,
+          "column": 13,
+          "fingerprint": "sha256:5fa50980625be3cc235e58a4ab51da40bf14c28b204b0aa584d28beb3bd7e252"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.logger_count",
+          "line": 395,
+          "column": 5,
+          "fingerprint": "sha256:465e12192bebcee537ae714120380911b885401272a0d4ed1e37c584ac50dc4b"
+        }
+      },
+      {
+        "ordinal": 136,
+        "id": "static:put_api_requests.logger_fails",
+        "path": "put_api_requests.logger_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:logger_fails",
+          "line": 226,
+          "column": 13,
+          "fingerprint": "sha256:835844e5a7921978ec77c39e53899875919a7b03a5d88eb068227cbed858f0b8"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.logger_fails",
+          "line": 397,
+          "column": 5,
+          "fingerprint": "sha256:98e55e99d503e788a433d0710943ac00118ec7c947a9cf2297349237b915d2c1"
+        }
+      },
+      {
+        "ordinal": 137,
+        "id": "static:put_api_requests.machine_cfg_count",
+        "path": "put_api_requests.machine_cfg_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:machine_cfg_count",
+          "line": 227,
+          "column": 13,
+          "fingerprint": "sha256:2c6e1febb1b5d5613ca735a2d94dbca42be2454ee845a213e5b61300ccf74fc1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.machine_cfg_count",
+          "line": 399,
+          "column": 5,
+          "fingerprint": "sha256:c3fafd056dec5ea226a7290675c88e9b10f7827cbd73462384cb7ca556bfdded"
+        }
+      },
+      {
+        "ordinal": 138,
+        "id": "static:put_api_requests.machine_cfg_fails",
+        "path": "put_api_requests.machine_cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:machine_cfg_fails",
+          "line": 228,
+          "column": 13,
+          "fingerprint": "sha256:a3b82ebf0aa3d3be4fde878d2c904eb5b5717743c60fe51875f05f53ac435346"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.machine_cfg_fails",
+          "line": 401,
+          "column": 5,
+          "fingerprint": "sha256:d82fae72cb46ff88b6fa23065954b70e252a834d26b99487e6794e8676b4580c"
+        }
+      },
+      {
+        "ordinal": 139,
+        "id": "static:put_api_requests.cpu_cfg_count",
+        "path": "put_api_requests.cpu_cfg_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:cpu_cfg_count",
+          "line": 229,
+          "column": 13,
+          "fingerprint": "sha256:264a6c7457465ed44b3cf363d1ab863a1cb4bd74b0b152cf83bc2ca0fe1b051b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.cpu_cfg_count",
+          "line": 403,
+          "column": 5,
+          "fingerprint": "sha256:eb64552dbaf91f8eec115de43987c237e167d6107f7243e3d5085047f0f90329"
+        }
+      },
+      {
+        "ordinal": 140,
+        "id": "static:put_api_requests.cpu_cfg_fails",
+        "path": "put_api_requests.cpu_cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:cpu_cfg_fails",
+          "line": 230,
+          "column": 13,
+          "fingerprint": "sha256:a86eb1c0c745a9496e336857d97ca410d517d1f625ef99015252e93d769d2e2a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.cpu_cfg_fails",
+          "line": 405,
+          "column": 5,
+          "fingerprint": "sha256:7e16155b58ee8d24b1c832552a6412de5576d79f44c19be1ac664b194627f535"
+        }
+      },
+      {
+        "ordinal": 141,
+        "id": "static:put_api_requests.metrics_count",
+        "path": "put_api_requests.metrics_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:metrics_count",
+          "line": 231,
+          "column": 13,
+          "fingerprint": "sha256:7c3dc4a50ebd2c6b29b498a0aeb2f1b385af256a85a97729c982678121394690"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.metrics_count",
+          "line": 407,
+          "column": 5,
+          "fingerprint": "sha256:d8168df989f365465cbc040ae2f4a0716cdbad05e27a1dbb1b6f89673d237be5"
+        }
+      },
+      {
+        "ordinal": 142,
+        "id": "static:put_api_requests.metrics_fails",
+        "path": "put_api_requests.metrics_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:metrics_fails",
+          "line": 232,
+          "column": 13,
+          "fingerprint": "sha256:8164283cbc3e076ab27a924b0b68c4a40443c6fb8a0dc17d7d292a7b1546cbdd"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.metrics_fails",
+          "line": 409,
+          "column": 5,
+          "fingerprint": "sha256:b0bc53ba38d3a5028a4ec4b8af96550babb636ce7bfacb3f70c73a96cacaac8b"
+        }
+      },
+      {
+        "ordinal": 143,
+        "id": "static:put_api_requests.network_count",
+        "path": "put_api_requests.network_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:network_count",
+          "line": 233,
+          "column": 13,
+          "fingerprint": "sha256:be27a2468fea6813d771376c12735964db22a24401de7a5c61edf5235ea55bda"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.network_count",
+          "line": 411,
+          "column": 5,
+          "fingerprint": "sha256:d0a019c8a81e4f1378d971f5f3d90d24d9b5b3f2a0e4df50ebf2df5792683caf"
+        }
+      },
+      {
+        "ordinal": 144,
+        "id": "static:put_api_requests.network_fails",
+        "path": "put_api_requests.network_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:network_fails",
+          "line": 234,
+          "column": 13,
+          "fingerprint": "sha256:943c40e414468a3d0be4a8d29c139123e87a472d521c360e9d7b96462d3a8e77"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.network_fails",
+          "line": 413,
+          "column": 5,
+          "fingerprint": "sha256:102d2f2369d97b1eee010eec3b7a4cac2bdc44827d6c0b1f492b273ff8d646a3"
+        }
+      },
+      {
+        "ordinal": 145,
+        "id": "static:put_api_requests.mmds_count",
+        "path": "put_api_requests.mmds_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:mmds_count",
+          "line": 235,
+          "column": 13,
+          "fingerprint": "sha256:1f61d179a7146d9082f827ad20da776b1cad30fb6fc6985af57bd4c13ef3238b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.mmds_count",
+          "line": 415,
+          "column": 5,
+          "fingerprint": "sha256:89bbb47a9c5220165cb7a087bdf07b862c63e4d17e525ed74fd363a28359d87f"
+        }
+      },
+      {
+        "ordinal": 146,
+        "id": "static:put_api_requests.mmds_fails",
+        "path": "put_api_requests.mmds_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:mmds_fails",
+          "line": 236,
+          "column": 13,
+          "fingerprint": "sha256:11b983f9bbc5f88491d80ccb99a11336f72284b25e0bdba8484dcdac7d2bad87"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.mmds_fails",
+          "line": 417,
+          "column": 5,
+          "fingerprint": "sha256:b23efdd738ce92e0595802ae958cf8691c2b586e846b54e39c7d807ee6baf4c7"
+        }
+      },
+      {
+        "ordinal": 147,
+        "id": "static:put_api_requests.vsock_count",
+        "path": "put_api_requests.vsock_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:vsock_count",
+          "line": 237,
+          "column": 13,
+          "fingerprint": "sha256:68cb800687f500010d603b5e75bc2776c4c3c9f52f7a72d01de54b4055cc1cfe"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.vsock_count",
+          "line": 419,
+          "column": 5,
+          "fingerprint": "sha256:d4dfdebea642390aa888521e1899e666251873572e66c4f96c97de1d6c2b6d87"
+        }
+      },
+      {
+        "ordinal": 148,
+        "id": "static:put_api_requests.vsock_fails",
+        "path": "put_api_requests.vsock_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:vsock_fails",
+          "line": 238,
+          "column": 13,
+          "fingerprint": "sha256:b5fe214cef25d6b863fb1856547d7c26b27cd72adb31a1bafde5a64dfc5c9550"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.vsock_fails",
+          "line": 421,
+          "column": 5,
+          "fingerprint": "sha256:889d96e228c97e64fd96680728ffe5ecbeabf08c7018007321f99305e1fda071"
+        }
+      },
+      {
+        "ordinal": 149,
+        "id": "static:put_api_requests.pmem_count",
+        "path": "put_api_requests.pmem_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:pmem_count",
+          "line": 239,
+          "column": 13,
+          "fingerprint": "sha256:a7a6ad83a457d7e78ce74151ca46c70c45c6d6731f409d2bd70a773c19fa4d8f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.pmem_count",
+          "line": 423,
+          "column": 5,
+          "fingerprint": "sha256:fe9a81254a2551d13eb056475aa59a63d7fef13e2c71fe13a3ec5ed77bda5a09"
+        }
+      },
+      {
+        "ordinal": 150,
+        "id": "static:put_api_requests.pmem_fails",
+        "path": "put_api_requests.pmem_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:pmem_fails",
+          "line": 240,
+          "column": 13,
+          "fingerprint": "sha256:2b7a959fce16e51c77d92b156b37471bbed2e7e42af95bf7e36cfdb1c47b4443"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.pmem_fails",
+          "line": 425,
+          "column": 5,
+          "fingerprint": "sha256:e6e75f6842801e615620c5bb91465fdb8a0132746359f13646d3389fff2700fc"
+        }
+      },
+      {
+        "ordinal": 151,
+        "id": "static:put_api_requests.serial_count",
+        "path": "put_api_requests.serial_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:serial_count",
+          "line": 241,
+          "column": 13,
+          "fingerprint": "sha256:7586d0268b26d27bdddae958113ce1a841500d75a242495936c2389396a035a0"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.serial_count",
+          "line": 427,
+          "column": 5,
+          "fingerprint": "sha256:7e836ed4b9aa9ea9c57009a47fca0f9770fb6b81702e9044ff0eda28dbd90523"
+        }
+      },
+      {
+        "ordinal": 152,
+        "id": "static:put_api_requests.serial_fails",
+        "path": "put_api_requests.serial_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:serial_fails",
+          "line": 242,
+          "column": 13,
+          "fingerprint": "sha256:752cd2f4db279131b25cca15eec65f0d5e09493debf0ea6ff84b2b3f04078c67"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.serial_fails",
+          "line": 429,
+          "column": 5,
+          "fingerprint": "sha256:72205221888a85e4bd176a50cc828309e97f213c94ec023e2d113a2a046e3934"
+        }
+      },
+      {
+        "ordinal": 153,
+        "id": "static:put_api_requests.hotplug_memory_count",
+        "path": "put_api_requests.hotplug_memory_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:hotplug_memory_count",
+          "line": 243,
+          "column": 13,
+          "fingerprint": "sha256:0068a9a1854fa6ffd4f1b781aec1736dbcc908094110fb882d5624eb8deb54db"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.hotplug_memory_count",
+          "line": 431,
+          "column": 5,
+          "fingerprint": "sha256:38a7860526a00dca0c1b959bee491856cd701c4558779002e376d5a49fa55166"
+        }
+      },
+      {
+        "ordinal": 154,
+        "id": "static:put_api_requests.hotplug_memory_fails",
+        "path": "put_api_requests.hotplug_memory_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:hotplug_memory_fails",
+          "line": 244,
+          "column": 13,
+          "fingerprint": "sha256:1aa2cacd9991faeeab3ba4ce07778cec13c5dcc4c713a96fed6980b62ba751b1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "PutRequestsMetrics.hotplug_memory_fails",
+          "line": 433,
+          "column": 5,
+          "fingerprint": "sha256:10ee8e7fda05c7a255e502e4c44eb374609d864490cc7a701e391c3678134fbf"
+        }
+      },
+      {
+        "ordinal": 155,
+        "id": "static:seccomp.num_faults",
+        "path": "seccomp.num_faults",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:num_faults",
+          "line": 247,
+          "column": 13,
+          "fingerprint": "sha256:44178f41051a5996cbff2e359b3fdaed35fb58909249fbd33de132cf6e3db645"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "SeccompMetrics.num_faults",
+          "line": 660,
+          "column": 5,
+          "fingerprint": "sha256:441e01dd9d256af34e05da888cc84d6bbb90475661886eee68c9e768ac242ea5"
+        }
+      },
+      {
+        "ordinal": 156,
+        "id": "static:vcpu.exit_io_in",
+        "path": "vcpu.exit_io_in",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:exit_io_in",
+          "line": 250,
+          "column": 13,
+          "fingerprint": "sha256:4e9ca011a91ee8a2fcbf2f062cdc3f14804fdfa17574e6c9cc5bff5d7e28b255"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "VcpuMetrics.exit_io_in",
+          "line": 787,
+          "column": 5,
+          "fingerprint": "sha256:7bd132c4576f6bfc297e31a79eb37f3a7e4d2468f62d3b4d6e277dfefd9d3880"
+        }
+      },
+      {
+        "ordinal": 157,
+        "id": "static:vcpu.exit_io_out",
+        "path": "vcpu.exit_io_out",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:exit_io_out",
+          "line": 251,
+          "column": 13,
+          "fingerprint": "sha256:a747d4e97e447a0136a53d8a524cbd383e220785710dd0b646b57b3806d8452a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "VcpuMetrics.exit_io_out",
+          "line": 789,
+          "column": 5,
+          "fingerprint": "sha256:1fcb527e503fad7f10d36b052c47a8ee8bf54cb71af1af6c049d9a9a40da00b9"
+        }
+      },
+      {
+        "ordinal": 158,
+        "id": "static:vcpu.exit_mmio_read",
+        "path": "vcpu.exit_mmio_read",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:exit_mmio_read",
+          "line": 252,
+          "column": 13,
+          "fingerprint": "sha256:035d798403be442b5fe22e5637ba5fd3e1d53afe4a593793a1a024ff98766944"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "VcpuMetrics.exit_mmio_read",
+          "line": 791,
+          "column": 5,
+          "fingerprint": "sha256:e3292773e5fa9b796d2a8c9d3bf0409c6b43202108daa896a1640bdae639f55d"
+        }
+      },
+      {
+        "ordinal": 159,
+        "id": "static:vcpu.exit_mmio_write",
+        "path": "vcpu.exit_mmio_write",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:exit_mmio_write",
+          "line": 253,
+          "column": 13,
+          "fingerprint": "sha256:0b2d9853f15da515bc01ca07b4e23ffa0cf7edcafbd5c571bcfe28fe16c4483c"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "VcpuMetrics.exit_mmio_write",
+          "line": 793,
+          "column": 5,
+          "fingerprint": "sha256:4e085f22c56523ae003901e0e910a74ad9677728c2af205033eb1b547c2cb389"
+        }
+      },
+      {
+        "ordinal": 160,
+        "id": "static:vcpu.failures",
+        "path": "vcpu.failures",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:failures",
+          "line": 254,
+          "column": 13,
+          "fingerprint": "sha256:8e4128d0d75edbe14d8682c356971ee2f18c4e5b6ee7a67035e26722654dbff5"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "VcpuMetrics.failures",
+          "line": 795,
+          "column": 5,
+          "fingerprint": "sha256:0eacba071fdab1f1891ca25e375a54ff4b6755a256adf41573c6bb0d19e2c0d5"
+        }
+      },
+      {
+        "ordinal": 161,
+        "id": "static:vcpu.kvmclock_ctrl_fails",
+        "path": "vcpu.kvmclock_ctrl_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:kvmclock_ctrl_fails",
+          "line": 255,
+          "column": 13,
+          "fingerprint": "sha256:2cfebc6b0172bcb48b555e2404737b968a9d8c6f0d394c12b41623d91550cd11"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "VcpuMetrics.kvmclock_ctrl_fails",
+          "line": 797,
+          "column": 5,
+          "fingerprint": "sha256:0032efcdaed3eeb9900243b3161c81d380fa3a6e0da238e80e6fcece6425b9d2"
+        }
+      },
+      {
+        "ordinal": 162,
+        "id": "static:vcpu.exit_io_in_agg.min_us",
+        "path": "vcpu.exit_io_in_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 163,
+        "id": "static:vcpu.exit_io_in_agg.max_us",
+        "path": "vcpu.exit_io_in_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 164,
+        "id": "static:vcpu.exit_io_in_agg.sum_us",
+        "path": "vcpu.exit_io_in_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 165,
+        "id": "static:vcpu.exit_io_out_agg.min_us",
+        "path": "vcpu.exit_io_out_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 166,
+        "id": "static:vcpu.exit_io_out_agg.max_us",
+        "path": "vcpu.exit_io_out_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 167,
+        "id": "static:vcpu.exit_io_out_agg.sum_us",
+        "path": "vcpu.exit_io_out_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 168,
+        "id": "static:vcpu.exit_mmio_read_agg.min_us",
+        "path": "vcpu.exit_mmio_read_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 169,
+        "id": "static:vcpu.exit_mmio_read_agg.max_us",
+        "path": "vcpu.exit_mmio_read_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 170,
+        "id": "static:vcpu.exit_mmio_read_agg.sum_us",
+        "path": "vcpu.exit_mmio_read_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 171,
+        "id": "static:vcpu.exit_mmio_write_agg.min_us",
+        "path": "vcpu.exit_mmio_write_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 172,
+        "id": "static:vcpu.exit_mmio_write_agg.max_us",
+        "path": "vcpu.exit_mmio_write_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 173,
+        "id": "static:vcpu.exit_mmio_write_agg.sum_us",
+        "path": "vcpu.exit_mmio_write_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 174,
+        "id": "static:vmm.panic_count",
+        "path": "vmm.panic_count",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:panic_count",
+          "line": 262,
+          "column": 13,
+          "fingerprint": "sha256:23a058cc2b391803325861f49824e5d9d18d6b607bca535ebcf5f13215142129"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "VmmMetrics.panic_count",
+          "line": 848,
+          "column": 5,
+          "fingerprint": "sha256:52b6b07934f2135ff20c4eb8cc80f77468ffb87d8118bb22272d2841b3c5983c"
+        }
+      },
+      {
+        "ordinal": 175,
+        "id": "static:signals.sigbus",
+        "path": "signals.sigbus",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sigbus",
+          "line": 274,
+          "column": 13,
+          "fingerprint": "sha256:f388b6f871c0c13f4b53f83ad3de65c098a391c1c9f01eb7a70017604ec2a0cd"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "SignalMetrics.sigbus",
+          "line": 678,
+          "column": 5,
+          "fingerprint": "sha256:7124cf519f66678888e90de9c6a150eaae6c3ecb47a65e726bc6ee4478e650dd"
+        }
+      },
+      {
+        "ordinal": 176,
+        "id": "static:signals.sigsegv",
+        "path": "signals.sigsegv",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sigsegv",
+          "line": 275,
+          "column": 13,
+          "fingerprint": "sha256:fee4849566fd8801d81dcb4b864d92b946359b196189721abcd8755cc029f292"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "SignalMetrics.sigsegv",
+          "line": 680,
+          "column": 5,
+          "fingerprint": "sha256:1ad3db4446424dfd927439b168aedbd14032bcdd47630b80cf8dbee3773fca63"
+        }
+      },
+      {
+        "ordinal": 177,
+        "id": "static:signals.sigxfsz",
+        "path": "signals.sigxfsz",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sigxfsz",
+          "line": 276,
+          "column": 13,
+          "fingerprint": "sha256:2729bdc629ce1fbb9e61eabf778141488ba1479e55b1d6e43402eec25a12dc0c"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "SignalMetrics.sigxfsz",
+          "line": 682,
+          "column": 5,
+          "fingerprint": "sha256:7fa10046afb9bd3bf3f4ea24dd341ddc1ef6650abbe965ec8ac0dacf1d297358"
+        }
+      },
+      {
+        "ordinal": 178,
+        "id": "static:signals.sigxcpu",
+        "path": "signals.sigxcpu",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sigxcpu",
+          "line": 277,
+          "column": 13,
+          "fingerprint": "sha256:ad2994e8d547637ecbd55d7b17662a5b994f7e127a6b0166da59799a1f5e1d31"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "SignalMetrics.sigxcpu",
+          "line": 684,
+          "column": 5,
+          "fingerprint": "sha256:ee3f7050b3f031255c327270f3b5e22276da0f5902f497eada55c9ea13be969c"
+        }
+      },
+      {
+        "ordinal": 179,
+        "id": "static:signals.sigpipe",
+        "path": "signals.sigpipe",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sigpipe",
+          "line": 278,
+          "column": 13,
+          "fingerprint": "sha256:8c1084db28b8d68f86134e03541d733e185fda3cb3099e2d1a730fd85bb86c92"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "SignalMetrics.sigpipe",
+          "line": 686,
+          "column": 5,
+          "fingerprint": "sha256:a123ee31b2837a8e1ceb39e61d2dcbd6c4ee3a2210f7a31823c08fc9c026b40b"
+        }
+      },
+      {
+        "ordinal": 180,
+        "id": "static:signals.sighup",
+        "path": "signals.sighup",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sighup",
+          "line": 279,
+          "column": 13,
+          "fingerprint": "sha256:95976fe1f53ad56e5fde9275fbb58ba00e517d84e9d299d814bcd8bc70cb46f9"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "SignalMetrics.sighup",
+          "line": 688,
+          "column": 5,
+          "fingerprint": "sha256:c1771b9dfeb5edfbc49d23d833a4b5d78af86cf19eb2ae139fb623ea35be9252"
+        }
+      },
+      {
+        "ordinal": 181,
+        "id": "static:signals.sigill",
+        "path": "signals.sigill",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sigill",
+          "line": 280,
+          "column": 13,
+          "fingerprint": "sha256:1e928aac4f7e8c417789eafb96879450eedc1185e652a5aaed1a0143bb74a475"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "SignalMetrics.sigill",
+          "line": 690,
+          "column": 5,
+          "fingerprint": "sha256:b718866265cd74bf8e00b3d22340748996f1bc578b6d8eabc00195bb75f233c0"
+        }
+      },
+      {
+        "ordinal": 182,
+        "id": "static:vsock.activate_fails",
+        "path": "vsock.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 283,
+          "column": 13,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.activate_fails",
+          "line": 57,
+          "column": 5,
+          "fingerprint": "sha256:45dc508f60c03068d92e0355e7dbe4c208ffac9c4a575d31b7b744f0c5c0391e"
+        }
+      },
+      {
+        "ordinal": 183,
+        "id": "static:vsock.cfg_fails",
+        "path": "vsock.cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:cfg_fails",
+          "line": 284,
+          "column": 13,
+          "fingerprint": "sha256:ddf6ccea8ce5f2e735df611b679382a9746297209cd37172297a36975bfbc8e4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.cfg_fails",
+          "line": 59,
+          "column": 5,
+          "fingerprint": "sha256:b61695fa75171c3ca67717ec768c90205219328108113122de8d97a6c250f0ea"
+        }
+      },
+      {
+        "ordinal": 184,
+        "id": "static:vsock.rx_queue_event_fails",
+        "path": "vsock.rx_queue_event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_queue_event_fails",
+          "line": 285,
+          "column": 13,
+          "fingerprint": "sha256:3adf22502a15694d58b203ccb05b1bb246137bdae785f5ffb10f8e2d6b74481f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.rx_queue_event_fails",
+          "line": 61,
+          "column": 5,
+          "fingerprint": "sha256:3f15886da34ee156260a6036dd319a3b15e5e64e73087ee958d19d23f57f1a6d"
+        }
+      },
+      {
+        "ordinal": 185,
+        "id": "static:vsock.tx_queue_event_fails",
+        "path": "vsock.tx_queue_event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_queue_event_fails",
+          "line": 286,
+          "column": 13,
+          "fingerprint": "sha256:44da04f2b48c5ebed233354a636a9368bb49ae1fdc134506e403501d7b0708c0"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.tx_queue_event_fails",
+          "line": 63,
+          "column": 5,
+          "fingerprint": "sha256:b5f663a9f14c836094b86432a92f3298196016e2f0f8839530d850363289ec6b"
+        }
+      },
+      {
+        "ordinal": 186,
+        "id": "static:vsock.ev_queue_event_fails",
+        "path": "vsock.ev_queue_event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:ev_queue_event_fails",
+          "line": 287,
+          "column": 13,
+          "fingerprint": "sha256:be788e19c17dda8692fc57b011f68fbc6cf1e2647afc5559251811640eca1c8b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.ev_queue_event_fails",
+          "line": 65,
+          "column": 5,
+          "fingerprint": "sha256:ffbd82f6ca790c6e04a0ccd32203649d5872cfa052f646df97415e4b54c299b6"
+        }
+      },
+      {
+        "ordinal": 187,
+        "id": "static:vsock.muxer_event_fails",
+        "path": "vsock.muxer_event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:muxer_event_fails",
+          "line": 288,
+          "column": 13,
+          "fingerprint": "sha256:cb8dc1fcc45ebd90fdf89187b0f87d3a017bbe08678544463a1b31e2422bb0a2"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.muxer_event_fails",
+          "line": 67,
+          "column": 5,
+          "fingerprint": "sha256:7d3a9cfe2877019ae09c23a905c7c89a52ccebbad9035b5ddaa06446a39a2e31"
+        }
+      },
+      {
+        "ordinal": 188,
+        "id": "static:vsock.conn_event_fails",
+        "path": "vsock.conn_event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:conn_event_fails",
+          "line": 289,
+          "column": 13,
+          "fingerprint": "sha256:9e00e1143d1a6fa77357f3adda76f554624335074ddbf6811f1d7ca34b6a0164"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.conn_event_fails",
+          "line": 69,
+          "column": 5,
+          "fingerprint": "sha256:31a445cdcf28f203c2fd45623040a5dda35134bc4ad491bff9e9b4c14e469d56"
+        }
+      },
+      {
+        "ordinal": 189,
+        "id": "static:vsock.rx_queue_event_count",
+        "path": "vsock.rx_queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_queue_event_count",
+          "line": 290,
+          "column": 13,
+          "fingerprint": "sha256:f60ad03226f86eb2e874f9b9dd39208b066e0a705d682adcb576f6f34dd7d48a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.rx_queue_event_count",
+          "line": 71,
+          "column": 5,
+          "fingerprint": "sha256:c4bbd22125da5c390344c321540faaeef83c679f7dd7e185216e055b2167ac38"
+        }
+      },
+      {
+        "ordinal": 190,
+        "id": "static:vsock.tx_queue_event_count",
+        "path": "vsock.tx_queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_queue_event_count",
+          "line": 291,
+          "column": 13,
+          "fingerprint": "sha256:3dd397e2fc51a3f3c1ce5c618515c56b160c75367dcf44dd9f15e608736f83c3"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.tx_queue_event_count",
+          "line": 73,
+          "column": 5,
+          "fingerprint": "sha256:efee9a2b38f5122a6a2a88d3b2e8312c7e52d9d13089bd4af5ec14a7da9babb2"
+        }
+      },
+      {
+        "ordinal": 191,
+        "id": "static:vsock.rx_bytes_count",
+        "path": "vsock.rx_bytes_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_bytes_count",
+          "line": 292,
+          "column": 13,
+          "fingerprint": "sha256:c46e1d8621e8290212400a1d437a94ea08474454c79bc3377e14fdbedbdc5ae5"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.rx_bytes_count",
+          "line": 75,
+          "column": 5,
+          "fingerprint": "sha256:7933a7942857d10b360f152c4feb84b8ec8c26ab4f8886fa2569d22b7bd34082"
+        }
+      },
+      {
+        "ordinal": 192,
+        "id": "static:vsock.tx_bytes_count",
+        "path": "vsock.tx_bytes_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_bytes_count",
+          "line": 293,
+          "column": 13,
+          "fingerprint": "sha256:cd470e94bc651b5d8eeb47c9238b775be646265969d1841a733c85d50ce3b1d1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.tx_bytes_count",
+          "line": 77,
+          "column": 5,
+          "fingerprint": "sha256:75fda4340f29f55e844856e8025dd45926da7be3c6f496799231af77fc11a3fc"
+        }
+      },
+      {
+        "ordinal": 193,
+        "id": "static:vsock.rx_packets_count",
+        "path": "vsock.rx_packets_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_packets_count",
+          "line": 294,
+          "column": 13,
+          "fingerprint": "sha256:f56f99b197b295d3734cf636eda998f16acc39da1e996bf2fc668d912f0054f2"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.rx_packets_count",
+          "line": 79,
+          "column": 5,
+          "fingerprint": "sha256:326d18233e88330c95e7a97709fe08fb60e60fab340ca85b57a603796265ba9a"
+        }
+      },
+      {
+        "ordinal": 194,
+        "id": "static:vsock.tx_packets_count",
+        "path": "vsock.tx_packets_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_packets_count",
+          "line": 295,
+          "column": 13,
+          "fingerprint": "sha256:8203eccfbd7be213263d324b3764df310788a1a386a9342c56778f2c07e5dec9"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.tx_packets_count",
+          "line": 81,
+          "column": 5,
+          "fingerprint": "sha256:d19d3a52f3f85d63e1c4c9e814de0bf7ff36a5499c24fe870df21abff02c3b3a"
+        }
+      },
+      {
+        "ordinal": 195,
+        "id": "static:vsock.conns_added",
+        "path": "vsock.conns_added",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:conns_added",
+          "line": 296,
+          "column": 13,
+          "fingerprint": "sha256:8da0af5283a491cd94c516892a29ce4cf149541182e055ae56f89d29f0476d04"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.conns_added",
+          "line": 83,
+          "column": 5,
+          "fingerprint": "sha256:3df6f071d7f32d30d555b1f87ace39a94b89ca62272a87c7d6d91fa9f23b237f"
+        }
+      },
+      {
+        "ordinal": 196,
+        "id": "static:vsock.conns_killed",
+        "path": "vsock.conns_killed",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:conns_killed",
+          "line": 297,
+          "column": 13,
+          "fingerprint": "sha256:6ae603dd6766bc7b8cb09db0561894c61153444be4fa8d73a4e866713094a611"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.conns_killed",
+          "line": 85,
+          "column": 5,
+          "fingerprint": "sha256:023a799d0f907fb2591bac777af32a029dfb800ddfad623ed2322288263b4346"
+        }
+      },
+      {
+        "ordinal": 197,
+        "id": "static:vsock.conns_removed",
+        "path": "vsock.conns_removed",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:conns_removed",
+          "line": 298,
+          "column": 13,
+          "fingerprint": "sha256:70972bad3653c6d6f696c0f8e07fb2de94d3a9d5c5a333503a9f203a76234a93"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.conns_removed",
+          "line": 87,
+          "column": 5,
+          "fingerprint": "sha256:7e51afe20cf167d93eaedd7d7ac41b1a27175333245e2b55d66a0426d8f20e91"
+        }
+      },
+      {
+        "ordinal": 198,
+        "id": "static:vsock.killq_resync",
+        "path": "vsock.killq_resync",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:killq_resync",
+          "line": 299,
+          "column": 13,
+          "fingerprint": "sha256:1a0cc615843df401d76e99cf8515a3da3f4d048c80d046e425e224d8a755c029"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.killq_resync",
+          "line": 89,
+          "column": 5,
+          "fingerprint": "sha256:032391f9e1c31279226b2f7bdf1923cf406fb1553bae41a6b537f2f208291be6"
+        }
+      },
+      {
+        "ordinal": 199,
+        "id": "static:vsock.tx_flush_fails",
+        "path": "vsock.tx_flush_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_flush_fails",
+          "line": 300,
+          "column": 13,
+          "fingerprint": "sha256:bf0dc7921eab1eaf9d301c29cfefaf301146992fb51c565e3c5c43ae0aa758c6"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.tx_flush_fails",
+          "line": 91,
+          "column": 5,
+          "fingerprint": "sha256:7eda8e3d9c152b49a48124e8ae25ccf2c85d500524cf5e6f2593b04d35c67135"
+        }
+      },
+      {
+        "ordinal": 200,
+        "id": "static:vsock.tx_write_fails",
+        "path": "vsock.tx_write_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_write_fails",
+          "line": 301,
+          "column": 13,
+          "fingerprint": "sha256:c35f8632ed78866188d760b02b69cac6130a5854339cd726f8de25bd55b7715e"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.tx_write_fails",
+          "line": 93,
+          "column": 5,
+          "fingerprint": "sha256:79e38cc9fddf8866f3f37708e388bd6ac39da555f3b8c5e567868d377ed50d20"
+        }
+      },
+      {
+        "ordinal": 201,
+        "id": "static:vsock.rx_read_fails",
+        "path": "vsock.rx_read_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_read_fails",
+          "line": 302,
+          "column": 13,
+          "fingerprint": "sha256:732fb9abda37d83cc45b2353bbc79d8a134509e8f316ac1fa51416dec1a06f3f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vsock/metrics.rs",
+          "symbol": "VsockDeviceMetrics.rx_read_fails",
+          "line": 95,
+          "column": 5,
+          "fingerprint": "sha256:bc7ccdfea2efe54b511c9b65582bcec614cc2304b6f640629ba95ebff99ff4ea"
+        }
+      },
+      {
+        "ordinal": 202,
+        "id": "static:entropy.activate_fails",
+        "path": "entropy.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 305,
+          "column": 13,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/rng/metrics.rs",
+          "symbol": "EntropyDeviceMetrics.activate_fails",
+          "line": 53,
+          "column": 5,
+          "fingerprint": "sha256:8821d3ff518a223d9ae1e796816a4ca1e79d8327788e7b5b8863ae75a787b979"
+        }
+      },
+      {
+        "ordinal": 203,
+        "id": "static:entropy.entropy_event_fails",
+        "path": "entropy.entropy_event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:entropy_event_fails",
+          "line": 306,
+          "column": 13,
+          "fingerprint": "sha256:c271c640103ac5e015dcc839d529eb245e3f20ae4acda10130c1c40ce31340ec"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/rng/metrics.rs",
+          "symbol": "EntropyDeviceMetrics.entropy_event_fails",
+          "line": 55,
+          "column": 5,
+          "fingerprint": "sha256:d227024c663148938d9a677a7a5055f4af1525e660d4e10a29001201c15ead1d"
+        }
+      },
+      {
+        "ordinal": 204,
+        "id": "static:entropy.entropy_event_count",
+        "path": "entropy.entropy_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:entropy_event_count",
+          "line": 307,
+          "column": 13,
+          "fingerprint": "sha256:3429f92367baafd88e0636c2329163b240f3f9484bd93f1ec5b82d52b52085d1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/rng/metrics.rs",
+          "symbol": "EntropyDeviceMetrics.entropy_event_count",
+          "line": 57,
+          "column": 5,
+          "fingerprint": "sha256:80b185c206d18d8ebba15c3e3dac693b2961c5b1999d6506420f2aba46985b94"
+        }
+      },
+      {
+        "ordinal": 205,
+        "id": "static:entropy.entropy_bytes",
+        "path": "entropy.entropy_bytes",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:entropy_bytes",
+          "line": 308,
+          "column": 13,
+          "fingerprint": "sha256:69db933f85c6301e498c7f5f55c6b7659ef2f15625ce4af0d3955219fdfe7a2e"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/rng/metrics.rs",
+          "symbol": "EntropyDeviceMetrics.entropy_bytes",
+          "line": 59,
+          "column": 5,
+          "fingerprint": "sha256:56c1e78ed3b08ad2099e740357f2dbf6c3a8bd749296a2a82ac1b4bbc05ecb27"
+        }
+      },
+      {
+        "ordinal": 206,
+        "id": "static:entropy.host_rng_fails",
+        "path": "entropy.host_rng_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:host_rng_fails",
+          "line": 309,
+          "column": 13,
+          "fingerprint": "sha256:f2008a9b45fea675015eb21272d820b5ea29b0fa4e16801f557cd7eb9a27a4c9"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/rng/metrics.rs",
+          "symbol": "EntropyDeviceMetrics.host_rng_fails",
+          "line": 61,
+          "column": 5,
+          "fingerprint": "sha256:332fab0cb8760704a4810673a22ae1f29580b42239a3e92dff5ea88aace64632"
+        }
+      },
+      {
+        "ordinal": 207,
+        "id": "static:entropy.entropy_rate_limiter_throttled",
+        "path": "entropy.entropy_rate_limiter_throttled",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:entropy_rate_limiter_throttled",
+          "line": 310,
+          "column": 13,
+          "fingerprint": "sha256:d7bc7b7d25d7da044b5c848b70db9764b322bd5f4cf485605db582a1061c223b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/rng/metrics.rs",
+          "symbol": "EntropyDeviceMetrics.entropy_rate_limiter_throttled",
+          "line": 63,
+          "column": 5,
+          "fingerprint": "sha256:e76a0332e66ce406c9729876c8732185ecad7261a12bc25ea43e3cea658a491e"
+        }
+      },
+      {
+        "ordinal": 208,
+        "id": "static:entropy.rate_limiter_event_count",
+        "path": "entropy.rate_limiter_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rate_limiter_event_count",
+          "line": 311,
+          "column": 13,
+          "fingerprint": "sha256:47bbc1808028b853194b35f7b105b7654a31703035c2f5c679a5b99d53ad6ffb"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/rng/metrics.rs",
+          "symbol": "EntropyDeviceMetrics.rate_limiter_event_count",
+          "line": 65,
+          "column": 5,
+          "fingerprint": "sha256:a09806fe6f5d8ebf78cb5b467576e6f0b76d313b6ee76f0ade90f34ef3782c15"
+        }
+      },
+      {
+        "ordinal": 209,
+        "id": "static:pmem.activate_fails",
+        "path": "pmem.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 315,
+          "column": 13,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+          "symbol": "PmemMetrics.activate_fails",
+          "line": 146,
+          "column": 5,
+          "fingerprint": "sha256:a14a6f74b88bdb2d5eab052c6ac3fa2e660076dcd11317a42410930ea212da2e"
+        }
+      },
+      {
+        "ordinal": 210,
+        "id": "static:pmem.cfg_fails",
+        "path": "pmem.cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:cfg_fails",
+          "line": 316,
+          "column": 13,
+          "fingerprint": "sha256:ddf6ccea8ce5f2e735df611b679382a9746297209cd37172297a36975bfbc8e4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+          "symbol": "PmemMetrics.cfg_fails",
+          "line": 148,
+          "column": 5,
+          "fingerprint": "sha256:4b1a689fe9a53c5e462050f11f6d07c1af51a7c3e014d76c848223fd4c1cb641"
+        }
+      },
+      {
+        "ordinal": 211,
+        "id": "static:pmem.event_fails",
+        "path": "pmem.event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:event_fails",
+          "line": 317,
+          "column": 13,
+          "fingerprint": "sha256:af808eac4d6aeffe1c5fc8f67a3a735f7f571acf68499b409872222ff7292154"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+          "symbol": "PmemMetrics.event_fails",
+          "line": 150,
+          "column": 5,
+          "fingerprint": "sha256:af84f706bfea009c8a9d19c2d7be8134c9a4b20dbbdd3483b9e95c7b5d87d050"
+        }
+      },
+      {
+        "ordinal": 212,
+        "id": "static:pmem.queue_event_count",
+        "path": "pmem.queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:queue_event_count",
+          "line": 318,
+          "column": 13,
+          "fingerprint": "sha256:c6df276e377d4594d51232bd6a88d40ff9de98fdc8d957cd6551951b7f7a5828"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+          "symbol": "PmemMetrics.queue_event_count",
+          "line": 152,
+          "column": 5,
+          "fingerprint": "sha256:b2b5d333e2cc3284ff6250eaae894351a0623682a357a46f0117d3cc5983a79d"
+        }
+      },
+      {
+        "ordinal": 213,
+        "id": "static:pmem.rate_limiter_throttled_events",
+        "path": "pmem.rate_limiter_throttled_events",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rate_limiter_throttled_events",
+          "line": 319,
+          "column": 13,
+          "fingerprint": "sha256:a15942a55baf426c576a5a146cff20f181c315fabca034a0dbeb98abef1e9bf7"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+          "symbol": "PmemMetrics.rate_limiter_throttled_events",
+          "line": 154,
+          "column": 5,
+          "fingerprint": "sha256:f4d6f3e7f66c1cfcc96ecbd3bf40b599151711bab4b39ae133e06bcede14304b"
+        }
+      },
+      {
+        "ordinal": 214,
+        "id": "static:pmem.rate_limiter_event_count",
+        "path": "pmem.rate_limiter_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rate_limiter_event_count",
+          "line": 320,
+          "column": 13,
+          "fingerprint": "sha256:47bbc1808028b853194b35f7b105b7654a31703035c2f5c679a5b99d53ad6ffb"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+          "symbol": "PmemMetrics.rate_limiter_event_count",
+          "line": 156,
+          "column": 5,
+          "fingerprint": "sha256:cca569cf6880b6610e82baac5e5e3d519455dfdb0ea1e05fa6ce185921a4bb79"
+        }
+      },
+      {
+        "ordinal": 215,
+        "id": "static:interrupts.triggers",
+        "path": "interrupts.triggers",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:triggers",
+          "line": 313,
+          "column": 24,
+          "fingerprint": "sha256:fc02f970573a5c59d5a05ff0a77786e4970b5aac23d47e142fb60963ebd0af21"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "InterruptMetrics.triggers",
+          "line": 829,
+          "column": 5,
+          "fingerprint": "sha256:b7546a76e91c301cca274890cdcf5b1e37d0b54662122cdfe010de79e37c37d7"
+        }
+      },
+      {
+        "ordinal": 216,
+        "id": "static:interrupts.config_updates",
+        "path": "interrupts.config_updates",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:config_updates",
+          "line": 313,
+          "column": 36,
+          "fingerprint": "sha256:47e739a95dbf296b0b88161d6f9c35f94d7639ce9bfe76610d2fb1cbd3c26589"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "InterruptMetrics.config_updates",
+          "line": 831,
+          "column": 5,
+          "fingerprint": "sha256:77bfa5541753cfff4b77d2a85510d83fb5dcbbdb0f5b6cbffa8c9c4398c37ff6"
+        }
+      },
+      {
+        "ordinal": 217,
+        "id": "static:memory_hotplug.activate_fails",
+        "path": "memory_hotplug.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 323,
+          "column": 13,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.activate_fails",
+          "line": 42,
+          "column": 5,
+          "fingerprint": "sha256:8821d3ff518a223d9ae1e796816a4ca1e79d8327788e7b5b8863ae75a787b979"
+        }
+      },
+      {
+        "ordinal": 218,
+        "id": "static:memory_hotplug.queue_event_fails",
+        "path": "memory_hotplug.queue_event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:queue_event_fails",
+          "line": 324,
+          "column": 13,
+          "fingerprint": "sha256:2a6913cad70635ce249e47be21a042cb046d072c23687f26cc050af97456549a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.queue_event_fails",
+          "line": 44,
+          "column": 5,
+          "fingerprint": "sha256:03c424ecbe271f07351170430a883c2bc9aa8180a81a247181d32c53a7a6478f"
+        }
+      },
+      {
+        "ordinal": 219,
+        "id": "static:memory_hotplug.queue_event_count",
+        "path": "memory_hotplug.queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:queue_event_count",
+          "line": 325,
+          "column": 13,
+          "fingerprint": "sha256:c6df276e377d4594d51232bd6a88d40ff9de98fdc8d957cd6551951b7f7a5828"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.queue_event_count",
+          "line": 46,
+          "column": 5,
+          "fingerprint": "sha256:f4832de19652c35974cc2a962015878037f6b2460d04dd6363e63bacf74e7c8c"
+        }
+      },
+      {
+        "ordinal": 220,
+        "id": "static:memory_hotplug.plug_agg.min_us",
+        "path": "memory_hotplug.plug_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 221,
+        "id": "static:memory_hotplug.plug_agg.max_us",
+        "path": "memory_hotplug.plug_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 222,
+        "id": "static:memory_hotplug.plug_agg.sum_us",
+        "path": "memory_hotplug.plug_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 223,
+        "id": "static:memory_hotplug.plug_count",
+        "path": "memory_hotplug.plug_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:plug_count",
+          "line": 326,
+          "column": 13,
+          "fingerprint": "sha256:1499bae6f7b0206a0c1066e96b6ee1a32f3905246204b5619bd00c897ac60a0c"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.plug_count",
+          "line": 50,
+          "column": 5,
+          "fingerprint": "sha256:533e9e6b09c1b051140f019cd2f9ed7b2726ab61a23ad59b32ef05b5309b5205"
+        }
+      },
+      {
+        "ordinal": 224,
+        "id": "static:memory_hotplug.plug_bytes",
+        "path": "memory_hotplug.plug_bytes",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:plug_bytes",
+          "line": 327,
+          "column": 13,
+          "fingerprint": "sha256:04ae29bbcf82786d02390cb27522776f587f3c1a8c9dfc89501bc5306e7bde4d"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.plug_bytes",
+          "line": 52,
+          "column": 5,
+          "fingerprint": "sha256:fb8091f1ef973ff023a1383710505a1aa8ccaa046183933077e8222b10d3f17d"
+        }
+      },
+      {
+        "ordinal": 225,
+        "id": "static:memory_hotplug.plug_fails",
+        "path": "memory_hotplug.plug_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:plug_fails",
+          "line": 328,
+          "column": 13,
+          "fingerprint": "sha256:a53ef20e3611ee16678e35bd395b5f47e637eb9f1ae738ff9ebf1bd6597f50a7"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.plug_fails",
+          "line": 54,
+          "column": 5,
+          "fingerprint": "sha256:34ab183d3a59e12e7299c3fd8287a4f8a9d280735a747532c1a8d851f96f8f40"
+        }
+      },
+      {
+        "ordinal": 226,
+        "id": "static:memory_hotplug.unplug_agg.min_us",
+        "path": "memory_hotplug.unplug_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 227,
+        "id": "static:memory_hotplug.unplug_agg.max_us",
+        "path": "memory_hotplug.unplug_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 228,
+        "id": "static:memory_hotplug.unplug_agg.sum_us",
+        "path": "memory_hotplug.unplug_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 229,
+        "id": "static:memory_hotplug.unplug_count",
+        "path": "memory_hotplug.unplug_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:unplug_count",
+          "line": 330,
+          "column": 13,
+          "fingerprint": "sha256:0fc6f2eb9ad3b494f1562e5e5c3ab77e990d878abc9c9aa720ba2556e6baf41d"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.unplug_count",
+          "line": 58,
+          "column": 5,
+          "fingerprint": "sha256:04895137ff12886c658c3e89464bedefb43aacb45f1280fb717fba68c6257940"
+        }
+      },
+      {
+        "ordinal": 230,
+        "id": "static:memory_hotplug.unplug_bytes",
+        "path": "memory_hotplug.unplug_bytes",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:unplug_bytes",
+          "line": 331,
+          "column": 13,
+          "fingerprint": "sha256:988c5638bc69fa4953965e47eea39869bbc9cfd9bf8e4e150a8939d1cd377bfd"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.unplug_bytes",
+          "line": 60,
+          "column": 5,
+          "fingerprint": "sha256:5863065c2cd0df5a968662a8b3ce764a1becc5938da79305d49802146ed88b54"
+        }
+      },
+      {
+        "ordinal": 231,
+        "id": "static:memory_hotplug.unplug_fails",
+        "path": "memory_hotplug.unplug_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:unplug_fails",
+          "line": 332,
+          "column": 13,
+          "fingerprint": "sha256:81fbda8c588bb3285b2b02641df0fca6e63893a9d393c710b325e245582bc8d3"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.unplug_fails",
+          "line": 62,
+          "column": 5,
+          "fingerprint": "sha256:fc84c4a8c6fee323b84dc8421357d2421f9da269cbf0b4a00af00bc6b08da4da"
+        }
+      },
+      {
+        "ordinal": 232,
+        "id": "static:memory_hotplug.unplug_discard_fails",
+        "path": "memory_hotplug.unplug_discard_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:unplug_discard_fails",
+          "line": 333,
+          "column": 13,
+          "fingerprint": "sha256:3089f04e4d8a9c415723ce6d0a7c12cdaa828d728730ee091d804929f1f8f0c0"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.unplug_discard_fails",
+          "line": 64,
+          "column": 5,
+          "fingerprint": "sha256:7db85fdcd1282551c54cc52fc74c733de65e767a082742c59c03f777ec531e4a"
+        }
+      },
+      {
+        "ordinal": 233,
+        "id": "static:memory_hotplug.unplug_all_agg.min_us",
+        "path": "memory_hotplug.unplug_all_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 234,
+        "id": "static:memory_hotplug.unplug_all_agg.max_us",
+        "path": "memory_hotplug.unplug_all_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 235,
+        "id": "static:memory_hotplug.unplug_all_agg.sum_us",
+        "path": "memory_hotplug.unplug_all_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 236,
+        "id": "static:memory_hotplug.unplug_all_count",
+        "path": "memory_hotplug.unplug_all_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:unplug_all_count",
+          "line": 338,
+          "column": 13,
+          "fingerprint": "sha256:358cd8ef0f58881c81e86e8e2d58931cc9f8156116cf9af29c0b4de96652f313"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.unplug_all_count",
+          "line": 68,
+          "column": 5,
+          "fingerprint": "sha256:601d2a5e638b2ab0fc378ff53a788da92108abcc2e5cff38d56cc86b4850fab9"
+        }
+      },
+      {
+        "ordinal": 237,
+        "id": "static:memory_hotplug.unplug_all_fails",
+        "path": "memory_hotplug.unplug_all_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:unplug_all_fails",
+          "line": 339,
+          "column": 13,
+          "fingerprint": "sha256:7855bea574a114b246b51156fab609964144b26950a60cedda7449effce350b8"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.unplug_all_fails",
+          "line": 70,
+          "column": 5,
+          "fingerprint": "sha256:c665ed40c5b9c07d24d69c5e1eaf2646567f95f0da3fe9c953b928846ef0c54d"
+        }
+      },
+      {
+        "ordinal": 238,
+        "id": "static:memory_hotplug.state_agg.min_us",
+        "path": "memory_hotplug.state_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 239,
+        "id": "static:memory_hotplug.state_agg.max_us",
+        "path": "memory_hotplug.state_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 240,
+        "id": "static:memory_hotplug.state_agg.sum_us",
+        "path": "memory_hotplug.state_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 241,
+        "id": "static:memory_hotplug.state_count",
+        "path": "memory_hotplug.state_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:state_count",
+          "line": 335,
+          "column": 13,
+          "fingerprint": "sha256:cd68037135dc39814fe326fbcc52e17ed955f5d4cec5588eea8ae60024f0134a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.state_count",
+          "line": 74,
+          "column": 5,
+          "fingerprint": "sha256:9a5755cdccd409ae70d0e1aff3f29653bb58715857f5e355be6bfb476cef2087"
+        }
+      },
+      {
+        "ordinal": 242,
+        "id": "static:memory_hotplug.state_fails",
+        "path": "memory_hotplug.state_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:state_fails",
+          "line": 336,
+          "column": 13,
+          "fingerprint": "sha256:02ef3d8acf6c1fcaaa08ff62a64a9c11b1ca9169ad8f3e4d706b70c2522a6539"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/mem/metrics.rs",
+          "symbol": "VirtioMemDeviceMetrics.state_fails",
+          "line": 76,
+          "column": 5,
+          "fingerprint": "sha256:6758ac17d7172a1a01036f75ac9dd27341ba25e532cd746ac329887fa543eb63"
+        }
+      },
+      {
+        "ordinal": 243,
+        "id": "dynamic:block_{drive_id}.activate_fails",
+        "path": "block_{drive_id}.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 81,
+          "column": 9,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.activate_fails",
+          "line": 146,
+          "column": 5,
+          "fingerprint": "sha256:d0faa9177e126ccc4c117fd3f17b242ab2e64d29fdcba624c3fe648776c73140"
+        }
+      },
+      {
+        "ordinal": 244,
+        "id": "dynamic:block_{drive_id}.cfg_fails",
+        "path": "block_{drive_id}.cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:cfg_fails",
+          "line": 82,
+          "column": 9,
+          "fingerprint": "sha256:ddf6ccea8ce5f2e735df611b679382a9746297209cd37172297a36975bfbc8e4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.cfg_fails",
+          "line": 148,
+          "column": 5,
+          "fingerprint": "sha256:1d20e600e190b9ccc33a8d36276aae832d3cea2dfef5a744b6d6758023eae958"
+        }
+      },
+      {
+        "ordinal": 245,
+        "id": "dynamic:block_{drive_id}.no_avail_buffer",
+        "path": "block_{drive_id}.no_avail_buffer",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:no_avail_buffer",
+          "line": 83,
+          "column": 9,
+          "fingerprint": "sha256:c4b08df3e09e11ff716de2102c61a0f5c57431ba2e95d7c1e738cc51cddcf756"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.no_avail_buffer",
+          "line": 150,
+          "column": 5,
+          "fingerprint": "sha256:82ab57968af118789495b487c180ce9d4c4e335935f07f4248794b507703568b"
+        }
+      },
+      {
+        "ordinal": 246,
+        "id": "dynamic:block_{drive_id}.event_fails",
+        "path": "block_{drive_id}.event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:event_fails",
+          "line": 84,
+          "column": 9,
+          "fingerprint": "sha256:af808eac4d6aeffe1c5fc8f67a3a735f7f571acf68499b409872222ff7292154"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.event_fails",
+          "line": 152,
+          "column": 5,
+          "fingerprint": "sha256:b2cae36491b21ff690c614dd823553ad87145b80eb9519028c3b998b79daf3e8"
+        }
+      },
+      {
+        "ordinal": 247,
+        "id": "dynamic:block_{drive_id}.execute_fails",
+        "path": "block_{drive_id}.execute_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:execute_fails",
+          "line": 85,
+          "column": 9,
+          "fingerprint": "sha256:209e2f3512f8ec0a84f3f5f6bc10d2e2a8173d0878a0ea3a571ed1ebb3108e3c"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.execute_fails",
+          "line": 154,
+          "column": 5,
+          "fingerprint": "sha256:6787fe87623831b31ccfc6c5a51ea854eded031ddc658e9488d0b0169de4122b"
+        }
+      },
+      {
+        "ordinal": 248,
+        "id": "dynamic:block_{drive_id}.invalid_reqs_count",
+        "path": "block_{drive_id}.invalid_reqs_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:invalid_reqs_count",
+          "line": 86,
+          "column": 9,
+          "fingerprint": "sha256:d798ca023381f26d428427ba184a8940e43641639420310b5d73528be3bbf6e2"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.invalid_reqs_count",
+          "line": 156,
+          "column": 5,
+          "fingerprint": "sha256:a2493b4f93bda4bad7e5a6d8b0bf5aadfc564b08501261e6be1b4600a9dca5d5"
+        }
+      },
+      {
+        "ordinal": 249,
+        "id": "dynamic:block_{drive_id}.flush_count",
+        "path": "block_{drive_id}.flush_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:flush_count",
+          "line": 87,
+          "column": 9,
+          "fingerprint": "sha256:a8a330c6ee94d8e4311bc3860de7734d800835f8de6828bf24df1eb5688ff36a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.flush_count",
+          "line": 158,
+          "column": 5,
+          "fingerprint": "sha256:f72c48ebd323479198987ff23457027a734f5b97f9bbbac7d8f92c1085fabb6f"
+        }
+      },
+      {
+        "ordinal": 250,
+        "id": "dynamic:block_{drive_id}.queue_event_count",
+        "path": "block_{drive_id}.queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:queue_event_count",
+          "line": 88,
+          "column": 9,
+          "fingerprint": "sha256:c6df276e377d4594d51232bd6a88d40ff9de98fdc8d957cd6551951b7f7a5828"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.queue_event_count",
+          "line": 160,
+          "column": 5,
+          "fingerprint": "sha256:f33bc18df961dfabb65cb649e7796d13b6ab450146a8ae7387344a070e6a0a85"
+        }
+      },
+      {
+        "ordinal": 251,
+        "id": "dynamic:block_{drive_id}.rate_limiter_event_count",
+        "path": "block_{drive_id}.rate_limiter_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rate_limiter_event_count",
+          "line": 89,
+          "column": 9,
+          "fingerprint": "sha256:47bbc1808028b853194b35f7b105b7654a31703035c2f5c679a5b99d53ad6ffb"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.rate_limiter_event_count",
+          "line": 162,
+          "column": 5,
+          "fingerprint": "sha256:05c66851865d4fccf91d80966f8fe720b0581ec2ffbde255e1a5bf35ade902ea"
+        }
+      },
+      {
+        "ordinal": 252,
+        "id": "dynamic:block_{drive_id}.update_count",
+        "path": "block_{drive_id}.update_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:update_count",
+          "line": 90,
+          "column": 9,
+          "fingerprint": "sha256:9d2a199e953e7c1e22b6a2953f04fdc7ad8def493b42934187299b30fb187da0"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.update_count",
+          "line": 164,
+          "column": 5,
+          "fingerprint": "sha256:c2186ce2966221c59caf039f7cd3db9f13e8f53e2f15df3f6ed82df5760518bb"
+        }
+      },
+      {
+        "ordinal": 253,
+        "id": "dynamic:block_{drive_id}.update_fails",
+        "path": "block_{drive_id}.update_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:update_fails",
+          "line": 91,
+          "column": 9,
+          "fingerprint": "sha256:15b8632ec5ff761f4b751b37a79175de601b0a5cdd7eec811563b7097cace668"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.update_fails",
+          "line": 166,
+          "column": 5,
+          "fingerprint": "sha256:0ba36387296cd931e6736c198fe0ee789c03dd6bc6e82e6a480be82f6f9d91ab"
+        }
+      },
+      {
+        "ordinal": 254,
+        "id": "dynamic:block_{drive_id}.read_bytes",
+        "path": "block_{drive_id}.read_bytes",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:read_bytes",
+          "line": 92,
+          "column": 9,
+          "fingerprint": "sha256:7e06cfe49ff3038a98ca232f81f6b9e7c44341255894e0fdbdd7ab97220b13d1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.read_bytes",
+          "line": 168,
+          "column": 5,
+          "fingerprint": "sha256:801deaf8f2e1ba22d2efe02c1b6c6bd98df3dd435ddbcbeffaad918bdf6f5c72"
+        }
+      },
+      {
+        "ordinal": 255,
+        "id": "dynamic:block_{drive_id}.write_bytes",
+        "path": "block_{drive_id}.write_bytes",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:write_bytes",
+          "line": 93,
+          "column": 9,
+          "fingerprint": "sha256:7be0557d1e6667c17fdfe20bcc81bd46013e7c21a7593dad113caf638be4478c"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.write_bytes",
+          "line": 170,
+          "column": 5,
+          "fingerprint": "sha256:80d193d5a92fb41dfce38f0ae5521d3ae2caf1edf4e8859e427add1d3030fcd1"
+        }
+      },
+      {
+        "ordinal": 256,
+        "id": "dynamic:block_{drive_id}.read_count",
+        "path": "block_{drive_id}.read_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:read_count",
+          "line": 94,
+          "column": 9,
+          "fingerprint": "sha256:09641191fe5b775bd1dd08d371e0b6a19143d773caf878393622201345daa079"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.read_count",
+          "line": 172,
+          "column": 5,
+          "fingerprint": "sha256:79163b58c88514ac86dba38a7ad8294db1847e727176b97fa6719be4d12cf8d1"
+        }
+      },
+      {
+        "ordinal": 257,
+        "id": "dynamic:block_{drive_id}.write_count",
+        "path": "block_{drive_id}.write_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:write_count",
+          "line": 95,
+          "column": 9,
+          "fingerprint": "sha256:d939c3af59febd992a3fdde689ad5aba7e0340fda909f165315d2e87f42de2d3"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.write_count",
+          "line": 174,
+          "column": 5,
+          "fingerprint": "sha256:bc6d9f11dac49eaf3ec0b1480e18ceee95edf36ef31f5b8104c64469b51e8891"
+        }
+      },
+      {
+        "ordinal": 258,
+        "id": "dynamic:block_{drive_id}.read_agg.min_us",
+        "path": "block_{drive_id}.read_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 259,
+        "id": "dynamic:block_{drive_id}.read_agg.max_us",
+        "path": "block_{drive_id}.read_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 260,
+        "id": "dynamic:block_{drive_id}.read_agg.sum_us",
+        "path": "block_{drive_id}.read_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 261,
+        "id": "dynamic:block_{drive_id}.write_agg.min_us",
+        "path": "block_{drive_id}.write_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 262,
+        "id": "dynamic:block_{drive_id}.write_agg.max_us",
+        "path": "block_{drive_id}.write_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 263,
+        "id": "dynamic:block_{drive_id}.write_agg.sum_us",
+        "path": "block_{drive_id}.write_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 264,
+        "id": "dynamic:block_{drive_id}.rate_limiter_throttled_events",
+        "path": "block_{drive_id}.rate_limiter_throttled_events",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rate_limiter_throttled_events",
+          "line": 96,
+          "column": 9,
+          "fingerprint": "sha256:a15942a55baf426c576a5a146cff20f181c315fabca034a0dbeb98abef1e9bf7"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.rate_limiter_throttled_events",
+          "line": 180,
+          "column": 5,
+          "fingerprint": "sha256:d0998ad739889c77941fe8303509ce9dfead9eeb0b47c13d079522c6009c497c"
+        }
+      },
+      {
+        "ordinal": 265,
+        "id": "dynamic:block_{drive_id}.io_engine_throttled_events",
+        "path": "block_{drive_id}.io_engine_throttled_events",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:io_engine_throttled_events",
+          "line": 97,
+          "column": 9,
+          "fingerprint": "sha256:4615461f13d46073a770c82470854ab11c2b963f40ec4a6ea27d65691370de72"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.io_engine_throttled_events",
+          "line": 182,
+          "column": 5,
+          "fingerprint": "sha256:51416d04714863c489413854646dfb2a68fbb7c77db5647b33199e7fae51a8f3"
+        }
+      },
+      {
+        "ordinal": 266,
+        "id": "dynamic:block_{drive_id}.remaining_reqs_count",
+        "path": "block_{drive_id}.remaining_reqs_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:remaining_reqs_count",
+          "line": 98,
+          "column": 9,
+          "fingerprint": "sha256:953e457ec5d6c18efeec153e392bf9ffc25995ad7c4368735c04a72c6e7525ec"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+          "symbol": "BlockDeviceMetrics.remaining_reqs_count",
+          "line": 185,
+          "column": 5,
+          "fingerprint": "sha256:ac49fc1d30bd49114a7160fd161e62859ebb42d3e6c2d4f946ba8ebee15c3cca"
+        }
+      },
+      {
+        "ordinal": 267,
+        "id": "dynamic:net_{iface_id}.activate_fails",
+        "path": "net_{iface_id}.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 103,
+          "column": 9,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.activate_fails",
+          "line": 148,
+          "column": 5,
+          "fingerprint": "sha256:4c3e548ddc5a4eaad3c6d98b1dfa638213fdfcd53bd47e058f21b93bcb727367"
+        }
+      },
+      {
+        "ordinal": 268,
+        "id": "dynamic:net_{iface_id}.cfg_fails",
+        "path": "net_{iface_id}.cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:cfg_fails",
+          "line": 104,
+          "column": 9,
+          "fingerprint": "sha256:ddf6ccea8ce5f2e735df611b679382a9746297209cd37172297a36975bfbc8e4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.cfg_fails",
+          "line": 150,
+          "column": 5,
+          "fingerprint": "sha256:5e05cb85492f765a5c64456f56250c084a72f7f829e852e0717dec7e261345b7"
+        }
+      },
+      {
+        "ordinal": 269,
+        "id": "dynamic:net_{iface_id}.mac_address_updates",
+        "path": "net_{iface_id}.mac_address_updates",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:mac_address_updates",
+          "line": 105,
+          "column": 9,
+          "fingerprint": "sha256:95d906e3e8d950e4d3c1d18716a674bf61654de2303afd03923531115de1c772"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.mac_address_updates",
+          "line": 152,
+          "column": 5,
+          "fingerprint": "sha256:5092bdd9e6a47db4d343cbbf09437fa848eabb1cf4055fe8dc682d71861614ad"
+        }
+      },
+      {
+        "ordinal": 270,
+        "id": "dynamic:net_{iface_id}.no_rx_avail_buffer",
+        "path": "net_{iface_id}.no_rx_avail_buffer",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:no_rx_avail_buffer",
+          "line": 106,
+          "column": 9,
+          "fingerprint": "sha256:6738401c387cd7e84a29ec5978cb7b0e46bf30257107721d7055b27953293660"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.no_rx_avail_buffer",
+          "line": 154,
+          "column": 5,
+          "fingerprint": "sha256:9077195cdb13b22b15bcef08e359de180887dcd805972a75986c5dff2ef8132c"
+        }
+      },
+      {
+        "ordinal": 271,
+        "id": "dynamic:net_{iface_id}.no_tx_avail_buffer",
+        "path": "net_{iface_id}.no_tx_avail_buffer",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:no_tx_avail_buffer",
+          "line": 107,
+          "column": 9,
+          "fingerprint": "sha256:21018758c80bcefab937a1d5a01f89140147d5f1529e74a9912b681c60c51537"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.no_tx_avail_buffer",
+          "line": 156,
+          "column": 5,
+          "fingerprint": "sha256:e96ea3b15f3959a47b4c30831818b904c8d2a13d72bfda2ac719622aed33917e"
+        }
+      },
+      {
+        "ordinal": 272,
+        "id": "dynamic:net_{iface_id}.event_fails",
+        "path": "net_{iface_id}.event_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:event_fails",
+          "line": 108,
+          "column": 9,
+          "fingerprint": "sha256:af808eac4d6aeffe1c5fc8f67a3a735f7f571acf68499b409872222ff7292154"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.event_fails",
+          "line": 158,
+          "column": 5,
+          "fingerprint": "sha256:c4a4a9a987f863119612bc3c228280310185d2d08e7e8ec3fe4c53cc665e58cc"
+        }
+      },
+      {
+        "ordinal": 273,
+        "id": "dynamic:net_{iface_id}.rx_queue_event_count",
+        "path": "net_{iface_id}.rx_queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_queue_event_count",
+          "line": 109,
+          "column": 9,
+          "fingerprint": "sha256:f60ad03226f86eb2e874f9b9dd39208b066e0a705d682adcb576f6f34dd7d48a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_queue_event_count",
+          "line": 160,
+          "column": 5,
+          "fingerprint": "sha256:c4bbd22125da5c390344c321540faaeef83c679f7dd7e185216e055b2167ac38"
+        }
+      },
+      {
+        "ordinal": 274,
+        "id": "dynamic:net_{iface_id}.rx_event_rate_limiter_count",
+        "path": "net_{iface_id}.rx_event_rate_limiter_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_event_rate_limiter_count",
+          "line": 110,
+          "column": 9,
+          "fingerprint": "sha256:799a5aef6283bef8ba0c2b60d58f83bac4bcb8547c3069be28cc3d3e95dff93a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_event_rate_limiter_count",
+          "line": 162,
+          "column": 5,
+          "fingerprint": "sha256:e381a0258e951f1610f78cd5dc12b515197372ed8665b798d8d438375f79dc74"
+        }
+      },
+      {
+        "ordinal": 275,
+        "id": "dynamic:net_{iface_id}.rx_rate_limiter_throttled",
+        "path": "net_{iface_id}.rx_rate_limiter_throttled",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_rate_limiter_throttled",
+          "line": 111,
+          "column": 9,
+          "fingerprint": "sha256:0030f620c284c6dc8b3f9c8febb41d47787a11508dd0b50daab16f4d6cd9cb7f"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_rate_limiter_throttled",
+          "line": 164,
+          "column": 5,
+          "fingerprint": "sha256:d927062707df0beb9a09cc8250d0718a6da52e70866bfa594cfab33f13106434"
+        }
+      },
+      {
+        "ordinal": 276,
+        "id": "dynamic:net_{iface_id}.rx_tap_event_count",
+        "path": "net_{iface_id}.rx_tap_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_tap_event_count",
+          "line": 112,
+          "column": 9,
+          "fingerprint": "sha256:18c8effb36b14efaa7bb5e035c53c36161d5a3ee06856ac599ed2e60b117db8d"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_tap_event_count",
+          "line": 166,
+          "column": 5,
+          "fingerprint": "sha256:8cfc6f47b123ae2317028fc3296bc29098cda61bd9f61caa007403368039a1a4"
+        }
+      },
+      {
+        "ordinal": 277,
+        "id": "dynamic:net_{iface_id}.rx_bytes_count",
+        "path": "net_{iface_id}.rx_bytes_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_bytes_count",
+          "line": 113,
+          "column": 9,
+          "fingerprint": "sha256:c46e1d8621e8290212400a1d437a94ea08474454c79bc3377e14fdbedbdc5ae5"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_bytes_count",
+          "line": 168,
+          "column": 5,
+          "fingerprint": "sha256:7933a7942857d10b360f152c4feb84b8ec8c26ab4f8886fa2569d22b7bd34082"
+        }
+      },
+      {
+        "ordinal": 278,
+        "id": "dynamic:net_{iface_id}.rx_packets_count",
+        "path": "net_{iface_id}.rx_packets_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_packets_count",
+          "line": 114,
+          "column": 9,
+          "fingerprint": "sha256:f56f99b197b295d3734cf636eda998f16acc39da1e996bf2fc668d912f0054f2"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_packets_count",
+          "line": 170,
+          "column": 5,
+          "fingerprint": "sha256:326d18233e88330c95e7a97709fe08fb60e60fab340ca85b57a603796265ba9a"
+        }
+      },
+      {
+        "ordinal": 279,
+        "id": "dynamic:net_{iface_id}.rx_fails",
+        "path": "net_{iface_id}.rx_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_fails",
+          "line": 115,
+          "column": 9,
+          "fingerprint": "sha256:6eeb534e1d15391f3099081d2d8f489f88a3166fecdbba8eb715289b4ecf4d32"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_fails",
+          "line": 172,
+          "column": 5,
+          "fingerprint": "sha256:96979263c732a9c6ac83505333edc501206e111a0f8b916a0a857c88fbcc047a"
+        }
+      },
+      {
+        "ordinal": 280,
+        "id": "dynamic:net_{iface_id}.rx_count",
+        "path": "net_{iface_id}.rx_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:rx_count",
+          "line": 116,
+          "column": 9,
+          "fingerprint": "sha256:36d9049dbbb004f3bbe78fb95dbed8dbb029c132944d070daf1900426e1d2050"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.rx_count",
+          "line": 174,
+          "column": 5,
+          "fingerprint": "sha256:5af94b008165c9f9b70e124f234df0ac70a859b6afd068b9df2517600f08b9f7"
+        }
+      },
+      {
+        "ordinal": 281,
+        "id": "dynamic:net_{iface_id}.tap_read_fails",
+        "path": "net_{iface_id}.tap_read_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tap_read_fails",
+          "line": 117,
+          "column": 9,
+          "fingerprint": "sha256:269a963df8d8bd382657c33b60ff3b826a5403aa8296375f660e2b8495ff807d"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tap_read_fails",
+          "line": 176,
+          "column": 5,
+          "fingerprint": "sha256:90c4654d5643f70e2f7b1a687592c9b283f4357ec9423f026ba9768e9e43860e"
+        }
+      },
+      {
+        "ordinal": 282,
+        "id": "dynamic:net_{iface_id}.tap_write_fails",
+        "path": "net_{iface_id}.tap_write_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tap_write_fails",
+          "line": 118,
+          "column": 9,
+          "fingerprint": "sha256:256f300abd6629a78404e26d8278419fc40069db495250973ad717616faaf46b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tap_write_fails",
+          "line": 178,
+          "column": 5,
+          "fingerprint": "sha256:c85a7f4267f8a5fd1f8f0fa141e0a888270c0658e8ad2dc48f2ded9c1601dfba"
+        }
+      },
+      {
+        "ordinal": 283,
+        "id": "dynamic:net_{iface_id}.tap_write_agg.min_us",
+        "path": "net_{iface_id}.tap_write_agg.min_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:min_us",
+          "line": 76,
+          "column": 9,
+          "fingerprint": "sha256:705b99d5f94f6b9a76e0c1cdde61efad3e69918ca86f849b0826fdd736fccbc4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.min_us",
+          "line": 746,
+          "column": 5,
+          "fingerprint": "sha256:4b3f0e4d1b62d20c78d2ce10fef9f01ade6906b0556d960618fe23f99dfb1efb"
+        }
+      },
+      {
+        "ordinal": 284,
+        "id": "dynamic:net_{iface_id}.tap_write_agg.max_us",
+        "path": "net_{iface_id}.tap_write_agg.max_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:max_us",
+          "line": 77,
+          "column": 9,
+          "fingerprint": "sha256:3156cc74d5c5906e95c9a75b183eecadb78f47f5214994dd066fd597d1a2d6f1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.max_us",
+          "line": 748,
+          "column": 5,
+          "fingerprint": "sha256:a4905ef5a9555c138a4eb46bc2f52a2c158b40f9fa2b14d9f97494b2d0e351ca"
+        }
+      },
+      {
+        "ordinal": 285,
+        "id": "dynamic:net_{iface_id}.tap_write_agg.sum_us",
+        "path": "net_{iface_id}.tap_write_agg.sum_us",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:sum_us",
+          "line": 78,
+          "column": 9,
+          "fingerprint": "sha256:0eb4e62adb52146ccd65ea46d0ff6437d02d7879a9941ef71b97281800585127"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/logger/metrics.rs",
+          "symbol": "LatencyAggregateMetrics.sum_us",
+          "line": 750,
+          "column": 5,
+          "fingerprint": "sha256:1d778138dc98ccd562969fef3c53b49ceb81fa25d11c88f7a655d8cf18b8d800"
+        }
+      },
+      {
+        "ordinal": 286,
+        "id": "dynamic:net_{iface_id}.tx_bytes_count",
+        "path": "net_{iface_id}.tx_bytes_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_bytes_count",
+          "line": 119,
+          "column": 9,
+          "fingerprint": "sha256:cd470e94bc651b5d8eeb47c9238b775be646265969d1841a733c85d50ce3b1d1"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_bytes_count",
+          "line": 182,
+          "column": 5,
+          "fingerprint": "sha256:75fda4340f29f55e844856e8025dd45926da7be3c6f496799231af77fc11a3fc"
+        }
+      },
+      {
+        "ordinal": 287,
+        "id": "dynamic:net_{iface_id}.tx_malformed_frames",
+        "path": "net_{iface_id}.tx_malformed_frames",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_malformed_frames",
+          "line": 120,
+          "column": 9,
+          "fingerprint": "sha256:376ac52ee5e4eca5e7b4f851c5b4aa106565f75d31ad72cfd1b06af98d987594"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_malformed_frames",
+          "line": 184,
+          "column": 5,
+          "fingerprint": "sha256:7d99fb7d430dbe3f84d49d6bdd4d206f1418e0fc3170a1e288310f0465c75887"
+        }
+      },
+      {
+        "ordinal": 288,
+        "id": "dynamic:net_{iface_id}.tx_fails",
+        "path": "net_{iface_id}.tx_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_fails",
+          "line": 121,
+          "column": 9,
+          "fingerprint": "sha256:ba5d7d049060d3edffaacd40f7a3330ff35c3c9434a2a2a3fb0fe56387ab995b"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_fails",
+          "line": 186,
+          "column": 5,
+          "fingerprint": "sha256:47ab1e31fceead4c0de7c72e06d97c13638ada2c8dacb6da47e6f015e9ccb3e3"
+        }
+      },
+      {
+        "ordinal": 289,
+        "id": "dynamic:net_{iface_id}.tx_count",
+        "path": "net_{iface_id}.tx_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_count",
+          "line": 122,
+          "column": 9,
+          "fingerprint": "sha256:4304fbf94751153c16613ef5fec5fad3e0c6b3441ae4e99cb5783c3e94011e1a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_count",
+          "line": 188,
+          "column": 5,
+          "fingerprint": "sha256:300f2c1d82af9964d4beb581a1e7928384f50e818621cf9157bebc58054b8d75"
+        }
+      },
+      {
+        "ordinal": 290,
+        "id": "dynamic:net_{iface_id}.tx_packets_count",
+        "path": "net_{iface_id}.tx_packets_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_packets_count",
+          "line": 123,
+          "column": 9,
+          "fingerprint": "sha256:8203eccfbd7be213263d324b3764df310788a1a386a9342c56778f2c07e5dec9"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_packets_count",
+          "line": 190,
+          "column": 5,
+          "fingerprint": "sha256:d19d3a52f3f85d63e1c4c9e814de0bf7ff36a5499c24fe870df21abff02c3b3a"
+        }
+      },
+      {
+        "ordinal": 291,
+        "id": "dynamic:net_{iface_id}.tx_queue_event_count",
+        "path": "net_{iface_id}.tx_queue_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_queue_event_count",
+          "line": 124,
+          "column": 9,
+          "fingerprint": "sha256:3dd397e2fc51a3f3c1ce5c618515c56b160c75367dcf44dd9f15e608736f83c3"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_queue_event_count",
+          "line": 192,
+          "column": 5,
+          "fingerprint": "sha256:efee9a2b38f5122a6a2a88d3b2e8312c7e52d9d13089bd4af5ec14a7da9babb2"
+        }
+      },
+      {
+        "ordinal": 292,
+        "id": "dynamic:net_{iface_id}.tx_rate_limiter_event_count",
+        "path": "net_{iface_id}.tx_rate_limiter_event_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_rate_limiter_event_count",
+          "line": 125,
+          "column": 9,
+          "fingerprint": "sha256:bdbf48711873943b7d761a3af82a754558db209b59b7a23c70c2bf63867af67a"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_rate_limiter_event_count",
+          "line": 194,
+          "column": 5,
+          "fingerprint": "sha256:27dc7888ebe248dbb122a66ab637d0810771150734126b3306e8bd48d1353562"
+        }
+      },
+      {
+        "ordinal": 293,
+        "id": "dynamic:net_{iface_id}.tx_rate_limiter_throttled",
+        "path": "net_{iface_id}.tx_rate_limiter_throttled",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_rate_limiter_throttled",
+          "line": 126,
+          "column": 9,
+          "fingerprint": "sha256:db0ef6c6709d5d4406a4caac80d9f90e026f9e9963d536d00f7b2f62c6160057"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_rate_limiter_throttled",
+          "line": 196,
+          "column": 5,
+          "fingerprint": "sha256:7e24af5cdd5b6ea076326a378ce86db8ddbe6baa9b74e9065444ba4db6caec06"
+        }
+      },
+      {
+        "ordinal": 294,
+        "id": "dynamic:net_{iface_id}.tx_spoofed_mac_count",
+        "path": "net_{iface_id}.tx_spoofed_mac_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_spoofed_mac_count",
+          "line": 127,
+          "column": 9,
+          "fingerprint": "sha256:17d9c56a471e6170bd888751c46ae13db228420a7fc5adcda8b9b3dfbcc88c45"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_spoofed_mac_count",
+          "line": 198,
+          "column": 5,
+          "fingerprint": "sha256:3a0f6e8be2b1d5009679427c6073402bb2f1186cd8cf11fdda791b7fcff62777"
+        }
+      },
+      {
+        "ordinal": 295,
+        "id": "dynamic:net_{iface_id}.tx_remaining_reqs_count",
+        "path": "net_{iface_id}.tx_remaining_reqs_count",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:tx_remaining_reqs_count",
+          "line": 128,
+          "column": 9,
+          "fingerprint": "sha256:ded59fcdcfc1df8cb34e5d7ace1dc1594ac4bb8dfb9ad89b2c705f00efec05a9"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+          "symbol": "NetDeviceMetrics.tx_remaining_reqs_count",
+          "line": 200,
+          "column": 5,
+          "fingerprint": "sha256:6e6d069191515892e2e907bab5ac9647f6ecfc4a7dd5bfd60b717425f29cac8b"
+        }
+      },
+      {
+        "ordinal": 296,
+        "id": "dynamic:vhost_user_block_{drive_id}.activate_fails",
+        "path": "vhost_user_block_{drive_id}.activate_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_fails",
+          "line": 366,
+          "column": 17,
+          "fingerprint": "sha256:5a047e1c749bf462546854cf3099d2a7f1b9c4849b5b2917e1bba7ea53b05454"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vhost_user_metrics.rs",
+          "symbol": "VhostUserDeviceMetrics.activate_fails",
+          "line": 133,
+          "column": 5,
+          "fingerprint": "sha256:1bd6fb0f5df12d2755192291b728d7d12abcbc94180d62f1f2e46b7b58d74360"
+        }
+      },
+      {
+        "ordinal": 297,
+        "id": "dynamic:vhost_user_block_{drive_id}.cfg_fails",
+        "path": "vhost_user_block_{drive_id}.cfg_fails",
+        "json_type": "number",
+        "value_kind": "incremental-interval",
+        "rust_type": "SharedIncMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:cfg_fails",
+          "line": 367,
+          "column": 17,
+          "fingerprint": "sha256:ddf6ccea8ce5f2e735df611b679382a9746297209cd37172297a36975bfbc8e4"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vhost_user_metrics.rs",
+          "symbol": "VhostUserDeviceMetrics.cfg_fails",
+          "line": 135,
+          "column": 5,
+          "fingerprint": "sha256:32628810d084575e32147cd7f25fb1f9ffbc12a743ec77619d542ac31617e839"
+        }
+      },
+      {
+        "ordinal": 298,
+        "id": "dynamic:vhost_user_block_{drive_id}.init_time_us",
+        "path": "vhost_user_block_{drive_id}.init_time_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:init_time_us",
+          "line": 368,
+          "column": 17,
+          "fingerprint": "sha256:e9a3b20590f052371a77771f820483421c5507a950c6e43398d33ffc6ddf1ff8"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vhost_user_metrics.rs",
+          "symbol": "VhostUserDeviceMetrics.init_time_us",
+          "line": 138,
+          "column": 5,
+          "fingerprint": "sha256:78be8c8fbd9c212c3c5d3e1ec00ef29d80297c01a354870ea7048298b2409ba9"
+        }
+      },
+      {
+        "ordinal": 299,
+        "id": "dynamic:vhost_user_block_{drive_id}.activate_time_us",
+        "path": "vhost_user_block_{drive_id}.activate_time_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:activate_time_us",
+          "line": 369,
+          "column": 17,
+          "fingerprint": "sha256:3325a2114537156f859aa02e90063bf2086c12945b58f0d9f2acda4d698f1495"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vhost_user_metrics.rs",
+          "symbol": "VhostUserDeviceMetrics.activate_time_us",
+          "line": 140,
+          "column": 5,
+          "fingerprint": "sha256:bed78cd8743575f3dc7fc9156225d96d059b931cf349eec4e2afcc0ed354b967"
+        }
+      },
+      {
+        "ordinal": 300,
+        "id": "dynamic:vhost_user_block_{drive_id}.config_change_time_us",
+        "path": "vhost_user_block_{drive_id}.config_change_time_us",
+        "json_type": "number",
+        "value_kind": "persistent-store",
+        "rust_type": "SharedStoreMetric",
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:literal:config_change_time_us",
+          "line": 370,
+          "column": 17,
+          "fingerprint": "sha256:08159d5a6d16e8c8b4e0555df5a97b3d88d6fef09d113fd3af8f84fedac3cfd9"
+        },
+        "producer_anchor": {
+          "path": "src/vmm/src/devices/virtio/vhost_user_metrics.rs",
+          "symbol": "VhostUserDeviceMetrics.config_change_time_us",
+          "line": 142,
+          "column": 5,
+          "fingerprint": "sha256:4aae1bf10d0b3dbb885d416d3e70116fd79d6633002b1e2e6a334eeb7a9e2226"
+        }
+      }
+    ],
+    "dynamic_families": [
+      {
+        "id": "block",
+        "fixture_prefix": "block_",
+        "producer_template": "block_{drive_id}",
+        "architecture": "all",
+        "schema_disposition": "configured-dynamic",
+        "cardinality": "configured-block",
+        "field_ids": [
+          "dynamic:block_{drive_id}.activate_fails",
+          "dynamic:block_{drive_id}.cfg_fails",
+          "dynamic:block_{drive_id}.no_avail_buffer",
+          "dynamic:block_{drive_id}.event_fails",
+          "dynamic:block_{drive_id}.execute_fails",
+          "dynamic:block_{drive_id}.invalid_reqs_count",
+          "dynamic:block_{drive_id}.flush_count",
+          "dynamic:block_{drive_id}.queue_event_count",
+          "dynamic:block_{drive_id}.rate_limiter_event_count",
+          "dynamic:block_{drive_id}.update_count",
+          "dynamic:block_{drive_id}.update_fails",
+          "dynamic:block_{drive_id}.read_bytes",
+          "dynamic:block_{drive_id}.write_bytes",
+          "dynamic:block_{drive_id}.read_count",
+          "dynamic:block_{drive_id}.write_count",
+          "dynamic:block_{drive_id}.read_agg.min_us",
+          "dynamic:block_{drive_id}.read_agg.max_us",
+          "dynamic:block_{drive_id}.read_agg.sum_us",
+          "dynamic:block_{drive_id}.write_agg.min_us",
+          "dynamic:block_{drive_id}.write_agg.max_us",
+          "dynamic:block_{drive_id}.write_agg.sum_us",
+          "dynamic:block_{drive_id}.rate_limiter_throttled_events",
+          "dynamic:block_{drive_id}.io_engine_throttled_events",
+          "dynamic:block_{drive_id}.remaining_reqs_count"
+        ],
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:dynamic-prefix:block_",
+          "line": 373,
+          "column": 36,
+          "fingerprint": "sha256:0d2edffa3889b9a79b5bf969d586aa113b8a9adb51c4d89397fcdf8f92c50cb2"
+        },
+        "producer_anchors": [
+          {
+            "path": "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+            "symbol": "producer-template:block_{drive_id}",
+            "line": 133,
+            "column": 20,
+            "fingerprint": "sha256:88647fb14fc06876c9a8b81dad5f0305eeb1fc48be617c77bafb22135fff3200"
+          }
+        ]
+      },
+      {
+        "id": "net",
+        "fixture_prefix": "net_",
+        "producer_template": "net_{iface_id}",
+        "architecture": "all",
+        "schema_disposition": "configured-dynamic",
+        "cardinality": "configured-network",
+        "field_ids": [
+          "dynamic:net_{iface_id}.activate_fails",
+          "dynamic:net_{iface_id}.cfg_fails",
+          "dynamic:net_{iface_id}.mac_address_updates",
+          "dynamic:net_{iface_id}.no_rx_avail_buffer",
+          "dynamic:net_{iface_id}.no_tx_avail_buffer",
+          "dynamic:net_{iface_id}.event_fails",
+          "dynamic:net_{iface_id}.rx_queue_event_count",
+          "dynamic:net_{iface_id}.rx_event_rate_limiter_count",
+          "dynamic:net_{iface_id}.rx_rate_limiter_throttled",
+          "dynamic:net_{iface_id}.rx_tap_event_count",
+          "dynamic:net_{iface_id}.rx_bytes_count",
+          "dynamic:net_{iface_id}.rx_packets_count",
+          "dynamic:net_{iface_id}.rx_fails",
+          "dynamic:net_{iface_id}.rx_count",
+          "dynamic:net_{iface_id}.tap_read_fails",
+          "dynamic:net_{iface_id}.tap_write_fails",
+          "dynamic:net_{iface_id}.tap_write_agg.min_us",
+          "dynamic:net_{iface_id}.tap_write_agg.max_us",
+          "dynamic:net_{iface_id}.tap_write_agg.sum_us",
+          "dynamic:net_{iface_id}.tx_bytes_count",
+          "dynamic:net_{iface_id}.tx_malformed_frames",
+          "dynamic:net_{iface_id}.tx_fails",
+          "dynamic:net_{iface_id}.tx_count",
+          "dynamic:net_{iface_id}.tx_packets_count",
+          "dynamic:net_{iface_id}.tx_queue_event_count",
+          "dynamic:net_{iface_id}.tx_rate_limiter_event_count",
+          "dynamic:net_{iface_id}.tx_rate_limiter_throttled",
+          "dynamic:net_{iface_id}.tx_spoofed_mac_count",
+          "dynamic:net_{iface_id}.tx_remaining_reqs_count"
+        ],
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:dynamic-prefix:net_",
+          "line": 375,
+          "column": 36,
+          "fingerprint": "sha256:623602ce4ebd960a4bc036f1155f582c999fb97c55837555f67fcfeeb6696f92"
+        },
+        "producer_anchors": [
+          {
+            "path": "src/vmm/src/devices/virtio/net/metrics.rs",
+            "symbol": "producer-template:net_{iface_id}",
+            "line": 135,
+            "column": 20,
+            "fingerprint": "sha256:375732e4d88b640540d380251b7b2759f5e00aa7a99c3cd754fb2bb15d1853b1"
+          }
+        ]
+      },
+      {
+        "id": "vhost-user-block",
+        "fixture_prefix": "vhost_user_",
+        "producer_template": "vhost_user_block_{drive_id}",
+        "architecture": "all",
+        "schema_disposition": "configured-dynamic",
+        "cardinality": "configured-vhost-user-block",
+        "field_ids": [
+          "dynamic:vhost_user_block_{drive_id}.activate_fails",
+          "dynamic:vhost_user_block_{drive_id}.cfg_fails",
+          "dynamic:vhost_user_block_{drive_id}.init_time_us",
+          "dynamic:vhost_user_block_{drive_id}.activate_time_us",
+          "dynamic:vhost_user_block_{drive_id}.config_change_time_us"
+        ],
+        "fixture_anchor": {
+          "path": "tests/host_tools/fcmetrics.py",
+          "symbol": "validate_fc_metrics:dynamic-prefix:vhost_user_",
+          "line": 364,
+          "column": 36,
+          "fingerprint": "sha256:e54babe9a7f6c91cf02e7c0ba2993198f9b83e00649152ecd80b67fa0b6d0760"
+        },
+        "producer_anchors": [
+          {
+            "path": "src/vmm/src/devices/virtio/vhost_user_metrics.rs",
+            "symbol": "producer-template:vhost_user_{module_name}",
+            "line": 124,
+            "column": 20,
+            "fingerprint": "sha256:4d505d802f686adef778d27d241c2892b09691095089f32a7fbacc3eea515928"
+          },
+          {
+            "path": "src/vmm/src/devices/virtio/block/vhost_user/device.rs",
+            "symbol": "producer-module:block_{drive_id}",
+            "line": 213,
+            "column": 45,
+            "fingerprint": "sha256:929a1939cc1d8eba94e88a8937c08f14567734b49f2f50f482350dae4b58a21b"
+          },
+          {
+            "path": "src/vmm/src/devices/virtio/block/vhost_user/device.rs",
+            "symbol": "producer-registration:vhost-user-block",
+            "line": 215,
+            "column": 23,
+            "fingerprint": "sha256:a4c2c98c5c2978ce5bcb3faed3aeb1ddf8f32c2a9d355a206f515567f8fa8f3f"
+          }
+        ]
+      }
+    ],
+    "reconciliations": [
+      {
+        "id": "producer-only:pmem_{pmem_id}",
+        "kind": "producer-only-dynamic-family",
+        "resolution": "Pinned Rust emits pmem_{pmem_id}, but the strict v1.16.0 fixture admits no pmem_ prefix; retain the producer fact without adding it to the canonical schema.",
+        "source_anchors": [
+          {
+            "path": "src/vmm/src/devices/virtio/pmem/metrics.rs",
+            "symbol": "producer-template:pmem_{pmem_id}",
+            "line": 133,
+            "column": 20,
+            "fingerprint": "sha256:602dd3deaa3a4c76baedb9fc982cc744266278da443803b1db974f0d7dc5a805"
+          },
+          {
+            "path": "tests/host_tools/fcmetrics.py",
+            "symbol": "validate_fc_metrics:dynamic-prefix-closure",
+            "line": 363,
+            "column": 5,
+            "fingerprint": "sha256:f4fbdd188777319bb2415451a66ecfe9e4b8c54ff132eff8aa38038c39a92dc3"
+          }
+        ]
+      }
+    ]
+  },
+  "policy_profiles": [
+    {
+      "id": "bytes-none-device-planned",
+      "unit": "bytes",
+      "aggregation": "none",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "bytes-sum-across-configured-devices-device-planned",
+      "unit": "bytes",
+      "aggregation": "sum-across-configured-devices",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "count-none-device-planned",
+      "unit": "count",
+      "aggregation": "none",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "count-none-device-platform-zero",
+      "unit": "count",
+      "aggregation": "none",
+      "producer_owner": "device",
+      "producer_disposition": "platform-zero",
+      "delivery_issue": "#1789",
+      "rationale": "The arm64 schema retains this Linux/x86-oriented field as a required numeric neutral value; #1789 owns terminal evidence.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "count-none-process-lifecycle-planned",
+      "unit": "count",
+      "aggregation": "none",
+      "producer_owner": "process-lifecycle",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1788",
+      "rationale": "#1788 owns the exact API, process, logger, signal, boot, and lifecycle producer boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "count-sum-across-configured-devices-device-planned",
+      "unit": "count",
+      "aggregation": "sum-across-configured-devices",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-maximum-device-planned",
+      "unit": "microseconds",
+      "aggregation": "maximum",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-maximum-device-platform-zero",
+      "unit": "microseconds",
+      "aggregation": "maximum",
+      "producer_owner": "device",
+      "producer_disposition": "platform-zero",
+      "delivery_issue": "#1789",
+      "rationale": "The arm64 schema retains this Linux/x86-oriented field as a required numeric neutral value; #1789 owns terminal evidence.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-minimum-device-planned",
+      "unit": "microseconds",
+      "aggregation": "minimum",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-minimum-device-platform-zero",
+      "unit": "microseconds",
+      "aggregation": "minimum",
+      "producer_owner": "device",
+      "producer_disposition": "platform-zero",
+      "delivery_issue": "#1789",
+      "rationale": "The arm64 schema retains this Linux/x86-oriented field as a required numeric neutral value; #1789 owns terminal evidence.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-none-device-planned",
+      "unit": "microseconds",
+      "aggregation": "none",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-none-process-lifecycle-planned",
+      "unit": "microseconds",
+      "aggregation": "none",
+      "producer_owner": "process-lifecycle",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1788",
+      "rationale": "#1788 owns the exact API, process, logger, signal, boot, and lifecycle producer boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-sum-across-configured-devices-device-planned",
+      "unit": "microseconds",
+      "aggregation": "sum-across-configured-devices",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-sum-device-planned",
+      "unit": "microseconds",
+      "aggregation": "sum",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-sum-device-platform-zero",
+      "unit": "microseconds",
+      "aggregation": "sum",
+      "producer_owner": "device",
+      "producer_disposition": "platform-zero",
+      "delivery_issue": "#1789",
+      "rationale": "The arm64 schema retains this Linux/x86-oriented field as a required numeric neutral value; #1789 owns terminal evidence.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "microseconds-zero-in-configured-device-aggregate-device-planned",
+      "unit": "microseconds",
+      "aggregation": "zero-in-configured-device-aggregate",
+      "producer_owner": "device",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1789",
+      "rationale": "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "id": "milliseconds-since-unix-epoch-none-schema-runtime-planned",
+      "unit": "milliseconds-since-unix-epoch",
+      "aggregation": "none",
+      "producer_owner": "schema-runtime",
+      "producer_disposition": "planned",
+      "delivery_issue": "#1822",
+      "rationale": "Canonical line construction and timestamp publication are delivered by #1822 before producer closure.",
+      "implementation": [],
+      "validation": []
+    }
+  ],
+  "field_policies": [
+    {
+      "field_id": "dynamic:block_{drive_id}.activate_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.cfg_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.execute_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.flush_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.invalid_reqs_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.io_engine_throttled_events",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.no_avail_buffer",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.queue_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.rate_limiter_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.rate_limiter_throttled_events",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_agg.max_us",
+      "profile_id": "microseconds-maximum-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_agg.min_us",
+      "profile_id": "microseconds-minimum-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_agg.sum_us",
+      "profile_id": "microseconds-sum-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_bytes",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.remaining_reqs_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.update_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.update_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_agg.max_us",
+      "profile_id": "microseconds-maximum-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_agg.min_us",
+      "profile_id": "microseconds-minimum-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_agg.sum_us",
+      "profile_id": "microseconds-sum-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_bytes",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.activate_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.cfg_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.mac_address_updates",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.no_rx_avail_buffer",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.no_tx_avail_buffer",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_bytes_count",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_event_rate_limiter_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_packets_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_queue_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_rate_limiter_throttled",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_tap_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_read_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_write_agg.max_us",
+      "profile_id": "microseconds-maximum-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_write_agg.min_us",
+      "profile_id": "microseconds-minimum-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_write_agg.sum_us",
+      "profile_id": "microseconds-sum-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_write_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_bytes_count",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_malformed_frames",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_packets_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_queue_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_rate_limiter_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_rate_limiter_throttled",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_remaining_reqs_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_spoofed_mac_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.activate_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.activate_time_us",
+      "profile_id": "microseconds-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.cfg_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.config_change_time_us",
+      "profile_id": "microseconds-none-device-planned"
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.init_time_us",
+      "profile_id": "microseconds-none-device-planned"
+    },
+    {
+      "field_id": "static:api_server.process_startup_time_cpu_us",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:api_server.process_startup_time_us",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:balloon.activate_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.deflate_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.free_page_hint_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.free_page_hint_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.free_page_hint_freed",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.free_page_report_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.free_page_report_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.free_page_report_freed",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.inflate_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.stats_update_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:balloon.stats_updates_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:block.activate_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.cfg_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.event_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.execute_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.flush_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.invalid_reqs_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.io_engine_throttled_events",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.no_avail_buffer",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.queue_event_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.rate_limiter_event_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.rate_limiter_throttled_events",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.read_agg.max_us",
+      "profile_id": "microseconds-zero-in-configured-device-aggregate-device-planned"
+    },
+    {
+      "field_id": "static:block.read_agg.min_us",
+      "profile_id": "microseconds-zero-in-configured-device-aggregate-device-planned"
+    },
+    {
+      "field_id": "static:block.read_agg.sum_us",
+      "profile_id": "microseconds-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.read_bytes",
+      "profile_id": "bytes-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.read_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.remaining_reqs_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.update_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.update_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.write_agg.max_us",
+      "profile_id": "microseconds-zero-in-configured-device-aggregate-device-planned"
+    },
+    {
+      "field_id": "static:block.write_agg.min_us",
+      "profile_id": "microseconds-zero-in-configured-device-aggregate-device-planned"
+    },
+    {
+      "field_id": "static:block.write_agg.sum_us",
+      "profile_id": "microseconds-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.write_bytes",
+      "profile_id": "bytes-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:block.write_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:deprecated_api.deprecated_http_api_calls",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:entropy.activate_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:entropy.entropy_bytes",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "static:entropy.entropy_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:entropy.entropy_event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:entropy.entropy_rate_limiter_throttled",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:entropy.host_rng_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:entropy.rate_limiter_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:get_api_requests.hotplug_memory_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:get_api_requests.instance_info_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:get_api_requests.machine_cfg_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:get_api_requests.mmds_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:get_api_requests.vmm_version_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:i8042.error_count",
+      "profile_id": "count-none-device-platform-zero"
+    },
+    {
+      "field_id": "static:i8042.missed_read_count",
+      "profile_id": "count-none-device-platform-zero"
+    },
+    {
+      "field_id": "static:i8042.missed_write_count",
+      "profile_id": "count-none-device-platform-zero"
+    },
+    {
+      "field_id": "static:i8042.read_count",
+      "profile_id": "count-none-device-platform-zero"
+    },
+    {
+      "field_id": "static:i8042.reset_count",
+      "profile_id": "count-none-device-platform-zero"
+    },
+    {
+      "field_id": "static:i8042.write_count",
+      "profile_id": "count-none-device-platform-zero"
+    },
+    {
+      "field_id": "static:interrupts.config_updates",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:interrupts.triggers",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:latencies_us.diff_create_snapshot",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:latencies_us.full_create_snapshot",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:latencies_us.load_snapshot",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:latencies_us.pause_vm",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:latencies_us.resume_vm",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:latencies_us.vmm_diff_create_snapshot",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:latencies_us.vmm_full_create_snapshot",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:latencies_us.vmm_load_snapshot",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:latencies_us.vmm_pause_vm",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:latencies_us.vmm_resume_vm",
+      "profile_id": "microseconds-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:logger.metrics_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:logger.missed_log_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:logger.missed_metrics_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:logger.rate_limited_log_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.activate_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_agg.max_us",
+      "profile_id": "microseconds-maximum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_agg.min_us",
+      "profile_id": "microseconds-minimum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_agg.sum_us",
+      "profile_id": "microseconds-sum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_bytes",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.queue_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.queue_event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.state_agg.max_us",
+      "profile_id": "microseconds-maximum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.state_agg.min_us",
+      "profile_id": "microseconds-minimum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.state_agg.sum_us",
+      "profile_id": "microseconds-sum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.state_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.state_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_agg.max_us",
+      "profile_id": "microseconds-maximum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_agg.min_us",
+      "profile_id": "microseconds-minimum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_agg.sum_us",
+      "profile_id": "microseconds-sum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_agg.max_us",
+      "profile_id": "microseconds-maximum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_agg.min_us",
+      "profile_id": "microseconds-minimum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_agg.sum_us",
+      "profile_id": "microseconds-sum-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_bytes",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_discard_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.connections_created",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.connections_destroyed",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.rx_accepted",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.rx_accepted_err",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.rx_accepted_unusual",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.rx_bad_eth",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.rx_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.rx_invalid_token",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.rx_no_token",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.tx_bytes",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.tx_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.tx_errors",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:mmds.tx_frames",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:net.activate_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.cfg_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.event_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.mac_address_updates",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.no_rx_avail_buffer",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.no_tx_avail_buffer",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.rx_bytes_count",
+      "profile_id": "bytes-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.rx_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.rx_event_rate_limiter_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.rx_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.rx_packets_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.rx_queue_event_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.rx_rate_limiter_throttled",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.rx_tap_event_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tap_read_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tap_write_agg.max_us",
+      "profile_id": "microseconds-zero-in-configured-device-aggregate-device-planned"
+    },
+    {
+      "field_id": "static:net.tap_write_agg.min_us",
+      "profile_id": "microseconds-zero-in-configured-device-aggregate-device-planned"
+    },
+    {
+      "field_id": "static:net.tap_write_agg.sum_us",
+      "profile_id": "microseconds-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tap_write_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_bytes_count",
+      "profile_id": "bytes-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_malformed_frames",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_packets_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_queue_event_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_rate_limiter_event_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_rate_limiter_throttled",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_remaining_reqs_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:net.tx_spoofed_mac_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.drive_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.drive_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.hotplug_memory_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.hotplug_memory_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.machine_cfg_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.machine_cfg_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.mmds_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.mmds_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.network_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.network_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.pmem_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:patch_api_requests.pmem_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:pmem.activate_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:pmem.cfg_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:pmem.event_fails",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:pmem.queue_event_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:pmem.rate_limiter_event_count",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:pmem.rate_limiter_throttled_events",
+      "profile_id": "count-sum-across-configured-devices-device-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.actions_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.actions_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.boot_source_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.boot_source_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.cpu_cfg_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.cpu_cfg_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.drive_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.drive_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.hotplug_memory_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.hotplug_memory_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.logger_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.logger_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.machine_cfg_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.machine_cfg_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.metrics_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.metrics_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.mmds_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.mmds_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.network_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.network_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.pmem_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.pmem_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.serial_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.serial_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.vsock_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:put_api_requests.vsock_fails",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:rtc.error_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:rtc.missed_read_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:rtc.missed_write_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:seccomp.num_faults",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:signals.sigbus",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:signals.sighup",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:signals.sigill",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:signals.sigpipe",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:signals.sigsegv",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:signals.sigxcpu",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:signals.sigxfsz",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:uart.error_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:uart.flush_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:uart.missed_read_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:uart.missed_write_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:uart.rate_limiter_dropped_bytes",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "static:uart.read_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:uart.write_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:utc_timestamp_ms",
+      "profile_id": "milliseconds-since-unix-epoch-none-schema-runtime-planned"
+    },
+    {
+      "field_id": "static:vcpu.exit_io_in",
+      "profile_id": "count-none-device-platform-zero"
+    },
+    {
+      "field_id": "static:vcpu.exit_io_in_agg.max_us",
+      "profile_id": "microseconds-maximum-device-platform-zero"
+    },
+    {
+      "field_id": "static:vcpu.exit_io_in_agg.min_us",
+      "profile_id": "microseconds-minimum-device-platform-zero"
+    },
+    {
+      "field_id": "static:vcpu.exit_io_in_agg.sum_us",
+      "profile_id": "microseconds-sum-device-platform-zero"
+    },
+    {
+      "field_id": "static:vcpu.exit_io_out",
+      "profile_id": "count-none-device-platform-zero"
+    },
+    {
+      "field_id": "static:vcpu.exit_io_out_agg.max_us",
+      "profile_id": "microseconds-maximum-device-platform-zero"
+    },
+    {
+      "field_id": "static:vcpu.exit_io_out_agg.min_us",
+      "profile_id": "microseconds-minimum-device-platform-zero"
+    },
+    {
+      "field_id": "static:vcpu.exit_io_out_agg.sum_us",
+      "profile_id": "microseconds-sum-device-platform-zero"
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_read",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_read_agg.max_us",
+      "profile_id": "microseconds-maximum-device-planned"
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_read_agg.min_us",
+      "profile_id": "microseconds-minimum-device-planned"
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_read_agg.sum_us",
+      "profile_id": "microseconds-sum-device-planned"
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_write",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_write_agg.max_us",
+      "profile_id": "microseconds-maximum-device-planned"
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_write_agg.min_us",
+      "profile_id": "microseconds-minimum-device-planned"
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_write_agg.sum_us",
+      "profile_id": "microseconds-sum-device-planned"
+    },
+    {
+      "field_id": "static:vcpu.failures",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vcpu.kvmclock_ctrl_fails",
+      "profile_id": "count-none-device-platform-zero"
+    },
+    {
+      "field_id": "static:vmm.panic_count",
+      "profile_id": "count-none-process-lifecycle-planned"
+    },
+    {
+      "field_id": "static:vsock.activate_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.cfg_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.conn_event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.conns_added",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.conns_killed",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.conns_removed",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.ev_queue_event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.killq_resync",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.muxer_event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.rx_bytes_count",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.rx_packets_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.rx_queue_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.rx_queue_event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.rx_read_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.tx_bytes_count",
+      "profile_id": "bytes-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.tx_flush_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.tx_packets_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.tx_queue_event_count",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.tx_queue_event_fails",
+      "profile_id": "count-none-device-planned"
+    },
+    {
+      "field_id": "static:vsock.tx_write_fails",
+      "profile_id": "count-none-device-planned"
+    }
+  ]
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1395,10 +1395,11 @@ cargo test -p bangbang-firecracker-capability-audit --all-targets --locked
 cargo run -p bangbang-firecracker-capability-audit --locked -- validate
 ```
 
-The workspace suite also validates all four checked JSON files: the general
-source manifest and capability overlay plus the logger producer manifest and
-human audit. Ordinary validation uses only the pinned checked-in inventory and
-does not discover or require a sibling Firecracker checkout.
+The workspace suite also validates all five checked JSON files: the general
+source manifest and capability overlay, the logger producer manifest and human
+audit, and the combined metrics source/policy authority. Ordinary validation
+uses only the pinned checked-in inventory and does not discover or require a
+sibling Firecracker checkout.
 
 ### Evidence Responsibilities
 
@@ -1533,6 +1534,34 @@ not-applicable classes, representing 402 implemented and 66 not-applicable
 source mappings. Four i8042 mappings moved to the exact x86-only class because
 their upstream source module is shared but construction, PIO, API/runtime
 ownership, and observable execution remain x86_64-only.
+
+The checked metrics authority uses one envelope with a machine-owned `source`
+projection and human-owned policy profiles/mappings. It records exactly 24
+arm64 static roots and 243 static scalar paths, plus configured block/network/
+vhost-user field populations of 24/29/5. Run its focused local mutations with:
+
+```sh
+cargo test -p bangbang-firecracker-capability-audit --test metrics_schema --locked
+```
+
+The ordinary `compare` command rederives the source projection together with
+the general and logger manifests. To create a metrics source-only candidate:
+
+```sh
+cargo run -p bangbang-firecracker-capability-audit --locked -- \
+  regenerate-metrics-schema-source \
+  --firecracker /path/to/firecracker \
+  --output codex-work/tmp/metrics-schema-source.candidate.json
+```
+
+The command never emits or carries forward policy. Review source identities,
+root/field order, Rust and fixture anchors, types/reset classes, dynamic
+grammar, architecture, reconciliations, and fingerprints before manually
+updating `metrics-schema.json`. Then review every affected unit, aggregation,
+producer owner/disposition, delivery issue, rationale, and evidence mapping.
+The destination must be a new non-alias of every checked JSON file. The exact
+shape and publication boundary are documented in the
+[metrics schema contract](../compat/firecracker/v1.16.0/metrics-contract.md).
 
 Host lifecycle logger coverage exercises backend and VM transitions, all three
 live device kinds, boot-worker observation, automatic metrics failures,

--- a/tools/firecracker-capability-audit/src/lib.rs
+++ b/tools/firecracker-capability-audit/src/lib.rs
@@ -4,6 +4,9 @@ mod logger_certify;
 mod logger_model;
 mod logger_upstream;
 mod logger_validate;
+mod metrics_model;
+mod metrics_upstream;
+mod metrics_validate;
 mod model;
 mod upstream;
 mod validate;
@@ -18,6 +21,16 @@ pub use logger_model::{
 };
 pub use logger_upstream::derive_logger_producer_manifest;
 pub use logger_validate::validate_logger_producers;
+pub use metrics_model::{
+    MetricsAggregation, MetricsArchitecture, MetricsCardinality, MetricsDynamicFamily,
+    MetricsFieldPolicy, MetricsJsonType, MetricsPolicyProfile, MetricsProducerDisposition,
+    MetricsProducerOwner, MetricsReconciliation, MetricsReconciliationKind, MetricsSchemaAuthority,
+    MetricsSchemaCounts, MetricsSchemaDisposition, MetricsSchemaSource,
+    MetricsSchemaSourceCandidate, MetricsSourceAnchor, MetricsSourceField, MetricsStaticRoot,
+    MetricsUnit, MetricsValueKind,
+};
+pub use metrics_upstream::derive_metrics_schema_source;
+pub use metrics_validate::validate_metrics_schema;
 pub use model::{
     AuditMode, Baseline, Capability, CapabilityInventory, Counts, Disposition, Input,
     PlatformExclusion, Reference, SourceItem, SourceManifest,
@@ -42,6 +55,10 @@ pub const GENERATOR_VERSION: u32 = 1;
 pub const LOGGER_PRODUCER_SCHEMA_VERSION: u32 = 1;
 /// Current generated logger producer format.
 pub const LOGGER_PRODUCER_GENERATOR_VERSION: u32 = 1;
+/// Current checked-in metrics schema authority.
+pub const METRICS_SCHEMA_VERSION: u32 = 1;
+/// Current generated metrics schema source format.
+pub const METRICS_SCHEMA_GENERATOR_VERSION: u32 = 1;
 /// Repository-relative generated source manifest path.
 pub const SOURCE_MANIFEST_PATH: &str = "compat/firecracker/v1.16.0/source-manifest.json";
 /// Repository-relative human capability overlay path.
@@ -52,6 +69,8 @@ pub const LOGGER_PRODUCER_MANIFEST_PATH: &str =
 /// Repository-relative human logger producer audit path.
 pub const LOGGER_PRODUCER_AUDIT_PATH: &str =
     "compat/firecracker/v1.16.0/logger-producer-audit.json";
+/// Repository-relative canonical metrics schema authority path.
+pub const METRICS_SCHEMA_AUTHORITY_PATH: &str = "compat/firecracker/v1.16.0/metrics-schema.json";
 
 /// Error produced while reading, parsing, or deriving an inventory.
 #[derive(Debug)]
@@ -108,6 +127,16 @@ pub fn read_logger_producer_audit(path: &Path) -> Result<LoggerProducerAudit, Au
         .map_err(|error| AuditError::new(format!("failed to parse logger producer audit: {error}")))
 }
 
+/// Read and parse the checked metrics schema authority.
+pub fn read_metrics_schema_authority(path: &Path) -> Result<MetricsSchemaAuthority, AuditError> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        AuditError::new(format!("failed to read metrics schema authority: {error}"))
+    })?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        AuditError::new(format!("failed to parse metrics schema authority: {error}"))
+    })
+}
+
 /// Serialize a generated source manifest using canonical pretty JSON.
 pub fn source_manifest_json(manifest: &SourceManifest) -> Result<Vec<u8>, AuditError> {
     let mut bytes = serde_json::to_vec_pretty(manifest).map_err(|error| {
@@ -137,6 +166,27 @@ pub fn logger_producer_audit_json(audit: &LoggerProducerAudit) -> Result<Vec<u8>
             "failed to serialize logger producer audit: {error}"
         ))
     })?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+/// Serialize a source-only metrics schema candidate using canonical pretty JSON.
+pub fn metrics_schema_source_candidate_json(
+    candidate: &MetricsSchemaSourceCandidate,
+) -> Result<Vec<u8>, AuditError> {
+    canonical_json(candidate, "metrics schema source candidate")
+}
+
+/// Serialize the checked metrics schema authority using canonical pretty JSON.
+pub fn metrics_schema_authority_json(
+    authority: &MetricsSchemaAuthority,
+) -> Result<Vec<u8>, AuditError> {
+    canonical_json(authority, "metrics schema authority")
+}
+
+fn canonical_json<T: serde::Serialize>(value: &T, label: &str) -> Result<Vec<u8>, AuditError> {
+    let mut bytes = serde_json::to_vec_pretty(value)
+        .map_err(|error| AuditError::new(format!("failed to serialize {label}: {error}")))?;
     bytes.push(b'\n');
     Ok(bytes)
 }

--- a/tools/firecracker-capability-audit/src/main.rs
+++ b/tools/firecracker-capability-audit/src/main.rs
@@ -6,10 +6,12 @@ use std::process::{Command, ExitCode};
 
 use bangbang_firecracker_capability_audit::{
     AuditError, AuditMode, CAPABILITY_INVENTORY_PATH, LOGGER_PRODUCER_AUDIT_PATH,
-    LOGGER_PRODUCER_MANIFEST_PATH, SOURCE_MANIFEST_PATH, derive_logger_producer_manifest,
-    derive_source_manifest, logger_producer_manifest_json, read_capability_inventory,
-    read_logger_producer_audit, read_logger_producer_manifest, read_source_manifest,
-    source_manifest_json, validate, validate_logger_compatibility, validate_logger_producers,
+    LOGGER_PRODUCER_MANIFEST_PATH, METRICS_SCHEMA_AUTHORITY_PATH, SOURCE_MANIFEST_PATH,
+    derive_logger_producer_manifest, derive_metrics_schema_source, derive_source_manifest,
+    logger_producer_manifest_json, metrics_schema_source_candidate_json, read_capability_inventory,
+    read_logger_producer_audit, read_logger_producer_manifest, read_metrics_schema_authority,
+    read_source_manifest, source_manifest_json, validate, validate_logger_compatibility,
+    validate_logger_producers, validate_metrics_schema,
 };
 
 fn main() -> ExitCode {
@@ -35,6 +37,7 @@ fn run(args: Vec<String>) -> Result<String, AuditError> {
         "compare" => run_compare(command_args),
         "regenerate" => run_regenerate(command_args),
         "regenerate-logger-producers" => run_regenerate_logger_producers(command_args),
+        "regenerate-metrics-schema-source" => run_regenerate_metrics_schema_source(command_args),
         "help" | "--help" | "-h" => Ok(usage().to_string()),
         _ => Err(AuditError::new(format!(
             "unknown command: {command}\n{}",
@@ -68,6 +71,8 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
     let inventory = read_capability_inventory(&root.join(CAPABILITY_INVENTORY_PATH))?;
     let logger_manifest = read_logger_producer_manifest(&root.join(LOGGER_PRODUCER_MANIFEST_PATH))?;
     let logger_audit = read_logger_producer_audit(&root.join(LOGGER_PRODUCER_AUDIT_PATH))?;
+    let metrics_authority =
+        read_metrics_schema_authority(&root.join(METRICS_SCHEMA_AUTHORITY_PATH))?;
     let audit_mode = match mode {
         ValidateMode::Delivery => AuditMode::Delivery,
         ValidateMode::Final => AuditMode::Final,
@@ -82,8 +87,12 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
             .map_err(|errors| {
                 AuditError::new(format!("logger compatibility validation errors:\n{errors}"))
             })?;
+            validate_metrics_schema(&metrics_authority, &manifest, &root, AuditMode::Delivery)
+                .map_err(|errors| {
+                    AuditError::new(format!("metrics schema validation errors:\n{errors}"))
+                })?;
             return Ok(
-                "Firecracker capability inventory and logger producer audit are valid for the terminal logger compatibility scope"
+                "Firecracker capability inventory, logger producer audit, and metrics schema authority are valid for the terminal logger compatibility scope"
                     .to_string(),
             );
         }
@@ -97,6 +106,9 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
     {
         failures.push(format!("logger producer validation errors:\n{errors}"));
     }
+    if let Err(errors) = validate_metrics_schema(&metrics_authority, &manifest, &root, audit_mode) {
+        failures.push(format!("metrics schema validation errors:\n{errors}"));
+    }
     if !failures.is_empty() {
         return Err(AuditError::new(failures.join("\n")));
     }
@@ -105,7 +117,7 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
         AuditMode::Final => "final",
     };
     Ok(format!(
-        "Firecracker capability inventory and logger producer audit are valid in {mode_name} mode"
+        "Firecracker capability inventory, logger producer audit, and metrics schema authority are valid in {mode_name} mode"
     ))
 }
 
@@ -116,6 +128,9 @@ fn run_compare(args: &[String]) -> Result<String, AuditError> {
     let derived = derive_source_manifest(Path::new(&firecracker))?;
     let checked_logger = read_logger_producer_manifest(&root.join(LOGGER_PRODUCER_MANIFEST_PATH))?;
     let derived_logger = derive_logger_producer_manifest(Path::new(&firecracker))?;
+    let checked_metrics = read_metrics_schema_authority(&root.join(METRICS_SCHEMA_AUTHORITY_PATH))?
+        .source_candidate();
+    let derived_metrics = derive_metrics_schema_source(Path::new(&firecracker))?;
     let mut differences = Vec::new();
     if checked_in != derived {
         let checked_json = String::from_utf8(source_manifest_json(&checked_in)?)
@@ -141,9 +156,23 @@ fn run_compare(args: &[String]) -> Result<String, AuditError> {
             canonical_line_diff(&checked_json, &derived_json)
         ));
     }
+    if checked_metrics != derived_metrics {
+        let checked_json = String::from_utf8(metrics_schema_source_candidate_json(
+            &checked_metrics,
+        )?)
+        .map_err(|_| AuditError::new("checked metrics schema source JSON is not valid UTF-8"))?;
+        let derived_json = String::from_utf8(metrics_schema_source_candidate_json(
+            &derived_metrics,
+        )?)
+        .map_err(|_| AuditError::new("derived metrics schema source JSON is not valid UTF-8"))?;
+        differences.push(format!(
+            "derived metrics schema source differs from {METRICS_SCHEMA_AUTHORITY_PATH}; run regenerate-metrics-schema-source to an explicit candidate path\n{}",
+            canonical_line_diff(&checked_json, &derived_json)
+        ));
+    }
     if differences.is_empty() {
         Ok(
-            "checked-in source and logger producer manifests match the pinned Firecracker checkout"
+            "checked-in source, logger producer, and metrics schema authorities match the pinned Firecracker checkout"
                 .to_string(),
         )
     } else {
@@ -221,18 +250,46 @@ fn run_regenerate_logger_producers(args: &[String]) -> Result<String, AuditError
     ))
 }
 
+fn run_regenerate_metrics_schema_source(args: &[String]) -> Result<String, AuditError> {
+    let options = required_options(args, &["--firecracker", "--output"])?;
+    let firecracker = options
+        .get("--firecracker")
+        .ok_or_else(|| AuditError::new("--firecracker is required"))?;
+    let output = options
+        .get("--output")
+        .ok_or_else(|| AuditError::new("--output is required"))?;
+    let root = repository_root()?;
+    let output_path = candidate_output_path(&root, Path::new(output))?;
+    let derived = derive_metrics_schema_source(Path::new(firecracker))?;
+    let bytes = metrics_schema_source_candidate_json(&derived)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&output_path)
+        .map_err(|error| AuditError::new(format!("failed to create candidate output: {error}")))?;
+    file.write_all(&bytes)
+        .and_then(|()| file.sync_all())
+        .map_err(|error| AuditError::new(format!("failed to write candidate output: {error}")))?;
+    Ok(format!(
+        "generated metrics schema source candidate: {}",
+        output_path.display()
+    ))
+}
+
 fn candidate_output_path(root: &Path, output: &Path) -> Result<PathBuf, AuditError> {
     let output_path = absolute_from(root, output);
     let source_path = root.join(SOURCE_MANIFEST_PATH);
     let inventory_path = root.join(CAPABILITY_INVENTORY_PATH);
     let logger_manifest_path = root.join(LOGGER_PRODUCER_MANIFEST_PATH);
     let logger_audit_path = root.join(LOGGER_PRODUCER_AUDIT_PATH);
+    let metrics_schema_path = root.join(METRICS_SCHEMA_AUTHORITY_PATH);
     let normalized_output = normalize_lexically(&output_path);
     let checked_paths = [
         &source_path,
         &inventory_path,
         &logger_manifest_path,
         &logger_audit_path,
+        &metrics_schema_path,
     ];
     if checked_paths
         .iter()
@@ -354,7 +411,7 @@ fn absolute_from(root: &Path, path: &Path) -> PathBuf {
 }
 
 fn usage() -> &'static str {
-    "Usage:\n  bangbang-firecracker-capability-audit validate [--final | --logger-final]\n  bangbang-firecracker-capability-audit compare --firecracker PATH\n  bangbang-firecracker-capability-audit regenerate --firecracker PATH --output PATH\n  bangbang-firecracker-capability-audit regenerate-logger-producers --firecracker PATH --output PATH"
+    "Usage:\n  bangbang-firecracker-capability-audit validate [--final | --logger-final]\n  bangbang-firecracker-capability-audit compare --firecracker PATH\n  bangbang-firecracker-capability-audit regenerate --firecracker PATH --output PATH\n  bangbang-firecracker-capability-audit regenerate-logger-producers --firecracker PATH --output PATH\n  bangbang-firecracker-capability-audit regenerate-metrics-schema-source --firecracker PATH --output PATH"
 }
 
 #[cfg(test)]
@@ -428,6 +485,7 @@ mod tests {
             CAPABILITY_INVENTORY_PATH,
             LOGGER_PRODUCER_MANIFEST_PATH,
             LOGGER_PRODUCER_AUDIT_PATH,
+            METRICS_SCHEMA_AUTHORITY_PATH,
         ] {
             let error = candidate_output_path(root, Path::new(path))
                 .expect_err("checked inventory path should be refused");
@@ -443,6 +501,7 @@ mod tests {
             "compat/firecracker/v1.16.0/./capabilities.json",
             "compat/firecracker/v1.16.0/./logger-producer-manifest.json",
             "compat/firecracker/v1.16.0/../v1.16.0/logger-producer-audit.json",
+            "compat/firecracker/v1.16.0/./metrics-schema.json",
         ] {
             let error = candidate_output_path(root, Path::new(path))
                 .expect_err("checked inventory alias should be refused");

--- a/tools/firecracker-capability-audit/src/metrics_model.rs
+++ b/tools/firecracker-capability-audit/src/metrics_model.rs
@@ -1,0 +1,275 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Baseline, Input, Reference};
+
+/// Cardinalities recorded for the pinned arm64 metrics schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsSchemaCounts {
+    pub static_roots: usize,
+    pub static_fields: usize,
+    pub dynamic_families: usize,
+    pub block_dynamic_fields: usize,
+    pub net_dynamic_fields: usize,
+    pub vhost_user_dynamic_fields: usize,
+}
+
+/// Architecture on which a public metrics schema identity is required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsArchitecture {
+    All,
+    Arm64,
+}
+
+/// Schema-presence rule for a metrics identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsSchemaDisposition {
+    RequiredStatic,
+    ConfiguredDynamic,
+}
+
+/// Cardinality rule for a metrics root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsCardinality {
+    Singleton,
+    Aggregate,
+    ConfiguredBlock,
+    ConfiguredNetwork,
+    ConfiguredVhostUserBlock,
+}
+
+/// JSON scalar type admitted by the pinned validator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsJsonType {
+    Number,
+}
+
+/// Collection and reset behavior supplied by the pinned Rust metric primitive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsValueKind {
+    AttemptTimestamp,
+    IncrementalInterval,
+    PersistentStore,
+}
+
+/// Exact syntax anchor used to prove one source fact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsSourceAnchor {
+    pub path: String,
+    pub symbol: String,
+    pub line: usize,
+    pub column: usize,
+    pub fingerprint: String,
+}
+
+/// One ordered, always-present arm64 root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsStaticRoot {
+    pub name: String,
+    pub architecture: MetricsArchitecture,
+    pub schema_disposition: MetricsSchemaDisposition,
+    pub cardinality: MetricsCardinality,
+    pub producer_anchor: MetricsSourceAnchor,
+    pub aggregation_anchor: Option<MetricsSourceAnchor>,
+}
+
+/// One scalar field definition shared by static and configured roots.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsSourceField {
+    pub ordinal: usize,
+    pub id: String,
+    pub path: String,
+    pub json_type: MetricsJsonType,
+    pub value_kind: MetricsValueKind,
+    pub rust_type: String,
+    pub fixture_anchor: MetricsSourceAnchor,
+    pub producer_anchor: MetricsSourceAnchor,
+}
+
+/// One configured dynamic-root grammar and its exact scalar population.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsDynamicFamily {
+    pub id: String,
+    pub fixture_prefix: String,
+    pub producer_template: String,
+    pub architecture: MetricsArchitecture,
+    pub schema_disposition: MetricsSchemaDisposition,
+    pub cardinality: MetricsCardinality,
+    pub field_ids: Vec<String>,
+    pub fixture_anchor: MetricsSourceAnchor,
+    pub producer_anchors: Vec<MetricsSourceAnchor>,
+}
+
+/// Closed category for a known fixture/producer discrepancy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsReconciliationKind {
+    DuplicateFixtureField,
+    ProducerOnlyDynamicFamily,
+}
+
+/// Explicit resolution of a source fact that does not become another schema identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsReconciliation {
+    pub id: String,
+    pub kind: MetricsReconciliationKind,
+    pub resolution: String,
+    pub source_anchors: Vec<MetricsSourceAnchor>,
+}
+
+/// Machine-derived portion of the checked authority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsSchemaSource {
+    pub inputs: Vec<Input>,
+    pub counts: MetricsSchemaCounts,
+    pub static_roots: Vec<MetricsStaticRoot>,
+    pub fields: Vec<MetricsSourceField>,
+    pub dynamic_families: Vec<MetricsDynamicFamily>,
+    pub reconciliations: Vec<MetricsReconciliation>,
+}
+
+/// Source-only envelope emitted by safe regeneration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsSchemaSourceCandidate {
+    pub schema_version: u32,
+    pub baseline: Baseline,
+    pub generator_version: u32,
+    pub source: MetricsSchemaSource,
+}
+
+/// Unit attached to a resolved public scalar field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsUnit {
+    Count,
+    Bytes,
+    Microseconds,
+    MillisecondsSinceUnixEpoch,
+}
+
+/// Aggregation behavior attached to a resolved public scalar field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsAggregation {
+    None,
+    Minimum,
+    Maximum,
+    Sum,
+    SumAcrossConfiguredDevices,
+    ZeroInConfiguredDeviceAggregate,
+}
+
+/// Bangbang subsystem responsible for eventually producing a field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsProducerOwner {
+    SchemaRuntime,
+    ProcessLifecycle,
+    Device,
+}
+
+/// Current producer status, independent of schema presence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsProducerDisposition {
+    Planned,
+    Implemented,
+    PlatformZero,
+}
+
+/// Reusable closed metadata and rationale for a set of fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsPolicyProfile {
+    pub id: String,
+    pub unit: MetricsUnit,
+    pub aggregation: MetricsAggregation,
+    pub producer_owner: MetricsProducerOwner,
+    pub producer_disposition: MetricsProducerDisposition,
+    #[serde(default)]
+    pub delivery_issue: Option<String>,
+    pub rationale: String,
+    #[serde(default)]
+    pub implementation: Vec<Reference>,
+    #[serde(default)]
+    pub validation: Vec<Reference>,
+}
+
+/// Exact one-to-one assignment of a source field to reviewed policy metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsFieldPolicy {
+    pub field_id: String,
+    pub profile_id: String,
+}
+
+/// Checked field authority: generated source facts plus reviewed policy facts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsSchemaAuthority {
+    pub schema_version: u32,
+    pub baseline: Baseline,
+    pub generator_version: u32,
+    pub source: MetricsSchemaSource,
+    pub policy_profiles: Vec<MetricsPolicyProfile>,
+    pub field_policies: Vec<MetricsFieldPolicy>,
+}
+
+impl MetricsSchemaAuthority {
+    /// Project the machine-owned portion for exact sibling comparison.
+    pub fn source_candidate(&self) -> MetricsSchemaSourceCandidate {
+        MetricsSchemaSourceCandidate {
+            schema_version: self.schema_version,
+            baseline: self.baseline.clone(),
+            generator_version: self.generator_version,
+            source: self.source.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_unknown_authority_fields() {
+        let error = serde_json::from_str::<MetricsSchemaAuthority>(
+            r#"{
+                "schema_version":1,
+                "baseline":{"version":"1.16.0","commit":"c","target":"t"},
+                "generator_version":1,
+                "source":{"inputs":[],"counts":{"static_roots":0,"static_fields":0,
+                    "dynamic_families":0,"block_dynamic_fields":0,"net_dynamic_fields":0,
+                    "vhost_user_dynamic_fields":0},"static_roots":[],"fields":[],
+                    "dynamic_families":[],"reconciliations":[]},
+                "policy_profiles":[],"field_policies":[],"typo":true
+            }"#,
+        )
+        .expect_err("unknown authority fields must fail");
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_open_ended_policy_values() {
+        let error = serde_json::from_str::<MetricsPolicyProfile>(
+            r##"{"id":"p","unit":"widgets","aggregation":"none",
+                "producer_owner":"device","producer_disposition":"planned",
+                "delivery_issue":"#1789","rationale":"test",
+                "implementation":[],"validation":[]}"##,
+        )
+        .expect_err("unknown units must fail");
+        assert!(error.to_string().contains("unknown variant"));
+    }
+}

--- a/tools/firecracker-capability-audit/src/metrics_upstream.rs
+++ b/tools/firecracker-capability-audit/src/metrics_upstream.rs
@@ -1339,22 +1339,46 @@ fn validate_fixture_assignment_boundary(
 ) -> Result<(), AuditError> {
     let marker = "    # validate timestamp before jsonschema validation";
     let end = unique_offset_in(source, function.clone(), marker)?;
+    let start = unique_offset_in(
+        source,
+        function.start..end,
+        "    latency_agg_metrics_fields =",
+    )?;
     let prefix = source
-        .get(function.start..end)
+        .get(start..end)
         .ok_or_else(|| AuditError::new("invalid metrics fixture schema boundary"))?;
-    let assignments = prefix
-        .lines()
-        .filter_map(|line| {
-            let rest = line.strip_prefix("    ")?;
-            if rest.starts_with(' ') {
-                return None;
-            }
-            let (name, _) = rest.split_once(" = ")?;
-            name.chars()
-                .all(|character| character == '_' || character.is_ascii_alphanumeric())
-                .then(|| name.to_string())
-        })
-        .collect::<Vec<_>>();
+    let mut assignments = Vec::new();
+    for line in prefix.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("    ") else {
+            return Err(AuditError::new(
+                "metrics fixture schema statements must use exact function indentation",
+            ));
+        };
+        if rest.starts_with(' ') {
+            continue;
+        }
+        let statement = rest.trim();
+        if statement.is_empty() || statement.starts_with('#') || matches!(statement, "]" | "}") {
+            continue;
+        }
+        let Some((name, _)) = statement.split_once(" = ") else {
+            return Err(AuditError::new(format!(
+                "unsupported top-level metrics fixture schema statement: {statement}"
+            )));
+        };
+        if !name
+            .chars()
+            .all(|character| character == '_' || character.is_ascii_alphanumeric())
+        {
+            return Err(AuditError::new(format!(
+                "unsupported top-level metrics fixture schema assignment: {name}"
+            )));
+        }
+        assignments.push(name.to_string());
+    }
     let expected = [
         "latency_agg_metrics_fields",
         "block_metrics",
@@ -1704,6 +1728,33 @@ class FcDeviceMetrics:
             .parse_value()
             .expect_err("escaped names must be outside the restricted grammar");
         assert!(error.to_string().contains("escaped"));
+    }
+
+    #[test]
+    fn restricted_fixture_rejects_an_unparsed_schema_mutation() {
+        let source = r#"def validate_fc_metrics(metrics):
+    latency_agg_metrics_fields = ["min_us", "max_us", "sum_us"]
+    block_metrics = [{"read_agg": latency_agg_metrics_fields}, "read_count"]
+    net_metrics = ["rx_count"]
+    firecracker_metrics = {"utc_timestamp_ms": "", "block": block_metrics}
+    firecracker_metrics["unparsed"] = ["count"]
+    # validate timestamp before jsonschema validation which some more time
+    if platform.machine() == "aarch64":
+        firecracker_metrics["rtc"] = ["error_count"]
+    for metrics_name in metrics.keys():
+        if metrics_name.startswith("vhost_user_"):
+            firecracker_metrics[metrics_name] = ["activate_fails"]
+        if metrics_name.startswith("block_"):
+            firecracker_metrics[metrics_name] = block_metrics
+        if metrics_name.startswith("net_"):
+            firecracker_metrics[metrics_name] = net_metrics
+
+class FcDeviceMetrics:
+    pass
+"#;
+        let error =
+            extract_fixture_schema(source).expect_err("unparsed schema mutations must fail closed");
+        assert!(error.to_string().contains("unsupported top-level"));
     }
 
     #[test]

--- a/tools/firecracker-capability-audit/src/metrics_upstream.rs
+++ b/tools/firecracker-capability-audit/src/metrics_upstream.rs
@@ -1,0 +1,1726 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use proc_macro2::{TokenStream, TokenTree};
+use quote::ToTokens;
+use sha2::{Digest, Sha256};
+use syn::spanned::Spanned;
+use syn::{Attribute, Fields, Item, ItemStruct, Type};
+
+use crate::upstream::{ensure_regular_input, git_output, read_input};
+use crate::{
+    AuditError, Baseline, FIRECRACKER_COMMIT, FIRECRACKER_TARGET, FIRECRACKER_VERSION, Input,
+    METRICS_SCHEMA_GENERATOR_VERSION, METRICS_SCHEMA_VERSION, MetricsArchitecture,
+    MetricsCardinality, MetricsDynamicFamily, MetricsJsonType, MetricsReconciliation,
+    MetricsReconciliationKind, MetricsSchemaCounts, MetricsSchemaDisposition, MetricsSchemaSource,
+    MetricsSchemaSourceCandidate, MetricsSourceAnchor, MetricsSourceField, MetricsStaticRoot,
+    MetricsValueKind, ensure_pinned_checkout,
+};
+
+const PYTHON_EXTRACTOR: &str = "python-metrics-schema-v1";
+const RUST_EXTRACTOR: &str = "rust-metrics-schema-v1";
+const FIXTURE_PATH: &str = "tests/host_tools/fcmetrics.py";
+const ROOT_METRICS_PATH: &str = "src/vmm/src/logger/metrics.rs";
+const LEGACY_PATH: &str = "src/vmm/src/devices/legacy/mod.rs";
+const I8042_PATH: &str = "src/vmm/src/devices/legacy/i8042.rs";
+const RTC_PATH: &str = "src/vmm/src/devices/legacy/rtc_pl031.rs";
+const SERIAL_PATH: &str = "src/vmm/src/devices/legacy/serial.rs";
+const BALLOON_PATH: &str = "src/vmm/src/devices/virtio/balloon/metrics.rs";
+const BLOCK_PATH: &str = "src/vmm/src/devices/virtio/block/virtio/metrics.rs";
+const VHOST_BLOCK_PATH: &str = "src/vmm/src/devices/virtio/block/vhost_user/device.rs";
+const MEMORY_HOTPLUG_PATH: &str = "src/vmm/src/devices/virtio/mem/metrics.rs";
+const NET_PATH: &str = "src/vmm/src/devices/virtio/net/metrics.rs";
+const PMEM_PATH: &str = "src/vmm/src/devices/virtio/pmem/metrics.rs";
+const ENTROPY_PATH: &str = "src/vmm/src/devices/virtio/rng/metrics.rs";
+const VHOST_USER_PATH: &str = "src/vmm/src/devices/virtio/vhost_user_metrics.rs";
+const VSOCK_PATH: &str = "src/vmm/src/devices/virtio/vsock/metrics.rs";
+
+const INPUT_PATHS: &[(&str, &str)] = &[
+    (I8042_PATH, RUST_EXTRACTOR),
+    (LEGACY_PATH, RUST_EXTRACTOR),
+    (RTC_PATH, RUST_EXTRACTOR),
+    (SERIAL_PATH, RUST_EXTRACTOR),
+    (BALLOON_PATH, RUST_EXTRACTOR),
+    (BLOCK_PATH, RUST_EXTRACTOR),
+    (VHOST_BLOCK_PATH, RUST_EXTRACTOR),
+    (MEMORY_HOTPLUG_PATH, RUST_EXTRACTOR),
+    (NET_PATH, RUST_EXTRACTOR),
+    (PMEM_PATH, RUST_EXTRACTOR),
+    (ENTROPY_PATH, RUST_EXTRACTOR),
+    (VHOST_USER_PATH, RUST_EXTRACTOR),
+    (VSOCK_PATH, RUST_EXTRACTOR),
+    (ROOT_METRICS_PATH, RUST_EXTRACTOR),
+    (FIXTURE_PATH, PYTHON_EXTRACTOR),
+];
+
+#[derive(Clone, Copy)]
+struct RootSpec {
+    name: &'static str,
+    rust_path: &'static str,
+    rust_struct: &'static str,
+    architecture: MetricsArchitecture,
+    cardinality: MetricsCardinality,
+}
+
+const ROOT_SPECS: &[RootSpec] = &[
+    root_spec("api_server", ROOT_METRICS_PATH, "ApiServerMetrics"),
+    root_spec("balloon", BALLOON_PATH, "BalloonDeviceMetrics"),
+    aggregate_root_spec("block", BLOCK_PATH, "BlockDeviceMetrics"),
+    root_spec("deprecated_api", ROOT_METRICS_PATH, "DeprecatedApiMetrics"),
+    root_spec("get_api_requests", ROOT_METRICS_PATH, "GetRequestsMetrics"),
+    root_spec("i8042", I8042_PATH, "I8042DeviceMetrics"),
+    RootSpec {
+        name: "rtc",
+        rust_path: RTC_PATH,
+        rust_struct: "RTCDeviceMetrics",
+        architecture: MetricsArchitecture::Arm64,
+        cardinality: MetricsCardinality::Singleton,
+    },
+    root_spec("uart", SERIAL_PATH, "SerialDeviceMetrics"),
+    root_spec("latencies_us", ROOT_METRICS_PATH, "PerformanceMetrics"),
+    root_spec("logger", ROOT_METRICS_PATH, "LoggerSystemMetrics"),
+    root_spec("mmds", ROOT_METRICS_PATH, "MmdsMetrics"),
+    aggregate_root_spec("net", NET_PATH, "NetDeviceMetrics"),
+    root_spec(
+        "patch_api_requests",
+        ROOT_METRICS_PATH,
+        "PatchRequestsMetrics",
+    ),
+    root_spec("put_api_requests", ROOT_METRICS_PATH, "PutRequestsMetrics"),
+    root_spec("seccomp", ROOT_METRICS_PATH, "SeccompMetrics"),
+    root_spec("vcpu", ROOT_METRICS_PATH, "VcpuMetrics"),
+    root_spec("vmm", ROOT_METRICS_PATH, "VmmMetrics"),
+    root_spec("signals", ROOT_METRICS_PATH, "SignalMetrics"),
+    root_spec("vsock", VSOCK_PATH, "VsockDeviceMetrics"),
+    root_spec("entropy", ENTROPY_PATH, "EntropyDeviceMetrics"),
+    aggregate_root_spec("pmem", PMEM_PATH, "PmemMetrics"),
+    root_spec("interrupts", ROOT_METRICS_PATH, "InterruptMetrics"),
+    root_spec(
+        "memory_hotplug",
+        MEMORY_HOTPLUG_PATH,
+        "VirtioMemDeviceMetrics",
+    ),
+];
+
+const fn root_spec(
+    name: &'static str,
+    rust_path: &'static str,
+    rust_struct: &'static str,
+) -> RootSpec {
+    RootSpec {
+        name,
+        rust_path,
+        rust_struct,
+        architecture: MetricsArchitecture::All,
+        cardinality: MetricsCardinality::Singleton,
+    }
+}
+
+const fn aggregate_root_spec(
+    name: &'static str,
+    rust_path: &'static str,
+    rust_struct: &'static str,
+) -> RootSpec {
+    RootSpec {
+        name,
+        rust_path,
+        rust_struct,
+        architecture: MetricsArchitecture::All,
+        cardinality: MetricsCardinality::Aggregate,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PythonString {
+    value: String,
+    anchor: MetricsSourceAnchor,
+}
+
+#[derive(Debug, Clone)]
+enum PythonValue {
+    String(PythonString),
+    Name(String),
+    List(Vec<PythonValue>),
+    Dict(Vec<(PythonString, PythonValue)>),
+}
+
+#[derive(Debug)]
+struct FixtureSchema {
+    roots: Vec<PythonString>,
+    static_fields: BTreeMap<String, Vec<MetricsSourceAnchor>>,
+    dynamic_fields: Vec<FixtureDynamicFamily>,
+}
+
+#[derive(Debug)]
+struct FixtureDynamicFamily {
+    id: String,
+    fields: Vec<(String, MetricsSourceAnchor)>,
+    anchor: MetricsSourceAnchor,
+}
+
+#[derive(Debug, Clone)]
+struct RustField {
+    name: String,
+    wire_name: String,
+    rust_type: String,
+    flatten: bool,
+    anchor: MetricsSourceAnchor,
+}
+
+#[derive(Debug, Clone)]
+struct RustStruct {
+    path: String,
+    name: String,
+    fields: Vec<RustField>,
+}
+
+#[derive(Debug, Clone)]
+struct FlattenedRustField {
+    path: String,
+    value_kind: MetricsValueKind,
+    rust_type: String,
+    anchor: MetricsSourceAnchor,
+}
+
+/// Derive the machine-owned metrics schema source from pinned upstream syntax.
+pub fn derive_metrics_schema_source(
+    path: &Path,
+) -> Result<MetricsSchemaSourceCandidate, AuditError> {
+    let checkout = ensure_pinned_checkout(path)?;
+    let (inputs, sources) = read_inputs(&checkout)?;
+    let fixture_source = sources
+        .get(FIXTURE_PATH)
+        .ok_or_else(|| AuditError::new("missing checked metrics fixture input"))?;
+    let fixture = extract_fixture_schema(fixture_source)?;
+    let structs = extract_rust_structs(&sources)?;
+    let root_order = extract_static_root_order(&structs, &sources)?;
+    let root_specs = ROOT_SPECS
+        .iter()
+        .map(|spec| (spec.name, *spec))
+        .collect::<BTreeMap<_, _>>();
+
+    let fixture_roots = fixture
+        .roots
+        .iter()
+        .map(|root| root.value.as_str())
+        .collect::<BTreeSet<_>>();
+    let derived_roots = root_order
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    if fixture_roots != derived_roots {
+        return Err(AuditError::new(format!(
+            "metrics fixture and Rust serializers disagree on arm64 static roots: fixture={fixture_roots:?}; rust={derived_roots:?}"
+        )));
+    }
+
+    let mut static_roots = Vec::new();
+    let mut fields = Vec::new();
+    for root_name in &root_order {
+        if root_name == "utc_timestamp_ms" {
+            let root_field = fixture
+                .static_fields
+                .get(root_name)
+                .and_then(|anchors| anchors.first())
+                .ok_or_else(|| AuditError::new("fixture is missing utc_timestamp_ms"))?;
+            let rust_field =
+                find_struct_field(&structs, ROOT_METRICS_PATH, "FirecrackerMetrics", root_name)?;
+            static_roots.push(MetricsStaticRoot {
+                name: root_name.clone(),
+                architecture: MetricsArchitecture::All,
+                schema_disposition: MetricsSchemaDisposition::RequiredStatic,
+                cardinality: MetricsCardinality::Singleton,
+                producer_anchor: rust_field.anchor.clone(),
+                aggregation_anchor: None,
+            });
+            fields.push(MetricsSourceField {
+                ordinal: fields.len(),
+                id: format!("static:{root_name}"),
+                path: root_name.clone(),
+                json_type: MetricsJsonType::Number,
+                value_kind: MetricsValueKind::AttemptTimestamp,
+                rust_type: rust_field.rust_type.clone(),
+                fixture_anchor: root_field.clone(),
+                producer_anchor: rust_field.anchor.clone(),
+            });
+            continue;
+        }
+
+        let spec = root_specs.get(root_name.as_str()).ok_or_else(|| {
+            AuditError::new(format!(
+                "unsupported metrics root derived from Rust: {root_name}"
+            ))
+        })?;
+        let producer_anchor = root_producer_anchor(spec, &structs, &sources)?;
+        static_roots.push(MetricsStaticRoot {
+            name: root_name.clone(),
+            architecture: spec.architecture,
+            schema_disposition: MetricsSchemaDisposition::RequiredStatic,
+            cardinality: spec.cardinality,
+            producer_anchor,
+            aggregation_anchor: root_aggregation_anchor(spec, &sources)?,
+        });
+        let rust_fields = flatten_struct(&structs, spec.rust_path, spec.rust_struct)?;
+        append_scope_fields(
+            &mut fields,
+            "static",
+            root_name,
+            &rust_fields,
+            &fixture.static_fields,
+        )?;
+    }
+
+    let mut reconciliations = duplicate_reconciliations(&fixture.static_fields);
+    let dynamic_families = build_dynamic_families(
+        &fixture,
+        &structs,
+        &sources,
+        &mut fields,
+        &mut reconciliations,
+    )?;
+
+    let counts = MetricsSchemaCounts {
+        static_roots: static_roots.len(),
+        static_fields: fields
+            .iter()
+            .filter(|field| field.id.starts_with("static:"))
+            .count(),
+        dynamic_families: dynamic_families.len(),
+        block_dynamic_fields: dynamic_field_count(&dynamic_families, "block"),
+        net_dynamic_fields: dynamic_field_count(&dynamic_families, "net"),
+        vhost_user_dynamic_fields: dynamic_field_count(&dynamic_families, "vhost-user-block"),
+    };
+
+    Ok(MetricsSchemaSourceCandidate {
+        schema_version: METRICS_SCHEMA_VERSION,
+        baseline: Baseline {
+            version: FIRECRACKER_VERSION.to_string(),
+            commit: FIRECRACKER_COMMIT.to_string(),
+            target: FIRECRACKER_TARGET.to_string(),
+        },
+        generator_version: METRICS_SCHEMA_GENERATOR_VERSION,
+        source: MetricsSchemaSource {
+            inputs,
+            counts,
+            static_roots,
+            fields,
+            dynamic_families,
+            reconciliations,
+        },
+    })
+}
+
+fn extract_rust_structs(
+    sources: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, RustStruct>, AuditError> {
+    let mut structs = BTreeMap::new();
+    for (path, source) in sources {
+        if !path.ends_with(".rs") {
+            continue;
+        }
+        let syntax = syn::parse_file(source)
+            .map_err(|_| AuditError::new(format!("failed to parse Rust metrics input: {path}")))?;
+        for item in syntax.items {
+            let Item::Struct(item_struct) = item else {
+                continue;
+            };
+            if !wanted_metrics_struct(path, &item_struct.ident.to_string()) {
+                continue;
+            }
+            let Some(parsed) = parse_rust_struct(path, &item_struct)? else {
+                continue;
+            };
+            let key = rust_struct_key(path, &parsed.name);
+            if structs.insert(key.clone(), parsed).is_some() {
+                return Err(AuditError::new(format!(
+                    "duplicate Rust metrics struct identity: {key}"
+                )));
+            }
+        }
+    }
+    Ok(structs)
+}
+
+fn parse_rust_struct(path: &str, item: &ItemStruct) -> Result<Option<RustStruct>, AuditError> {
+    if !item
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("derive"))
+        .any(|attr| {
+            attr.meta
+                .to_token_stream()
+                .to_string()
+                .contains("Serialize")
+        })
+    {
+        return Err(AuditError::new(format!(
+            "Rust metrics struct must derive Serialize: {path}:{}",
+            item.ident
+        )));
+    }
+    let Fields::Named(named) = &item.fields else {
+        return Ok(None);
+    };
+    let mut fields = Vec::new();
+    for field in &named.named {
+        let Some(ident) = &field.ident else {
+            return Err(AuditError::new(format!(
+                "named Rust metrics struct has an unnamed field: {path}:{}",
+                item.ident
+            )));
+        };
+        let rust_type = rust_type_name(&field.ty).ok_or_else(|| {
+            AuditError::new(format!(
+                "unsupported Rust metrics field type: {path}:{}.{}",
+                item.ident, ident
+            ))
+        })?;
+        let (wire_name, flatten) = serde_field_policy(&field.attrs, &ident.to_string())?;
+        let start = field.span().start();
+        fields.push(RustField {
+            name: ident.to_string(),
+            wire_name,
+            rust_type,
+            flatten,
+            anchor: MetricsSourceAnchor {
+                path: path.to_string(),
+                symbol: format!("{}.{}", item.ident, ident),
+                line: start.line,
+                column: start.column + 1,
+                fingerprint: fingerprint_tokens(field.to_token_stream()),
+            },
+        });
+    }
+    Ok(Some(RustStruct {
+        path: path.to_string(),
+        name: item.ident.to_string(),
+        fields,
+    }))
+}
+
+fn wanted_metrics_struct(path: &str, name: &str) -> bool {
+    (path == ROOT_METRICS_PATH && matches!(name, "FirecrackerMetrics" | "LatencyAggregateMetrics"))
+        || ROOT_SPECS
+            .iter()
+            .any(|spec| spec.rust_path == path && spec.rust_struct == name)
+        || (path == VHOST_USER_PATH && name == "VhostUserDeviceMetrics")
+}
+
+fn rust_type_name(ty: &Type) -> Option<String> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+    (path.qself.is_none())
+        .then(|| {
+            path.path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string())
+        })
+        .flatten()
+}
+
+fn serde_field_policy(
+    attrs: &[Attribute],
+    default_name: &str,
+) -> Result<(String, bool), AuditError> {
+    let mut wire_name = default_name.to_string();
+    let mut flatten = false;
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("flatten") {
+                flatten = true;
+                return Ok(());
+            }
+            if meta.path.is_ident("rename") {
+                let value = meta.value()?;
+                let literal: syn::LitStr = value.parse()?;
+                wire_name = literal.value();
+                return Ok(());
+            }
+            Err(meta.error("unsupported serde attribute on metrics field"))
+        })
+        .map_err(|_| {
+            AuditError::new(format!(
+                "unsupported serde attribute on metrics field: {default_name}"
+            ))
+        })?;
+    }
+    Ok((wire_name, flatten))
+}
+
+fn extract_static_root_order(
+    structs: &BTreeMap<String, RustStruct>,
+    sources: &BTreeMap<String, String>,
+) -> Result<Vec<String>, AuditError> {
+    let root = find_struct(structs, ROOT_METRICS_PATH, "FirecrackerMetrics")?;
+    let root_source = sources
+        .get(ROOT_METRICS_PATH)
+        .ok_or_else(|| AuditError::new("missing root metrics serializer input"))?;
+    verify_ordered_snippets(
+        root_source,
+        &[
+            "create_serialize_proxy!(BlockMetricsSerializeProxy, block_metrics);",
+            "create_serialize_proxy!(NetMetricsSerializeProxy, net_metrics);",
+            "create_serialize_proxy!(VhostUserMetricsSerializeProxy, vhost_user_metrics);",
+            "create_serialize_proxy!(BalloonMetricsSerializeProxy, balloon_metrics);",
+            "create_serialize_proxy!(EntropyMetricsSerializeProxy, entropy_metrics);",
+            "create_serialize_proxy!(VsockMetricsSerializeProxy, vsock_metrics);",
+            "create_serialize_proxy!(PmemMetricsSerializeProxy, pmem_metrics);",
+            "create_serialize_proxy!(LegacyDevMetricsSerializeProxy, legacy);",
+            "create_serialize_proxy!(MemoryHotplugSerializeProxy, virtio_mem_metrics);",
+        ],
+        "FirecrackerMetrics flattening proxies",
+    )?;
+    let root_types = ROOT_SPECS
+        .iter()
+        .map(|spec| (spec.rust_struct, spec.name))
+        .collect::<BTreeMap<_, _>>();
+    let mut roots = Vec::new();
+    for field in &root.fields {
+        let expansion: &[&str] = match field.rust_type.as_str() {
+            "SerializeToUtcTimestampMs" => &["utc_timestamp_ms"],
+            "BalloonMetricsSerializeProxy" => &["balloon"],
+            "BlockMetricsSerializeProxy" => &["block"],
+            "LegacyDevMetricsSerializeProxy" => &["i8042", "rtc", "uart"],
+            "NetMetricsSerializeProxy" => &["net"],
+            "VhostUserMetricsSerializeProxy" => &[],
+            "EntropyMetricsSerializeProxy" => &["entropy"],
+            "VsockMetricsSerializeProxy" => &["vsock"],
+            "PmemMetricsSerializeProxy" => &["pmem"],
+            "MemoryHotplugSerializeProxy" => &["memory_hotplug"],
+            other => {
+                let expected = root_types.get(other).ok_or_else(|| {
+                    AuditError::new(format!(
+                        "unsupported FirecrackerMetrics field type: {} -> {other}",
+                        field.name
+                    ))
+                })?;
+                if field.flatten || field.wire_name != *expected {
+                    return Err(AuditError::new(format!(
+                        "unexpected FirecrackerMetrics field serialization: {}",
+                        field.name
+                    )));
+                }
+                roots.push((*expected).to_string());
+                continue;
+            }
+        };
+        if field.rust_type.ends_with("SerializeProxy") && !field.flatten {
+            return Err(AuditError::new(format!(
+                "metrics serialize proxy is not flattened: {}",
+                field.name
+            )));
+        }
+        roots.extend(expansion.iter().map(|root| (*root).to_string()));
+    }
+
+    let legacy = sources
+        .get(LEGACY_PATH)
+        .ok_or_else(|| AuditError::new("missing legacy metrics serializer input"))?;
+    verify_ordered_snippets(
+        legacy,
+        &[
+            "serialize_entry(\"i8042\"",
+            "serialize_entry(\"rtc\"",
+            "serialize_entry(\"uart\"",
+        ],
+        "legacy metrics roots",
+    )?;
+    let rtc_offset = unique_offset(legacy, "serialize_entry(\"rtc\"")?;
+    let rtc_prefix = legacy
+        .get(rtc_offset.saturating_sub(96)..rtc_offset)
+        .ok_or_else(|| AuditError::new("invalid rtc serializer source range"))?;
+    if !rtc_prefix.contains("#[cfg(target_arch = \"aarch64\")]") {
+        return Err(AuditError::new(
+            "rtc metrics root must be guarded by target_arch = aarch64",
+        ));
+    }
+    Ok(roots)
+}
+
+fn root_producer_anchor(
+    spec: &RootSpec,
+    structs: &BTreeMap<String, RustStruct>,
+    sources: &BTreeMap<String, String>,
+) -> Result<MetricsSourceAnchor, AuditError> {
+    if spec.rust_path == ROOT_METRICS_PATH {
+        return Ok(
+            find_struct_field(structs, ROOT_METRICS_PATH, "FirecrackerMetrics", spec.name)?
+                .anchor
+                .clone(),
+        );
+    }
+    let serializer_path = match spec.name {
+        "i8042" | "rtc" | "uart" => LEGACY_PATH,
+        _ => spec.rust_path,
+    };
+    let source = sources.get(serializer_path).ok_or_else(|| {
+        AuditError::new(format!(
+            "missing metrics serializer input: {serializer_path}"
+        ))
+    })?;
+    anchor_for_snippet(
+        source,
+        serializer_path,
+        &format!("serialize_entry(\"{}\"", spec.name),
+        format!("serialize-root:{}", spec.name),
+    )
+}
+
+fn root_aggregation_anchor(
+    spec: &RootSpec,
+    sources: &BTreeMap<String, String>,
+) -> Result<Option<MetricsSourceAnchor>, AuditError> {
+    if spec.cardinality != MetricsCardinality::Aggregate {
+        return Ok(None);
+    }
+    let source = sources.get(spec.rust_path).ok_or_else(|| {
+        AuditError::new(format!(
+            "missing aggregate metrics input: {}",
+            spec.rust_path
+        ))
+    })?;
+    let syntax = syn::parse_file(source).map_err(|_| {
+        AuditError::new(format!(
+            "failed to parse aggregate metrics input: {}",
+            spec.rust_path
+        ))
+    })?;
+    let mut matches = Vec::new();
+    for item in syntax.items {
+        let Item::Impl(item_impl) = item else {
+            continue;
+        };
+        let Some(self_type) = rust_type_name(&item_impl.self_ty) else {
+            continue;
+        };
+        if self_type != spec.rust_struct {
+            continue;
+        }
+        for impl_item in item_impl.items {
+            let syn::ImplItem::Fn(method) = impl_item else {
+                continue;
+            };
+            if method.sig.ident == "aggregate" {
+                let start = method.span().start();
+                matches.push(MetricsSourceAnchor {
+                    path: spec.rust_path.to_string(),
+                    symbol: format!("{}::aggregate", spec.rust_struct),
+                    line: start.line,
+                    column: start.column + 1,
+                    fingerprint: fingerprint_tokens(method.to_token_stream()),
+                });
+            }
+        }
+    }
+    match matches.as_slice() {
+        [anchor] => Ok(Some(anchor.clone())),
+        [] => Err(AuditError::new(format!(
+            "aggregate metrics root is missing its aggregate method: {}",
+            spec.name
+        ))),
+        _ => Err(AuditError::new(format!(
+            "aggregate metrics root has multiple aggregate methods: {}",
+            spec.name
+        ))),
+    }
+}
+
+fn flatten_struct(
+    structs: &BTreeMap<String, RustStruct>,
+    path: &str,
+    name: &str,
+) -> Result<Vec<FlattenedRustField>, AuditError> {
+    let root = find_struct(structs, path, name)?;
+    let mut fields = Vec::new();
+    let mut stack = BTreeSet::new();
+    flatten_rust_struct(structs, root, "", &mut stack, &mut fields)?;
+    Ok(fields)
+}
+
+fn flatten_rust_struct(
+    structs: &BTreeMap<String, RustStruct>,
+    item: &RustStruct,
+    prefix: &str,
+    stack: &mut BTreeSet<String>,
+    output: &mut Vec<FlattenedRustField>,
+) -> Result<(), AuditError> {
+    let identity = rust_struct_key(&item.path, &item.name);
+    if !stack.insert(identity.clone()) {
+        return Err(AuditError::new(format!(
+            "recursive Rust metrics struct: {identity}"
+        )));
+    }
+    for field in &item.fields {
+        if field.flatten {
+            return Err(AuditError::new(format!(
+                "nested metrics value struct unexpectedly flattens field: {identity}.{}",
+                field.name
+            )));
+        }
+        let field_path = join_path(prefix, &field.wire_name);
+        let value_kind = match field.rust_type.as_str() {
+            "SharedIncMetric" => Some(MetricsValueKind::IncrementalInterval),
+            "SharedStoreMetric" => Some(MetricsValueKind::PersistentStore),
+            _ => None,
+        };
+        if let Some(value_kind) = value_kind {
+            output.push(FlattenedRustField {
+                path: field_path,
+                value_kind,
+                rust_type: field.rust_type.clone(),
+                anchor: field.anchor.clone(),
+            });
+            continue;
+        }
+        let nested = find_struct_by_name(structs, &field.rust_type)?;
+        flatten_rust_struct(structs, nested, &field_path, stack, output)?;
+    }
+    stack.remove(&identity);
+    Ok(())
+}
+
+fn append_scope_fields(
+    output: &mut Vec<MetricsSourceField>,
+    scope: &str,
+    root_or_template: &str,
+    rust_fields: &[FlattenedRustField],
+    fixture_fields: &BTreeMap<String, Vec<MetricsSourceAnchor>>,
+) -> Result<Vec<String>, AuditError> {
+    let fixture_prefix = format!("{root_or_template}.");
+    let expected = fixture_fields
+        .keys()
+        .filter(|path| path.starts_with(&fixture_prefix))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let actual = rust_fields
+        .iter()
+        .map(|field| join_path(root_or_template, &field.path))
+        .collect::<BTreeSet<_>>();
+    if expected != actual {
+        return Err(AuditError::new(format!(
+            "metrics fixture and Rust struct disagree for {root_or_template}: fixture={expected:?}; rust={actual:?}"
+        )));
+    }
+
+    let mut ids = Vec::new();
+    for field in rust_fields {
+        let path = join_path(root_or_template, &field.path);
+        let anchors = fixture_fields
+            .get(&path)
+            .ok_or_else(|| AuditError::new(format!("metrics fixture field is missing: {path}")))?;
+        let fixture_anchor = anchors.first().ok_or_else(|| {
+            AuditError::new(format!("metrics fixture field has no anchor: {path}"))
+        })?;
+        let id = format!("{scope}:{path}");
+        ids.push(id.clone());
+        output.push(MetricsSourceField {
+            ordinal: output.len(),
+            id,
+            path,
+            json_type: MetricsJsonType::Number,
+            value_kind: field.value_kind,
+            rust_type: field.rust_type.clone(),
+            fixture_anchor: fixture_anchor.clone(),
+            producer_anchor: field.anchor.clone(),
+        });
+    }
+    Ok(ids)
+}
+
+fn build_dynamic_families(
+    fixture: &FixtureSchema,
+    structs: &BTreeMap<String, RustStruct>,
+    sources: &BTreeMap<String, String>,
+    fields: &mut Vec<MetricsSourceField>,
+    reconciliations: &mut Vec<MetricsReconciliation>,
+) -> Result<Vec<MetricsDynamicFamily>, AuditError> {
+    struct DynamicSpec {
+        id: &'static str,
+        prefix: &'static str,
+        template: &'static str,
+        cardinality: MetricsCardinality,
+        rust_path: &'static str,
+        rust_struct: &'static str,
+    }
+    let specs = [
+        DynamicSpec {
+            id: "block",
+            prefix: "block_",
+            template: "block_{drive_id}",
+            cardinality: MetricsCardinality::ConfiguredBlock,
+            rust_path: BLOCK_PATH,
+            rust_struct: "BlockDeviceMetrics",
+        },
+        DynamicSpec {
+            id: "net",
+            prefix: "net_",
+            template: "net_{iface_id}",
+            cardinality: MetricsCardinality::ConfiguredNetwork,
+            rust_path: NET_PATH,
+            rust_struct: "NetDeviceMetrics",
+        },
+        DynamicSpec {
+            id: "vhost-user-block",
+            prefix: "vhost_user_",
+            template: "vhost_user_block_{drive_id}",
+            cardinality: MetricsCardinality::ConfiguredVhostUserBlock,
+            rust_path: VHOST_USER_PATH,
+            rust_struct: "VhostUserDeviceMetrics",
+        },
+    ];
+
+    let mut families = Vec::new();
+    for spec in specs {
+        let fixture_family = fixture
+            .dynamic_fields
+            .iter()
+            .find(|family| family.id == spec.id)
+            .ok_or_else(|| {
+                AuditError::new(format!(
+                    "metrics fixture dynamic family is missing: {}",
+                    spec.id
+                ))
+            })?;
+        let fixture_map = fixture_family
+            .fields
+            .iter()
+            .map(|(path, anchor)| (join_path(spec.template, path), vec![anchor.clone()]))
+            .collect::<BTreeMap<_, _>>();
+        let rust_fields = flatten_struct(structs, spec.rust_path, spec.rust_struct)?;
+        let field_ids =
+            append_scope_fields(fields, "dynamic", spec.template, &rust_fields, &fixture_map)?;
+        let producer_anchors = dynamic_producer_anchors(spec.id, sources)?;
+        families.push(MetricsDynamicFamily {
+            id: spec.id.to_string(),
+            fixture_prefix: spec.prefix.to_string(),
+            producer_template: spec.template.to_string(),
+            architecture: MetricsArchitecture::All,
+            schema_disposition: MetricsSchemaDisposition::ConfiguredDynamic,
+            cardinality: spec.cardinality,
+            field_ids,
+            fixture_anchor: fixture_family.anchor.clone(),
+            producer_anchors,
+        });
+    }
+
+    let pmem_source = sources
+        .get(PMEM_PATH)
+        .ok_or_else(|| AuditError::new("missing pmem metrics source"))?;
+    let fixture_source = sources
+        .get(FIXTURE_PATH)
+        .ok_or_else(|| AuditError::new("missing metrics fixture source"))?;
+    reconciliations.push(MetricsReconciliation {
+        id: "producer-only:pmem_{pmem_id}".to_string(),
+        kind: MetricsReconciliationKind::ProducerOnlyDynamicFamily,
+        resolution: "Pinned Rust emits pmem_{pmem_id}, but the strict v1.16.0 fixture admits no pmem_ prefix; retain the producer fact without adding it to the canonical schema."
+            .to_string(),
+        source_anchors: vec![
+            anchor_for_snippet(
+                pmem_source,
+                PMEM_PATH,
+                "format!(\"pmem_{}\", name)",
+                "producer-template:pmem_{pmem_id}".to_string(),
+            )?,
+            anchor_for_snippet(
+                fixture_source,
+                FIXTURE_PATH,
+                "for metrics_name in metrics.keys():",
+                "validate_fc_metrics:dynamic-prefix-closure".to_string(),
+            )?,
+        ],
+    });
+    Ok(families)
+}
+
+fn dynamic_producer_anchors(
+    id: &str,
+    sources: &BTreeMap<String, String>,
+) -> Result<Vec<MetricsSourceAnchor>, AuditError> {
+    let specs: &[(&str, &str, &str)] = match id {
+        "block" => &[(
+            BLOCK_PATH,
+            "format!(\"block_{}\", name)",
+            "producer-template:block_{drive_id}",
+        )],
+        "net" => &[(
+            NET_PATH,
+            "format!(\"net_{}\", name)",
+            "producer-template:net_{iface_id}",
+        )],
+        "vhost-user-block" => &[
+            (
+                VHOST_USER_PATH,
+                "format!(\"vhost_user_{}\", name)",
+                "producer-template:vhost_user_{module_name}",
+            ),
+            (
+                VHOST_BLOCK_PATH,
+                "format!(\"block_{}\", config.drive_id)",
+                "producer-module:block_{drive_id}",
+            ),
+            (
+                VHOST_BLOCK_PATH,
+                "VhostUserMetricsPerDevice::alloc(vhost_user_block_metrics_name)",
+                "producer-registration:vhost-user-block",
+            ),
+        ],
+        _ => {
+            return Err(AuditError::new(format!(
+                "unsupported metrics dynamic family: {id}"
+            )));
+        }
+    };
+    if id == "vhost-user-block"
+        && sources
+            .get(VHOST_BLOCK_PATH)
+            .is_some_and(|source| source.contains("BlockMetricsPerDevice::alloc"))
+    {
+        return Err(AuditError::new(
+            "vhost-user block must not also register ordinary block metrics",
+        ));
+    }
+    specs
+        .iter()
+        .map(|(path, snippet, symbol)| {
+            let source = sources
+                .get(*path)
+                .ok_or_else(|| AuditError::new(format!("missing dynamic metrics input: {path}")))?;
+            anchor_for_snippet(source, path, snippet, (*symbol).to_string())
+        })
+        .collect()
+}
+
+fn duplicate_reconciliations(
+    fields: &BTreeMap<String, Vec<MetricsSourceAnchor>>,
+) -> Vec<MetricsReconciliation> {
+    fields
+        .iter()
+        .filter(|(_, anchors)| anchors.len() > 1)
+        .map(|(path, anchors)| MetricsReconciliation {
+            id: format!("duplicate-fixture-field:{path}"),
+            kind: MetricsReconciliationKind::DuplicateFixtureField,
+            resolution: "Repeated fixture literals identify one required JSON property and are deduplicated by path."
+                .to_string(),
+            source_anchors: anchors.clone(),
+        })
+        .collect()
+}
+
+fn find_struct<'a>(
+    structs: &'a BTreeMap<String, RustStruct>,
+    path: &str,
+    name: &str,
+) -> Result<&'a RustStruct, AuditError> {
+    structs
+        .get(&rust_struct_key(path, name))
+        .ok_or_else(|| AuditError::new(format!("missing Rust metrics struct: {path}:{name}")))
+}
+
+fn find_struct_by_name<'a>(
+    structs: &'a BTreeMap<String, RustStruct>,
+    name: &str,
+) -> Result<&'a RustStruct, AuditError> {
+    let matches = structs
+        .values()
+        .filter(|item| item.name == name)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [item] => Ok(*item),
+        [] => Err(AuditError::new(format!(
+            "missing nested Rust metrics struct: {name}"
+        ))),
+        _ => Err(AuditError::new(format!(
+            "ambiguous nested Rust metrics struct: {name}"
+        ))),
+    }
+}
+
+fn find_struct_field<'a>(
+    structs: &'a BTreeMap<String, RustStruct>,
+    path: &str,
+    name: &str,
+    field: &str,
+) -> Result<&'a RustField, AuditError> {
+    find_struct(structs, path, name)?
+        .fields
+        .iter()
+        .find(|candidate| candidate.wire_name == field)
+        .ok_or_else(|| {
+            AuditError::new(format!("missing Rust metrics field: {path}:{name}.{field}"))
+        })
+}
+
+fn rust_struct_key(path: &str, name: &str) -> String {
+    format!("{path}#{name}")
+}
+
+fn unique_offset(source: &str, needle: &str) -> Result<usize, AuditError> {
+    unique_offset_in(source, 0..source.len(), needle)
+}
+
+fn unique_offset_in(
+    source: &str,
+    range: std::ops::Range<usize>,
+    needle: &str,
+) -> Result<usize, AuditError> {
+    let haystack = source
+        .get(range.clone())
+        .ok_or_else(|| AuditError::new("invalid metrics source search range"))?;
+    let mut matches = haystack.match_indices(needle);
+    let first = matches.next().map(|(offset, _)| range.start + offset);
+    if matches.next().is_some() {
+        return Err(AuditError::new(format!(
+            "metrics source anchor is not unique: {needle}"
+        )));
+    }
+    first.ok_or_else(|| AuditError::new(format!("metrics source anchor is missing: {needle}")))
+}
+
+fn verify_ordered_snippets(source: &str, snippets: &[&str], label: &str) -> Result<(), AuditError> {
+    let mut previous = None;
+    for snippet in snippets {
+        let offset = unique_offset(source, snippet)?;
+        if previous.is_some_and(|previous| offset <= previous) {
+            return Err(AuditError::new(format!(
+                "metrics source snippets are not in canonical order: {label}"
+            )));
+        }
+        previous = Some(offset);
+    }
+    Ok(())
+}
+
+fn anchor_for_snippet(
+    source: &str,
+    path: &str,
+    snippet: &str,
+    symbol: String,
+) -> Result<MetricsSourceAnchor, AuditError> {
+    let start = unique_offset(source, snippet)?;
+    let (line, column) = line_column(source, start);
+    Ok(MetricsSourceAnchor {
+        path: path.to_string(),
+        symbol,
+        line,
+        column,
+        fingerprint: fingerprint_text(snippet),
+    })
+}
+
+fn anchor_for_range(source: &str, start: usize, end: usize, symbol: String) -> MetricsSourceAnchor {
+    let snippet = source.get(start..end).unwrap_or_default();
+    let (line, column) = line_column(source, start);
+    MetricsSourceAnchor {
+        path: FIXTURE_PATH.to_string(),
+        symbol,
+        line,
+        column,
+        fingerprint: fingerprint_text(snippet),
+    }
+}
+
+fn line_column(source: &str, offset: usize) -> (usize, usize) {
+    let prefix = source.get(..offset).unwrap_or_default();
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let column = prefix
+        .rsplit_once('\n')
+        .map_or(prefix.len() + 1, |(_, tail)| tail.len() + 1);
+    (line, column)
+}
+
+fn fingerprint_text(text: &str) -> String {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    sha256_fingerprint(normalized.as_bytes())
+}
+
+fn fingerprint_tokens(tokens: TokenStream) -> String {
+    let mut normalized = String::new();
+    append_normalized_tokens(tokens, &mut normalized);
+    sha256_fingerprint(normalized.as_bytes())
+}
+
+fn sha256_fingerprint(bytes: &[u8]) -> String {
+    let hex_digit = |nibble: u8| {
+        char::from(if nibble < 10 {
+            b'0' + nibble
+        } else {
+            b'a' + (nibble - 10)
+        })
+    };
+    let digest = Sha256::digest(bytes);
+    let mut fingerprint = String::with_capacity(71);
+    fingerprint.push_str("sha256:");
+    for byte in digest {
+        fingerprint.push(hex_digit(byte >> 4));
+        fingerprint.push(hex_digit(byte & 0x0f));
+    }
+    fingerprint
+}
+
+fn append_normalized_tokens(tokens: TokenStream, output: &mut String) {
+    for token in tokens {
+        match token {
+            TokenTree::Group(group) => {
+                output.push(match group.delimiter() {
+                    proc_macro2::Delimiter::Parenthesis => '(',
+                    proc_macro2::Delimiter::Brace => '{',
+                    proc_macro2::Delimiter::Bracket => '[',
+                    proc_macro2::Delimiter::None => '<',
+                });
+                append_normalized_tokens(group.stream(), output);
+                output.push(match group.delimiter() {
+                    proc_macro2::Delimiter::Parenthesis => ')',
+                    proc_macro2::Delimiter::Brace => '}',
+                    proc_macro2::Delimiter::Bracket => ']',
+                    proc_macro2::Delimiter::None => '>',
+                });
+            }
+            other => {
+                output.push_str(&other.to_string());
+                output.push(' ');
+            }
+        }
+    }
+}
+
+fn read_inputs(checkout: &Path) -> Result<(Vec<Input>, BTreeMap<String, String>), AuditError> {
+    let mut inputs = Vec::new();
+    let mut sources = BTreeMap::new();
+    for (path, extractor) in INPUT_PATHS {
+        ensure_regular_input(checkout, path)?;
+        let source = read_input(checkout, path)?;
+        let object = format!("HEAD:{path}");
+        let git_blob = git_output(checkout, &["rev-parse", &object])?;
+        let worktree_blob = git_output(checkout, &["hash-object", "--", path])?;
+        if git_blob != worktree_blob {
+            return Err(AuditError::new(format!(
+                "metrics source input differs from its pinned Git blob: {path}"
+            )));
+        }
+        inputs.push(Input {
+            path: (*path).to_string(),
+            git_blob,
+            extractor: (*extractor).to_string(),
+        });
+        sources.insert((*path).to_string(), source);
+    }
+    inputs.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok((inputs, sources))
+}
+
+fn dynamic_field_count(families: &[MetricsDynamicFamily], id: &str) -> usize {
+    families
+        .iter()
+        .find(|family| family.id == id)
+        .map_or(0, |family| family.field_ids.len())
+}
+
+fn extract_fixture_schema(source: &str) -> Result<FixtureSchema, AuditError> {
+    let function = function_slice(
+        source,
+        "def validate_fc_metrics(metrics):",
+        "class FcDeviceMetrics:",
+    )?;
+    let mut values = BTreeMap::new();
+    for name in [
+        "latency_agg_metrics_fields",
+        "block_metrics",
+        "net_metrics",
+        "firecracker_metrics",
+    ] {
+        values.insert(
+            name.to_string(),
+            parse_assignment(source, function.clone(), name)?,
+        );
+    }
+
+    validate_fixture_assignment_boundary(source, function.clone())?;
+    let static_value = values
+        .get("firecracker_metrics")
+        .ok_or_else(|| AuditError::new("metrics fixture static dictionary is missing"))?;
+    let PythonValue::Dict(entries) = static_value else {
+        return Err(AuditError::new(
+            "metrics fixture firecracker_metrics must be a dictionary literal",
+        ));
+    };
+    let mut roots = Vec::new();
+    let mut static_fields = BTreeMap::<String, Vec<MetricsSourceAnchor>>::new();
+    for (root, value) in entries {
+        roots.push(root.clone());
+        if root.value == "utc_timestamp_ms" {
+            if !matches!(value, PythonValue::String(value) if value.value.is_empty()) {
+                return Err(AuditError::new(
+                    "metrics fixture utc_timestamp_ms sentinel must be an empty string",
+                ));
+            }
+            static_fields
+                .entry(root.value.clone())
+                .or_default()
+                .push(root.anchor.clone());
+        } else {
+            flatten_python_fields(value, &values, &root.value, &mut static_fields, 0)?;
+        }
+    }
+
+    let rtc_value =
+        parse_index_assignment(source, function.clone(), "firecracker_metrics[\"rtc\"]")?;
+    let rtc_assignment = unique_offset_in(
+        source,
+        function.clone(),
+        "        firecracker_metrics[\"rtc\"] =",
+    )?;
+    let arm64_condition = unique_offset_in(
+        source,
+        function.start..rtc_assignment,
+        "    if platform.machine() == \"aarch64\":",
+    )?;
+    let condition_end = arm64_condition + "    if platform.machine() == \"aarch64\":".len();
+    if rtc_assignment <= condition_end
+        || source
+            .get(condition_end..rtc_assignment)
+            .is_none_or(|between| !between.trim().is_empty())
+    {
+        return Err(AuditError::new(
+            "metrics fixture rtc insertion must be the exact arm64 conditional body",
+        ));
+    }
+    let rtc_literal_start = rtc_assignment + "        firecracker_metrics[".len();
+    let rtc_literal = anchor_for_range(
+        source,
+        rtc_literal_start,
+        rtc_literal_start + "\"rtc\"".len(),
+        "validate_fc_metrics:arm64-root:rtc".to_string(),
+    );
+    roots.push(PythonString {
+        value: "rtc".to_string(),
+        anchor: rtc_literal,
+    });
+    flatten_python_fields(&rtc_value, &values, "rtc", &mut static_fields, 0)?;
+
+    let prefixes = startswith_prefixes(source, function.clone())?;
+    let expected = ["vhost_user_", "block_", "net_"];
+    if prefixes.as_slice() != expected {
+        return Err(AuditError::new(format!(
+            "metrics fixture dynamic prefixes must be {expected:?}, found {prefixes:?}"
+        )));
+    }
+
+    let mut dynamic_fields = Vec::new();
+    for (id, prefix) in [
+        ("block", "block_"),
+        ("net", "net_"),
+        ("vhost-user-block", "vhost_user_"),
+    ] {
+        let (value, anchor) = parse_dynamic_assignment(source, function.clone(), prefix)?;
+        let mut flattened = BTreeMap::<String, Vec<MetricsSourceAnchor>>::new();
+        flatten_python_fields(&value, &values, "", &mut flattened, 0)?;
+        let fields = flattened
+            .into_iter()
+            .map(|(path, anchors)| {
+                let [anchor] = anchors.as_slice() else {
+                    return Err(AuditError::new(format!(
+                        "dynamic metrics fixture field must occur exactly once: {prefix}{path}"
+                    )));
+                };
+                Ok((path, anchor.clone()))
+            })
+            .collect::<Result<Vec<_>, AuditError>>()?;
+        dynamic_fields.push(FixtureDynamicFamily {
+            id: id.to_string(),
+            fields,
+            anchor,
+        });
+    }
+
+    Ok(FixtureSchema {
+        roots,
+        static_fields,
+        dynamic_fields,
+    })
+}
+
+fn function_slice(
+    source: &str,
+    start_marker: &str,
+    end_marker: &str,
+) -> Result<std::ops::Range<usize>, AuditError> {
+    let start = unique_offset(source, start_marker)?;
+    let remainder = source
+        .get(start..)
+        .ok_or_else(|| AuditError::new("invalid metrics fixture function offset"))?;
+    let relative_end = remainder.find(end_marker).ok_or_else(|| {
+        AuditError::new(format!("metrics fixture is missing marker: {end_marker}"))
+    })?;
+    Ok(start..start + relative_end)
+}
+
+fn parse_assignment(
+    source: &str,
+    function: std::ops::Range<usize>,
+    name: &str,
+) -> Result<PythonValue, AuditError> {
+    let needle = format!("    {name} =");
+    let assignment = unique_offset_in(source, function.clone(), &needle)?;
+    parse_assignment_value(source, assignment + needle.len(), function.end, name)
+}
+
+fn parse_index_assignment(
+    source: &str,
+    function: std::ops::Range<usize>,
+    left: &str,
+) -> Result<PythonValue, AuditError> {
+    let needle = format!("        {left} =");
+    let assignment = unique_offset_in(source, function.clone(), &needle)?;
+    parse_assignment_value(source, assignment + needle.len(), function.end, left)
+}
+
+fn parse_dynamic_assignment(
+    source: &str,
+    function: std::ops::Range<usize>,
+    prefix: &str,
+) -> Result<(PythonValue, MetricsSourceAnchor), AuditError> {
+    let condition = format!("        if metrics_name.startswith(\"{prefix}\"):");
+    let condition_offset = unique_offset_in(source, function.clone(), &condition)?;
+    let next_condition = source
+        .get(condition_offset + condition.len()..function.end)
+        .and_then(|remaining| remaining.find("\n        if metrics_name.startswith("))
+        .map_or(function.end, |relative| {
+            condition_offset + condition.len() + relative
+        });
+    let branch = condition_offset..next_condition;
+    let left = "            firecracker_metrics[metrics_name] =";
+    let assignment = unique_offset_in(source, branch, left)?;
+    let value = parse_assignment_value(source, assignment + left.len(), next_condition, prefix)?;
+    let prefix_offset = condition_offset
+        + condition
+            .find('"')
+            .ok_or_else(|| AuditError::new("metrics dynamic prefix quote is missing"))?;
+    let anchor = anchor_for_range(
+        source,
+        prefix_offset,
+        prefix_offset + prefix.len() + 2,
+        format!("validate_fc_metrics:dynamic-prefix:{prefix}"),
+    );
+    Ok((value, anchor))
+}
+
+fn parse_assignment_value(
+    source: &str,
+    start: usize,
+    limit: usize,
+    label: &str,
+) -> Result<PythonValue, AuditError> {
+    let mut parser = PythonLiteralParser::new(source, start, limit);
+    let value = parser.parse_value()?;
+    let line_end = source
+        .get(parser.position..limit)
+        .and_then(|remaining| remaining.find('\n'))
+        .map_or(limit, |relative| parser.position + relative);
+    let trailing = source
+        .get(parser.position..line_end)
+        .ok_or_else(|| AuditError::new("invalid metrics fixture assignment suffix"))?
+        .trim();
+    if !trailing.is_empty() && !trailing.starts_with('#') {
+        return Err(AuditError::new(format!(
+            "unsupported trailing metrics fixture syntax for {label}"
+        )));
+    }
+    Ok(value)
+}
+
+fn validate_fixture_assignment_boundary(
+    source: &str,
+    function: std::ops::Range<usize>,
+) -> Result<(), AuditError> {
+    let marker = "    # validate timestamp before jsonschema validation";
+    let end = unique_offset_in(source, function.clone(), marker)?;
+    let prefix = source
+        .get(function.start..end)
+        .ok_or_else(|| AuditError::new("invalid metrics fixture schema boundary"))?;
+    let assignments = prefix
+        .lines()
+        .filter_map(|line| {
+            let rest = line.strip_prefix("    ")?;
+            if rest.starts_with(' ') {
+                return None;
+            }
+            let (name, _) = rest.split_once(" = ")?;
+            name.chars()
+                .all(|character| character == '_' || character.is_ascii_alphanumeric())
+                .then(|| name.to_string())
+        })
+        .collect::<Vec<_>>();
+    let expected = [
+        "latency_agg_metrics_fields",
+        "block_metrics",
+        "net_metrics",
+        "firecracker_metrics",
+    ];
+    if assignments.iter().map(String::as_str).collect::<Vec<_>>() != expected {
+        return Err(AuditError::new(format!(
+            "unsupported metrics fixture schema assignments: {assignments:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn startswith_prefixes(
+    source: &str,
+    function: std::ops::Range<usize>,
+) -> Result<Vec<String>, AuditError> {
+    let function_source = source
+        .get(function)
+        .ok_or_else(|| AuditError::new("invalid metrics fixture function range"))?;
+    let marker = "if metrics_name.startswith(\"";
+    let mut prefixes = Vec::new();
+    let mut remaining = function_source;
+    while let Some(offset) = remaining.find(marker) {
+        let after = remaining
+            .get(offset + marker.len()..)
+            .ok_or_else(|| AuditError::new("invalid metrics dynamic prefix offset"))?;
+        let end = after.find("\"):").ok_or_else(|| {
+            AuditError::new("unterminated metrics fixture dynamic prefix condition")
+        })?;
+        let prefix = after
+            .get(..end)
+            .ok_or_else(|| AuditError::new("invalid metrics dynamic prefix range"))?;
+        if prefix.is_empty()
+            || !prefix
+                .chars()
+                .all(|character| character == '_' || character.is_ascii_alphanumeric())
+        {
+            return Err(AuditError::new(
+                "unsupported metrics fixture dynamic prefix literal",
+            ));
+        }
+        prefixes.push(prefix.to_string());
+        remaining = after
+            .get(end + 3..)
+            .ok_or_else(|| AuditError::new("invalid metrics dynamic condition suffix"))?;
+    }
+    Ok(prefixes)
+}
+
+fn flatten_python_fields(
+    value: &PythonValue,
+    values: &BTreeMap<String, PythonValue>,
+    prefix: &str,
+    fields: &mut BTreeMap<String, Vec<MetricsSourceAnchor>>,
+    depth: usize,
+) -> Result<(), AuditError> {
+    if depth > 8 {
+        return Err(AuditError::new(
+            "metrics fixture literal references are recursively nested",
+        ));
+    }
+    match value {
+        PythonValue::String(field) => {
+            if field.value.is_empty() {
+                return Err(AuditError::new(
+                    "empty metrics fixture field is allowed only for utc_timestamp_ms",
+                ));
+            }
+            let path = join_path(prefix, &field.value);
+            fields.entry(path).or_default().push(field.anchor.clone());
+        }
+        PythonValue::Name(name) => {
+            let referenced = values.get(name).ok_or_else(|| {
+                AuditError::new(format!("unknown metrics fixture literal reference: {name}"))
+            })?;
+            flatten_python_fields(referenced, values, prefix, fields, depth + 1)?;
+        }
+        PythonValue::List(items) => {
+            for item in items {
+                flatten_python_fields(item, values, prefix, fields, depth + 1)?;
+            }
+        }
+        PythonValue::Dict(entries) => {
+            for (name, nested) in entries {
+                let nested_prefix = join_path(prefix, &name.value);
+                flatten_python_fields(nested, values, &nested_prefix, fields, depth + 1)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn join_path(prefix: &str, field: &str) -> String {
+    if prefix.is_empty() {
+        field.to_string()
+    } else {
+        format!("{prefix}.{field}")
+    }
+}
+
+struct PythonLiteralParser<'a> {
+    source: &'a str,
+    position: usize,
+    limit: usize,
+}
+
+impl<'a> PythonLiteralParser<'a> {
+    fn new(source: &'a str, position: usize, limit: usize) -> Self {
+        Self {
+            source,
+            position,
+            limit,
+        }
+    }
+
+    fn parse_value(&mut self) -> Result<PythonValue, AuditError> {
+        self.skip_space_and_comments();
+        match self.peek_byte() {
+            Some(b'[') => self.parse_list(),
+            Some(b'{') => self.parse_dict(),
+            Some(b'\'' | b'"') => self.parse_string().map(PythonValue::String),
+            Some(byte) if byte == b'_' || byte.is_ascii_alphabetic() => {
+                self.parse_name().map(PythonValue::Name)
+            }
+            _ => Err(AuditError::new(
+                "unsupported value in restricted metrics fixture literal",
+            )),
+        }
+    }
+
+    fn parse_list(&mut self) -> Result<PythonValue, AuditError> {
+        self.expect_byte(b'[')?;
+        let mut items = Vec::new();
+        loop {
+            self.skip_space_and_comments();
+            if self.consume_byte(b']') {
+                return Ok(PythonValue::List(items));
+            }
+            items.push(self.parse_value()?);
+            self.skip_space_and_comments();
+            if self.consume_byte(b']') {
+                return Ok(PythonValue::List(items));
+            }
+            self.expect_byte(b',')?;
+        }
+    }
+
+    fn parse_dict(&mut self) -> Result<PythonValue, AuditError> {
+        self.expect_byte(b'{')?;
+        let mut entries = Vec::new();
+        loop {
+            self.skip_space_and_comments();
+            if self.consume_byte(b'}') {
+                return Ok(PythonValue::Dict(entries));
+            }
+            let key = self.parse_string()?;
+            self.skip_space_and_comments();
+            self.expect_byte(b':')?;
+            let value = self.parse_value()?;
+            entries.push((key, value));
+            self.skip_space_and_comments();
+            if self.consume_byte(b'}') {
+                return Ok(PythonValue::Dict(entries));
+            }
+            self.expect_byte(b',')?;
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<PythonString, AuditError> {
+        self.skip_space_and_comments();
+        let start = self.position;
+        let quote = self
+            .peek_byte()
+            .filter(|byte| matches!(byte, b'\'' | b'"'))
+            .ok_or_else(|| AuditError::new("metrics fixture dictionary keys must be strings"))?;
+        self.position += 1;
+        let value_start = self.position;
+        while let Some(byte) = self.peek_byte() {
+            match byte {
+                b'\\' => {
+                    return Err(AuditError::new(
+                        "escaped metrics fixture strings are outside the restricted grammar",
+                    ));
+                }
+                byte if byte == quote => {
+                    let value = self
+                        .source
+                        .get(value_start..self.position)
+                        .ok_or_else(|| AuditError::new("invalid metrics fixture string range"))?;
+                    if !value
+                        .chars()
+                        .all(|character| character == '_' || character.is_ascii_alphanumeric())
+                    {
+                        return Err(AuditError::new(
+                            "metrics fixture schema strings must use identifier characters",
+                        ));
+                    }
+                    self.position += 1;
+                    return Ok(PythonString {
+                        value: value.to_string(),
+                        anchor: anchor_for_range(
+                            self.source,
+                            start,
+                            self.position,
+                            format!("validate_fc_metrics:literal:{value}"),
+                        ),
+                    });
+                }
+                b'\n' | b'\r' => {
+                    return Err(AuditError::new(
+                        "unterminated metrics fixture schema string",
+                    ));
+                }
+                _ => self.position += 1,
+            }
+        }
+        Err(AuditError::new(
+            "unterminated metrics fixture schema string",
+        ))
+    }
+
+    fn parse_name(&mut self) -> Result<String, AuditError> {
+        self.skip_space_and_comments();
+        let start = self.position;
+        while self
+            .peek_byte()
+            .is_some_and(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+        {
+            self.position += 1;
+        }
+        let name = self
+            .source
+            .get(start..self.position)
+            .ok_or_else(|| AuditError::new("invalid metrics fixture name range"))?;
+        if name.is_empty() || name.as_bytes().first().is_some_and(u8::is_ascii_digit) {
+            return Err(AuditError::new("invalid metrics fixture literal reference"));
+        }
+        Ok(name.to_string())
+    }
+
+    fn skip_space_and_comments(&mut self) {
+        loop {
+            while self
+                .peek_byte()
+                .is_some_and(|byte| byte.is_ascii_whitespace())
+            {
+                self.position += 1;
+            }
+            if self.peek_byte() != Some(b'#') {
+                break;
+            }
+            while self.peek_byte().is_some_and(|byte| byte != b'\n') {
+                self.position += 1;
+            }
+        }
+    }
+
+    fn expect_byte(&mut self, expected: u8) -> Result<(), AuditError> {
+        self.skip_space_and_comments();
+        if self.consume_byte(expected) {
+            Ok(())
+        } else {
+            Err(AuditError::new(format!(
+                "restricted metrics fixture literal expected `{}`",
+                char::from(expected)
+            )))
+        }
+    }
+
+    fn consume_byte(&mut self, expected: u8) -> bool {
+        if self.peek_byte() == Some(expected) {
+            self.position += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn peek_byte(&self) -> Option<u8> {
+        (self.position < self.limit)
+            .then(|| self.source.as_bytes().get(self.position).copied())
+            .flatten()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restricted_python_literals_resolve_nested_references() {
+        let source = r#"def validate_fc_metrics(metrics):
+    latency_agg_metrics_fields = ["min_us", "max_us", "sum_us"]
+    block_metrics = [{"read_agg": latency_agg_metrics_fields}, "read_count"]
+    net_metrics = ["rx_count"]
+    firecracker_metrics = {"utc_timestamp_ms": "", "block": block_metrics}
+    # validate timestamp before jsonschema validation which some more time
+    if platform.machine() == "aarch64":
+        firecracker_metrics["rtc"] = ["error_count"]
+    for metrics_name in metrics.keys():
+        if metrics_name.startswith("vhost_user_"):
+            firecracker_metrics[metrics_name] = ["activate_fails"]
+        if metrics_name.startswith("block_"):
+            firecracker_metrics[metrics_name] = block_metrics
+        if metrics_name.startswith("net_"):
+            firecracker_metrics[metrics_name] = net_metrics
+
+class FcDeviceMetrics:
+    pass
+"#;
+        let fixture = extract_fixture_schema(source).expect("restricted fixture must parse");
+        assert_eq!(
+            fixture
+                .static_fields
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            [
+                "block.read_agg.max_us",
+                "block.read_agg.min_us",
+                "block.read_agg.sum_us",
+                "block.read_count",
+                "rtc.error_count",
+                "utc_timestamp_ms",
+            ]
+        );
+        assert_eq!(fixture.dynamic_fields.len(), 3);
+    }
+
+    #[test]
+    fn restricted_python_literals_reject_calls() {
+        let source = "[metric_name()]";
+        let mut parser = PythonLiteralParser::new(source, 0, source.len());
+        let error = parser
+            .parse_value()
+            .expect_err("calls must be outside the restricted grammar");
+        assert!(error.to_string().contains("expected `,`"));
+    }
+
+    #[test]
+    fn restricted_python_literals_reject_escaped_schema_names() {
+        let source = r#"["read\x5fcount"]"#;
+        let mut parser = PythonLiteralParser::new(source, 0, source.len());
+        let error = parser
+            .parse_value()
+            .expect_err("escaped names must be outside the restricted grammar");
+        assert!(error.to_string().contains("escaped"));
+    }
+
+    #[test]
+    fn token_fingerprints_ignore_formatting_but_not_syntax() {
+        let compact: syn::Field = syn::parse_quote!(pub count: SharedIncMetric);
+        let documented: syn::Field = syn::parse_quote!(
+            /// Count.
+            pub count: SharedIncMetric
+        );
+        let store: syn::Field = syn::parse_quote!(pub count: SharedStoreMetric);
+        assert_ne!(
+            fingerprint_tokens(compact.to_token_stream()),
+            fingerprint_tokens(documented.to_token_stream())
+        );
+        assert_ne!(
+            fingerprint_tokens(compact.to_token_stream()),
+            fingerprint_tokens(store.to_token_stream())
+        );
+    }
+}

--- a/tools/firecracker-capability-audit/src/metrics_upstream.rs
+++ b/tools/firecracker-capability-audit/src/metrics_upstream.rs
@@ -1390,6 +1390,42 @@ fn validate_fixture_assignment_boundary(
             "unsupported metrics fixture schema assignments: {assignments:?}"
         )));
     }
+
+    let body = source
+        .get(start..function.end)
+        .ok_or_else(|| AuditError::new("invalid metrics fixture schema body"))?;
+    let schema_uses = body
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            line.split(|character: char| character != '_' && !character.is_ascii_alphanumeric())
+                .any(|token| token == "firecracker_metrics")
+        })
+        .map(|line| {
+            if line.starts_with("firecracker_metrics = ") {
+                "firecracker_metrics ="
+            } else if line.starts_with("firecracker_metrics[\"rtc\"] = ") {
+                "firecracker_metrics[\"rtc\"] ="
+            } else if line.starts_with("firecracker_metrics[metrics_name] = ") {
+                "firecracker_metrics[metrics_name] ="
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>();
+    let expected_schema_uses = [
+        "firecracker_metrics =",
+        "firecracker_metrics[\"rtc\"] =",
+        "firecracker_metrics[metrics_name] =",
+        "firecracker_metrics[metrics_name] =",
+        "firecracker_metrics[metrics_name] =",
+        "firecracker_metrics_schema = create_metrics_schema_objects(firecracker_metrics)",
+    ];
+    if schema_uses != expected_schema_uses {
+        return Err(AuditError::new(format!(
+            "unsupported metrics fixture schema use: {schema_uses:?}"
+        )));
+    }
     Ok(())
 }
 
@@ -1687,6 +1723,7 @@ mod tests {
             firecracker_metrics[metrics_name] = block_metrics
         if metrics_name.startswith("net_"):
             firecracker_metrics[metrics_name] = net_metrics
+    firecracker_metrics_schema = create_metrics_schema_objects(firecracker_metrics)
 
 class FcDeviceMetrics:
     pass
@@ -1731,7 +1768,7 @@ class FcDeviceMetrics:
     }
 
     #[test]
-    fn restricted_fixture_rejects_an_unparsed_schema_mutation() {
+    fn restricted_fixture_rejects_an_unparsed_schema_mutation_before_the_timestamp_boundary() {
         let source = r#"def validate_fc_metrics(metrics):
     latency_agg_metrics_fields = ["min_us", "max_us", "sum_us"]
     block_metrics = [{"read_agg": latency_agg_metrics_fields}, "read_count"]
@@ -1748,6 +1785,7 @@ class FcDeviceMetrics:
             firecracker_metrics[metrics_name] = block_metrics
         if metrics_name.startswith("net_"):
             firecracker_metrics[metrics_name] = net_metrics
+    firecracker_metrics_schema = create_metrics_schema_objects(firecracker_metrics)
 
 class FcDeviceMetrics:
     pass
@@ -1755,6 +1793,38 @@ class FcDeviceMetrics:
         let error =
             extract_fixture_schema(source).expect_err("unparsed schema mutations must fail closed");
         assert!(error.to_string().contains("unsupported top-level"));
+    }
+
+    #[test]
+    fn restricted_fixture_rejects_an_unparsed_schema_mutation_after_the_timestamp_boundary() {
+        let source = r#"def validate_fc_metrics(metrics):
+    latency_agg_metrics_fields = ["min_us", "max_us", "sum_us"]
+    block_metrics = [{"read_agg": latency_agg_metrics_fields}, "read_count"]
+    net_metrics = ["rx_count"]
+    firecracker_metrics = {"utc_timestamp_ms": "", "block": block_metrics}
+    # validate timestamp before jsonschema validation which some more time
+    firecracker_metrics["unparsed"] = ["count"]
+    if platform.machine() == "aarch64":
+        firecracker_metrics["rtc"] = ["error_count"]
+    for metrics_name in metrics.keys():
+        if metrics_name.startswith("vhost_user_"):
+            firecracker_metrics[metrics_name] = ["activate_fails"]
+        if metrics_name.startswith("block_"):
+            firecracker_metrics[metrics_name] = block_metrics
+        if metrics_name.startswith("net_"):
+            firecracker_metrics[metrics_name] = net_metrics
+    firecracker_metrics_schema = create_metrics_schema_objects(firecracker_metrics)
+
+class FcDeviceMetrics:
+    pass
+"#;
+        let error = extract_fixture_schema(source)
+            .expect_err("post-marker schema mutations must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported metrics fixture schema use")
+        );
     }
 
     #[test]

--- a/tools/firecracker-capability-audit/src/metrics_validate.rs
+++ b/tools/firecracker-capability-audit/src/metrics_validate.rs
@@ -1,0 +1,932 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path};
+
+use crate::validate::{tracked_repository_files, validate_reference};
+use crate::{
+    AuditMode, FIRECRACKER_COMMIT, FIRECRACKER_TARGET, FIRECRACKER_VERSION,
+    METRICS_SCHEMA_GENERATOR_VERSION, METRICS_SCHEMA_VERSION, MetricsAggregation,
+    MetricsArchitecture, MetricsCardinality, MetricsFieldPolicy, MetricsPolicyProfile,
+    MetricsProducerDisposition, MetricsProducerOwner, MetricsReconciliationKind,
+    MetricsSchemaAuthority, MetricsSchemaDisposition, MetricsSourceAnchor, MetricsSourceField,
+    MetricsUnit, MetricsValueKind, SourceManifest, ValidationErrors,
+};
+
+const EXPECTED_STATIC_ROOTS: usize = 24;
+const EXPECTED_STATIC_FIELDS: usize = 243;
+const EXPECTED_DYNAMIC_FAMILIES: usize = 3;
+const EXPECTED_BLOCK_DYNAMIC_FIELDS: usize = 24;
+const EXPECTED_NET_DYNAMIC_FIELDS: usize = 29;
+const EXPECTED_VHOST_USER_DYNAMIC_FIELDS: usize = 5;
+const EXPECTED_TOTAL_FIELDS: usize = EXPECTED_STATIC_FIELDS
+    + EXPECTED_BLOCK_DYNAMIC_FIELDS
+    + EXPECTED_NET_DYNAMIC_FIELDS
+    + EXPECTED_VHOST_USER_DYNAMIC_FIELDS;
+const PYTHON_EXTRACTOR: &str = "python-metrics-schema-v1";
+const RUST_EXTRACTOR: &str = "rust-metrics-schema-v1";
+const FIXTURE_PATH: &str = "tests/host_tools/fcmetrics.py";
+
+const EXPECTED_ROOT_ORDER: &[&str] = &[
+    "utc_timestamp_ms",
+    "api_server",
+    "balloon",
+    "block",
+    "deprecated_api",
+    "get_api_requests",
+    "i8042",
+    "rtc",
+    "uart",
+    "latencies_us",
+    "logger",
+    "mmds",
+    "net",
+    "patch_api_requests",
+    "put_api_requests",
+    "seccomp",
+    "vcpu",
+    "vmm",
+    "signals",
+    "vsock",
+    "entropy",
+    "pmem",
+    "interrupts",
+    "memory_hotplug",
+];
+
+const EXPECTED_INPUTS: &[(&str, &str)] = &[
+    ("src/vmm/src/devices/legacy/i8042.rs", RUST_EXTRACTOR),
+    ("src/vmm/src/devices/legacy/mod.rs", RUST_EXTRACTOR),
+    ("src/vmm/src/devices/legacy/rtc_pl031.rs", RUST_EXTRACTOR),
+    ("src/vmm/src/devices/legacy/serial.rs", RUST_EXTRACTOR),
+    (
+        "src/vmm/src/devices/virtio/balloon/metrics.rs",
+        RUST_EXTRACTOR,
+    ),
+    (
+        "src/vmm/src/devices/virtio/block/vhost_user/device.rs",
+        RUST_EXTRACTOR,
+    ),
+    (
+        "src/vmm/src/devices/virtio/block/virtio/metrics.rs",
+        RUST_EXTRACTOR,
+    ),
+    ("src/vmm/src/devices/virtio/mem/metrics.rs", RUST_EXTRACTOR),
+    ("src/vmm/src/devices/virtio/net/metrics.rs", RUST_EXTRACTOR),
+    ("src/vmm/src/devices/virtio/pmem/metrics.rs", RUST_EXTRACTOR),
+    ("src/vmm/src/devices/virtio/rng/metrics.rs", RUST_EXTRACTOR),
+    (
+        "src/vmm/src/devices/virtio/vhost_user_metrics.rs",
+        RUST_EXTRACTOR,
+    ),
+    (
+        "src/vmm/src/devices/virtio/vsock/metrics.rs",
+        RUST_EXTRACTOR,
+    ),
+    ("src/vmm/src/logger/metrics.rs", RUST_EXTRACTOR),
+    (FIXTURE_PATH, PYTHON_EXTRACTOR),
+];
+
+/// Validate the checked metrics source and reviewed field policy locally.
+pub fn validate_metrics_schema(
+    authority: &MetricsSchemaAuthority,
+    manifest: &SourceManifest,
+    repository_root: &Path,
+    mode: AuditMode,
+) -> Result<(), ValidationErrors> {
+    let mut errors = Vec::new();
+    validate_baseline(authority, manifest, &mut errors);
+    validate_source_manifest_agreement(manifest, &mut errors);
+    validate_inputs(authority, &mut errors);
+    validate_counts(authority, &mut errors);
+    validate_roots(authority, &mut errors);
+    validate_fields(authority, &mut errors);
+    validate_dynamic_families(authority, &mut errors);
+    validate_reconciliations(authority, &mut errors);
+    validate_policies(authority, repository_root, mode, &mut errors);
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(ValidationErrors::from_messages(errors))
+    }
+}
+
+fn validate_baseline(
+    authority: &MetricsSchemaAuthority,
+    manifest: &SourceManifest,
+    errors: &mut Vec<String>,
+) {
+    if authority.schema_version != METRICS_SCHEMA_VERSION {
+        errors.push(format!(
+            "metrics schema_version must be {METRICS_SCHEMA_VERSION}, found {}",
+            authority.schema_version
+        ));
+    }
+    if authority.generator_version != METRICS_SCHEMA_GENERATOR_VERSION {
+        errors.push(format!(
+            "metrics generator_version must be {METRICS_SCHEMA_GENERATOR_VERSION}, found {}",
+            authority.generator_version
+        ));
+    }
+    if authority.baseline != manifest.baseline {
+        errors.push("metrics authority and source manifest baselines differ".to_string());
+    }
+    if authority.baseline.version != FIRECRACKER_VERSION {
+        errors.push(format!(
+            "metrics version must be {FIRECRACKER_VERSION}, found {}",
+            authority.baseline.version
+        ));
+    }
+    if authority.baseline.commit != FIRECRACKER_COMMIT {
+        errors.push(format!(
+            "metrics commit must be {FIRECRACKER_COMMIT}, found {}",
+            authority.baseline.commit
+        ));
+    }
+    if authority.baseline.target != FIRECRACKER_TARGET {
+        errors.push(format!(
+            "metrics target must be {FIRECRACKER_TARGET}, found {}",
+            authority.baseline.target
+        ));
+    }
+}
+
+fn validate_source_manifest_agreement(manifest: &SourceManifest, errors: &mut Vec<String>) {
+    let matches = manifest
+        .items
+        .iter()
+        .filter(|item| item.id == "corpus:metrics")
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [item]
+            if item.kind == "corpus"
+                && item.key == "metrics"
+                && item.path == "docs/metrics.md"
+                && item.family == "observability" => {}
+        [_] => errors.push(
+            "metrics authority requires the exact corpus:metrics source-manifest identity"
+                .to_string(),
+        ),
+        [] => errors.push("source manifest is missing corpus:metrics".to_string()),
+        _ => {
+            errors.push("source manifest contains duplicate corpus:metrics identities".to_string())
+        }
+    }
+}
+
+fn validate_inputs(authority: &MetricsSchemaAuthority, errors: &mut Vec<String>) {
+    let actual = authority
+        .source
+        .inputs
+        .iter()
+        .map(|input| (input.path.as_str(), input.extractor.as_str()))
+        .collect::<Vec<_>>();
+    if actual != EXPECTED_INPUTS {
+        errors.push(format!(
+            "metrics source inputs must match the exact curated set: found {actual:?}"
+        ));
+    }
+    for input in &authority.source.inputs {
+        if !is_safe_upstream_path(&input.path) {
+            errors.push(format!("metrics input path is unsafe: {}", input.path));
+        }
+        if !is_hex(&input.git_blob, 40) {
+            errors.push(format!(
+                "metrics input git_blob must be a 40-character lowercase hex object id: {}",
+                input.path
+            ));
+        }
+    }
+}
+
+fn validate_counts(authority: &MetricsSchemaAuthority, errors: &mut Vec<String>) {
+    let counts = &authority.source.counts;
+    let expected = [
+        ("static_roots", counts.static_roots, EXPECTED_STATIC_ROOTS),
+        (
+            "static_fields",
+            counts.static_fields,
+            EXPECTED_STATIC_FIELDS,
+        ),
+        (
+            "dynamic_families",
+            counts.dynamic_families,
+            EXPECTED_DYNAMIC_FAMILIES,
+        ),
+        (
+            "block_dynamic_fields",
+            counts.block_dynamic_fields,
+            EXPECTED_BLOCK_DYNAMIC_FIELDS,
+        ),
+        (
+            "net_dynamic_fields",
+            counts.net_dynamic_fields,
+            EXPECTED_NET_DYNAMIC_FIELDS,
+        ),
+        (
+            "vhost_user_dynamic_fields",
+            counts.vhost_user_dynamic_fields,
+            EXPECTED_VHOST_USER_DYNAMIC_FIELDS,
+        ),
+    ];
+    for (name, actual, expected) in expected {
+        if actual != expected {
+            errors.push(format!("metrics {name} must be {expected}, found {actual}"));
+        }
+    }
+    let actual_static = authority
+        .source
+        .fields
+        .iter()
+        .filter(|field| field.id.starts_with("static:"))
+        .count();
+    if actual_static != counts.static_fields {
+        errors.push(format!(
+            "metrics static field count does not match records: declared={}; actual={actual_static}",
+            counts.static_fields
+        ));
+    }
+    if authority.source.fields.len() != EXPECTED_TOTAL_FIELDS {
+        errors.push(format!(
+            "metrics total field population must be {EXPECTED_TOTAL_FIELDS}, found {}",
+            authority.source.fields.len()
+        ));
+    }
+}
+
+fn validate_roots(authority: &MetricsSchemaAuthority, errors: &mut Vec<String>) {
+    let names = authority
+        .source
+        .static_roots
+        .iter()
+        .map(|root| root.name.as_str())
+        .collect::<Vec<_>>();
+    if names != EXPECTED_ROOT_ORDER {
+        errors.push(format!(
+            "metrics static root order must be {EXPECTED_ROOT_ORDER:?}, found {names:?}"
+        ));
+    }
+    for root in &authority.source.static_roots {
+        let expected_architecture = if root.name == "rtc" {
+            MetricsArchitecture::Arm64
+        } else {
+            MetricsArchitecture::All
+        };
+        if root.architecture != expected_architecture {
+            errors.push(format!("metrics root architecture is wrong: {}", root.name));
+        }
+        if root.schema_disposition != MetricsSchemaDisposition::RequiredStatic {
+            errors.push(format!(
+                "metrics static root must be required-static: {}",
+                root.name
+            ));
+        }
+        let expected_cardinality = if matches!(root.name.as_str(), "block" | "net" | "pmem") {
+            MetricsCardinality::Aggregate
+        } else {
+            MetricsCardinality::Singleton
+        };
+        if root.cardinality != expected_cardinality {
+            errors.push(format!("metrics root cardinality is wrong: {}", root.name));
+        }
+        validate_anchor(authority, &root.producer_anchor, "root producer", errors);
+        match (&root.aggregation_anchor, expected_cardinality) {
+            (Some(anchor), MetricsCardinality::Aggregate) => {
+                validate_anchor(authority, anchor, "root aggregation", errors);
+            }
+            (None, MetricsCardinality::Aggregate) => errors.push(format!(
+                "aggregate metrics root is missing its aggregation anchor: {}",
+                root.name
+            )),
+            (Some(_), _) => errors.push(format!(
+                "singleton metrics root must not have an aggregation anchor: {}",
+                root.name
+            )),
+            (None, _) => {}
+        }
+    }
+}
+
+fn validate_fields(authority: &MetricsSchemaAuthority, errors: &mut Vec<String>) {
+    let mut ids = BTreeSet::new();
+    let mut paths = BTreeSet::new();
+    let roots = authority
+        .source
+        .static_roots
+        .iter()
+        .map(|root| root.name.as_str())
+        .collect::<BTreeSet<_>>();
+    for (ordinal, field) in authority.source.fields.iter().enumerate() {
+        if field.ordinal != ordinal {
+            errors.push(format!(
+                "metrics field ordinal must match canonical wire order: {} -> {} instead of {ordinal}",
+                field.id, field.ordinal
+            ));
+        }
+        if !ids.insert(field.id.as_str()) {
+            errors.push(format!("duplicate metrics field id: {}", field.id));
+        }
+        if !paths.insert(field.path.as_str()) {
+            errors.push(format!("duplicate metrics field path: {}", field.path));
+        }
+        let scope = if field.id.starts_with("static:") {
+            "static"
+        } else if field.id.starts_with("dynamic:") {
+            "dynamic"
+        } else {
+            errors.push(format!(
+                "metrics field id has an unknown scope: {}",
+                field.id
+            ));
+            "invalid"
+        };
+        if field.id != format!("{scope}:{}", field.path) {
+            errors.push(format!(
+                "metrics field id must match its exact path: {}",
+                field.id
+            ));
+        }
+        if scope == "static" {
+            let root = field.path.split('.').next().unwrap_or_default();
+            if !roots.contains(root) {
+                errors.push(format!(
+                    "metrics static field names an unknown root: {}",
+                    field.id
+                ));
+            }
+        }
+        let expected_kind = match field.rust_type.as_str() {
+            "SharedIncMetric" => MetricsValueKind::IncrementalInterval,
+            "SharedStoreMetric" => MetricsValueKind::PersistentStore,
+            "SerializeToUtcTimestampMs" => MetricsValueKind::AttemptTimestamp,
+            _ => {
+                errors.push(format!(
+                    "metrics field has an unsupported Rust scalar type: {} -> {}",
+                    field.id, field.rust_type
+                ));
+                field.value_kind
+            }
+        };
+        if field.value_kind != expected_kind {
+            errors.push(format!(
+                "metrics field reset/value kind disagrees with its Rust type: {}",
+                field.id
+            ));
+        }
+        if field.fixture_anchor.path != FIXTURE_PATH {
+            errors.push(format!(
+                "metrics field fixture anchor must name {FIXTURE_PATH}: {}",
+                field.id
+            ));
+        }
+        if !field.producer_anchor.path.ends_with(".rs") {
+            errors.push(format!(
+                "metrics field producer anchor must name Rust source: {}",
+                field.id
+            ));
+        }
+        validate_anchor(authority, &field.fixture_anchor, "field fixture", errors);
+        validate_anchor(authority, &field.producer_anchor, "field producer", errors);
+    }
+}
+
+fn validate_dynamic_families(authority: &MetricsSchemaAuthority, errors: &mut Vec<String>) {
+    let expected = [
+        (
+            "block",
+            "block_",
+            "block_{drive_id}",
+            MetricsCardinality::ConfiguredBlock,
+            EXPECTED_BLOCK_DYNAMIC_FIELDS,
+            1,
+        ),
+        (
+            "net",
+            "net_",
+            "net_{iface_id}",
+            MetricsCardinality::ConfiguredNetwork,
+            EXPECTED_NET_DYNAMIC_FIELDS,
+            1,
+        ),
+        (
+            "vhost-user-block",
+            "vhost_user_",
+            "vhost_user_block_{drive_id}",
+            MetricsCardinality::ConfiguredVhostUserBlock,
+            EXPECTED_VHOST_USER_DYNAMIC_FIELDS,
+            3,
+        ),
+    ];
+    let field_ids = authority
+        .source
+        .fields
+        .iter()
+        .map(|field| field.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut family_field_ids = BTreeSet::new();
+    for (index, family) in authority.source.dynamic_families.iter().enumerate() {
+        let Some((id, prefix, template, cardinality, count, producer_anchor_count)) =
+            expected.get(index)
+        else {
+            errors.push(format!("unexpected metrics dynamic family: {}", family.id));
+            continue;
+        };
+        if family.id != *id
+            || family.fixture_prefix != *prefix
+            || family.producer_template != *template
+            || family.cardinality != *cardinality
+            || family.field_ids.len() != *count
+        {
+            errors.push(format!(
+                "metrics dynamic family contract is wrong: {}",
+                family.id
+            ));
+        }
+        if family.architecture != MetricsArchitecture::All
+            || family.schema_disposition != MetricsSchemaDisposition::ConfiguredDynamic
+        {
+            errors.push(format!(
+                "metrics dynamic family architecture/disposition is wrong: {}",
+                family.id
+            ));
+        }
+        if family.producer_anchors.len() != *producer_anchor_count {
+            errors.push(format!(
+                "metrics dynamic family producer anchor count is wrong: {}",
+                family.id
+            ));
+        }
+        validate_anchor(authority, &family.fixture_anchor, "dynamic fixture", errors);
+        for anchor in &family.producer_anchors {
+            validate_anchor(authority, anchor, "dynamic producer", errors);
+        }
+        for field_id in &family.field_ids {
+            if !field_ids.contains(field_id.as_str()) {
+                errors.push(format!(
+                    "metrics dynamic family references a missing field: {} -> {field_id}",
+                    family.id
+                ));
+            }
+            if !field_id.starts_with(&format!("dynamic:{template}.")) {
+                errors.push(format!(
+                    "metrics dynamic family field has malformed template identity: {} -> {field_id}",
+                    family.id
+                ));
+            }
+            if !family_field_ids.insert(field_id.as_str()) {
+                errors.push(format!(
+                    "metrics dynamic field belongs to multiple families: {field_id}"
+                ));
+            }
+        }
+    }
+    let all_dynamic = authority
+        .source
+        .fields
+        .iter()
+        .filter(|field| field.id.starts_with("dynamic:"))
+        .map(|field| field.id.as_str())
+        .collect::<BTreeSet<_>>();
+    if all_dynamic != family_field_ids {
+        errors.push(
+            "metrics dynamic family membership does not exactly cover dynamic fields".to_string(),
+        );
+    }
+}
+
+fn validate_reconciliations(authority: &MetricsSchemaAuthority, errors: &mut Vec<String>) {
+    let expected = [(
+        "producer-only:pmem_{pmem_id}",
+        MetricsReconciliationKind::ProducerOnlyDynamicFamily,
+        2,
+    )];
+    if authority.source.reconciliations.len() != expected.len() {
+        errors.push(format!(
+            "metrics source must contain exactly {} reconciliations, found {}",
+            expected.len(),
+            authority.source.reconciliations.len()
+        ));
+    }
+    for (index, reconciliation) in authority.source.reconciliations.iter().enumerate() {
+        let Some((id, kind, anchor_count)) = expected.get(index) else {
+            errors.push(format!(
+                "unexpected metrics source reconciliation: {}",
+                reconciliation.id
+            ));
+            continue;
+        };
+        if reconciliation.id != *id
+            || reconciliation.kind != *kind
+            || reconciliation.source_anchors.len() != *anchor_count
+        {
+            errors.push(format!(
+                "metrics source reconciliation is wrong: {}",
+                reconciliation.id
+            ));
+        }
+        if reconciliation.resolution.trim().len() < 32 {
+            errors.push(format!(
+                "metrics source reconciliation needs an exact resolution: {}",
+                reconciliation.id
+            ));
+        }
+        for anchor in &reconciliation.source_anchors {
+            validate_anchor(authority, anchor, "source reconciliation", errors);
+        }
+    }
+}
+
+fn validate_policies(
+    authority: &MetricsSchemaAuthority,
+    repository_root: &Path,
+    mode: AuditMode,
+    errors: &mut Vec<String>,
+) {
+    let mut profiles = BTreeMap::new();
+    let mut previous_profile = None;
+    for profile in &authority.policy_profiles {
+        if previous_profile.is_some_and(|previous| profile.id.as_str() <= previous) {
+            errors.push("metrics policy profiles must be sorted and unique by id".to_string());
+        }
+        previous_profile = Some(profile.id.as_str());
+        if profiles.insert(profile.id.as_str(), profile).is_some() {
+            errors.push(format!("duplicate metrics policy profile: {}", profile.id));
+        }
+        validate_profile(profile, repository_root, mode, errors);
+    }
+
+    let source_fields = authority
+        .source
+        .fields
+        .iter()
+        .map(|field| (field.id.as_str(), field))
+        .collect::<BTreeMap<_, _>>();
+    let mut mappings = BTreeMap::<&str, &MetricsFieldPolicy>::new();
+    let mut previous_field = None;
+    for policy in &authority.field_policies {
+        if previous_field.is_some_and(|previous| policy.field_id.as_str() <= previous) {
+            errors.push("metrics field policies must be sorted and unique by field_id".to_string());
+        }
+        previous_field = Some(policy.field_id.as_str());
+        if mappings.insert(policy.field_id.as_str(), policy).is_some() {
+            errors.push(format!(
+                "duplicate metrics field policy: {}",
+                policy.field_id
+            ));
+        }
+        let Some(field) = source_fields.get(policy.field_id.as_str()) else {
+            errors.push(format!("stale metrics field policy: {}", policy.field_id));
+            continue;
+        };
+        let Some(profile) = profiles.get(policy.profile_id.as_str()) else {
+            errors.push(format!(
+                "metrics field policy references an unknown profile: {} -> {}",
+                policy.field_id, policy.profile_id
+            ));
+            continue;
+        };
+        validate_field_policy(field, profile, errors);
+    }
+    for field_id in source_fields.keys() {
+        if !mappings.contains_key(field_id) {
+            errors.push(format!("missing metrics field policy: {field_id}"));
+        }
+    }
+    let used_profiles = mappings
+        .values()
+        .map(|policy| policy.profile_id.as_str())
+        .collect::<BTreeSet<_>>();
+    for profile_id in profiles.keys() {
+        if !used_profiles.contains(profile_id) {
+            errors.push(format!("unused metrics policy profile: {profile_id}"));
+        }
+    }
+}
+
+fn validate_profile(
+    profile: &MetricsPolicyProfile,
+    repository_root: &Path,
+    mode: AuditMode,
+    errors: &mut Vec<String>,
+) {
+    let expected_id = policy_profile_id(profile);
+    if profile.id != expected_id {
+        errors.push(format!(
+            "metrics policy profile id must encode its closed metadata: {} != {expected_id}",
+            profile.id
+        ));
+    }
+    let expected_issue = match profile.producer_disposition {
+        MetricsProducerDisposition::Planned | MetricsProducerDisposition::PlatformZero => {
+            Some(match profile.producer_owner {
+                MetricsProducerOwner::SchemaRuntime => "#1822",
+                MetricsProducerOwner::ProcessLifecycle => "#1788",
+                MetricsProducerOwner::Device => "#1789",
+            })
+        }
+        MetricsProducerDisposition::Implemented => None,
+    };
+    if profile.delivery_issue.as_deref() != expected_issue {
+        errors.push(format!(
+            "metrics policy profile has the wrong delivery issue: {}",
+            profile.id
+        ));
+    }
+    if profile.rationale != expected_rationale(profile) {
+        errors.push(format!(
+            "metrics policy profile has a stale rationale: {}",
+            profile.id
+        ));
+    }
+    match profile.producer_disposition {
+        MetricsProducerDisposition::Planned | MetricsProducerDisposition::PlatformZero => {
+            if !profile.implementation.is_empty() || !profile.validation.is_empty() {
+                errors.push(format!(
+                    "nonterminal metrics policy must not claim implementation evidence: {}",
+                    profile.id
+                ));
+            }
+            if mode == AuditMode::Final {
+                errors.push(format!(
+                    "final metrics validation rejects nonterminal producer policy: {}",
+                    profile.id
+                ));
+            }
+        }
+        MetricsProducerDisposition::Implemented => {
+            if profile.implementation.is_empty() || profile.validation.is_empty() {
+                errors.push(format!(
+                    "implemented metrics policy needs implementation and validation evidence: {}",
+                    profile.id
+                ));
+            }
+            let tracked = tracked_repository_files(repository_root, errors);
+            for (kind, references) in [
+                ("implementation", &profile.implementation),
+                ("validation", &profile.validation),
+            ] {
+                for reference in references {
+                    validate_reference(
+                        reference,
+                        repository_root,
+                        &tracked,
+                        &format!("metrics profile {} {kind}", profile.id),
+                        errors,
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn validate_field_policy(
+    field: &MetricsSourceField,
+    profile: &MetricsPolicyProfile,
+    errors: &mut Vec<String>,
+) {
+    let expected_unit = expected_unit(&field.path);
+    if profile.unit != expected_unit {
+        errors.push(format!("metrics field has the wrong unit: {}", field.id));
+    }
+    let expected_aggregation = expected_aggregation(&field.path);
+    if profile.aggregation != expected_aggregation {
+        errors.push(format!(
+            "metrics field has the wrong aggregation policy: {}",
+            field.id
+        ));
+    }
+    let expected_owner = expected_owner(&field.path);
+    if profile.producer_owner != expected_owner {
+        errors.push(format!(
+            "metrics field has the wrong producer owner: {}",
+            field.id
+        ));
+    }
+    let platform_zero = is_platform_zero(&field.path);
+    if platform_zero != (profile.producer_disposition == MetricsProducerDisposition::PlatformZero) {
+        errors.push(format!(
+            "metrics field has the wrong platform producer disposition: {}",
+            field.id
+        ));
+    }
+}
+
+fn expected_unit(path: &str) -> MetricsUnit {
+    if path == "utc_timestamp_ms" {
+        MetricsUnit::MillisecondsSinceUnixEpoch
+    } else if path.starts_with("latencies_us.")
+        || path.ends_with("_us")
+        || path.contains("_agg.min_us")
+        || path.contains("_agg.max_us")
+        || path.contains("_agg.sum_us")
+    {
+        MetricsUnit::Microseconds
+    } else if path.contains("bytes")
+        || path.ends_with("free_page_report_freed")
+        || path.ends_with("free_page_hint_freed")
+    {
+        MetricsUnit::Bytes
+    } else {
+        MetricsUnit::Count
+    }
+}
+
+fn expected_aggregation(path: &str) -> MetricsAggregation {
+    let static_device_aggregate =
+        path.starts_with("block.") || path.starts_with("net.") || path.starts_with("pmem.");
+    if static_device_aggregate {
+        if path.ends_with(".min_us") || path.ends_with(".max_us") {
+            MetricsAggregation::ZeroInConfiguredDeviceAggregate
+        } else {
+            MetricsAggregation::SumAcrossConfiguredDevices
+        }
+    } else if path.ends_with(".min_us") {
+        MetricsAggregation::Minimum
+    } else if path.ends_with(".max_us") {
+        MetricsAggregation::Maximum
+    } else if path.ends_with(".sum_us") {
+        MetricsAggregation::Sum
+    } else {
+        MetricsAggregation::None
+    }
+}
+
+fn expected_owner(path: &str) -> MetricsProducerOwner {
+    if path == "utc_timestamp_ms" {
+        return MetricsProducerOwner::SchemaRuntime;
+    }
+    let root = path.split('.').next().unwrap_or_default();
+    if root.starts_with("block_{")
+        || root.starts_with("net_{")
+        || root.starts_with("vhost_user_block_{")
+        || matches!(
+            root,
+            "balloon"
+                | "block"
+                | "i8042"
+                | "mmds"
+                | "net"
+                | "vcpu"
+                | "uart"
+                | "vsock"
+                | "entropy"
+                | "interrupts"
+                | "pmem"
+                | "memory_hotplug"
+                | "rtc"
+        )
+    {
+        MetricsProducerOwner::Device
+    } else {
+        MetricsProducerOwner::ProcessLifecycle
+    }
+}
+
+fn is_platform_zero(path: &str) -> bool {
+    path.starts_with("i8042.")
+        || matches!(
+            path,
+            "vcpu.exit_io_in"
+                | "vcpu.exit_io_out"
+                | "vcpu.exit_io_in_agg.min_us"
+                | "vcpu.exit_io_in_agg.max_us"
+                | "vcpu.exit_io_in_agg.sum_us"
+                | "vcpu.exit_io_out_agg.min_us"
+                | "vcpu.exit_io_out_agg.max_us"
+                | "vcpu.exit_io_out_agg.sum_us"
+                | "vcpu.kvmclock_ctrl_fails"
+        )
+}
+
+fn policy_profile_id(profile: &MetricsPolicyProfile) -> String {
+    format!(
+        "{}-{}-{}-{}",
+        enum_json_name(&profile.unit),
+        enum_json_name(&profile.aggregation),
+        enum_json_name(&profile.producer_owner),
+        enum_json_name(&profile.producer_disposition),
+    )
+}
+
+fn enum_json_name<T: serde::Serialize>(value: &T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_else(|| "invalid".to_string())
+}
+
+fn expected_rationale(profile: &MetricsPolicyProfile) -> &'static str {
+    match profile.producer_disposition {
+        MetricsProducerDisposition::PlatformZero => {
+            "The arm64 schema retains this Linux/x86-oriented field as a required numeric neutral value; #1789 owns terminal evidence."
+        }
+        MetricsProducerDisposition::Planned => match profile.producer_owner {
+            MetricsProducerOwner::SchemaRuntime => {
+                "Canonical line construction and timestamp publication are delivered by #1822 before producer closure."
+            }
+            MetricsProducerOwner::ProcessLifecycle => {
+                "#1788 owns the exact API, process, logger, signal, boot, and lifecycle producer boundary."
+            }
+            MetricsProducerOwner::Device => {
+                "#1789 owns the exact supported-device producer, neutral-value, and bounded-key boundary."
+            }
+        },
+        MetricsProducerDisposition::Implemented => {
+            "The producer has exact implementation and validation evidence for this checked field policy."
+        }
+    }
+}
+
+fn validate_anchor(
+    authority: &MetricsSchemaAuthority,
+    anchor: &MetricsSourceAnchor,
+    label: &str,
+    errors: &mut Vec<String>,
+) {
+    let input_paths = authority
+        .source
+        .inputs
+        .iter()
+        .map(|input| input.path.as_str())
+        .collect::<BTreeSet<_>>();
+    if !input_paths.contains(anchor.path.as_str()) {
+        errors.push(format!(
+            "metrics {label} anchor names an untracked input: {}",
+            anchor.path
+        ));
+    }
+    if !is_safe_upstream_path(&anchor.path) {
+        errors.push(format!(
+            "metrics {label} anchor path is unsafe: {}",
+            anchor.path
+        ));
+    }
+    if anchor.symbol.trim().is_empty() || anchor.line == 0 || anchor.column == 0 {
+        errors.push(format!(
+            "metrics {label} anchor is incomplete: {}",
+            anchor.path
+        ));
+    }
+    let Some(hash) = anchor.fingerprint.strip_prefix("sha256:") else {
+        errors.push(format!(
+            "metrics {label} anchor fingerprint lacks sha256 prefix: {}",
+            anchor.path
+        ));
+        return;
+    };
+    if !is_hex(hash, 64) {
+        errors.push(format!(
+            "metrics {label} anchor fingerprint must contain 64 lowercase hex characters: {}",
+            anchor.path
+        ));
+    }
+}
+
+fn is_safe_upstream_path(path: &str) -> bool {
+    let path = Path::new(path);
+    !path.as_os_str().is_empty()
+        && !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_units_and_aggregation_without_name_substrings_only() {
+        assert_eq!(
+            expected_unit("utc_timestamp_ms"),
+            MetricsUnit::MillisecondsSinceUnixEpoch
+        );
+        assert_eq!(
+            expected_unit("memory_hotplug.plug_agg.sum_us"),
+            MetricsUnit::Microseconds
+        );
+        assert_eq!(
+            expected_unit("balloon.free_page_report_freed"),
+            MetricsUnit::Bytes
+        );
+        assert_eq!(
+            expected_aggregation("block.read_agg.min_us"),
+            MetricsAggregation::ZeroInConfiguredDeviceAggregate
+        );
+        assert_eq!(expected_aggregation("dynamic"), MetricsAggregation::None);
+    }
+
+    #[test]
+    fn only_exact_arm64_neutral_fields_are_platform_zero() {
+        assert!(is_platform_zero("i8042.read_count"));
+        assert!(is_platform_zero("vcpu.exit_io_in_agg.sum_us"));
+        assert!(!is_platform_zero("vcpu.exit_mmio_read_agg.sum_us"));
+        assert!(!is_platform_zero("rtc.error_count"));
+    }
+}

--- a/tools/firecracker-capability-audit/tests/metrics_schema.rs
+++ b/tools/firecracker-capability-audit/tests/metrics_schema.rs
@@ -1,0 +1,260 @@
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
+
+use std::path::PathBuf;
+
+use bangbang_firecracker_capability_audit::{
+    AuditMode, METRICS_SCHEMA_AUTHORITY_PATH, MetricsAggregation, MetricsArchitecture,
+    MetricsProducerDisposition, MetricsSchemaAuthority, MetricsUnit, MetricsValueKind, Reference,
+    SOURCE_MANIFEST_PATH, metrics_schema_authority_json, read_metrics_schema_authority,
+    read_source_manifest, validate_metrics_schema,
+};
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repository root must resolve")
+}
+
+fn checked_authority() -> MetricsSchemaAuthority {
+    let root = repository_root();
+    read_metrics_schema_authority(&root.join(METRICS_SCHEMA_AUTHORITY_PATH))
+        .expect("checked metrics authority must parse")
+}
+
+fn validation_error(authority: &MetricsSchemaAuthority) -> String {
+    let root = repository_root();
+    let manifest = read_source_manifest(&root.join(SOURCE_MANIFEST_PATH))
+        .expect("checked source manifest must parse");
+    validate_metrics_schema(authority, &manifest, &root, AuditMode::Delivery)
+        .expect_err("mutated metrics authority must fail")
+        .to_string()
+}
+
+#[test]
+fn checked_metrics_authority_is_canonical_and_valid_without_a_sibling() {
+    let root = repository_root();
+    let path = root.join(METRICS_SCHEMA_AUTHORITY_PATH);
+    let authority = checked_authority();
+    let manifest = read_source_manifest(&root.join(SOURCE_MANIFEST_PATH))
+        .expect("checked source manifest must parse");
+    validate_metrics_schema(&authority, &manifest, &root, AuditMode::Delivery)
+        .expect("checked metrics authority must validate locally");
+    assert_eq!(
+        std::fs::read(path).expect("checked authority must be readable"),
+        metrics_schema_authority_json(&authority).expect("authority must serialize canonically")
+    );
+    assert_eq!(authority.source.counts.static_roots, 24);
+    assert_eq!(authority.source.counts.static_fields, 243);
+    assert_eq!(authority.source.fields.len(), 301);
+    assert_eq!(authority.source.dynamic_families[0].field_ids.len(), 24);
+    assert_eq!(authority.source.dynamic_families[1].field_ids.len(), 29);
+    assert_eq!(authority.source.dynamic_families[2].field_ids.len(), 5);
+}
+
+#[test]
+fn checked_metrics_authority_keeps_all_producers_nonterminal() {
+    let authority = checked_authority();
+    assert!(authority.policy_profiles.iter().all(|profile| matches!(
+        profile.producer_disposition,
+        MetricsProducerDisposition::Planned | MetricsProducerDisposition::PlatformZero
+    )));
+    let root = repository_root();
+    let manifest = read_source_manifest(&root.join(SOURCE_MANIFEST_PATH))
+        .expect("checked source manifest must parse");
+    let error = validate_metrics_schema(&authority, &manifest, &root, AuditMode::Final)
+        .expect_err("planned metrics producers must fail final mode");
+    assert!(error.to_string().contains("nonterminal producer policy"));
+}
+
+#[test]
+fn rejects_missing_duplicate_and_stale_field_identities() {
+    let mut missing = checked_authority();
+    let removed = missing.source.fields.remove(0);
+    let error = validation_error(&missing);
+    assert!(error.contains("field count"));
+    assert!(error.contains(&format!("stale metrics field policy: {}", removed.id)));
+
+    let mut duplicate = checked_authority();
+    duplicate
+        .source
+        .fields
+        .push(duplicate.source.fields[0].clone());
+    let error = validation_error(&duplicate);
+    assert!(error.contains("duplicate metrics field id"));
+    assert!(error.contains("duplicate metrics field path"));
+
+    let mut stale = checked_authority();
+    stale.field_policies[0].field_id = "static:not.a.real.field".to_string();
+    let error = validation_error(&stale);
+    assert!(error.contains("stale metrics field policy"));
+    assert!(error.contains("missing metrics field policy"));
+}
+
+#[test]
+fn rejects_field_order_drift_even_when_the_identity_set_is_unchanged() {
+    let mut authority = checked_authority();
+    authority.source.fields.swap(0, 1);
+    assert!(validation_error(&authority).contains("canonical wire order"));
+}
+
+#[test]
+fn rejects_extra_and_duplicate_field_policies() {
+    let mut extra = checked_authority();
+    let mut policy = extra.field_policies[0].clone();
+    policy.field_id = "static:extra.field".to_string();
+    extra.field_policies.push(policy);
+    let error = validation_error(&extra);
+    assert!(error.contains("stale metrics field policy"));
+
+    let mut duplicate = checked_authority();
+    duplicate
+        .field_policies
+        .push(duplicate.field_policies[0].clone());
+    let error = validation_error(&duplicate);
+    assert!(error.contains("duplicate metrics field policy"));
+}
+
+#[test]
+fn rejects_unknown_json_types_during_strict_parsing() {
+    let authority = checked_authority();
+    let mut value = serde_json::to_value(authority).expect("authority must become JSON");
+    value["source"]["fields"][0]["json_type"] = serde_json::Value::String("string".to_string());
+    let error = serde_json::from_value::<MetricsSchemaAuthority>(value)
+        .expect_err("open-ended JSON types must fail")
+        .to_string();
+    assert!(error.contains("unknown variant"));
+}
+
+#[test]
+fn rejects_wrong_reset_unit_and_aggregation_semantics() {
+    let mut reset = checked_authority();
+    let field = reset
+        .source
+        .fields
+        .iter_mut()
+        .find(|field| field.rust_type == "SharedIncMetric")
+        .expect("incremental field must exist");
+    field.value_kind = MetricsValueKind::PersistentStore;
+    assert!(validation_error(&reset).contains("reset/value kind"));
+
+    let mut unit = checked_authority();
+    let profile = unit
+        .policy_profiles
+        .iter_mut()
+        .find(|profile| profile.unit == MetricsUnit::Bytes)
+        .expect("byte profile must exist");
+    profile.unit = MetricsUnit::Count;
+    let error = validation_error(&unit);
+    assert!(error.contains("wrong unit"));
+    assert!(error.contains("profile id must encode"));
+
+    let mut aggregation = checked_authority();
+    let profile = aggregation
+        .policy_profiles
+        .iter_mut()
+        .find(|profile| profile.aggregation == MetricsAggregation::SumAcrossConfiguredDevices)
+        .expect("device aggregate profile must exist");
+    profile.aggregation = MetricsAggregation::None;
+    assert!(validation_error(&aggregation).contains("wrong aggregation policy"));
+}
+
+#[test]
+fn rejects_dynamic_grammar_and_architecture_drift() {
+    let mut dynamic = checked_authority();
+    dynamic.source.dynamic_families[2].producer_template = "vhost_user_{drive_id}".to_string();
+    dynamic.source.dynamic_families[2].field_ids[0] =
+        "dynamic:vhost_user_{drive_id}.activate_fails".to_string();
+    let error = validation_error(&dynamic);
+    assert!(error.contains("dynamic family contract is wrong"));
+    assert!(error.contains("malformed template identity"));
+
+    let mut architecture = checked_authority();
+    let rtc = architecture
+        .source
+        .static_roots
+        .iter_mut()
+        .find(|root| root.name == "rtc")
+        .expect("rtc root must exist");
+    rtc.architecture = MetricsArchitecture::All;
+    assert!(validation_error(&architecture).contains("root architecture is wrong"));
+}
+
+#[test]
+fn rejects_disposition_issue_and_rationale_drift() {
+    let mut disposition = checked_authority();
+    let profile = disposition
+        .policy_profiles
+        .iter_mut()
+        .find(|profile| profile.producer_disposition == MetricsProducerDisposition::Planned)
+        .expect("planned profile must exist");
+    profile.producer_disposition = MetricsProducerDisposition::PlatformZero;
+    assert!(validation_error(&disposition).contains("wrong platform producer disposition"));
+
+    let mut issue = checked_authority();
+    issue.policy_profiles[0].delivery_issue = Some("#9999".to_string());
+    assert!(validation_error(&issue).contains("wrong delivery issue"));
+
+    let mut rationale = checked_authority();
+    rationale.policy_profiles[0].rationale.clear();
+    assert!(validation_error(&rationale).contains("stale rationale"));
+}
+
+#[test]
+fn rejects_unresolved_or_unsafe_implementation_evidence() {
+    let mut authority = checked_authority();
+    let profile = authority
+        .policy_profiles
+        .iter_mut()
+        .find(|profile| profile.producer_disposition == MetricsProducerDisposition::Planned)
+        .expect("planned profile must exist");
+    profile.producer_disposition = MetricsProducerDisposition::Implemented;
+    profile.delivery_issue = None;
+    profile.rationale =
+        "The producer has exact implementation and validation evidence for this checked field policy."
+            .to_string();
+    profile.implementation.push(Reference::Local {
+        path: "../escape".to_string(),
+        anchor: None,
+    });
+    profile.validation.push(Reference::Local {
+        path: "../escape".to_string(),
+        anchor: None,
+    });
+    let error = validation_error(&authority);
+    assert!(error.contains("path escapes repository"));
+}
+
+#[test]
+fn rejects_input_source_and_anchor_fingerprint_drift() {
+    let mut input = checked_authority();
+    input.source.inputs[0].git_blob = "0".repeat(39);
+    assert!(validation_error(&input).contains("git_blob"));
+
+    let mut fingerprint = checked_authority();
+    fingerprint.source.fields[0].producer_anchor.fingerprint = "sha256:not-hex".to_string();
+    assert!(validation_error(&fingerprint).contains("64 lowercase hex"));
+
+    let mut anchor = checked_authority();
+    anchor.source.fields[0].producer_anchor.path = "../outside.rs".to_string();
+    let error = validation_error(&anchor);
+    assert!(error.contains("untracked input"));
+    assert!(error.contains("path is unsafe"));
+}
+
+#[test]
+fn rejects_source_manifest_and_population_count_drift() {
+    let root = repository_root();
+    let authority = checked_authority();
+    let mut manifest = read_source_manifest(&root.join(SOURCE_MANIFEST_PATH))
+        .expect("checked source manifest must parse");
+    manifest.items.retain(|item| item.id != "corpus:metrics");
+    let error = validate_metrics_schema(&authority, &manifest, &root, AuditMode::Delivery)
+        .expect_err("missing corpus authority must fail")
+        .to_string();
+    assert!(error.contains("missing corpus:metrics"));
+
+    let mut count = checked_authority();
+    count.source.counts.net_dynamic_fields -= 1;
+    assert!(validation_error(&count).contains("net_dynamic_fields must be 29"));
+}


### PR DESCRIPTION
## Summary

- add a strict Firecracker v1.16.0 metrics schema authority with exact arm64 roots, static fields, configured dynamic families, source fingerprints, and human-owned field policy
- extend the capability audit to validate the authority offline, compare its source projection with the pinned sibling checkout, and generate source-only candidates without overwriting checked authorities
- document the metrics contract and add focused mutation coverage for drift, ordering, policy, evidence, and regeneration safety

## Scope exclusions

- does not expose or emit runtime metrics; that delivery remains in #1822
- does not add executable compatibility certification; that delivery remains in #1823
- does not close the Wave 7 parent #1787

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target integration-test Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `git diff --check`

Closes #1821

Parent: #1787
