### PR TITLE
feat: certify exact API metrics producers

### DIFF
--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -30,6 +30,11 @@ For commands and test-layer selection, see the
   Its `source` projection is machine-derived from the pinned Rust serializers
   and Python fixture; its policy profiles and exact field mappings are
   human-owned and never regenerated.
+- [`metrics-process-producer-audit.json`](metrics-process-producer-audit.json)
+  is the human-owned incremental audit for the exact 69 fields assigned to the
+  process producer profile. It records one closed producer boundary, delivery
+  child, disposition, rationale, and evidence set per field without duplicating
+  the schema or shared field policy.
 - Contract Markdown files are human-owned evidence ledgers. They define a
   selected capability family, its exact supported or excluded boundary, and
   the implementation and validation evidence for its dispositions.
@@ -70,7 +75,7 @@ reviewed delta.
 | [Snapshot Wave 6](snapshot-wave6-contract.md) | Exact 70-row load, artifact, version, device, tool, time/identity, portability, and downstream-owner certification |
 | [Observability, tools, and specification](observability-tools-specification-contract.md) | Exact Wave 7 ownership, core API certification, x86 CPUID/MSR platform exclusions, and retained downstream handoffs |
 | [Logger producers](logger-contract.md) | Certified 11-row logger aggregate with exact 468-invocation source closure, 24 implemented classes, 7 exact platform/developer exclusions, no planned producer classes, safe fields, and bounded default-stdout admission/forwarding policy |
-| [Metrics schema](metrics-contract.md) | Terminal twelve-row #1787 API/schema certification, exact 24-root/243-static-field arm64 line shape, 24/29/5 configured dynamic families, source fingerprints, closed units/reset/aggregation policy, and truthful #1788/#1789 producer handoffs |
+| [Metrics schema and process producers](metrics-contract.md) | Terminal twelve-row #1787 API/schema certification, exact 24-root/243-static-field arm64 line shape, 24/29/5 configured dynamic families, source fingerprints, closed units/reset/aggregation policy, and the incremental 69-field #1788 process audit with 44 #1827 request/deprecation producers implemented |
 
 ## Dispositions
 
@@ -137,8 +142,9 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- validate --metric
 This command validates the complete capability inventory and metrics authority
 in delivery mode, requires the exact twelve #1787 capability and contract rows
 as `implemented-and-verified`, pins the one implemented schema-runtime profile
-and exact #1788/#1789 producer partition, and requires both #1790 aggregate rows
-to remain `audit-required`. Focused parser, direct-process privacy, signed
+and exact #1788/#1789 producer partition, validates the 69-field process audit
+with only completed child #1827 promoted, and requires both #1790 aggregate
+rows to remain `audit-required`. Focused parser, direct-process privacy, signed
 ordinary-production/App Sandbox privacy, and real Paused/Running 60-second
 lifecycle evidence support the terminal claim. It does not promote later
 producer, corpus, or cross-producer work; repository-global `validate --final`
@@ -157,5 +163,5 @@ normal repository checks using
 [Testing Guide](../../../docs/testing.md#firecracker-capability-inventory).
 Review candidate identity changes before updating a machine-owned projection.
 Never use regeneration to alter `capabilities.json`,
-`logger-producer-audit.json`, or the human policy projections in
-`metrics-schema.json`.
+`logger-producer-audit.json`, `metrics-process-producer-audit.json`, or the
+human policy projections in `metrics-schema.json`.

--- a/compat/firecracker/v1.16.0/metrics-contract.md
+++ b/compat/firecracker/v1.16.0/metrics-contract.md
@@ -86,9 +86,10 @@ delivery, remote telemetry, or a versioned extension format.
 The process audit is an exact, sorted bijection over the 69 static fields whose
 schema policy owner is `process`. Missing, duplicate, extra, stale, reordered,
 or differently owned records fail closed. Its delivery partition is also
-fixed: #1827 owns 44 API request and deprecation fields, #1828 owns 12 startup,
-logger, panic, signal, and seccomp fields, #1829 owns five successful inner-VMM
-operation fields, and #1830 owns eight successful outer API-operation fields.
+fixed: #1827 owns 44 API request and deprecation fields, #1828 owns two startup
+and ten successful outer/inner operation-latency fields, #1829 owns four logger
+fields plus SIGPIPE, and #1830 owns six fatal-signal fields plus panic and
+seccomp.
 Only a completed child may use the `implemented` disposition and carry
 resolvable production and validation evidence. #1827 is the sole completed
 child in this slice; the remaining 25 records stay `planned` until their owning

--- a/compat/firecracker/v1.16.0/metrics-contract.md
+++ b/compat/firecracker/v1.16.0/metrics-contract.md
@@ -2,22 +2,30 @@
 
 This contract defines the checked public metrics-line authority used by
 Bangbang for the pinned Firecracker v1.16.0 arm64 target. It separates schema
-presence from producer completion. The machine-readable authority is
-[`metrics-schema.json`](metrics-schema.json); this document explains how to
-interpret and update it.
+presence, shared producer policy, and incremental producer completion. The
+machine-readable artifacts are [`metrics-schema.json`](metrics-schema.json)
+and
+[`metrics-process-producer-audit.json`](metrics-process-producer-audit.json);
+this document explains how to interpret and update them.
 
 ## Authority Boundary
 
-`metrics-schema.json` is one strict envelope with two ownership domains:
+The checked contract has three layers:
 
-- `source` is machine-derived from the pinned Rust serializers and
+- `metrics-schema.json.source` is machine-derived from the pinned Rust serializers and
   `tests/host_tools/fcmetrics.py`. It owns inputs and Git blobs, exact roots,
   scalar paths, JSON type, reset primitive, architecture, configured-root
   grammar, source anchors, and normalized SHA-256 fingerprints.
-- `policy_profiles` and `field_policies` are reviewed Bangbang policy. Together
+- `metrics-schema.json.policy_profiles` and `field_policies` are reviewed
+  shared Bangbang policy. Together
   they attach one closed unit, aggregation rule, producer owner/disposition,
   delivery issue, rationale, and eventual implementation/validation evidence
   to every source field.
+- `metrics-process-producer-audit.json` is the human-owned incremental audit of
+  the exact fields selected by the process producer profile. It records each
+  field's closed production boundary, delivery child, current disposition,
+  rationale, and evidence without copying source shape, unit, reset, or
+  aggregation policy.
 
 The policy mapping is an exact bijection over the source fields. Policy cannot
 create or remove schema identities, and source regeneration cannot manufacture
@@ -72,6 +80,47 @@ Bangbang-only fields.
 This certification is deliberately narrower than producer or corpus closure.
 It does not complete #1788, #1789, either #1790 aggregate, tracing, durable
 delivery, remote telemetry, or a versioned extension format.
+
+## Incremental Process Producer Audit
+
+The process audit is an exact, sorted bijection over the 69 static fields whose
+schema policy owner is `process`. Missing, duplicate, extra, stale, reordered,
+or differently owned records fail closed. Its delivery partition is also
+fixed: #1827 owns 44 API request and deprecation fields, #1828 owns 12 startup,
+logger, panic, signal, and seccomp fields, #1829 owns five successful inner-VMM
+operation fields, and #1830 owns eight successful outer API-operation fields.
+Only a completed child may use the `implemented` disposition and carry
+resolvable production and validation evidence. #1827 is the sole completed
+child in this slice; the remaining 25 records stay `planned` until their owning
+pull requests land. `source-neutral` and `platform-zero` are terminal policy
+choices, not aliases for an undelivered feasible producer.
+
+For #1827, request metrics are created as a typed, value-free effect only after
+the HTTP request passes admission. The effect is applied exactly once before
+dispatch, so parser results—not later lifecycle, configuration, or backend
+action results—control request failure counters. Exact GET routes increment
+their count only. Exact PUT and PATCH routes increment once and add a failure
+only when their endpoint parser rejects the request, with these pinned
+exceptions:
+
+- arm64 `SendCtrlAltDel` increments `actions_count` without incrementing
+  `actions_fails`;
+- an empty machine-config PATCH object increments `machine_cfg_count` without
+  incrementing `machine_cfg_fails`;
+- a missing or mismatched network PATCH identifier contributes the pinned
+  count delta of two and no failure, while malformed JSON contributes one count
+  and one failure;
+- an invalid nonempty resource identifier contributes one count and no
+  failure, while a missing identifier contributes one count and one failure
+  except for the network PATCH rule above;
+- one unrecognized nonempty `/mmds/<token>` route contributes one MMDS count
+  and one failure; strict extra segments and unrelated routes have no effect.
+
+Bodies rejected during HTTP admission are never parsed for metrics. Deprecated
+API accounting is emitted only for an accepted typed deprecated value and
+contains no request value. Saturating counters, canonical JSON shape, omission
+of newer balloon request fields, redaction, and the initial successful
+`PUT /metrics` self-count remain unchanged.
 
 ## Exact Arm64 Shape
 
@@ -261,9 +310,11 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- validate --metric
 
 `validate --metrics-schema-final` runs repository delivery validation, the
 metrics authority delivery gate, the exact twelve-row #1787 certification, and
-the logger producer delivery gate needed by metrics collection. It permits only
-the explicit #1788/#1789 producer handoffs and retained #1790 aggregate rows;
-repository-global `validate --final` remains the stronger all-capability gate.
+the logger producer delivery gate needed by metrics collection. It validates
+the exact 69-field process audit and accepts only its recorded completed-child
+set. It permits only the explicit #1788/#1789 producer handoffs and retained
+#1790 aggregate rows; repository-global `validate --final` remains the stronger
+all-capability gate.
 
 With an explicit clean sibling at the pinned commit, compare every source
 identity, Git blob, root/path/template, type/reset fact, architecture rule, and
@@ -285,6 +336,8 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- \
 
 The destination must not exist and cannot directly, lexically, or through a
 symlink alias any checked inventory file. Review exact source changes, then
-manually reconcile them with human policy. Never copy old policy onto a changed
-identity without reviewing its unit, reset, aggregation, architecture,
-cardinality, producer owner, disposition, rationale, and evidence.
+manually reconcile them with human policy and, when process-profile membership
+changes, the process audit. Regeneration never writes either human-owned layer.
+Never copy old policy onto a changed identity without reviewing its unit,
+reset, aggregation, architecture, cardinality, producer owner, disposition,
+rationale, boundary, delivery child, and evidence.

--- a/compat/firecracker/v1.16.0/metrics-process-producer-audit.json
+++ b/compat/firecracker/v1.16.0/metrics-process-producer-audit.json
@@ -1,0 +1,1819 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "version": "1.16.0",
+    "commit": "d83d72b710361a10294480131377b1b00b163af8",
+    "target": "aarch64-macos-hvf"
+  },
+  "records": [
+    {
+      "field_id": "static:api_server.process_startup_time_cpu_us",
+      "boundary": "process-startup",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the exact process startup clock boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:api_server.process_startup_time_us",
+      "boundary": "process-startup",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the exact process startup clock boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:deprecated_api.deprecated_http_api_calls",
+      "boundary": "accepted-deprecated-api-value",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this counter only after typed parsing accepts a deprecated API value; Bangbang records the redacted parse effect once.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:get_api_requests.hotplug_memory_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:get_api_requests.instance_info_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:get_api_requests.machine_cfg_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:get_api_requests.mmds_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:get_api_requests.vmm_version_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:latencies_us.diff_create_snapshot",
+      "boundary": "successful-outer-api-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:latencies_us.full_create_snapshot",
+      "boundary": "successful-outer-api-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:latencies_us.load_snapshot",
+      "boundary": "successful-outer-api-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:latencies_us.pause_vm",
+      "boundary": "successful-outer-api-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:latencies_us.resume_vm",
+      "boundary": "successful-outer-api-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:latencies_us.vmm_diff_create_snapshot",
+      "boundary": "successful-inner-vmm-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:latencies_us.vmm_full_create_snapshot",
+      "boundary": "successful-inner-vmm-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:latencies_us.vmm_load_snapshot",
+      "boundary": "successful-inner-vmm-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:latencies_us.vmm_pause_vm",
+      "boundary": "successful-inner-vmm-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:latencies_us.vmm_resume_vm",
+      "boundary": "successful-inner-vmm-operation",
+      "disposition": "planned",
+      "delivery_issue": "#1828",
+      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:logger.metrics_fails",
+      "boundary": "logger-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1829",
+      "rationale": "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:logger.missed_log_count",
+      "boundary": "logger-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1829",
+      "rationale": "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:logger.missed_metrics_count",
+      "boundary": "logger-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1829",
+      "rationale": "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:logger.rate_limited_log_count",
+      "boundary": "logger-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1829",
+      "rationale": "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:patch_api_requests.drive_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.drive_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.hotplug_memory_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.hotplug_memory_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.machine_cfg_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.machine_cfg_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.mmds_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.mmds_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.network_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this count at parser entry and again for a missing or mismatched interface ID; Bangbang applies the bounded typed effect once.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.network_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only for typed PATCH body conversion or validation, not for missing or mismatched interface IDs or later action errors.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.pmem_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:patch_api_requests.pmem_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.actions_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.actions_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.boot_source_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.boot_source_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.cpu_cfg_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.cpu_cfg_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.drive_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.drive_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.hotplug_memory_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.hotplug_memory_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.logger_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.logger_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.machine_cfg_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.machine_cfg_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.metrics_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.metrics_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.mmds_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.mmds_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.network_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.network_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.pmem_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.pmem_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.serial_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.serial_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.vsock_count",
+      "boundary": "request-parser-entry",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:put_api_requests.vsock_fails",
+      "boundary": "request-parser-failure",
+      "disposition": "implemented",
+      "delivery_issue": "#1827",
+      "rationale": "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "typed admitted parser metric effect"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "single saturating API metric effect application"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "Firecracker v1.16.0 metric effect tables"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "parser versus action metric compatibility tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
+    },
+    {
+      "field_id": "static:seccomp.num_faults",
+      "boundary": "seccomp-fault",
+      "disposition": "planned",
+      "delivery_issue": "#1830",
+      "rationale": "Delivery child #1830 owns the platform seccomp-fault disposition and evidence and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:signals.sigbus",
+      "boundary": "signal-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1830",
+      "rationale": "Delivery child #1830 owns fatal process-signal classification and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:signals.sighup",
+      "boundary": "signal-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1830",
+      "rationale": "Delivery child #1830 owns fatal process-signal classification and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:signals.sigill",
+      "boundary": "signal-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1830",
+      "rationale": "Delivery child #1830 owns fatal process-signal classification and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:signals.sigpipe",
+      "boundary": "signal-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1829",
+      "rationale": "Delivery child #1829 owns the generation-consistent SIGPIPE capture boundary and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:signals.sigsegv",
+      "boundary": "signal-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1830",
+      "rationale": "Delivery child #1830 owns fatal process-signal classification and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:signals.sigxcpu",
+      "boundary": "signal-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1830",
+      "rationale": "Delivery child #1830 owns fatal process-signal classification and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:signals.sigxfsz",
+      "boundary": "signal-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1830",
+      "rationale": "Delivery child #1830 owns fatal process-signal classification and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vmm.panic_count",
+      "boundary": "panic-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1830",
+      "rationale": "Delivery child #1830 owns panic capture and fatal convergence and remains unresolved in this audit slice.",
+      "implementation": [],
+      "validation": []
+    }
+  ]
+}

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -115,16 +115,28 @@ impl fmt::Display for RequestError {
 
 impl std::error::Error for RequestError {}
 
+/// Firecracker v1.16.0 request-metric family selected by an admitted API request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApiRequestMetricEndpoint {
+    Get(ApiRequestMetricGetEndpoint),
     Patch(ApiRequestMetricPatchEndpoint),
     Put(ApiRequestMetricPutEndpoint),
 }
 
+/// GET endpoint with a canonical Firecracker v1.16.0 request counter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiRequestMetricGetEndpoint {
+    HotplugMemory,
+    InstanceInfo,
+    MachineConfig,
+    Mmds,
+    VmmVersion,
+}
+
+/// PUT endpoint with canonical Firecracker v1.16.0 count and failure counters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApiRequestMetricPutEndpoint {
     Actions,
-    Balloon,
     BootSource,
     CpuConfig,
     Drive,
@@ -139,9 +151,9 @@ pub enum ApiRequestMetricPutEndpoint {
     Vsock,
 }
 
+/// PATCH endpoint with canonical Firecracker v1.16.0 count and failure counters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApiRequestMetricPatchEndpoint {
-    Balloon,
     Drive,
     HotplugMemory,
     MachineConfig,
@@ -150,62 +162,63 @@ pub enum ApiRequestMetricPatchEndpoint {
     Pmem,
 }
 
-pub fn api_request_metric_endpoint(bytes: &[u8]) -> Option<ApiRequestMetricEndpoint> {
-    let (method, path, _, _) = parse_request_head(bytes).ok()?;
+/// Value-free request counter delta established by one admitted endpoint parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApiRequestMetricDelta {
+    endpoint: ApiRequestMetricEndpoint,
+    count: u8,
+    failures: u8,
+}
 
-    match method {
-        "PATCH" => patch_api_request_metric_endpoint(path).map(ApiRequestMetricEndpoint::Patch),
-        "PUT" => put_api_request_metric_endpoint(path).map(ApiRequestMetricEndpoint::Put),
-        _ => None,
+impl ApiRequestMetricDelta {
+    pub const fn endpoint(self) -> ApiRequestMetricEndpoint {
+        self.endpoint
+    }
+
+    pub const fn count(self) -> u8 {
+        self.count
+    }
+
+    pub const fn failures(self) -> u8 {
+        self.failures
     }
 }
 
-fn put_api_request_metric_endpoint(path: &str) -> Option<ApiRequestMetricPutEndpoint> {
-    if drive_path_id(path).is_some() {
-        return Some(ApiRequestMetricPutEndpoint::Drive);
-    }
-    if network_interface_path_id(path).is_some() {
-        return Some(ApiRequestMetricPutEndpoint::Network);
-    }
-    if pmem_path_id(path).is_some() {
-        return Some(ApiRequestMetricPutEndpoint::Pmem);
+/// Complete value-free metrics effect of parsing one HTTP request.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ApiRequestMetricEffect {
+    request: Option<ApiRequestMetricDelta>,
+    deprecated_api_calls: u8,
+}
+
+impl ApiRequestMetricEffect {
+    pub const fn request(self) -> Option<ApiRequestMetricDelta> {
+        self.request
     }
 
-    match path {
-        "/actions" => Some(ApiRequestMetricPutEndpoint::Actions),
-        "/balloon" => Some(ApiRequestMetricPutEndpoint::Balloon),
-        "/boot-source" => Some(ApiRequestMetricPutEndpoint::BootSource),
-        "/cpu-config" => Some(ApiRequestMetricPutEndpoint::CpuConfig),
-        "/hotplug/memory" => Some(ApiRequestMetricPutEndpoint::HotplugMemory),
-        "/logger" => Some(ApiRequestMetricPutEndpoint::Logger),
-        "/machine-config" => Some(ApiRequestMetricPutEndpoint::MachineConfig),
-        "/metrics" => Some(ApiRequestMetricPutEndpoint::Metrics),
-        "/mmds" | "/mmds/config" => Some(ApiRequestMetricPutEndpoint::Mmds),
-        "/serial" => Some(ApiRequestMetricPutEndpoint::Serial),
-        "/vsock" => Some(ApiRequestMetricPutEndpoint::Vsock),
-        _ => None,
+    pub const fn deprecated_api_calls(self) -> u8 {
+        self.deprecated_api_calls
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.request.is_none() && self.deprecated_api_calls == 0
     }
 }
 
-fn patch_api_request_metric_endpoint(path: &str) -> Option<ApiRequestMetricPatchEndpoint> {
-    if drive_path_id(path).is_some() {
-        return Some(ApiRequestMetricPatchEndpoint::Drive);
-    }
-    if network_interface_path_id(path).is_some() {
-        return Some(ApiRequestMetricPatchEndpoint::Network);
-    }
-    if pmem_path_id(path).is_some() {
-        return Some(ApiRequestMetricPatchEndpoint::Pmem);
+/// Existing parse result paired with the exact metrics effect for its parser boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiRequestParseOutcome {
+    request: Result<ApiRequest, RequestError>,
+    metric_effect: ApiRequestMetricEffect,
+}
+
+impl ApiRequestParseOutcome {
+    pub fn into_parts(self) -> (Result<ApiRequest, RequestError>, ApiRequestMetricEffect) {
+        (self.request, self.metric_effect)
     }
 
-    match path {
-        "/balloon" | "/balloon/statistics" | "/balloon/hinting/start" | "/balloon/hinting/stop" => {
-            Some(ApiRequestMetricPatchEndpoint::Balloon)
-        }
-        "/hotplug/memory" => Some(ApiRequestMetricPatchEndpoint::HotplugMemory),
-        "/machine-config" => Some(ApiRequestMetricPatchEndpoint::MachineConfig),
-        "/mmds" => Some(ApiRequestMetricPatchEndpoint::Mmds),
-        _ => None,
+    pub const fn metric_effect(&self) -> ApiRequestMetricEffect {
+        self.metric_effect
     }
 }
 
@@ -3141,35 +3154,74 @@ pub fn parse_request_with_limit(
     bytes: &[u8],
     max_payload_size: usize,
 ) -> Result<ApiRequest, RequestError> {
-    let (method, path, header_len, request_body) = parse_request_head(bytes)?;
-    checked_request_head_len(header_len)?;
-    let body = bytes
-        .get(header_len..)
-        .ok_or(RequestError::MalformedRequest)?;
+    parse_request_outcome_with_limit(bytes, max_payload_size)
+        .into_parts()
+        .0
+}
 
-    if request_body.has_unsupported_encoding() {
-        return Err(RequestError::MalformedRequest);
-    }
+pub fn parse_request_outcome(bytes: &[u8]) -> ApiRequestParseOutcome {
+    parse_request_outcome_with_limit(bytes, HTTP_MAX_PAYLOAD_SIZE)
+}
 
-    checked_payload_len(request_body.content_length(), max_payload_size)?;
+pub fn parse_request_outcome_with_limit(
+    bytes: &[u8],
+    max_payload_size: usize,
+) -> ApiRequestParseOutcome {
+    let admitted = (|| {
+        let (method, path, header_len, request_body) = parse_request_head(bytes)?;
+        checked_request_head_len(header_len)?;
+        let body = bytes
+            .get(header_len..)
+            .ok_or(RequestError::MalformedRequest)?;
 
-    if body.len() != request_body.content_length() {
-        return Err(RequestError::MalformedRequest);
-    }
+        if request_body.has_unsupported_encoding() {
+            return Err(RequestError::MalformedRequest);
+        }
 
-    if method == "GET" && request_body.has_content() {
-        return Err(RequestError::GetRequestBody);
-    }
-    if method == "DELETE" && request_body.has_content() {
-        return Err(RequestError::EmptyDeleteRequest);
-    }
-    if method == "PUT" && body.is_empty() {
-        return Err(RequestError::EmptyPutRequest);
-    }
-    if method == "PATCH" && body.is_empty() && !patch_request_path_accepts_empty_body(path) {
-        return Err(RequestError::EmptyPatchRequest);
-    }
+        checked_payload_len(request_body.content_length(), max_payload_size)?;
 
+        if body.len() != request_body.content_length() {
+            return Err(RequestError::MalformedRequest);
+        }
+
+        if method == "GET" && request_body.has_content() {
+            return Err(RequestError::GetRequestBody);
+        }
+        if method == "DELETE" && request_body.has_content() {
+            return Err(RequestError::EmptyDeleteRequest);
+        }
+        if method == "PUT" && body.is_empty() {
+            return Err(RequestError::EmptyPutRequest);
+        }
+        if method == "PATCH" && body.is_empty() && !patch_request_path_accepts_empty_body(path) {
+            return Err(RequestError::EmptyPatchRequest);
+        }
+
+        Ok((method, path, body))
+    })();
+
+    let (method, path, body) = match admitted {
+        Ok(admitted) => admitted,
+        Err(error) => {
+            return ApiRequestParseOutcome {
+                request: Err(error),
+                metric_effect: ApiRequestMetricEffect::default(),
+            };
+        }
+    };
+    let request = parse_admitted_request(method, path, body);
+    let metric_effect = api_request_metric_effect(method, path, &request);
+    ApiRequestParseOutcome {
+        request,
+        metric_effect,
+    }
+}
+
+fn parse_admitted_request(
+    method: &str,
+    path: &str,
+    body: &[u8],
+) -> Result<ApiRequest, RequestError> {
     if let Some(request) = balloon_request_without_body_parsing(method, path) {
         return Ok(request);
     }
@@ -3305,6 +3357,233 @@ pub fn parse_request_with_limit(
         ("GET", "/vm/config") => Ok(ApiRequest::GetVmConfig),
         ("GET", "/version") => Ok(ApiRequest::GetVersion),
         _ => Err(RequestError::InvalidPathMethod),
+    }
+}
+
+fn api_request_metric_effect(
+    method: &str,
+    path: &str,
+    parse_result: &Result<ApiRequest, RequestError>,
+) -> ApiRequestMetricEffect {
+    let request = match method {
+        "GET" => get_api_request_metric_delta(path),
+        "PATCH" => patch_api_request_metric_delta(path, parse_result),
+        "PUT" => put_api_request_metric_delta(path, parse_result),
+        _ => None,
+    };
+    let deprecated_api_calls = parse_result.as_ref().is_ok_and(request_uses_deprecated_api);
+
+    ApiRequestMetricEffect {
+        request,
+        deprecated_api_calls: u8::from(deprecated_api_calls),
+    }
+}
+
+fn get_api_request_metric_delta(path: &str) -> Option<ApiRequestMetricDelta> {
+    let endpoint = match path {
+        "/" => ApiRequestMetricGetEndpoint::InstanceInfo,
+        "/hotplug/memory" => ApiRequestMetricGetEndpoint::HotplugMemory,
+        "/machine-config" => ApiRequestMetricGetEndpoint::MachineConfig,
+        "/mmds" => ApiRequestMetricGetEndpoint::Mmds,
+        "/version" => ApiRequestMetricGetEndpoint::VmmVersion,
+        _ => return None,
+    };
+    metric_delta(ApiRequestMetricEndpoint::Get(endpoint), 1, 0)
+}
+
+fn put_api_request_metric_delta(
+    path: &str,
+    parse_result: &Result<ApiRequest, RequestError>,
+) -> Option<ApiRequestMetricDelta> {
+    for (root, endpoint) in [
+        ("/drives", ApiRequestMetricPutEndpoint::Drive),
+        ("/network-interfaces", ApiRequestMetricPutEndpoint::Network),
+        ("/pmem", ApiRequestMetricPutEndpoint::Pmem),
+    ] {
+        if let Some(shape) = resource_path_shape(path, root) {
+            return resource_metric_delta(
+                ApiRequestMetricEndpoint::Put(endpoint),
+                shape,
+                parse_result,
+                false,
+            );
+        }
+    }
+
+    let endpoint = match path {
+        "/actions" => ApiRequestMetricPutEndpoint::Actions,
+        "/boot-source" => ApiRequestMetricPutEndpoint::BootSource,
+        "/cpu-config" => ApiRequestMetricPutEndpoint::CpuConfig,
+        "/hotplug/memory" => ApiRequestMetricPutEndpoint::HotplugMemory,
+        "/logger" => ApiRequestMetricPutEndpoint::Logger,
+        "/machine-config" => ApiRequestMetricPutEndpoint::MachineConfig,
+        "/metrics" => ApiRequestMetricPutEndpoint::Metrics,
+        "/mmds" | "/mmds/config" => ApiRequestMetricPutEndpoint::Mmds,
+        "/serial" => ApiRequestMetricPutEndpoint::Serial,
+        "/vsock" => ApiRequestMetricPutEndpoint::Vsock,
+        _ if is_unrecognized_mmds_path(path) => {
+            return metric_delta(
+                ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Mmds),
+                1,
+                1,
+            );
+        }
+        _ => return None,
+    };
+    let failures = if endpoint == ApiRequestMetricPutEndpoint::Actions
+        && matches!(parse_result, Err(RequestError::SendCtrlAltDelUnsupported))
+    {
+        0
+    } else {
+        u8::from(parse_result.is_err())
+    };
+    metric_delta(ApiRequestMetricEndpoint::Put(endpoint), 1, failures)
+}
+
+fn patch_api_request_metric_delta(
+    path: &str,
+    parse_result: &Result<ApiRequest, RequestError>,
+) -> Option<ApiRequestMetricDelta> {
+    for (root, endpoint, network_patch) in [
+        ("/drives", ApiRequestMetricPatchEndpoint::Drive, false),
+        (
+            "/network-interfaces",
+            ApiRequestMetricPatchEndpoint::Network,
+            true,
+        ),
+        ("/pmem", ApiRequestMetricPatchEndpoint::Pmem, false),
+    ] {
+        if let Some(shape) = resource_path_shape(path, root) {
+            return resource_metric_delta(
+                ApiRequestMetricEndpoint::Patch(endpoint),
+                shape,
+                parse_result,
+                network_patch,
+            );
+        }
+    }
+
+    let endpoint = match path {
+        "/hotplug/memory" => ApiRequestMetricPatchEndpoint::HotplugMemory,
+        "/machine-config" => ApiRequestMetricPatchEndpoint::MachineConfig,
+        "/mmds" => ApiRequestMetricPatchEndpoint::Mmds,
+        _ => return None,
+    };
+    let failures = if endpoint == ApiRequestMetricPatchEndpoint::MachineConfig
+        && matches!(parse_result, Err(RequestError::EmptyPatchRequest))
+    {
+        0
+    } else {
+        u8::from(parse_result.is_err())
+    };
+    metric_delta(ApiRequestMetricEndpoint::Patch(endpoint), 1, failures)
+}
+
+fn metric_delta(
+    endpoint: ApiRequestMetricEndpoint,
+    count: u8,
+    failures: u8,
+) -> Option<ApiRequestMetricDelta> {
+    debug_assert!((1..=2).contains(&count));
+    debug_assert!(failures <= 1);
+    Some(ApiRequestMetricDelta {
+        endpoint,
+        count,
+        failures,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResourcePathShape {
+    Missing,
+    Valid,
+    Invalid,
+    Extra,
+}
+
+fn resource_path_shape(path: &str, root: &str) -> Option<ResourcePathShape> {
+    let rest = path.strip_prefix(root)?;
+    if rest.is_empty() || rest == "/" {
+        return Some(ResourcePathShape::Missing);
+    }
+    let rest = rest.strip_prefix('/')?;
+    if rest.contains('/') || rest.contains('?') || rest.contains('#') {
+        return Some(ResourcePathShape::Extra);
+    }
+    if single_segment_id(rest).is_some() {
+        Some(ResourcePathShape::Valid)
+    } else {
+        Some(ResourcePathShape::Invalid)
+    }
+}
+
+fn resource_metric_delta(
+    endpoint: ApiRequestMetricEndpoint,
+    shape: ResourcePathShape,
+    parse_result: &Result<ApiRequest, RequestError>,
+    network_patch: bool,
+) -> Option<ApiRequestMetricDelta> {
+    match shape {
+        ResourcePathShape::Missing if network_patch => metric_delta(endpoint, 2, 0),
+        ResourcePathShape::Missing => metric_delta(endpoint, 1, 1),
+        ResourcePathShape::Invalid => metric_delta(endpoint, 1, 0),
+        ResourcePathShape::Extra => None,
+        ResourcePathShape::Valid
+            if network_patch
+                && matches!(parse_result, Err(RequestError::MismatchedInterfaceId)) =>
+        {
+            metric_delta(endpoint, 2, 0)
+        }
+        ResourcePathShape::Valid => metric_delta(endpoint, 1, u8::from(parse_result.is_err())),
+    }
+}
+
+fn is_unrecognized_mmds_path(path: &str) -> bool {
+    path.strip_prefix("/mmds/")
+        .is_some_and(|token| !token.is_empty() && !token.contains('/') && token != "config")
+}
+
+fn request_uses_deprecated_api(request: &ApiRequest) -> bool {
+    match request {
+        ApiRequest::PutMachineConfig(config) => config.cpu_template().is_some(),
+        ApiRequest::PatchMachineConfig(config) => config.cpu_template().is_some(),
+        ApiRequest::PutMmdsConfig(config) => config.version() == MmdsVersion::V1,
+        ApiRequest::PutSnapshotLoad(config) => config.deprecated_fields_used(),
+        ApiRequest::PutVsock(config) => config.vsock_id().is_some(),
+        ApiRequest::GetInstanceInfo
+        | ApiRequest::GetBalloon
+        | ApiRequest::GetBalloonStats
+        | ApiRequest::GetBalloonHintingStatus
+        | ApiRequest::GetMemoryHotplug
+        | ApiRequest::GetMachineConfig
+        | ApiRequest::GetMmds
+        | ApiRequest::GetVmConfig
+        | ApiRequest::GetVersion
+        | ApiRequest::PutAction(_)
+        | ApiRequest::PutBalloon(_)
+        | ApiRequest::PutBootSource(_)
+        | ApiRequest::PutCpuConfig(_)
+        | ApiRequest::PutDrive(_)
+        | ApiRequest::PutEntropy(_)
+        | ApiRequest::PutMemoryHotplug(_)
+        | ApiRequest::PatchBalloon(_)
+        | ApiRequest::PatchBalloonStats(_)
+        | ApiRequest::PatchBalloonHintingStart(_)
+        | ApiRequest::PatchBalloonHintingStop
+        | ApiRequest::PatchMemoryHotplug(_)
+        | ApiRequest::PatchDrive(_)
+        | ApiRequest::PatchVmState(_)
+        | ApiRequest::PutLogger(_)
+        | ApiRequest::PutMetrics(_)
+        | ApiRequest::PutMmds(_)
+        | ApiRequest::PutNetworkInterface(_)
+        | ApiRequest::PatchNetworkInterface(_)
+        | ApiRequest::HotUnplugDevice(_)
+        | ApiRequest::PutPmem(_)
+        | ApiRequest::PatchPmem(_)
+        | ApiRequest::PutSerial(_)
+        | ApiRequest::PutSnapshotCreate(_)
+        | ApiRequest::PatchMmds(_) => false,
     }
 }
 
@@ -4357,6 +4636,23 @@ mod tests {
         format!("{method} {path} HTTP/1.1\r\nHost: localhost\r\n\r\n").into_bytes()
     }
 
+    fn assert_request_metric_delta(
+        request: &[u8],
+        endpoint: ApiRequestMetricEndpoint,
+        count: u8,
+        failures: u8,
+    ) {
+        let outcome = parse_request_outcome(request);
+        let delta = outcome
+            .metric_effect()
+            .request()
+            .expect("request must return a metric delta");
+
+        assert_eq!(delta.endpoint(), endpoint);
+        assert_eq!(delta.count(), count);
+        assert_eq!(delta.failures(), failures);
+    }
+
     fn rate_limited_drive_body(bucket: &str, field: &str, value: &str) -> String {
         let size = if field == "size" { value } else { "1" };
         let one_time_burst = if field == "one_time_burst" {
@@ -4424,10 +4720,9 @@ mod tests {
     }
 
     #[test]
-    fn identifies_put_api_request_metric_endpoints_from_request_head() {
+    fn admitted_put_parsers_return_closed_metric_endpoints() {
         for (path, endpoint) in [
             ("/actions", ApiRequestMetricPutEndpoint::Actions),
-            ("/balloon", ApiRequestMetricPutEndpoint::Balloon),
             ("/boot-source", ApiRequestMetricPutEndpoint::BootSource),
             ("/cpu-config", ApiRequestMetricPutEndpoint::CpuConfig),
             ("/drives/rootfs", ApiRequestMetricPutEndpoint::Drive),
@@ -4451,30 +4746,24 @@ mod tests {
             ("/serial", ApiRequestMetricPutEndpoint::Serial),
             ("/vsock", ApiRequestMetricPutEndpoint::Vsock),
         ] {
+            let outcome = parse_request_outcome(&request_with_body("PUT", path, "{"));
+            let delta = outcome
+                .metric_effect()
+                .request()
+                .expect("known PUT parser must return a request delta");
             assert_eq!(
-                api_request_metric_endpoint(&request_with_body("PUT", path, "{")),
-                Some(ApiRequestMetricEndpoint::Put(endpoint)),
+                delta.endpoint(),
+                ApiRequestMetricEndpoint::Put(endpoint),
                 "PUT {path}"
             );
+            assert_eq!(delta.count(), 1, "PUT {path}");
+            assert_eq!(delta.failures(), 1, "PUT {path}");
         }
     }
 
     #[test]
-    fn identifies_patch_api_request_metric_endpoints_from_request_head() {
+    fn admitted_patch_parsers_return_closed_metric_endpoints() {
         for (path, endpoint) in [
-            ("/balloon", ApiRequestMetricPatchEndpoint::Balloon),
-            (
-                "/balloon/statistics",
-                ApiRequestMetricPatchEndpoint::Balloon,
-            ),
-            (
-                "/balloon/hinting/start",
-                ApiRequestMetricPatchEndpoint::Balloon,
-            ),
-            (
-                "/balloon/hinting/stop",
-                ApiRequestMetricPatchEndpoint::Balloon,
-            ),
             ("/drives/rootfs", ApiRequestMetricPatchEndpoint::Drive),
             (
                 "/hotplug/memory",
@@ -4491,31 +4780,166 @@ mod tests {
             ),
             ("/pmem/pmem0", ApiRequestMetricPatchEndpoint::Pmem),
         ] {
+            let outcome = parse_request_outcome(&request_with_body("PATCH", path, "{"));
+            let delta = outcome
+                .metric_effect()
+                .request()
+                .expect("known PATCH parser must return a request delta");
             assert_eq!(
-                api_request_metric_endpoint(&request_with_body("PATCH", path, "{")),
-                Some(ApiRequestMetricEndpoint::Patch(endpoint)),
+                delta.endpoint(),
+                ApiRequestMetricEndpoint::Patch(endpoint),
                 "PATCH {path}"
+            );
+            assert_eq!(delta.count(), 1, "PATCH {path}");
+            assert_eq!(delta.failures(), 1, "PATCH {path}");
+        }
+    }
+
+    #[test]
+    fn exact_get_routes_return_their_firecracker_metric_deltas() {
+        for (path, endpoint) in [
+            ("/", ApiRequestMetricGetEndpoint::InstanceInfo),
+            (
+                "/hotplug/memory",
+                ApiRequestMetricGetEndpoint::HotplugMemory,
+            ),
+            (
+                "/machine-config",
+                ApiRequestMetricGetEndpoint::MachineConfig,
+            ),
+            ("/mmds", ApiRequestMetricGetEndpoint::Mmds),
+            ("/version", ApiRequestMetricGetEndpoint::VmmVersion),
+        ] {
+            assert_request_metric_delta(
+                &request_without_body("GET", path),
+                ApiRequestMetricEndpoint::Get(endpoint),
+                1,
+                0,
             );
         }
     }
 
     #[test]
-    fn ignores_requests_without_matching_api_request_metric_endpoint() {
+    fn parser_metric_special_cases_match_firecracker_v1_16() {
+        for (request, endpoint, count, failures) in [
+            (
+                request_with_body("PUT", "/actions", r#"{"action_type":"SendCtrlAltDel"}"#),
+                ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Actions),
+                1,
+                0,
+            ),
+            (
+                request_with_body("PATCH", "/machine-config", "{}"),
+                ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::MachineConfig),
+                1,
+                0,
+            ),
+            (
+                request_with_body("PUT", "/mmds/unrecognized", "{}"),
+                ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Mmds),
+                1,
+                1,
+            ),
+            (
+                request_with_body("PUT", "/drives", "{}"),
+                ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Drive),
+                1,
+                1,
+            ),
+            (
+                request_with_body("PATCH", "/pmem", "{}"),
+                ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Pmem),
+                1,
+                1,
+            ),
+            (
+                request_with_body("PATCH", "/network-interfaces", "{}"),
+                ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Network),
+                2,
+                0,
+            ),
+            (
+                request_with_body("PUT", "/drives/bad-id", "{}"),
+                ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Drive),
+                1,
+                0,
+            ),
+            (
+                request_with_body("PATCH", "/pmem/bad-id", "{}"),
+                ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Pmem),
+                1,
+                0,
+            ),
+            (
+                request_with_body(
+                    "PATCH",
+                    "/network-interfaces/eth0",
+                    r#"{"iface_id":"eth1"}"#,
+                ),
+                ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Network),
+                2,
+                0,
+            ),
+        ] {
+            assert_request_metric_delta(&request, endpoint, count, failures);
+        }
+    }
+
+    #[test]
+    fn parser_effect_tracks_each_deprecated_request_category_without_values() {
         for request in [
-            request_with_body("GET", "/metrics", "{}"),
-            request_with_body("GET", "/balloon", "{}"),
+            request_with_body(
+                "PUT",
+                "/machine-config",
+                r#"{"vcpu_count":1,"mem_size_mib":256,"cpu_template":"None"}"#,
+            ),
+            request_with_body("PATCH", "/machine-config", r#"{"cpu_template":"T2A"}"#),
+            request_with_body("PUT", "/mmds/config", r#"{"network_interfaces":[]}"#),
+            request_with_body(
+                "PUT",
+                "/vsock",
+                r#"{"vsock_id":"deprecated","guest_cid":3,"uds_path":"./v.sock"}"#,
+            ),
+            request_with_body(
+                "PUT",
+                "/snapshot/load",
+                r#"{"snapshot_path":"vmstate","mem_file_path":"memory"}"#,
+            ),
+        ] {
+            let effect = parse_request_outcome(&request).metric_effect();
+            assert_eq!(effect.deprecated_api_calls(), 1);
+        }
+    }
+
+    #[test]
+    fn parser_effect_omits_noncanonical_and_strict_extra_routes() {
+        for request in [
+            request_without_body("GET", "/vm/config"),
+            request_without_body("GET", "/balloon"),
             request_with_body("DELETE", "/drives/rootfs", "{}"),
             request_with_body("PUT", "/entropy", "{}"),
+            request_with_body("PUT", "/balloon", "{}"),
             request_with_body("PATCH", "/vm", "{}"),
-            request_with_body("PUT", "/balloon/extra", "{}"),
+            request_with_body("PATCH", "/balloon", "{}"),
             request_with_body("PATCH", "/balloon/hinting/status", "{}"),
             request_with_body("PATCH", "/balloon/hinting/start/extra", "{}"),
             request_with_body("PUT", "/metrics/extra", "{}"),
             request_with_body("PUT", "/drives/rootfs/extra", "{}"),
             request_with_body("PUT", "/drives/rootfs?debug=true", "{}"),
+        ] {
+            assert!(parse_request_outcome(&request).metric_effect().is_empty());
+        }
+    }
+
+    #[test]
+    fn pre_admission_errors_have_no_metric_effect() {
+        for request in [
+            request_without_body("PUT", "/metrics"),
+            request_without_body("PATCH", "/machine-config"),
+            request_with_body("GET", "/", "{}"),
             b"PUT /metrics HTTP/1.1\r\nHost: localhost\r\n".to_vec(),
         ] {
-            assert_eq!(api_request_metric_endpoint(&request), None);
+            assert!(parse_request_outcome(&request).metric_effect().is_empty());
         }
     }
 

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -13,8 +13,7 @@ use std::time::{Duration, Instant};
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 use bangbang_api::HTTP_MAX_REQUEST_HEAD_SIZE;
 use bangbang_api::http::{
-    ActionRequest, ActionType, ApiRequest, ApiRequestMetricEndpoint, ApiRequestMetricPatchEndpoint,
-    ApiRequestMetricPutEndpoint, BalloonConfigRequest, BalloonConfigResponse,
+    ActionRequest, ActionType, ApiRequest, BalloonConfigRequest, BalloonConfigResponse,
     BalloonHintingStartRequest, BalloonHintingStatusResponse, BalloonStatsResponse,
     BalloonStatsUpdateRequest, BalloonUpdateRequest, BootSourceRequest, BootSourceResponse,
     CpuConfigArmRegisterWidth as ApiCpuConfigArmRegisterWidth,
@@ -33,9 +32,11 @@ use bangbang_api::http::{
     SnapshotCreateRequest, SnapshotLoadRequest,
     SnapshotMemoryBackendType as ApiSnapshotMemoryBackendType, SnapshotType as ApiSnapshotType,
     StatusCode, TokenBucketRequest, VmConfigResponse, VmStateUpdate, VmStateUpdateRequest,
-    VsockConfigRequest, VsockConfigResponse, api_request_metric_endpoint, parse_request_with_limit,
+    VsockConfigRequest, VsockConfigResponse, parse_request_outcome_with_limit,
     request_total_len_with_limit,
 };
+#[cfg(test)]
+use bangbang_api::http::{ApiRequestMetricEffect, parse_request_with_limit};
 use bangbang_runtime::balloon::{
     BalloonConfig, BalloonConfigInput, BalloonHintingStartInput, BalloonHintingStatus,
     BalloonStats, BalloonStatsUpdateInput, BalloonUpdateInput,
@@ -98,9 +99,8 @@ use crate::periodic_metrics::{
     PeriodicBalloonStatisticsScheduler, PeriodicMetricsScheduler, min_poll_timeout_ms,
 };
 use crate::vmm::{
-    ApiRequestMetricParseFailure, ApiRequestMetricPatchParseFailure,
-    ApiRequestMetricPutParseFailure, GetApiRequest, PatchApiRequest, ProcessSessionExitDecision,
-    ProcessSessionExitStatus, PutApiRequest, VmmRequestHandler,
+    GetApiRequest, PatchApiRequest, ProcessSessionExitDecision, ProcessSessionExitStatus,
+    PutApiRequest, VmmRequestHandler,
 };
 
 const READ_CHUNK_SIZE: usize = 4096;
@@ -668,20 +668,23 @@ fn handle_request_bytes_with_limit(
     vmm: &mut impl VmmRequestHandler,
     http_api_max_payload_size: usize,
 ) -> HttpResponse {
-    match parse_request_with_limit(bytes, http_api_max_payload_size) {
+    let (request, metric_effect) =
+        parse_request_outcome_with_limit(bytes, http_api_max_payload_size).into_parts();
+    let deprecated_api_call = metric_effect.deprecated_api_calls() != 0;
+    vmm.record_api_request_metric_effect(metric_effect);
+
+    match request {
         Ok(request) => {
             log_api_request(&request, vmm);
+            if deprecated_api_call {
+                let _ = vmm.log_api_control(LoggerApiControlOutcome::RequestDeprecated);
+            }
             let response = handle_api_request(request, vmm);
             let _ = vmm.log_api_result(api_result_outcome(response.status()));
             vmm.handle_initial_metrics_flush();
             response
         }
         Err(err) => {
-            if err == RequestError::SendCtrlAltDelUnsupported {
-                record_unsupported_put_action_request(bytes, vmm);
-            } else if should_record_api_request_parse_failure(&err) {
-                record_api_request_parse_failure(bytes, vmm);
-            }
             if err == RequestError::PayloadTooLarge {
                 let _ = vmm.log_api_control(LoggerApiControlOutcome::RequestParsePayloadTooLarge);
                 HttpResponse::payload_too_large_fault()
@@ -826,96 +829,7 @@ fn log_api_request(request: &ApiRequest, vmm: &mut impl VmmRequestHandler) -> bo
     }
 }
 
-fn record_unsupported_put_action_request(bytes: &[u8], vmm: &mut impl VmmRequestHandler) {
-    if matches!(
-        api_request_metric_endpoint(bytes),
-        Some(ApiRequestMetricEndpoint::Put(
-            ApiRequestMetricPutEndpoint::Actions
-        ))
-    ) {
-        vmm.record_put_actions_request();
-    }
-}
-
-const fn should_record_api_request_parse_failure(err: &RequestError) -> bool {
-    matches!(
-        err,
-        RequestError::EmptyPatchRequest
-            | RequestError::EmptyPutRequest
-            | RequestError::MalformedRequest
-            | RequestError::MismatchedDriveId
-            | RequestError::MismatchedInterfaceId
-            | RequestError::MismatchedPmemId
-    )
-}
-
-fn record_api_request_parse_failure(bytes: &[u8], vmm: &mut impl VmmRequestHandler) {
-    let Some(endpoint) = api_request_metric_endpoint(bytes) else {
-        return;
-    };
-
-    vmm.record_api_request_parse_failure(api_request_metric_parse_failure(endpoint));
-}
-
-const fn api_request_metric_parse_failure(
-    endpoint: ApiRequestMetricEndpoint,
-) -> ApiRequestMetricParseFailure {
-    match endpoint {
-        ApiRequestMetricEndpoint::Patch(endpoint) => {
-            ApiRequestMetricParseFailure::Patch(api_request_metric_patch_parse_failure(endpoint))
-        }
-        ApiRequestMetricEndpoint::Put(endpoint) => {
-            ApiRequestMetricParseFailure::Put(api_request_metric_put_parse_failure(endpoint))
-        }
-    }
-}
-
-const fn api_request_metric_put_parse_failure(
-    endpoint: ApiRequestMetricPutEndpoint,
-) -> ApiRequestMetricPutParseFailure {
-    match endpoint {
-        ApiRequestMetricPutEndpoint::Actions => ApiRequestMetricPutParseFailure::Actions,
-        ApiRequestMetricPutEndpoint::Balloon => ApiRequestMetricPutParseFailure::Balloon,
-        ApiRequestMetricPutEndpoint::BootSource => ApiRequestMetricPutParseFailure::BootSource,
-        ApiRequestMetricPutEndpoint::CpuConfig => ApiRequestMetricPutParseFailure::CpuConfig,
-        ApiRequestMetricPutEndpoint::Drive => ApiRequestMetricPutParseFailure::Drive,
-        ApiRequestMetricPutEndpoint::HotplugMemory => {
-            ApiRequestMetricPutParseFailure::HotplugMemory
-        }
-        ApiRequestMetricPutEndpoint::Logger => ApiRequestMetricPutParseFailure::Logger,
-        ApiRequestMetricPutEndpoint::MachineConfig => {
-            ApiRequestMetricPutParseFailure::MachineConfig
-        }
-        ApiRequestMetricPutEndpoint::Metrics => ApiRequestMetricPutParseFailure::Metrics,
-        ApiRequestMetricPutEndpoint::Mmds => ApiRequestMetricPutParseFailure::Mmds,
-        ApiRequestMetricPutEndpoint::Network => ApiRequestMetricPutParseFailure::Network,
-        ApiRequestMetricPutEndpoint::Pmem => ApiRequestMetricPutParseFailure::Pmem,
-        ApiRequestMetricPutEndpoint::Serial => ApiRequestMetricPutParseFailure::Serial,
-        ApiRequestMetricPutEndpoint::Vsock => ApiRequestMetricPutParseFailure::Vsock,
-    }
-}
-
-const fn api_request_metric_patch_parse_failure(
-    endpoint: ApiRequestMetricPatchEndpoint,
-) -> ApiRequestMetricPatchParseFailure {
-    match endpoint {
-        ApiRequestMetricPatchEndpoint::Balloon => ApiRequestMetricPatchParseFailure::Balloon,
-        ApiRequestMetricPatchEndpoint::Drive => ApiRequestMetricPatchParseFailure::Drive,
-        ApiRequestMetricPatchEndpoint::HotplugMemory => {
-            ApiRequestMetricPatchParseFailure::HotplugMemory
-        }
-        ApiRequestMetricPatchEndpoint::MachineConfig => {
-            ApiRequestMetricPatchParseFailure::MachineConfig
-        }
-        ApiRequestMetricPatchEndpoint::Mmds => ApiRequestMetricPatchParseFailure::Mmds,
-        ApiRequestMetricPatchEndpoint::Network => ApiRequestMetricPatchParseFailure::Network,
-        ApiRequestMetricPatchEndpoint::Pmem => ApiRequestMetricPatchParseFailure::Pmem,
-    }
-}
-
 fn handle_api_request(request: ApiRequest, vmm: &mut impl VmmRequestHandler) -> HttpResponse {
-    record_deprecated_api_usage(&request, vmm);
-
     match request {
         ApiRequest::GetInstanceInfo => {
             handle_instance_info(vmm.handle_get_request(GetApiRequest::InstanceInfo))
@@ -1034,57 +948,6 @@ fn handle_api_request(request: ApiRequest, vmm: &mut impl VmmRequestHandler) -> 
         ApiRequest::PutVsock(config) => handle_empty(vmm.handle_put_request(PutApiRequest::vsock(
             vsock_config_input_from_request(config.as_ref()),
         ))),
-    }
-}
-
-fn record_deprecated_api_usage(request: &ApiRequest, vmm: &mut impl VmmRequestHandler) {
-    if request_uses_deprecated_api(request) {
-        vmm.record_deprecated_api_call();
-        let _ = vmm.log_api_control(LoggerApiControlOutcome::RequestDeprecated);
-    }
-}
-
-fn request_uses_deprecated_api(request: &ApiRequest) -> bool {
-    match request {
-        ApiRequest::PutMachineConfig(config) => config.cpu_template().is_some(),
-        ApiRequest::PatchMachineConfig(config) => config.cpu_template().is_some(),
-        ApiRequest::PutMmdsConfig(config) => config.version() == ApiMmdsVersion::V1,
-        ApiRequest::PutSnapshotLoad(config) => config.deprecated_fields_used(),
-        ApiRequest::PutVsock(config) => config.vsock_id().is_some(),
-        ApiRequest::GetInstanceInfo
-        | ApiRequest::GetBalloon
-        | ApiRequest::GetBalloonStats
-        | ApiRequest::GetBalloonHintingStatus
-        | ApiRequest::GetMachineConfig
-        | ApiRequest::GetMemoryHotplug
-        | ApiRequest::GetMmds
-        | ApiRequest::GetVmConfig
-        | ApiRequest::GetVersion
-        | ApiRequest::HotUnplugDevice(_)
-        | ApiRequest::PatchBalloon(_)
-        | ApiRequest::PatchBalloonStats(_)
-        | ApiRequest::PatchBalloonHintingStart(_)
-        | ApiRequest::PatchBalloonHintingStop
-        | ApiRequest::PatchDrive(_)
-        | ApiRequest::PatchMemoryHotplug(_)
-        | ApiRequest::PatchMmds(_)
-        | ApiRequest::PatchNetworkInterface(_)
-        | ApiRequest::PatchPmem(_)
-        | ApiRequest::PatchVmState(_)
-        | ApiRequest::PutAction(_)
-        | ApiRequest::PutBalloon(_)
-        | ApiRequest::PutBootSource(_)
-        | ApiRequest::PutCpuConfig(_)
-        | ApiRequest::PutDrive(_)
-        | ApiRequest::PutEntropy(_)
-        | ApiRequest::PutLogger(_)
-        | ApiRequest::PutMemoryHotplug(_)
-        | ApiRequest::PutMetrics(_)
-        | ApiRequest::PutMmds(_)
-        | ApiRequest::PutNetworkInterface(_)
-        | ApiRequest::PutPmem(_)
-        | ApiRequest::PutSerial(_)
-        | ApiRequest::PutSnapshotCreate(_) => false,
     }
 }
 
@@ -4466,12 +4329,8 @@ mod tests {
             self.inner.handle_put_request(request)
         }
 
-        fn record_api_request_parse_failure(&mut self, request: ApiRequestMetricParseFailure) {
-            self.inner.record_api_request_parse_failure(request);
-        }
-
-        fn record_put_actions_request(&mut self) {
-            self.inner.record_put_actions_request();
+        fn record_api_request_metric_effect(&mut self, effect: ApiRequestMetricEffect) {
+            self.inner.record_api_request_metric_effect(effect);
         }
 
         fn handle_put_action_request(
@@ -4479,10 +4338,6 @@ mod tests {
             action: VmmAction,
         ) -> Result<VmmData, VmmActionError> {
             self.inner.handle_put_action_request(action)
-        }
-
-        fn record_deprecated_api_call(&mut self) {
-            self.inner.record_deprecated_api_call();
         }
 
         #[track_caller]
@@ -6999,7 +6854,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_two_line_api_metrics_total(
             &metrics_path,
-            "{\"put_api_requests\":{\"actions_count\":4,\"actions_fails\":1,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            "{\"put_api_requests\":{\"actions_count\":4,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -7273,7 +7128,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_two_line_api_metrics_total(
             &metrics_path,
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":2,\"logger_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":2,\"serial_fails\":1,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":2,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":2,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -7550,7 +7405,8 @@ mod tests {
             "pmem",
         ] {
             let (count, fails) = match field {
-                "drive" | "network" | "pmem" => (2, 2),
+                "drive" | "pmem" => (2, 2),
+                "network" => (3, 1),
                 _ => (1, 1),
             };
             assert_metric(
@@ -7732,7 +7588,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_two_line_api_metrics_total(
             &metrics_path,
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":2,\"boot_source_fails\":1,\"cpu_cfg_count\":2,\"cpu_cfg_fails\":1,\"drive_count\":2,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":2,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":2,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":2,\"boot_source_fails\":0,\"cpu_cfg_count\":2,\"cpu_cfg_fails\":0,\"drive_count\":2,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":2,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":2,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         assert!(!drive_path.exists());
@@ -7820,7 +7676,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_two_line_api_metrics_total(
             &metrics_path,
-            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":1,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":4,\"mmds_fails\":2,\"network_count\":1,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":1,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":4,\"mmds_fails\":0,\"network_count\":1,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -7902,7 +7758,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         let metrics_output = assert_two_line_api_metrics_total(
             &metrics_path,
-            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":3,\"pmem_fails\":2},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":2,\"pmem_fails\":1,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":3,\"pmem_fails\":1},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":2,\"pmem_fails\":1,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
         assert!(!metrics_output.contains("pmem0"));
         assert!(!metrics_output.contains("/private/tmp/pmem.img"));
@@ -8013,7 +7869,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         let metrics_output = assert_two_line_api_metrics_total(
             &metrics_path,
-            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":1,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":2,\"hotplug_memory_fails\":2,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":3,\"hotplug_memory_fails\":3,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":1,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":2,\"hotplug_memory_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":3,\"hotplug_memory_fails\":1,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
         assert!(!metrics_output.contains("222222222"));
         assert!(!metrics_output.contains("333333333"));
@@ -8050,11 +7906,11 @@ mod tests {
             ("PATCH", r#"{"cpu_template":"T2A"}"#, true),
         ] {
             let request = request_with_body(method, "/machine-config", body);
-            let parsed = parse_request_with_limit(request.as_bytes(), HTTP_MAX_PAYLOAD_SIZE)
-                .expect("machine config request should parse");
+            let outcome =
+                parse_request_outcome_with_limit(request.as_bytes(), HTTP_MAX_PAYLOAD_SIZE);
 
             assert_eq!(
-                request_uses_deprecated_api(&parsed),
+                outcome.metric_effect().deprecated_api_calls() != 0,
                 expected,
                 "{method} {body}"
             );
@@ -8191,7 +8047,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         let metrics_output = assert_two_line_api_metrics_total(
             &metrics_path,
-            "{\"deprecated_api\":{\"deprecated_http_api_calls\":5},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":3,\"machine_cfg_fails\":1,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":1,\"mmds_fails\":1,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":1,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            "{\"deprecated_api\":{\"deprecated_http_api_calls\":5},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":3,\"machine_cfg_fails\":1,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":1,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":1,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
         assert!(!metrics_output.contains("vsock-secret"));
         assert!(!metrics_output.contains("deprecated-vsock-secret"));
@@ -8378,7 +8234,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_two_line_api_metrics_total(
             &metrics_path,
-            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":1,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":2,\"mmds_fails\":1,\"network_count\":4,\"network_fails\":4,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":1,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":0,\"mmds_count\":2,\"mmds_fails\":0,\"network_count\":5,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -8571,7 +8427,7 @@ mod tests {
 
         assert_two_line_api_metrics_total(
             &startup_metrics_path,
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
         assert!(!api_metrics_path.exists());
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -2708,6 +2708,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+    use bangbang_api::http::ApiRequestMetricEffect;
     use bangbang_runtime::balloon::BalloonConfigInput;
     use bangbang_runtime::block::{DriveConfig, DriveConfigInput};
     use bangbang_runtime::boot::BootSourceConfigInput;
@@ -2744,7 +2745,7 @@ mod tests {
 
     use crate::test_support::minimal_arm64_boot_resource_config;
     use crate::vmm::{
-        ApiRequestMetricParseFailure, GetApiRequest, InstanceStartError, InstanceStartExecutor,
+        GetApiRequest, InstanceStartError, InstanceStartExecutor,
         NativeV1SnapshotCaptureCancellation, NativeV1SnapshotLoadError,
         NativeV1SnapshotPublicationError, PatchApiRequest, ProcessSessionDiagnostics,
         ProcessSessionExitStatus, ProcessVmm, PutApiRequest, SnapshotV1LoadSuccess,
@@ -3083,12 +3084,8 @@ mod tests {
             self.inner.handle_put_request(request)
         }
 
-        fn record_api_request_parse_failure(&mut self, request: ApiRequestMetricParseFailure) {
-            self.inner.record_api_request_parse_failure(request);
-        }
-
-        fn record_put_actions_request(&mut self) {
-            self.inner.record_put_actions_request();
+        fn record_api_request_metric_effect(&mut self, effect: ApiRequestMetricEffect) {
+            self.inner.record_api_request_metric_effect(effect);
         }
 
         fn handle_put_action_request(
@@ -3096,10 +3093,6 @@ mod tests {
             action: VmmAction,
         ) -> Result<VmmData, VmmActionError> {
             self.inner.handle_put_action_request(action)
-        }
-
-        fn record_deprecated_api_call(&mut self) {
-            self.inner.record_deprecated_api_call();
         }
 
         #[track_caller]

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -17,6 +17,10 @@ use std::sync::{Arc, Condvar, Mutex, MutexGuard, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+use bangbang_api::http::{
+    ApiRequestMetricEffect, ApiRequestMetricEndpoint, ApiRequestMetricGetEndpoint,
+    ApiRequestMetricPatchEndpoint, ApiRequestMetricPutEndpoint,
+};
 use bangbang_hvf::{
     HvfArm64BootBalloonCaptureError, HvfArm64BootBalloonCaptureState,
     HvfArm64BootBalloonDeviceConfig, HvfArm64BootEntropyCaptureError,
@@ -5116,128 +5120,96 @@ impl GetApiRequest {
             Self::Mmds => VmmAction::GetMmds,
         }
     }
-
-    fn record(self, controller: &mut VmmController) {
-        match self {
-            Self::Balloon | Self::BalloonHintingStatus | Self::BalloonStats => {
-                controller.record_get_balloon_request();
-            }
-            Self::HotplugMemory => controller.record_get_hotplug_memory_request(),
-            Self::InstanceInfo => controller.record_get_instance_info_request(),
-            Self::VmmVersion => controller.record_get_vmm_version_request(),
-            Self::MachineConfig => controller.record_get_machine_config_request(),
-            Self::Mmds => controller.record_get_mmds_request(),
-        }
-    }
 }
 
 #[derive(Debug)]
 pub(crate) struct PutApiRequest {
-    kind: PutApiRequestKind,
     action: VmmAction,
 }
 
 impl PutApiRequest {
     pub(crate) const fn balloon(input: BalloonConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Balloon,
             action: VmmAction::PutBalloon(input),
         }
     }
 
     pub(crate) fn boot_source(input: BootSourceConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::BootSource,
             action: VmmAction::PutBootSource(input),
         }
     }
 
     pub(crate) fn cpu_config(input: CpuConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::CpuConfig,
             action: VmmAction::PutCpuConfig(input),
         }
     }
 
     pub(crate) fn drive(input: DriveConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Drive,
             action: VmmAction::PutDrive(input),
         }
     }
 
     pub(crate) fn metrics(input: MetricsConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Metrics,
             action: VmmAction::PutMetrics(input),
         }
     }
 
     pub(crate) const fn memory_hotplug(input: MemoryHotplugConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::HotplugMemory,
             action: VmmAction::PutMemoryHotplug(input),
         }
     }
 
     pub(crate) fn logger(input: LoggerConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Logger,
             action: VmmAction::PutLogger(input),
         }
     }
 
     pub(crate) fn machine_config(input: MachineConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::MachineConfig,
             action: VmmAction::PutMachineConfig(input),
         }
     }
 
     pub(crate) fn mmds(input: MmdsContentInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Mmds,
             action: VmmAction::PutMmds(input),
         }
     }
 
     pub(crate) fn mmds_config(input: MmdsConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Mmds,
             action: VmmAction::PutMmdsConfig(input),
         }
     }
 
     pub(crate) fn network(input: NetworkInterfaceConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Network,
             action: VmmAction::PutNetworkInterface(input),
         }
     }
 
     pub(crate) fn pmem(input: bangbang_runtime::pmem::PmemConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Pmem,
             action: VmmAction::PutPmem(input),
         }
     }
 
     pub(crate) fn serial(input: SerialConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Serial,
             action: VmmAction::PutSerial(input),
         }
     }
 
     pub(crate) fn vsock(input: VsockConfigInput) -> Self {
         Self {
-            kind: PutApiRequestKind::Vsock,
             action: VmmAction::PutVsock(input),
         }
-    }
-
-    fn record_request(&self, controller: &mut VmmController) {
-        self.kind.record_request(controller);
     }
 
     fn into_action(self) -> VmmAction {
@@ -5245,145 +5217,70 @@ impl PutApiRequest {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PutApiRequestKind {
-    Balloon,
-    BootSource,
-    CpuConfig,
-    Drive,
-    HotplugMemory,
-    Metrics,
-    Logger,
-    MachineConfig,
-    Mmds,
-    Network,
-    Pmem,
-    Serial,
-    Vsock,
-}
-
-impl PutApiRequestKind {
-    fn record_request(self, controller: &mut VmmController) {
-        match self {
-            Self::Balloon => controller.record_put_balloon_request(),
-            Self::BootSource => controller.record_put_boot_source_request(),
-            Self::CpuConfig => controller.record_put_cpu_config_request(),
-            Self::Drive => controller.record_put_drive_request(),
-            Self::HotplugMemory => controller.record_put_hotplug_memory_request(),
-            Self::Metrics => controller.record_put_metrics_request(),
-            Self::Logger => controller.record_put_logger_request(),
-            Self::MachineConfig => controller.record_put_machine_config_request(),
-            Self::Mmds => controller.record_put_mmds_request(),
-            Self::Network => controller.record_put_network_request(),
-            Self::Pmem => controller.record_put_pmem_request(),
-            Self::Serial => controller.record_put_serial_request(),
-            Self::Vsock => controller.record_put_vsock_request(),
-        }
-    }
-
-    fn record_failure(self, controller: &mut VmmController) {
-        match self {
-            Self::Balloon => controller.record_put_balloon_failure(),
-            Self::BootSource => controller.record_put_boot_source_failure(),
-            Self::CpuConfig => controller.record_put_cpu_config_failure(),
-            Self::Drive => controller.record_put_drive_failure(),
-            Self::HotplugMemory => controller.record_put_hotplug_memory_failure(),
-            Self::Metrics => controller.record_put_metrics_failure(),
-            Self::Logger => controller.record_put_logger_failure(),
-            Self::MachineConfig => controller.record_put_machine_config_failure(),
-            Self::Mmds => controller.record_put_mmds_failure(),
-            Self::Network => controller.record_put_network_failure(),
-            Self::Pmem => controller.record_put_pmem_failure(),
-            Self::Serial => controller.record_put_serial_failure(),
-            Self::Vsock => controller.record_put_vsock_failure(),
-        }
-    }
-
-    fn record_parse_failure(self, controller: &mut VmmController) {
-        self.record_request(controller);
-        self.record_failure(controller);
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct PatchApiRequest {
-    kind: PatchApiRequestKind,
     action: VmmAction,
 }
 
 impl PatchApiRequest {
     pub(crate) const fn balloon(input: BalloonUpdateInput) -> Self {
         Self {
-            kind: PatchApiRequestKind::Balloon,
             action: VmmAction::PatchBalloon(input),
         }
     }
 
     pub(crate) const fn balloon_hinting_start(input: BalloonHintingStartInput) -> Self {
         Self {
-            kind: PatchApiRequestKind::Balloon,
             action: VmmAction::PatchBalloonHintingStart(input),
         }
     }
 
     pub(crate) const fn balloon_hinting_stop() -> Self {
         Self {
-            kind: PatchApiRequestKind::Balloon,
             action: VmmAction::PatchBalloonHintingStop,
         }
     }
 
     pub(crate) const fn balloon_stats(input: BalloonStatsUpdateInput) -> Self {
         Self {
-            kind: PatchApiRequestKind::Balloon,
             action: VmmAction::PatchBalloonStats(input),
         }
     }
 
     pub(crate) fn drive(input: DriveUpdateInput) -> Self {
         Self {
-            kind: PatchApiRequestKind::Drive,
             action: VmmAction::UpdateBlockDevice(input),
         }
     }
 
     pub(crate) fn machine_config(input: MachineConfigPatchInput) -> Self {
         Self {
-            kind: PatchApiRequestKind::MachineConfig,
             action: VmmAction::PatchMachineConfig(input),
         }
     }
 
     pub(crate) fn mmds(input: MmdsContentInput) -> Self {
         Self {
-            kind: PatchApiRequestKind::Mmds,
             action: VmmAction::PatchMmds(input),
         }
     }
 
     pub(crate) const fn memory_hotplug(input: MemoryHotplugSizeUpdateInput) -> Self {
         Self {
-            kind: PatchApiRequestKind::HotplugMemory,
             action: VmmAction::PatchMemoryHotplug(input),
         }
     }
 
     pub(crate) fn network(input: NetworkInterfaceUpdateInput) -> Self {
         Self {
-            kind: PatchApiRequestKind::Network,
             action: VmmAction::UpdateNetworkInterface(input),
         }
     }
 
     pub(crate) const fn pmem(input: PmemUpdateInput) -> Self {
         Self {
-            kind: PatchApiRequestKind::Pmem,
             action: VmmAction::PatchPmem(input),
         }
-    }
-
-    fn record_request(&self, controller: &mut VmmController) {
-        self.kind.record_request(controller);
     }
 
     fn into_action(self) -> VmmAction {
@@ -5391,135 +5288,160 @@ impl PatchApiRequest {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ApiRequestMetricParseFailure {
-    Patch(ApiRequestMetricPatchParseFailure),
-    Put(ApiRequestMetricPutParseFailure),
+fn apply_api_request_metric_effect(controller: &mut VmmController, effect: ApiRequestMetricEffect) {
+    if let Some(delta) = effect.request() {
+        debug_assert!(
+            !matches!(delta.endpoint(), ApiRequestMetricEndpoint::Get(_)) || delta.failures() == 0
+        );
+        for _ in 0..delta.count() {
+            record_api_request_count(controller, delta.endpoint());
+        }
+        for _ in 0..delta.failures() {
+            record_api_request_failure(controller, delta.endpoint());
+        }
+    }
+    for _ in 0..effect.deprecated_api_calls() {
+        controller.record_deprecated_api_call();
+    }
 }
 
-impl ApiRequestMetricParseFailure {
-    fn record(self, controller: &mut VmmController) {
-        match self {
-            Self::Patch(request) => request.record(controller),
-            Self::Put(request) => request.record(controller),
+fn record_api_request_count(controller: &mut VmmController, endpoint: ApiRequestMetricEndpoint) {
+    match endpoint {
+        ApiRequestMetricEndpoint::Get(ApiRequestMetricGetEndpoint::HotplugMemory) => {
+            controller.record_get_hotplug_memory_request();
+        }
+        ApiRequestMetricEndpoint::Get(ApiRequestMetricGetEndpoint::InstanceInfo) => {
+            controller.record_get_instance_info_request();
+        }
+        ApiRequestMetricEndpoint::Get(ApiRequestMetricGetEndpoint::MachineConfig) => {
+            controller.record_get_machine_config_request();
+        }
+        ApiRequestMetricEndpoint::Get(ApiRequestMetricGetEndpoint::Mmds) => {
+            controller.record_get_mmds_request();
+        }
+        ApiRequestMetricEndpoint::Get(ApiRequestMetricGetEndpoint::VmmVersion) => {
+            controller.record_get_vmm_version_request();
+        }
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Drive) => {
+            controller.record_patch_drive_request();
+        }
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::HotplugMemory) => {
+            controller.record_patch_hotplug_memory_request();
+        }
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::MachineConfig) => {
+            controller.record_patch_machine_config_request();
+        }
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Mmds) => {
+            controller.record_patch_mmds_request();
+        }
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Network) => {
+            controller.record_patch_network_request();
+        }
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Pmem) => {
+            controller.record_patch_pmem_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Actions) => {
+            controller.record_put_actions_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::BootSource) => {
+            controller.record_put_boot_source_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::CpuConfig) => {
+            controller.record_put_cpu_config_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Drive) => {
+            controller.record_put_drive_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::HotplugMemory) => {
+            controller.record_put_hotplug_memory_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Logger) => {
+            controller.record_put_logger_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::MachineConfig) => {
+            controller.record_put_machine_config_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Metrics) => {
+            controller.record_put_metrics_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Mmds) => {
+            controller.record_put_mmds_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Network) => {
+            controller.record_put_network_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Pmem) => {
+            controller.record_put_pmem_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Serial) => {
+            controller.record_put_serial_request();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Vsock) => {
+            controller.record_put_vsock_request();
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ApiRequestMetricPutParseFailure {
-    Actions,
-    Balloon,
-    BootSource,
-    CpuConfig,
-    Drive,
-    HotplugMemory,
-    Logger,
-    MachineConfig,
-    Metrics,
-    Mmds,
-    Network,
-    Pmem,
-    Serial,
-    Vsock,
-}
-
-impl ApiRequestMetricPutParseFailure {
-    fn record(self, controller: &mut VmmController) {
-        match self {
-            Self::Actions => {
-                controller.record_put_actions_request();
-                controller.record_put_actions_failure();
-            }
-            Self::Balloon => PutApiRequestKind::Balloon.record_parse_failure(controller),
-            Self::BootSource => PutApiRequestKind::BootSource.record_parse_failure(controller),
-            Self::CpuConfig => PutApiRequestKind::CpuConfig.record_parse_failure(controller),
-            Self::Drive => PutApiRequestKind::Drive.record_parse_failure(controller),
-            Self::HotplugMemory => {
-                PutApiRequestKind::HotplugMemory.record_parse_failure(controller)
-            }
-            Self::Logger => PutApiRequestKind::Logger.record_parse_failure(controller),
-            Self::MachineConfig => {
-                PutApiRequestKind::MachineConfig.record_parse_failure(controller)
-            }
-            Self::Metrics => PutApiRequestKind::Metrics.record_parse_failure(controller),
-            Self::Mmds => PutApiRequestKind::Mmds.record_parse_failure(controller),
-            Self::Network => PutApiRequestKind::Network.record_parse_failure(controller),
-            Self::Pmem => PutApiRequestKind::Pmem.record_parse_failure(controller),
-            Self::Serial => PutApiRequestKind::Serial.record_parse_failure(controller),
-            Self::Vsock => PutApiRequestKind::Vsock.record_parse_failure(controller),
+fn record_api_request_failure(controller: &mut VmmController, endpoint: ApiRequestMetricEndpoint) {
+    match endpoint {
+        ApiRequestMetricEndpoint::Get(_) => {}
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Drive) => {
+            controller.record_patch_drive_failure();
         }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ApiRequestMetricPatchParseFailure {
-    Balloon,
-    Drive,
-    HotplugMemory,
-    MachineConfig,
-    Mmds,
-    Network,
-    Pmem,
-}
-
-impl ApiRequestMetricPatchParseFailure {
-    fn record(self, controller: &mut VmmController) {
-        match self {
-            Self::Balloon => PatchApiRequestKind::Balloon.record_parse_failure(controller),
-            Self::Drive => PatchApiRequestKind::Drive.record_parse_failure(controller),
-            Self::HotplugMemory => {
-                PatchApiRequestKind::HotplugMemory.record_parse_failure(controller)
-            }
-            Self::MachineConfig => {
-                PatchApiRequestKind::MachineConfig.record_parse_failure(controller)
-            }
-            Self::Mmds => PatchApiRequestKind::Mmds.record_parse_failure(controller),
-            Self::Network => PatchApiRequestKind::Network.record_parse_failure(controller),
-            Self::Pmem => PatchApiRequestKind::Pmem.record_parse_failure(controller),
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::HotplugMemory) => {
+            controller.record_patch_hotplug_memory_failure();
         }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PatchApiRequestKind {
-    Balloon,
-    Drive,
-    HotplugMemory,
-    MachineConfig,
-    Mmds,
-    Network,
-    Pmem,
-}
-
-impl PatchApiRequestKind {
-    fn record_request(self, controller: &mut VmmController) {
-        match self {
-            Self::Balloon => controller.record_patch_balloon_request(),
-            Self::Drive => controller.record_patch_drive_request(),
-            Self::HotplugMemory => controller.record_patch_hotplug_memory_request(),
-            Self::MachineConfig => controller.record_patch_machine_config_request(),
-            Self::Mmds => controller.record_patch_mmds_request(),
-            Self::Network => controller.record_patch_network_request(),
-            Self::Pmem => controller.record_patch_pmem_request(),
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::MachineConfig) => {
+            controller.record_patch_machine_config_failure();
         }
-    }
-
-    fn record_failure(self, controller: &mut VmmController) {
-        match self {
-            Self::Balloon => controller.record_patch_balloon_failure(),
-            Self::Drive => controller.record_patch_drive_failure(),
-            Self::HotplugMemory => controller.record_patch_hotplug_memory_failure(),
-            Self::MachineConfig => controller.record_patch_machine_config_failure(),
-            Self::Mmds => controller.record_patch_mmds_failure(),
-            Self::Network => controller.record_patch_network_failure(),
-            Self::Pmem => controller.record_patch_pmem_failure(),
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Mmds) => {
+            controller.record_patch_mmds_failure();
         }
-    }
-
-    fn record_parse_failure(self, controller: &mut VmmController) {
-        self.record_request(controller);
-        self.record_failure(controller);
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Network) => {
+            controller.record_patch_network_failure();
+        }
+        ApiRequestMetricEndpoint::Patch(ApiRequestMetricPatchEndpoint::Pmem) => {
+            controller.record_patch_pmem_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Actions) => {
+            controller.record_put_actions_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::BootSource) => {
+            controller.record_put_boot_source_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::CpuConfig) => {
+            controller.record_put_cpu_config_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Drive) => {
+            controller.record_put_drive_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::HotplugMemory) => {
+            controller.record_put_hotplug_memory_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Logger) => {
+            controller.record_put_logger_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::MachineConfig) => {
+            controller.record_put_machine_config_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Metrics) => {
+            controller.record_put_metrics_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Mmds) => {
+            controller.record_put_mmds_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Network) => {
+            controller.record_put_network_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Pmem) => {
+            controller.record_put_pmem_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Serial) => {
+            controller.record_put_serial_failure();
+        }
+        ApiRequestMetricEndpoint::Put(ApiRequestMetricPutEndpoint::Vsock) => {
+            controller.record_put_vsock_failure();
+        }
     }
 }
 
@@ -5533,13 +5455,9 @@ pub(crate) trait VmmRequestHandler {
 
     fn handle_put_request(&mut self, request: PutApiRequest) -> Result<VmmData, VmmActionError>;
 
-    fn record_api_request_parse_failure(&mut self, request: ApiRequestMetricParseFailure);
-
-    fn record_put_actions_request(&mut self);
+    fn record_api_request_metric_effect(&mut self, effect: ApiRequestMetricEffect);
 
     fn handle_put_action_request(&mut self, action: VmmAction) -> Result<VmmData, VmmActionError>;
-
-    fn record_deprecated_api_call(&mut self);
 
     #[track_caller]
     fn log_api_request(&mut self, method: LoggerHttpMethod, route: LoggerApiRoute) -> bool;
@@ -6189,16 +6107,10 @@ where
     }
 
     fn handle_put_action_request(&mut self, action: VmmAction) -> Result<VmmData, VmmActionError> {
-        self.controller.record_put_actions_request();
-        let result = self.handle_action(action);
-        if result.is_err() {
-            self.controller.record_put_actions_failure();
-        }
-        result
+        self.handle_action(action)
     }
 
     fn handle_get_request(&mut self, request: GetApiRequest) -> Result<VmmData, VmmActionError> {
-        request.record(&mut self.controller);
         self.handle_action(request.action())
     }
 
@@ -6206,37 +6118,15 @@ where
         &mut self,
         request: PatchApiRequest,
     ) -> Result<VmmData, VmmActionError> {
-        let kind = request.kind;
-        request.record_request(&mut self.controller);
-        let action = request.into_action();
-        let result = self.handle_action(action);
-        if result.is_err() {
-            kind.record_failure(&mut self.controller);
-        }
-        result
+        self.handle_action(request.into_action())
     }
 
     fn handle_put_request(&mut self, request: PutApiRequest) -> Result<VmmData, VmmActionError> {
-        let kind = request.kind;
-        request.record_request(&mut self.controller);
-        let action = request.into_action();
-        let result = self.handle_action(action);
-        if result.is_err() {
-            kind.record_failure(&mut self.controller);
-        }
-        result
+        self.handle_action(request.into_action())
     }
 
-    fn record_api_request_parse_failure(&mut self, request: ApiRequestMetricParseFailure) {
-        request.record(&mut self.controller);
-    }
-
-    fn record_put_actions_request(&mut self) {
-        self.controller.record_put_actions_request();
-    }
-
-    fn record_deprecated_api_call(&mut self) {
-        self.controller.record_deprecated_api_call();
+    fn record_api_request_metric_effect(&mut self, effect: ApiRequestMetricEffect) {
+        apply_api_request_metric_effect(&mut self.controller, effect);
     }
 
     #[track_caller]
@@ -10851,16 +10741,8 @@ where
         ProcessVmm::handle_put_request(self, request)
     }
 
-    fn record_api_request_parse_failure(&mut self, request: ApiRequestMetricParseFailure) {
-        ProcessVmm::record_api_request_parse_failure(self, request);
-    }
-
-    fn record_put_actions_request(&mut self) {
-        ProcessVmm::record_put_actions_request(self);
-    }
-
-    fn record_deprecated_api_call(&mut self) {
-        ProcessVmm::record_deprecated_api_call(self);
+    fn record_api_request_metric_effect(&mut self, effect: ApiRequestMetricEffect) {
+        ProcessVmm::record_api_request_metric_effect(self, effect);
     }
 
     #[track_caller]

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -7268,13 +7268,14 @@ mod tests {
     use super::{
         BalloonDeviceMetrics, BalloonDiscardMetrics, BalloonFreePageReportMetrics,
         BlockDeviceMetrics, BlockDeviceMetricsByDrive, BlockDeviceMetricsRegistryError,
-        BootRunLoopMetricStatus, EntropyDeviceMetrics, MemoryHotplugMetricOperation,
-        MetricsConfigError, MetricsConfigInput, MetricsDiagnostics, MetricsFlushError,
-        MetricsOutput, MetricsState, MmdsMetrics, NetworkInterfaceMetrics,
+        BootRunLoopMetricStatus, DeprecatedApiMetrics, EntropyDeviceMetrics, GetApiRequestMetrics,
+        MemoryHotplugMetricOperation, MetricsConfigError, MetricsConfigInput, MetricsDiagnostics,
+        MetricsFlushError, MetricsOutput, MetricsState, MmdsMetrics, NetworkInterfaceMetrics,
         NetworkInterfaceMetricsByInterface, NetworkInterfaceMetricsCaptureError,
-        NetworkInterfaceMetricsRegistryError, PmemDeviceMetrics, PmemDeviceMetricsByDevice,
-        PmemDeviceMetricsRegistryError, RtcDeviceMetrics, SharedBalloonDeviceMetrics,
-        SharedBlockDeviceMetrics, SharedBlockDeviceMetricsRegistry, SharedEntropyDeviceMetrics,
+        NetworkInterfaceMetricsRegistryError, PatchApiRequestMetrics, PmemDeviceMetrics,
+        PmemDeviceMetricsByDevice, PmemDeviceMetricsRegistryError, PutApiRequestMetrics,
+        RtcDeviceMetrics, SharedBalloonDeviceMetrics, SharedBlockDeviceMetrics,
+        SharedBlockDeviceMetricsRegistry, SharedEntropyDeviceMetrics,
         SharedMemoryHotplugDeviceMetrics, SharedMemoryHotplugLatencyMetricsInner,
         SharedMmdsMetrics, SharedNetworkInterfaceMetrics, SharedNetworkInterfaceMetricsRegistry,
         SharedPmemDeviceMetrics, SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics,
@@ -10325,6 +10326,124 @@ mod tests {
         assert_eq!(value["api_server"]["process_startup_time_cpu_us"], u64::MAX);
 
         fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn api_request_metric_recorders_saturate_all_schema_fields() {
+        let mut state = MetricsState {
+            deprecated_api: DeprecatedApiMetrics {
+                deprecated_http_api_calls: u64::MAX,
+            },
+            get_api_requests: GetApiRequestMetrics {
+                balloon_count: 0,
+                hotplug_memory_count: u64::MAX,
+                instance_info_count: u64::MAX,
+                vmm_version_count: u64::MAX,
+                machine_cfg_count: u64::MAX,
+                mmds_count: u64::MAX,
+            },
+            patch_api_requests: PatchApiRequestMetrics {
+                balloon_count: 0,
+                balloon_fails: 0,
+                drive_count: u64::MAX,
+                drive_fails: u64::MAX,
+                network_count: u64::MAX,
+                network_fails: u64::MAX,
+                machine_cfg_count: u64::MAX,
+                machine_cfg_fails: u64::MAX,
+                mmds_count: u64::MAX,
+                mmds_fails: u64::MAX,
+                hotplug_memory_count: u64::MAX,
+                hotplug_memory_fails: u64::MAX,
+                pmem_count: u64::MAX,
+                pmem_fails: u64::MAX,
+            },
+            put_api_requests: PutApiRequestMetrics {
+                actions_count: u64::MAX,
+                actions_fails: u64::MAX,
+                balloon_count: 0,
+                balloon_fails: 0,
+                boot_source_count: u64::MAX,
+                boot_source_fails: u64::MAX,
+                cpu_cfg_count: u64::MAX,
+                cpu_cfg_fails: u64::MAX,
+                drive_count: u64::MAX,
+                drive_fails: u64::MAX,
+                logger_count: u64::MAX,
+                logger_fails: u64::MAX,
+                machine_cfg_count: u64::MAX,
+                machine_cfg_fails: u64::MAX,
+                metrics_count: u64::MAX,
+                metrics_fails: u64::MAX,
+                hotplug_memory_count: u64::MAX,
+                hotplug_memory_fails: u64::MAX,
+                mmds_count: u64::MAX,
+                mmds_fails: u64::MAX,
+                network_count: u64::MAX,
+                network_fails: u64::MAX,
+                pmem_count: u64::MAX,
+                pmem_fails: u64::MAX,
+                serial_count: u64::MAX,
+                serial_fails: u64::MAX,
+                vsock_count: u64::MAX,
+                vsock_fails: u64::MAX,
+            },
+            ..MetricsState::default()
+        };
+        let expected_deprecated = state.deprecated_api;
+        let expected_get = state.get_api_requests;
+        let expected_patch = state.patch_api_requests;
+        let expected_put = state.put_api_requests;
+
+        state.record_deprecated_api_call();
+        state.record_get_hotplug_memory_request();
+        state.record_get_instance_info_request();
+        state.record_get_machine_config_request();
+        state.record_get_mmds_request();
+        state.record_get_vmm_version_request();
+        state.record_patch_drive_request();
+        state.record_patch_drive_failure();
+        state.record_patch_hotplug_memory_request();
+        state.record_patch_hotplug_memory_failure();
+        state.record_patch_machine_config_request();
+        state.record_patch_machine_config_failure();
+        state.record_patch_mmds_request();
+        state.record_patch_mmds_failure();
+        state.record_patch_network_request();
+        state.record_patch_network_failure();
+        state.record_patch_pmem_request();
+        state.record_patch_pmem_failure();
+        state.record_put_actions_request();
+        state.record_put_actions_failure();
+        state.record_put_boot_source_request();
+        state.record_put_boot_source_failure();
+        state.record_put_cpu_config_request();
+        state.record_put_cpu_config_failure();
+        state.record_put_drive_request();
+        state.record_put_drive_failure();
+        state.record_put_hotplug_memory_request();
+        state.record_put_hotplug_memory_failure();
+        state.record_put_logger_request();
+        state.record_put_logger_failure();
+        state.record_put_machine_config_request();
+        state.record_put_machine_config_failure();
+        state.record_put_metrics_request();
+        state.record_put_metrics_failure();
+        state.record_put_mmds_request();
+        state.record_put_mmds_failure();
+        state.record_put_network_request();
+        state.record_put_network_failure();
+        state.record_put_pmem_request();
+        state.record_put_pmem_failure();
+        state.record_put_serial_request();
+        state.record_put_serial_failure();
+        state.record_put_vsock_request();
+        state.record_put_vsock_failure();
+
+        assert_eq!(state.deprecated_api, expected_deprecated);
+        assert_eq!(state.get_api_requests, expected_get);
+        assert_eq!(state.patch_api_requests, expected_patch);
+        assert_eq!(state.put_api_requests, expected_put);
     }
 
     #[test]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1538,7 +1538,11 @@ ownership, and observable execution remain x86_64-only.
 The checked metrics authority uses one envelope with a machine-owned `source`
 projection and human-owned policy profiles/mappings. It records exactly 24
 arm64 static roots and 243 static scalar paths, plus configured block/network/
-vhost-user field populations of 24/29/5. Run its focused local mutations with:
+vhost-user field populations of 24/29/5. The separate human-owned
+`metrics-process-producer-audit.json` is an exact incremental mapping of the 69
+fields assigned to the process profile; it records 44 implemented #1827
+request/deprecation fields and 25 planned fields owned by #1828–#1830. Run the
+schema and process-audit focused local mutations with:
 
 ```sh
 cargo test -p bangbang-firecracker-capability-audit --test metrics_schema --locked
@@ -1554,11 +1558,14 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- \
   --output codex-work/tmp/metrics-schema-source.candidate.json
 ```
 
-The command never emits or carries forward policy. Review source identities,
+The command never emits or carries forward policy or a process-producer audit.
+Review source identities,
 root/field order, Rust and fixture anchors, types/reset classes, dynamic
 grammar, architecture, reconciliations, and fingerprints before manually
 updating `metrics-schema.json`. Then review every affected unit, aggregation,
 producer owner/disposition, delivery issue, rationale, and evidence mapping.
+If process-profile membership changes, manually reconcile the exact audit
+membership and its boundary/child/evidence policy in the same pull request.
 The destination must be a new non-alias of every checked JSON file. The exact
 shape and publication boundary are documented in the
 [metrics schema contract](../compat/firecracker/v1.16.0/metrics-contract.md).
@@ -1578,9 +1585,11 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- validate --metric
 Metrics-schema-final mode requires the exact twelve #1787 rows to be terminal,
 the schema-runtime timestamp profile to be implemented, both #1790 aggregates
 to remain nonterminal, and the remaining policy profiles to retain their exact
-#1788/#1789 owner/disposition partition. Focused tests inject missing, extra,
-promoted, stale, and wrongly handed-off records; API tests cover duplicate keys
-and the full unsigned token-bucket boundary; direct and contained process tests
+#1788/#1789 owner/disposition partition. It also validates the exact 69-field
+process audit and its completed-child set. Focused tests inject missing, extra,
+promoted, stale, wrongly handed-off, invalid-evidence, and boundary-drift
+records; API tests cover duplicate keys, the full unsigned token-bucket
+boundary, and the exact parser-metric table; direct and contained process tests
 cover `/vm/config` privacy. The signed product oracle
 `normal_bundle_certifies_metrics_schema_across_real_periodic_and_terminal_lifecycle`
 uses the unmodified 60-second scheduler and observes initial,

--- a/tools/firecracker-capability-audit/src/lib.rs
+++ b/tools/firecracker-capability-audit/src/lib.rs
@@ -6,6 +6,8 @@ mod logger_upstream;
 mod logger_validate;
 mod metrics_certify;
 mod metrics_model;
+mod metrics_process_model;
+mod metrics_process_validate;
 mod metrics_upstream;
 mod metrics_validate;
 mod model;
@@ -34,6 +36,11 @@ pub use metrics_model::{
     MetricsSchemaSourceCandidate, MetricsSourceAnchor, MetricsSourceField, MetricsStaticRoot,
     MetricsUnit, MetricsValueKind,
 };
+pub use metrics_process_model::{
+    MetricsProcessProducerAudit, MetricsProcessProducerBoundary, MetricsProcessProducerDisposition,
+    MetricsProcessProducerRecord,
+};
+pub use metrics_process_validate::validate_metrics_process_producers;
 pub use metrics_upstream::derive_metrics_schema_source;
 pub use metrics_validate::validate_metrics_schema;
 pub use model::{
@@ -64,6 +71,8 @@ pub const LOGGER_PRODUCER_GENERATOR_VERSION: u32 = 1;
 pub const METRICS_SCHEMA_VERSION: u32 = 1;
 /// Current generated metrics schema source format.
 pub const METRICS_SCHEMA_GENERATOR_VERSION: u32 = 1;
+/// Current checked-in process-producer audit format.
+pub const METRICS_PROCESS_PRODUCER_AUDIT_SCHEMA_VERSION: u32 = 1;
 /// Repository-relative generated source manifest path.
 pub const SOURCE_MANIFEST_PATH: &str = "compat/firecracker/v1.16.0/source-manifest.json";
 /// Repository-relative human capability overlay path.
@@ -76,6 +85,9 @@ pub const LOGGER_PRODUCER_AUDIT_PATH: &str =
     "compat/firecracker/v1.16.0/logger-producer-audit.json";
 /// Repository-relative canonical metrics schema authority path.
 pub const METRICS_SCHEMA_AUTHORITY_PATH: &str = "compat/firecracker/v1.16.0/metrics-schema.json";
+/// Repository-relative exact process-producer audit path.
+pub const METRICS_PROCESS_PRODUCER_AUDIT_PATH: &str =
+    "compat/firecracker/v1.16.0/metrics-process-producer-audit.json";
 
 /// Error produced while reading, parsing, or deriving an inventory.
 #[derive(Debug)]
@@ -142,6 +154,22 @@ pub fn read_metrics_schema_authority(path: &Path) -> Result<MetricsSchemaAuthori
     })
 }
 
+/// Read and parse the checked process-producer audit.
+pub fn read_metrics_process_producer_audit(
+    path: &Path,
+) -> Result<MetricsProcessProducerAudit, AuditError> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        AuditError::new(format!(
+            "failed to read metrics process producer audit: {error}"
+        ))
+    })?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        AuditError::new(format!(
+            "failed to parse metrics process producer audit: {error}"
+        ))
+    })
+}
+
 /// Serialize a generated source manifest using canonical pretty JSON.
 pub fn source_manifest_json(manifest: &SourceManifest) -> Result<Vec<u8>, AuditError> {
     let mut bytes = serde_json::to_vec_pretty(manifest).map_err(|error| {
@@ -187,6 +215,13 @@ pub fn metrics_schema_authority_json(
     authority: &MetricsSchemaAuthority,
 ) -> Result<Vec<u8>, AuditError> {
     canonical_json(authority, "metrics schema authority")
+}
+
+/// Serialize the human process-producer audit using canonical pretty JSON.
+pub fn metrics_process_producer_audit_json(
+    audit: &MetricsProcessProducerAudit,
+) -> Result<Vec<u8>, AuditError> {
+    canonical_json(audit, "metrics process producer audit")
 }
 
 fn canonical_json<T: serde::Serialize>(value: &T, label: &str) -> Result<Vec<u8>, AuditError> {

--- a/tools/firecracker-capability-audit/src/main.rs
+++ b/tools/firecracker-capability-audit/src/main.rs
@@ -6,12 +6,14 @@ use std::process::{Command, ExitCode};
 
 use bangbang_firecracker_capability_audit::{
     AuditError, AuditMode, CAPABILITY_INVENTORY_PATH, LOGGER_PRODUCER_AUDIT_PATH,
-    LOGGER_PRODUCER_MANIFEST_PATH, METRICS_SCHEMA_AUTHORITY_PATH, SOURCE_MANIFEST_PATH,
-    derive_logger_producer_manifest, derive_metrics_schema_source, derive_source_manifest,
-    logger_producer_manifest_json, metrics_schema_source_candidate_json, read_capability_inventory,
-    read_logger_producer_audit, read_logger_producer_manifest, read_metrics_schema_authority,
-    read_source_manifest, source_manifest_json, validate, validate_logger_compatibility,
-    validate_logger_producers, validate_metrics_schema, validate_metrics_schema_compatibility,
+    LOGGER_PRODUCER_MANIFEST_PATH, METRICS_PROCESS_PRODUCER_AUDIT_PATH,
+    METRICS_SCHEMA_AUTHORITY_PATH, SOURCE_MANIFEST_PATH, derive_logger_producer_manifest,
+    derive_metrics_schema_source, derive_source_manifest, logger_producer_manifest_json,
+    metrics_schema_source_candidate_json, read_capability_inventory, read_logger_producer_audit,
+    read_logger_producer_manifest, read_metrics_process_producer_audit,
+    read_metrics_schema_authority, read_source_manifest, source_manifest_json, validate,
+    validate_logger_compatibility, validate_logger_producers, validate_metrics_process_producers,
+    validate_metrics_schema, validate_metrics_schema_compatibility,
 };
 
 fn main() -> ExitCode {
@@ -75,6 +77,8 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
     let logger_audit = read_logger_producer_audit(&root.join(LOGGER_PRODUCER_AUDIT_PATH))?;
     let metrics_authority =
         read_metrics_schema_authority(&root.join(METRICS_SCHEMA_AUTHORITY_PATH))?;
+    let metrics_process_audit =
+        read_metrics_process_producer_audit(&root.join(METRICS_PROCESS_PRODUCER_AUDIT_PATH))?;
     let audit_mode = match mode {
         ValidateMode::Delivery => AuditMode::Delivery,
         ValidateMode::Final => AuditMode::Final,
@@ -93,8 +97,19 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
                 .map_err(|errors| {
                     AuditError::new(format!("metrics schema validation errors:\n{errors}"))
                 })?;
+            validate_metrics_process_producers(
+                &metrics_process_audit,
+                &metrics_authority,
+                &root,
+                AuditMode::Delivery,
+            )
+            .map_err(|errors| {
+                AuditError::new(format!(
+                    "metrics process producer validation errors:\n{errors}"
+                ))
+            })?;
             return Ok(
-                "Firecracker capability inventory, logger producer audit, and metrics schema authority are valid for the terminal logger compatibility scope"
+                "Firecracker capability inventory, logger producer audit, metrics schema authority, and process producer audit are valid for the terminal logger compatibility scope"
                     .to_string(),
             );
         }
@@ -109,8 +124,19 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
                 .map_err(|errors| {
                     AuditError::new(format!("logger producer validation errors:\n{errors}"))
                 })?;
+            validate_metrics_process_producers(
+                &metrics_process_audit,
+                &metrics_authority,
+                &root,
+                AuditMode::Delivery,
+            )
+            .map_err(|errors| {
+                AuditError::new(format!(
+                    "metrics process producer validation errors:\n{errors}"
+                ))
+            })?;
             return Ok(
-                "Firecracker capability inventory, logger producer audit, and metrics schema authority are valid for the terminal metrics API/schema compatibility scope"
+                "Firecracker capability inventory, logger producer audit, metrics schema authority, and process producer audit are valid for the terminal metrics API/schema compatibility scope"
                     .to_string(),
             );
         }
@@ -127,6 +153,16 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
     if let Err(errors) = validate_metrics_schema(&metrics_authority, &manifest, &root, audit_mode) {
         failures.push(format!("metrics schema validation errors:\n{errors}"));
     }
+    if let Err(errors) = validate_metrics_process_producers(
+        &metrics_process_audit,
+        &metrics_authority,
+        &root,
+        audit_mode,
+    ) {
+        failures.push(format!(
+            "metrics process producer validation errors:\n{errors}"
+        ));
+    }
     if !failures.is_empty() {
         return Err(AuditError::new(failures.join("\n")));
     }
@@ -135,7 +171,7 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
         AuditMode::Final => "final",
     };
     Ok(format!(
-        "Firecracker capability inventory, logger producer audit, and metrics schema authority are valid in {mode_name} mode"
+        "Firecracker capability inventory, logger producer audit, metrics schema authority, and process producer audit are valid in {mode_name} mode"
     ))
 }
 
@@ -301,6 +337,7 @@ fn candidate_output_path(root: &Path, output: &Path) -> Result<PathBuf, AuditErr
     let logger_manifest_path = root.join(LOGGER_PRODUCER_MANIFEST_PATH);
     let logger_audit_path = root.join(LOGGER_PRODUCER_AUDIT_PATH);
     let metrics_schema_path = root.join(METRICS_SCHEMA_AUTHORITY_PATH);
+    let metrics_process_audit_path = root.join(METRICS_PROCESS_PRODUCER_AUDIT_PATH);
     let normalized_output = normalize_lexically(&output_path);
     let checked_paths = [
         &source_path,
@@ -308,6 +345,7 @@ fn candidate_output_path(root: &Path, output: &Path) -> Result<PathBuf, AuditErr
         &logger_manifest_path,
         &logger_audit_path,
         &metrics_schema_path,
+        &metrics_process_audit_path,
     ];
     if checked_paths
         .iter()
@@ -512,6 +550,7 @@ mod tests {
             LOGGER_PRODUCER_MANIFEST_PATH,
             LOGGER_PRODUCER_AUDIT_PATH,
             METRICS_SCHEMA_AUTHORITY_PATH,
+            METRICS_PROCESS_PRODUCER_AUDIT_PATH,
         ] {
             let error = candidate_output_path(root, Path::new(path))
                 .expect_err("checked inventory path should be refused");
@@ -528,6 +567,7 @@ mod tests {
             "compat/firecracker/v1.16.0/./logger-producer-manifest.json",
             "compat/firecracker/v1.16.0/../v1.16.0/logger-producer-audit.json",
             "compat/firecracker/v1.16.0/./metrics-schema.json",
+            "compat/firecracker/v1.16.0/./metrics-process-producer-audit.json",
         ] {
             let error = candidate_output_path(root, Path::new(path))
                 .expect_err("checked inventory alias should be refused");

--- a/tools/firecracker-capability-audit/src/metrics_process_model.rs
+++ b/tools/firecracker-capability-audit/src/metrics_process_model.rs
@@ -1,0 +1,93 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Baseline, Reference};
+
+/// Closed semantic producer boundary for a process-owned metrics field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsProcessProducerBoundary {
+    RequestParserEntry,
+    RequestParserFailure,
+    AcceptedDeprecatedApiValue,
+    ProcessStartup,
+    SuccessfulOuterApiOperation,
+    SuccessfulInnerVmmOperation,
+    LoggerLifecycle,
+    SignalLifecycle,
+    PanicLifecycle,
+    SeccompFault,
+}
+
+/// Terminal or unresolved state of one exact process producer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsProcessProducerDisposition {
+    Planned,
+    Implemented,
+    SourceNeutral,
+    PlatformZero,
+}
+
+impl MetricsProcessProducerDisposition {
+    pub const fn is_terminal(self) -> bool {
+        !matches!(self, Self::Planned)
+    }
+}
+
+/// Reviewed producer authority for one canonical metrics field identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsProcessProducerRecord {
+    pub field_id: String,
+    pub boundary: MetricsProcessProducerBoundary,
+    pub disposition: MetricsProcessProducerDisposition,
+    pub delivery_issue: String,
+    pub rationale: String,
+    #[serde(default)]
+    pub implementation: Vec<Reference>,
+    #[serde(default)]
+    pub validation: Vec<Reference>,
+}
+
+/// Human-reviewed exact-field producer overlay for process-owned metrics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsProcessProducerAudit {
+    pub schema_version: u32,
+    pub baseline: Baseline,
+    pub records: Vec<MetricsProcessProducerRecord>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_unknown_process_audit_fields() {
+        let error = serde_json::from_str::<MetricsProcessProducerAudit>(
+            r#"{
+                "schema_version":1,
+                "baseline":{"version":"1.16.0","commit":"c","target":"t"},
+                "records":[],
+                "typo":true
+            }"#,
+        )
+        .expect_err("unknown audit fields must fail");
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_open_ended_process_boundaries() {
+        let error = serde_json::from_str::<MetricsProcessProducerRecord>(
+            r##"{
+                "field_id":"static:test.field",
+                "boundary":"somewhere",
+                "disposition":"planned",
+                "delivery_issue":"#1",
+                "rationale":"test"
+            }"##,
+        )
+        .expect_err("unknown boundaries must fail");
+        assert!(error.to_string().contains("unknown variant"));
+    }
+}

--- a/tools/firecracker-capability-audit/src/metrics_process_validate.rs
+++ b/tools/firecracker-capability-audit/src/metrics_process_validate.rs
@@ -1,0 +1,383 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use crate::validate::{tracked_repository_files, validate_reference};
+use crate::{
+    AuditMode, FIRECRACKER_COMMIT, FIRECRACKER_TARGET, FIRECRACKER_VERSION,
+    METRICS_PROCESS_PRODUCER_AUDIT_SCHEMA_VERSION, MetricsProcessProducerAudit,
+    MetricsProcessProducerBoundary, MetricsProcessProducerDisposition, MetricsProducerOwner,
+    MetricsSchemaAuthority, Reference, ValidationErrors,
+};
+
+const EXPECTED_PROCESS_FIELDS: usize = 69;
+const COMPLETED_DELIVERY_ISSUES: &[&str] = &["#1827"];
+
+/// Validate exact process-producer authority against the resolved metrics schema.
+pub fn validate_metrics_process_producers(
+    audit: &MetricsProcessProducerAudit,
+    authority: &MetricsSchemaAuthority,
+    repository_root: &Path,
+    mode: AuditMode,
+) -> Result<(), ValidationErrors> {
+    let mut errors = Vec::new();
+    validate_baseline(audit, authority, &mut errors);
+
+    let process_profiles = authority
+        .policy_profiles
+        .iter()
+        .filter(|profile| profile.producer_owner == MetricsProducerOwner::ProcessLifecycle)
+        .map(|profile| profile.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let source_paths = authority
+        .source
+        .fields
+        .iter()
+        .map(|field| (field.id.as_str(), field.path.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    let expected = authority
+        .field_policies
+        .iter()
+        .filter(|policy| process_profiles.contains(policy.profile_id.as_str()))
+        .filter_map(|policy| {
+            source_paths
+                .get(policy.field_id.as_str())
+                .map(|path| (policy.field_id.as_str(), *path))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    if expected.len() != EXPECTED_PROCESS_FIELDS {
+        errors.push(format!(
+            "metrics process producer schema set must contain {EXPECTED_PROCESS_FIELDS} fields, found {}",
+            expected.len()
+        ));
+    }
+    if audit.records.len() != EXPECTED_PROCESS_FIELDS {
+        errors.push(format!(
+            "metrics process producer audit must contain {EXPECTED_PROCESS_FIELDS} records, found {}",
+            audit.records.len()
+        ));
+    }
+
+    let tracked = tracked_repository_files(repository_root, &mut errors);
+    let mut records = BTreeMap::new();
+    let mut previous = None;
+    for record in &audit.records {
+        if previous.is_some_and(|field_id| record.field_id.as_str() <= field_id) {
+            errors.push(
+                "metrics process producer records must be sorted and unique by field_id"
+                    .to_string(),
+            );
+        }
+        previous = Some(record.field_id.as_str());
+        if records.insert(record.field_id.as_str(), record).is_some() {
+            errors.push(format!(
+                "duplicate metrics process producer record: {}",
+                record.field_id
+            ));
+        }
+
+        let Some(path) = expected.get(record.field_id.as_str()).copied() else {
+            errors.push(format!(
+                "stale or unowned metrics process producer record: {}",
+                record.field_id
+            ));
+            continue;
+        };
+        validate_record(record, path, repository_root, &tracked, mode, &mut errors);
+    }
+    for field_id in expected.keys() {
+        if !records.contains_key(field_id) {
+            errors.push(format!(
+                "missing metrics process producer record: {field_id}"
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(ValidationErrors::from_messages(errors))
+    }
+}
+
+fn validate_baseline(
+    audit: &MetricsProcessProducerAudit,
+    authority: &MetricsSchemaAuthority,
+    errors: &mut Vec<String>,
+) {
+    if audit.schema_version != METRICS_PROCESS_PRODUCER_AUDIT_SCHEMA_VERSION {
+        errors.push(format!(
+            "metrics process producer schema_version must be {METRICS_PROCESS_PRODUCER_AUDIT_SCHEMA_VERSION}, found {}",
+            audit.schema_version
+        ));
+    }
+    if audit.baseline != authority.baseline {
+        errors.push("metrics process producer and metrics schema baselines differ".to_string());
+    }
+    if audit.baseline.version != FIRECRACKER_VERSION
+        || audit.baseline.commit != FIRECRACKER_COMMIT
+        || audit.baseline.target != FIRECRACKER_TARGET
+    {
+        errors.push("metrics process producer baseline is not the pinned release".to_string());
+    }
+}
+
+fn validate_record(
+    record: &crate::MetricsProcessProducerRecord,
+    path: &str,
+    repository_root: &Path,
+    tracked: &BTreeSet<std::path::PathBuf>,
+    mode: AuditMode,
+    errors: &mut Vec<String>,
+) {
+    let Some(delivery_issue) = expected_delivery_issue(path) else {
+        errors.push(format!(
+            "metrics process producer field has no closed delivery owner: {}",
+            record.field_id
+        ));
+        return;
+    };
+    if record.delivery_issue != delivery_issue {
+        errors.push(format!(
+            "metrics process producer has the wrong delivery issue: {}",
+            record.field_id
+        ));
+    }
+
+    let Some(boundary) = expected_boundary(path) else {
+        errors.push(format!(
+            "metrics process producer field has no closed boundary: {}",
+            record.field_id
+        ));
+        return;
+    };
+    if record.boundary != boundary {
+        errors.push(format!(
+            "metrics process producer has the wrong boundary: {}",
+            record.field_id
+        ));
+    }
+    if record.rationale != expected_rationale(path, delivery_issue, boundary) {
+        errors.push(format!(
+            "metrics process producer has a stale rationale: {}",
+            record.field_id
+        ));
+    }
+
+    let completed = COMPLETED_DELIVERY_ISSUES.contains(&delivery_issue);
+    if completed && !record.disposition.is_terminal() {
+        errors.push(format!(
+            "completed metrics process producer slice must be terminal: {}",
+            record.field_id
+        ));
+    }
+    if !completed && record.disposition != MetricsProcessProducerDisposition::Planned {
+        errors.push(format!(
+            "uncompleted metrics process producer slice must remain planned: {}",
+            record.field_id
+        ));
+    }
+    if delivery_issue == "#1827"
+        && record.disposition != MetricsProcessProducerDisposition::Implemented
+    {
+        errors.push(format!(
+            "API metrics producer must be implemented, not neutral or zero: {}",
+            record.field_id
+        ));
+    }
+
+    match record.disposition {
+        MetricsProcessProducerDisposition::Planned => {
+            if !record.implementation.is_empty() || !record.validation.is_empty() {
+                errors.push(format!(
+                    "planned metrics process producer must not claim terminal evidence: {}",
+                    record.field_id
+                ));
+            }
+            if mode == AuditMode::Final {
+                errors.push(format!(
+                    "final metrics process producer validation rejects planned record: {}",
+                    record.field_id
+                ));
+            }
+        }
+        MetricsProcessProducerDisposition::Implemented
+        | MetricsProcessProducerDisposition::SourceNeutral
+        | MetricsProcessProducerDisposition::PlatformZero => {
+            if record.implementation.is_empty() || record.validation.is_empty() {
+                errors.push(format!(
+                    "terminal metrics process producer needs implementation and validation evidence: {}",
+                    record.field_id
+                ));
+            }
+            validate_references(
+                &record.implementation,
+                "implementation",
+                &record.field_id,
+                repository_root,
+                tracked,
+                errors,
+            );
+            validate_references(
+                &record.validation,
+                "validation",
+                &record.field_id,
+                repository_root,
+                tracked,
+                errors,
+            );
+        }
+    }
+}
+
+fn validate_references(
+    references: &[Reference],
+    kind: &str,
+    field_id: &str,
+    repository_root: &Path,
+    tracked: &BTreeSet<std::path::PathBuf>,
+    errors: &mut Vec<String>,
+) {
+    if references.windows(2).any(|pair| {
+        let [previous, current] = pair else {
+            return false;
+        };
+        previous >= current
+    }) {
+        errors.push(format!(
+            "metrics process producer {kind} references must be sorted and unique: {field_id}"
+        ));
+    }
+    for (index, reference) in references.iter().enumerate() {
+        validate_reference(
+            reference,
+            repository_root,
+            tracked,
+            &format!("metrics process producer {field_id} {kind}[{index}]"),
+            errors,
+        );
+    }
+}
+
+fn expected_delivery_issue(path: &str) -> Option<&'static str> {
+    if path == "deprecated_api.deprecated_http_api_calls"
+        || path.starts_with("get_api_requests.")
+        || path.starts_with("patch_api_requests.")
+        || path.starts_with("put_api_requests.")
+    {
+        Some("#1827")
+    } else if path.starts_with("api_server.process_startup_time_")
+        || path.starts_with("latencies_us.")
+    {
+        Some("#1828")
+    } else if path.starts_with("logger.") || path == "signals.sigpipe" {
+        Some("#1829")
+    } else if path == "seccomp.num_faults"
+        || (path.starts_with("signals.") && path != "signals.sigpipe")
+        || path == "vmm.panic_count"
+    {
+        Some("#1830")
+    } else {
+        None
+    }
+}
+
+fn expected_boundary(path: &str) -> Option<MetricsProcessProducerBoundary> {
+    if path == "deprecated_api.deprecated_http_api_calls" {
+        Some(MetricsProcessProducerBoundary::AcceptedDeprecatedApiValue)
+    } else if path.starts_with("get_api_requests.")
+        || ((path.starts_with("patch_api_requests.") || path.starts_with("put_api_requests."))
+            && path.ends_with("_count"))
+    {
+        Some(MetricsProcessProducerBoundary::RequestParserEntry)
+    } else if (path.starts_with("patch_api_requests.") || path.starts_with("put_api_requests."))
+        && path.ends_with("_fails")
+    {
+        Some(MetricsProcessProducerBoundary::RequestParserFailure)
+    } else if path.starts_with("api_server.process_startup_time_") {
+        Some(MetricsProcessProducerBoundary::ProcessStartup)
+    } else if path.starts_with("latencies_us.vmm_") {
+        Some(MetricsProcessProducerBoundary::SuccessfulInnerVmmOperation)
+    } else if path.starts_with("latencies_us.") {
+        Some(MetricsProcessProducerBoundary::SuccessfulOuterApiOperation)
+    } else if path.starts_with("logger.") {
+        Some(MetricsProcessProducerBoundary::LoggerLifecycle)
+    } else if path.starts_with("signals.") {
+        Some(MetricsProcessProducerBoundary::SignalLifecycle)
+    } else if path == "vmm.panic_count" {
+        Some(MetricsProcessProducerBoundary::PanicLifecycle)
+    } else if path == "seccomp.num_faults" {
+        Some(MetricsProcessProducerBoundary::SeccompFault)
+    } else {
+        None
+    }
+}
+
+fn expected_rationale(
+    path: &str,
+    delivery_issue: &str,
+    boundary: MetricsProcessProducerBoundary,
+) -> &'static str {
+    if path == "patch_api_requests.network_count" {
+        return "Pinned Firecracker increments this count at parser entry and again for a missing or mismatched interface ID; Bangbang applies the bounded typed effect once.";
+    }
+    if path == "patch_api_requests.network_fails" {
+        return "Pinned Firecracker increments this failure only for typed PATCH body conversion or validation, not for missing or mismatched interface IDs or later action errors.";
+    }
+    match (delivery_issue, boundary) {
+        ("#1827", MetricsProcessProducerBoundary::RequestParserEntry) => {
+            "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch."
+        }
+        ("#1827", MetricsProcessProducerBoundary::RequestParserFailure) => {
+            "Pinned Firecracker increments this failure only on endpoint conversion or validation failure; later VMM action errors do not change it."
+        }
+        ("#1827", MetricsProcessProducerBoundary::AcceptedDeprecatedApiValue) => {
+            "Pinned Firecracker increments this counter only after typed parsing accepts a deprecated API value; Bangbang records the redacted parse effect once."
+        }
+        ("#1828", MetricsProcessProducerBoundary::ProcessStartup) => {
+            "Delivery child #1828 owns the exact process startup clock boundary and remains unresolved in this audit slice."
+        }
+        ("#1828", MetricsProcessProducerBoundary::SuccessfulOuterApiOperation) => {
+            "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice."
+        }
+        ("#1828", MetricsProcessProducerBoundary::SuccessfulInnerVmmOperation) => {
+            "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice."
+        }
+        ("#1829", MetricsProcessProducerBoundary::LoggerLifecycle) => {
+            "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice."
+        }
+        ("#1829", MetricsProcessProducerBoundary::SignalLifecycle) => {
+            "Delivery child #1829 owns the generation-consistent SIGPIPE capture boundary and remains unresolved in this audit slice."
+        }
+        ("#1830", MetricsProcessProducerBoundary::SignalLifecycle) => {
+            "Delivery child #1830 owns fatal process-signal classification and remains unresolved in this audit slice."
+        }
+        ("#1830", MetricsProcessProducerBoundary::PanicLifecycle) => {
+            "Delivery child #1830 owns panic capture and fatal convergence and remains unresolved in this audit slice."
+        }
+        ("#1830", MetricsProcessProducerBoundary::SeccompFault) => {
+            "Delivery child #1830 owns the platform seccomp-fault disposition and evidence and remains unresolved in this audit slice."
+        }
+        _ => "No reviewed rationale exists for this process producer boundary.",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partitions_exact_known_process_paths() {
+        assert_eq!(
+            expected_delivery_issue("put_api_requests.actions_count"),
+            Some("#1827")
+        );
+        assert_eq!(
+            expected_delivery_issue("latencies_us.vmm_pause_vm"),
+            Some("#1828")
+        );
+        assert_eq!(expected_delivery_issue("signals.sigpipe"), Some("#1829"));
+        assert_eq!(expected_delivery_issue("signals.sigsegv"), Some("#1830"));
+        assert_eq!(expected_delivery_issue("block.read_count"), None);
+    }
+}

--- a/tools/firecracker-capability-audit/src/metrics_process_validate.rs
+++ b/tools/firecracker-capability-audit/src/metrics_process_validate.rs
@@ -157,7 +157,14 @@ fn validate_record(
             record.field_id
         ));
     }
-    if record.rationale != expected_rationale(path, delivery_issue, boundary) {
+    let Some(rationale) = expected_rationale(path, delivery_issue, boundary) else {
+        errors.push(format!(
+            "metrics process producer field has no closed rationale: {}",
+            record.field_id
+        ));
+        return;
+    };
+    if record.rationale != rationale {
         errors.push(format!(
             "metrics process producer has a stale rationale: {}",
             record.field_id
@@ -317,14 +324,18 @@ fn expected_rationale(
     path: &str,
     delivery_issue: &str,
     boundary: MetricsProcessProducerBoundary,
-) -> &'static str {
+) -> Option<&'static str> {
     if path == "patch_api_requests.network_count" {
-        return "Pinned Firecracker increments this count at parser entry and again for a missing or mismatched interface ID; Bangbang applies the bounded typed effect once.";
+        return Some(
+            "Pinned Firecracker increments this count at parser entry and again for a missing or mismatched interface ID; Bangbang applies the bounded typed effect once.",
+        );
     }
     if path == "patch_api_requests.network_fails" {
-        return "Pinned Firecracker increments this failure only for typed PATCH body conversion or validation, not for missing or mismatched interface IDs or later action errors.";
+        return Some(
+            "Pinned Firecracker increments this failure only for typed PATCH body conversion or validation, not for missing or mismatched interface IDs or later action errors.",
+        );
     }
-    match (delivery_issue, boundary) {
+    Some(match (delivery_issue, boundary) {
         ("#1827", MetricsProcessProducerBoundary::RequestParserEntry) => {
             "Pinned Firecracker increments this request count at endpoint parser entry; Bangbang applies the value-free typed parser effect once before dispatch."
         }
@@ -358,8 +369,8 @@ fn expected_rationale(
         ("#1830", MetricsProcessProducerBoundary::SeccompFault) => {
             "Delivery child #1830 owns the platform seccomp-fault disposition and evidence and remains unresolved in this audit slice."
         }
-        _ => "No reviewed rationale exists for this process producer boundary.",
-    }
+        _ => return None,
+    })
 }
 
 #[cfg(test)]
@@ -379,5 +390,13 @@ mod tests {
         assert_eq!(expected_delivery_issue("signals.sigpipe"), Some("#1829"));
         assert_eq!(expected_delivery_issue("signals.sigsegv"), Some("#1830"));
         assert_eq!(expected_delivery_issue("block.read_count"), None);
+        assert_eq!(
+            expected_rationale(
+                "future.field",
+                "#9999",
+                MetricsProcessProducerBoundary::PanicLifecycle,
+            ),
+            None
+        );
     }
 }

--- a/tools/firecracker-capability-audit/tests/metrics_schema.rs
+++ b/tools/firecracker-capability-audit/tests/metrics_schema.rs
@@ -3,10 +3,13 @@
 use std::path::PathBuf;
 
 use bangbang_firecracker_capability_audit::{
-    AuditMode, METRICS_SCHEMA_AUTHORITY_PATH, MetricsAggregation, MetricsArchitecture,
-    MetricsProducerDisposition, MetricsProducerOwner, MetricsSchemaAuthority, MetricsUnit,
-    MetricsValueKind, Reference, SOURCE_MANIFEST_PATH, metrics_schema_authority_json,
-    read_metrics_schema_authority, read_source_manifest, validate_metrics_schema,
+    AuditMode, METRICS_PROCESS_PRODUCER_AUDIT_PATH, METRICS_SCHEMA_AUTHORITY_PATH,
+    MetricsAggregation, MetricsArchitecture, MetricsProcessProducerAudit,
+    MetricsProcessProducerBoundary, MetricsProcessProducerDisposition, MetricsProducerDisposition,
+    MetricsProducerOwner, MetricsSchemaAuthority, MetricsUnit, MetricsValueKind, Reference,
+    SOURCE_MANIFEST_PATH, metrics_process_producer_audit_json, metrics_schema_authority_json,
+    read_metrics_process_producer_audit, read_metrics_schema_authority, read_source_manifest,
+    validate_metrics_process_producers, validate_metrics_schema,
 };
 
 fn repository_root() -> PathBuf {
@@ -22,12 +25,25 @@ fn checked_authority() -> MetricsSchemaAuthority {
         .expect("checked metrics authority must parse")
 }
 
+fn checked_process_audit() -> MetricsProcessProducerAudit {
+    let root = repository_root();
+    read_metrics_process_producer_audit(&root.join(METRICS_PROCESS_PRODUCER_AUDIT_PATH))
+        .expect("checked metrics process producer audit must parse")
+}
+
 fn validation_error(authority: &MetricsSchemaAuthority) -> String {
     let root = repository_root();
     let manifest = read_source_manifest(&root.join(SOURCE_MANIFEST_PATH))
         .expect("checked source manifest must parse");
     validate_metrics_schema(authority, &manifest, &root, AuditMode::Delivery)
         .expect_err("mutated metrics authority must fail")
+        .to_string()
+}
+
+fn process_validation_error(audit: &MetricsProcessProducerAudit) -> String {
+    let root = repository_root();
+    validate_metrics_process_producers(audit, &checked_authority(), &root, AuditMode::Delivery)
+        .expect_err("mutated metrics process producer audit must fail")
         .to_string()
 }
 
@@ -50,6 +66,173 @@ fn checked_metrics_authority_is_canonical_and_valid_without_a_sibling() {
     assert_eq!(authority.source.dynamic_families[0].field_ids.len(), 24);
     assert_eq!(authority.source.dynamic_families[1].field_ids.len(), 29);
     assert_eq!(authority.source.dynamic_families[2].field_ids.len(), 5);
+}
+
+#[test]
+fn checked_process_producer_audit_is_canonical_and_exact() {
+    let root = repository_root();
+    let path = root.join(METRICS_PROCESS_PRODUCER_AUDIT_PATH);
+    let authority = checked_authority();
+    let audit = checked_process_audit();
+    validate_metrics_process_producers(&audit, &authority, &root, AuditMode::Delivery)
+        .expect("checked process producer audit must validate locally");
+    assert_eq!(
+        std::fs::read(path).expect("checked process producer audit must be readable"),
+        metrics_process_producer_audit_json(&audit)
+            .expect("process producer audit must serialize canonically")
+    );
+    assert_eq!(audit.records.len(), 69);
+    for (issue, count) in [("#1827", 44), ("#1828", 12), ("#1829", 5), ("#1830", 8)] {
+        assert_eq!(
+            audit
+                .records
+                .iter()
+                .filter(|record| record.delivery_issue == issue)
+                .count(),
+            count,
+            "{issue}"
+        );
+    }
+    assert_eq!(
+        audit
+            .records
+            .iter()
+            .filter(|record| {
+                record.disposition == MetricsProcessProducerDisposition::Implemented
+            })
+            .count(),
+        44
+    );
+    assert_eq!(
+        audit
+            .records
+            .iter()
+            .filter(|record| record.disposition == MetricsProcessProducerDisposition::Planned)
+            .count(),
+        25
+    );
+
+    let error = validate_metrics_process_producers(&audit, &authority, &root, AuditMode::Final)
+        .expect_err("planned downstream process producers must fail global final mode")
+        .to_string();
+    assert!(error.contains("rejects planned record"));
+}
+
+#[test]
+fn process_producer_audit_rejects_membership_and_order_drift() {
+    let mut missing = checked_process_audit();
+    let removed = missing.records.remove(0);
+    let error = process_validation_error(&missing);
+    assert!(error.contains("must contain 69 records"));
+    assert!(error.contains(&format!(
+        "missing metrics process producer record: {}",
+        removed.field_id
+    )));
+
+    let mut duplicate = checked_process_audit();
+    duplicate.records.push(duplicate.records[0].clone());
+    let error = process_validation_error(&duplicate);
+    assert!(error.contains("sorted and unique"));
+    assert!(error.contains("duplicate metrics process producer record"));
+
+    let mut stale = checked_process_audit();
+    stale.records[0].field_id = "static:not.process_owned".to_string();
+    let error = process_validation_error(&stale);
+    assert!(error.contains("stale or unowned"));
+    assert!(error.contains("missing metrics process producer record"));
+
+    let mut order = checked_process_audit();
+    order.records.swap(0, 1);
+    assert!(process_validation_error(&order).contains("sorted and unique"));
+}
+
+#[test]
+fn process_producer_audit_rejects_boundary_child_and_completion_drift() {
+    let mut boundary = checked_process_audit();
+    boundary.records[0].boundary = MetricsProcessProducerBoundary::PanicLifecycle;
+    assert!(process_validation_error(&boundary).contains("wrong boundary"));
+
+    let mut child = checked_process_audit();
+    child.records[0].delivery_issue = "#1830".to_string();
+    assert!(process_validation_error(&child).contains("wrong delivery issue"));
+
+    let mut completed = checked_process_audit();
+    let api = completed
+        .records
+        .iter_mut()
+        .find(|record| record.delivery_issue == "#1827")
+        .expect("API record must exist");
+    api.disposition = MetricsProcessProducerDisposition::Planned;
+    api.implementation.clear();
+    api.validation.clear();
+    let error = process_validation_error(&completed);
+    assert!(error.contains("completed metrics process producer slice must be terminal"));
+    assert!(error.contains("API metrics producer must be implemented"));
+
+    let mut premature = checked_process_audit();
+    let downstream = premature
+        .records
+        .iter_mut()
+        .find(|record| record.delivery_issue == "#1828")
+        .expect("downstream record must exist");
+    downstream.disposition = MetricsProcessProducerDisposition::Implemented;
+    downstream.implementation.push(Reference::Local {
+        path: "crates/api/src/http.rs".to_string(),
+        anchor: Some("test".to_string()),
+    });
+    downstream.validation.push(Reference::Local {
+        path: "crates/api/src/http.rs".to_string(),
+        anchor: Some("test".to_string()),
+    });
+    assert!(process_validation_error(&premature).contains("must remain planned"));
+}
+
+#[test]
+fn process_producer_audit_rejects_neutral_aliases_and_bad_evidence() {
+    let mut neutral = checked_process_audit();
+    let api = neutral
+        .records
+        .iter_mut()
+        .find(|record| record.delivery_issue == "#1827")
+        .expect("API record must exist");
+    api.disposition = MetricsProcessProducerDisposition::SourceNeutral;
+    assert!(
+        process_validation_error(&neutral).contains("must be implemented, not neutral or zero")
+    );
+
+    let mut missing = checked_process_audit();
+    missing
+        .records
+        .iter_mut()
+        .find(|record| record.disposition == MetricsProcessProducerDisposition::Implemented)
+        .expect("implemented record must exist")
+        .implementation
+        .clear();
+    assert!(
+        process_validation_error(&missing).contains("needs implementation and validation evidence")
+    );
+
+    let mut unsafe_reference = checked_process_audit();
+    let implemented = unsafe_reference
+        .records
+        .iter_mut()
+        .find(|record| record.disposition == MetricsProcessProducerDisposition::Implemented)
+        .expect("implemented record must exist");
+    implemented.implementation[0] = Reference::Local {
+        path: "../escape".to_string(),
+        anchor: None,
+    };
+    assert!(process_validation_error(&unsafe_reference).contains("path escapes repository"));
+
+    let mut rationale = checked_process_audit();
+    rationale.records[0].rationale.clear();
+    assert!(process_validation_error(&rationale).contains("stale rationale"));
+
+    let mut baseline = checked_process_audit();
+    baseline.baseline.commit = "0".repeat(40);
+    let error = process_validation_error(&baseline);
+    assert!(error.contains("baselines differ"));
+    assert!(error.contains("not the pinned release"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a fail-closed, canonical producer audit for all 69 process-owned Firecracker v1.16.0 metrics fields
- make all 44 deprecated/GET/PUT/PATCH request counters follow the pinned parser and validation boundaries, including upstream edge cases
- apply value-free typed metric effects exactly once before dispatch, keep action failures out of parser-failure counters, and add exhaustive saturation/audit regression coverage
- document the schema, shared policy, incremental producer-audit boundary, and remaining delivery slices

## Scope

Closes #1827.

Relates to parent #1788, which remains open for its later delivery slices. This PR deliberately leaves the 25 fields owned by #1828, #1829, and #1830 as `planned`; device metrics (#1789), corpus aggregates (#1790), and the canonical metrics JSON shape are outside this slice.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- focused API, runtime, process, and capability-audit test suites
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate --metrics-schema-final`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target Clippy commands for the signed integration targets
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`

`validate --final` was also run as a negative gate and failed as expected on the 25 explicitly planned downstream process records plus the repository's other unfinished Firecracker inventory. The signed HVF integration wrapper was not required for this parser-owned counter slice; its signed process boundaries are unchanged.
