### PR TITLE
feat: add dual process latency metrics

### DIFF
--- a/compat/firecracker/v1.16.0/metrics-contract.md
+++ b/compat/firecracker/v1.16.0/metrics-contract.md
@@ -91,10 +91,10 @@ and ten successful outer/inner operation-latency fields, #1829 owns four logger
 fields plus SIGPIPE, and #1830 owns six fatal-signal fields plus panic and
 seccomp.
 Only a completed child may use the `implemented` disposition and carry
-resolvable production and validation evidence. #1827 is the sole completed
-child in this slice; the remaining 25 records stay `planned` until their owning
-pull requests land. `source-neutral` and `platform-zero` are terminal policy
-choices, not aliases for an undelivered feasible producer.
+resolvable production and validation evidence. #1827 and #1828 are complete,
+so 56 records are `implemented`; the remaining 13 records stay `planned` until
+their #1829 or #1830 pull requests land. `source-neutral` and `platform-zero`
+are terminal policy choices, not aliases for an undelivered feasible producer.
 
 For #1827, request metrics are created as a typed, value-free effect only after
 the HTTP request passes admission. The effect is applied exactly once before
@@ -122,6 +122,19 @@ API accounting is emitted only for an accepted typed deprecated value and
 contains no request value. Saturating counters, canonical JSON shape, omission
 of newer balloon request fields, redaction, and the initial successful
 `PUT /metrics` self-count remain unchanged.
+
+For #1828, the two startup stores retain one process-local monotonic/CPU clock
+sample, saturating elapsed arithmetic, and optional parent CPU accounting. The
+five outer API latency stores start after the bounded socket read at typed
+request handling entry and commit only after the VMM action, successful control
+log attempt, and response construction succeed. The matching five `vmm_*`
+stores cover only their functional pause, resume, Full create, Diff create, or
+load action and commit before lifecycle/snapshot outcome logging. Failures do
+not replace the previous successful store. Snapshot load's optional automatic
+resume is part of `vmm_load_snapshot` and does not write `vmm_resume_vm`;
+explicit `PATCH /vm` resume does. Both layers use the same injectable
+process-local monotonic clock, but no ordering relationship between the two
+reported durations is promised.
 
 ## Exact Arm64 Shape
 

--- a/compat/firecracker/v1.16.0/metrics-process-producer-audit.json
+++ b/compat/firecracker/v1.16.0/metrics-process-producer-audit.json
@@ -9,20 +9,64 @@
     {
       "field_id": "static:api_server.process_startup_time_cpu_us",
       "boundary": "process-startup",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the exact process startup clock boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Bangbang samples one process monotonic clock and one process CPU clock at startup, uses saturating elapsed arithmetic, and adds optional parent CPU time before storing the canonical values.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "single startup clock capture and saturating process diagnostics"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "canonical startup metric stores"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "startup clock and parent CPU accounting tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:api_server.process_startup_time_us",
       "boundary": "process-startup",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the exact process startup clock boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Bangbang samples one process monotonic clock and one process CPU clock at startup, uses saturating elapsed arithmetic, and adds optional parent CPU time before storing the canonical values.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "single startup clock capture and saturating process diagnostics"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "canonical startup metric stores"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "startup clock and parent CPU accounting tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:deprecated_api.deprecated_http_api_calls",
@@ -243,92 +287,362 @@
     {
       "field_id": "static:latencies_us.diff_create_snapshot",
       "boundary": "successful-outer-api-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the complete typed API operation succeeds; Bangbang measures from bounded request entry through successful response construction and leaves the prior value unchanged on failure.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "typed successful outer operation latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "controlled outer latency success and failure tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:latencies_us.full_create_snapshot",
       "boundary": "successful-outer-api-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the complete typed API operation succeeds; Bangbang measures from bounded request entry through successful response construction and leaves the prior value unchanged on failure.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "typed successful outer operation latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "controlled outer latency success and failure tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:latencies_us.load_snapshot",
       "boundary": "successful-outer-api-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the complete typed API operation succeeds; Bangbang measures from bounded request entry through successful response construction and leaves the prior value unchanged on failure.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "typed successful outer operation latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "controlled outer latency success and failure tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:latencies_us.pause_vm",
       "boundary": "successful-outer-api-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the complete typed API operation succeeds; Bangbang measures from bounded request entry through successful response construction and leaves the prior value unchanged on failure.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "typed successful outer operation latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "controlled outer latency success and failure tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:latencies_us.resume_vm",
       "boundary": "successful-outer-api-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the complete typed API operation succeeds; Bangbang measures from bounded request entry through successful response construction and leaves the prior value unchanged on failure.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "typed successful outer operation latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "controlled outer latency success and failure tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:latencies_us.vmm_diff_create_snapshot",
       "boundary": "successful-inner-vmm-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the corresponding VMM operation succeeds; Bangbang commits at the functional action boundary before outcome logging and folds automatic snapshot-load resume into load.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "successful inner VMM action latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "controlled inner latency and automatic-resume tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:latencies_us.vmm_full_create_snapshot",
       "boundary": "successful-inner-vmm-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the corresponding VMM operation succeeds; Bangbang commits at the functional action boundary before outcome logging and folds automatic snapshot-load resume into load.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "successful inner VMM action latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "controlled inner latency and automatic-resume tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:latencies_us.vmm_load_snapshot",
       "boundary": "successful-inner-vmm-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the corresponding VMM operation succeeds; Bangbang commits at the functional action boundary before outcome logging and folds automatic snapshot-load resume into load.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "successful inner VMM action latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "controlled inner latency and automatic-resume tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:latencies_us.vmm_pause_vm",
       "boundary": "successful-inner-vmm-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the corresponding VMM operation succeeds; Bangbang commits at the functional action boundary before outcome logging and folds automatic snapshot-load resume into load.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "successful inner VMM action latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "controlled inner latency and automatic-resume tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:latencies_us.vmm_resume_vm",
       "boundary": "successful-inner-vmm-operation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1828",
-      "rationale": "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker stores this latency only after the corresponding VMM operation succeeds; Bangbang commits at the functional action boundary before outcome logging and folds automatic snapshot-load resume into load.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "successful inner VMM action latency boundary"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "typed process latency store mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "controlled inner latency and automatic-resume tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "exhaustive outer and inner latency serialization tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "process producer audit mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:logger.metrics_fails",

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -66,7 +66,9 @@ use bangbang_runtime::memory_hotplug::{
     MemoryHotplugConfig, MemoryHotplugConfigInput, MemoryHotplugSizeUpdateInput,
     MemoryHotplugStatus,
 };
-use bangbang_runtime::metrics::MetricsConfigInput;
+use bangbang_runtime::metrics::{
+    MetricsConfigInput, ProcessLatencyBoundary, ProcessLatencyOperation,
+};
 use bangbang_runtime::mmds::{
     MmdsConfig, MmdsConfigInput, MmdsContentInput, MmdsVersion as RuntimeMmdsVersion,
 };
@@ -99,8 +101,8 @@ use crate::periodic_metrics::{
     PeriodicBalloonStatisticsScheduler, PeriodicMetricsScheduler, min_poll_timeout_ms,
 };
 use crate::vmm::{
-    GetApiRequest, PatchApiRequest, ProcessSessionExitDecision, ProcessSessionExitStatus,
-    PutApiRequest, VmmRequestHandler,
+    GetApiRequest, PatchApiRequest, ProcessLatencyTimestamp, ProcessSessionExitDecision,
+    ProcessSessionExitStatus, PutApiRequest, VmmRequestHandler,
 };
 
 const READ_CHUNK_SIZE: usize = 4096;
@@ -668,6 +670,7 @@ fn handle_request_bytes_with_limit(
     vmm: &mut impl VmmRequestHandler,
     http_api_max_payload_size: usize,
 ) -> HttpResponse {
+    let request_started = vmm.process_latency_timestamp();
     let (request, metric_effect) =
         parse_request_outcome_with_limit(bytes, http_api_max_payload_size).into_parts();
     let deprecated_api_call = metric_effect.deprecated_api_calls() != 0;
@@ -679,7 +682,7 @@ fn handle_request_bytes_with_limit(
             if deprecated_api_call {
                 let _ = vmm.log_api_control(LoggerApiControlOutcome::RequestDeprecated);
             }
-            let response = handle_api_request(request, vmm);
+            let response = handle_api_request(request, request_started, vmm);
             let _ = vmm.log_api_result(api_result_outcome(response.status()));
             vmm.handle_initial_metrics_flush();
             response
@@ -829,7 +832,11 @@ fn log_api_request(request: &ApiRequest, vmm: &mut impl VmmRequestHandler) -> bo
     }
 }
 
-fn handle_api_request(request: ApiRequest, vmm: &mut impl VmmRequestHandler) -> HttpResponse {
+fn handle_api_request(
+    request: ApiRequest,
+    request_started: ProcessLatencyTimestamp,
+    vmm: &mut impl VmmRequestHandler,
+) -> HttpResponse {
     match request {
         ApiRequest::GetInstanceInfo => {
             handle_instance_info(vmm.handle_get_request(GetApiRequest::InstanceInfo))
@@ -882,12 +889,12 @@ fn handle_api_request(request: ApiRequest, vmm: &mut impl VmmRequestHandler) -> 
         )),
         ApiRequest::PatchVmState(update) => {
             let state = update.state();
-            let started = Instant::now();
-            let result = vmm.handle_action(vm_state_action_from_request(update.as_ref()));
-            if result.is_ok() {
-                record_vm_state_latency(state, duration_as_micros_u64(started.elapsed()), vmm);
-            }
-            handle_empty(result)
+            handle_timed_process_action(
+                vm_state_latency_operation(state),
+                request_started,
+                vm_state_action_from_request(update.as_ref()),
+                vmm,
+            )
         }
         ApiRequest::PutNetworkInterface(config) => handle_empty(vmm.handle_put_request(
             PutApiRequest::network(network_interface_config_input_from_request(config.as_ref())),
@@ -943,8 +950,12 @@ fn handle_api_request(request: ApiRequest, vmm: &mut impl VmmRequestHandler) -> 
         ApiRequest::PatchPmem(config) => handle_empty(vmm.handle_patch_request(
             PatchApiRequest::pmem(pmem_update_input_from_request(config.as_ref())),
         )),
-        ApiRequest::PutSnapshotCreate(config) => handle_snapshot_create_request(config, vmm),
-        ApiRequest::PutSnapshotLoad(config) => handle_snapshot_load_request(config, vmm),
+        ApiRequest::PutSnapshotCreate(config) => {
+            handle_snapshot_create_request(config, request_started, vmm)
+        }
+        ApiRequest::PutSnapshotLoad(config) => {
+            handle_snapshot_load_request(config, request_started, vmm)
+        }
         ApiRequest::PutVsock(config) => handle_empty(vmm.handle_put_request(PutApiRequest::vsock(
             vsock_config_input_from_request(config.as_ref()),
         ))),
@@ -965,16 +976,11 @@ fn vm_state_action_from_request(update: &VmStateUpdateRequest) -> VmmAction {
     }
 }
 
-fn record_vm_state_latency(
-    state: VmStateUpdate,
-    duration_us: u64,
-    vmm: &mut impl VmmRequestHandler,
-) {
+const fn vm_state_latency_operation(state: VmStateUpdate) -> ProcessLatencyOperation {
     match state {
-        VmStateUpdate::Paused => vmm.record_pause_vm_latency_us(duration_us),
-        VmStateUpdate::Resumed => vmm.record_resume_vm_latency_us(duration_us),
+        VmStateUpdate::Paused => ProcessLatencyOperation::PauseVm,
+        VmStateUpdate::Resumed => ProcessLatencyOperation::ResumeVm,
     }
-    let _ = vmm.log_api_control(LoggerApiControlOutcome::RequestCompleted);
 }
 
 fn snapshot_type_from_request(snapshot_type: ApiSnapshotType) -> RuntimeSnapshotType {
@@ -1035,62 +1041,53 @@ fn snapshot_load_input_from_request(request: &SnapshotLoadRequest) -> SnapshotLo
 
 fn handle_snapshot_create_request(
     request: SnapshotCreateRequest,
+    request_started: ProcessLatencyTimestamp,
     vmm: &mut impl VmmRequestHandler,
 ) -> HttpResponse {
-    let snapshot_type = request.snapshot_type();
-    let started = Instant::now();
-    let result = vmm.handle_action(VmmAction::CreateSnapshot(
-        snapshot_create_input_from_request(&request),
-    ));
-    if matches!(
-        &result,
-        Ok(_) | Err(VmmActionError::SnapshotUnsupported | VmmActionError::SnapshotCreate(_))
-    ) {
-        record_snapshot_create_latency(
-            snapshot_type,
-            duration_as_micros_u64(started.elapsed()),
-            vmm,
-        );
-    }
-    if result.is_ok() {
-        let _ = vmm.log_api_control(LoggerApiControlOutcome::RequestCompleted);
-    }
-    handle_empty(result)
+    let operation = match request.snapshot_type() {
+        ApiSnapshotType::Full => ProcessLatencyOperation::FullCreateSnapshot,
+        ApiSnapshotType::Diff => ProcessLatencyOperation::DiffCreateSnapshot,
+    };
+    handle_timed_process_action(
+        operation,
+        request_started,
+        VmmAction::CreateSnapshot(snapshot_create_input_from_request(&request)),
+        vmm,
+    )
 }
 
 fn handle_snapshot_load_request(
     request: SnapshotLoadRequest,
+    request_started: ProcessLatencyTimestamp,
     vmm: &mut impl VmmRequestHandler,
 ) -> HttpResponse {
-    let started = Instant::now();
-    let result = vmm.handle_action(VmmAction::LoadSnapshot(snapshot_load_input_from_request(
-        &request,
-    )));
-    if matches!(
-        &result,
-        Ok(_) | Err(VmmActionError::SnapshotUnsupported | VmmActionError::SnapshotLoad(_))
-    ) {
-        vmm.record_load_snapshot_latency_us(duration_as_micros_u64(started.elapsed()));
-    }
-    if result.is_ok() {
+    handle_timed_process_action(
+        ProcessLatencyOperation::LoadSnapshot,
+        request_started,
+        VmmAction::LoadSnapshot(snapshot_load_input_from_request(&request)),
+        vmm,
+    )
+}
+
+fn handle_timed_process_action(
+    operation: ProcessLatencyOperation,
+    request_started: ProcessLatencyTimestamp,
+    action: VmmAction,
+    vmm: &mut impl VmmRequestHandler,
+) -> HttpResponse {
+    let result = vmm.handle_action(action);
+    let succeeded = matches!(&result, Ok(VmmData::Empty));
+    if succeeded {
         let _ = vmm.log_api_control(LoggerApiControlOutcome::RequestCompleted);
     }
-    handle_empty(result)
-}
-
-fn record_snapshot_create_latency(
-    snapshot_type: ApiSnapshotType,
-    duration_us: u64,
-    vmm: &mut impl VmmRequestHandler,
-) {
-    match snapshot_type {
-        ApiSnapshotType::Full => vmm.record_full_create_snapshot_latency_us(duration_us),
-        ApiSnapshotType::Diff => vmm.record_diff_create_snapshot_latency_us(duration_us),
+    let response = handle_empty(result);
+    if succeeded {
+        let duration_us = vmm
+            .process_latency_timestamp()
+            .elapsed_us_since(request_started);
+        vmm.record_process_latency_us(operation, ProcessLatencyBoundary::OuterApi, duration_us);
     }
-}
-
-fn duration_as_micros_u64(duration: Duration) -> u64 {
-    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+    response
 }
 
 fn hot_unplug_action_from_request(request: &HotUnplugDeviceRequest) -> VmmAction {
@@ -2212,6 +2209,7 @@ fn read_request_until_with_limit(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::env;
     use std::io::{Read, Write};
     use std::os::unix::io::{AsRawFd, RawFd};
@@ -4264,6 +4262,259 @@ mod tests {
         );
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum LatencyProbeEvent {
+        Timestamp,
+        Action(&'static str),
+        Control(LoggerApiControlOutcome),
+        Record(ProcessLatencyOperation, ProcessLatencyBoundary, u64),
+    }
+
+    #[derive(Debug)]
+    struct LatencyProbeVmm {
+        timestamps: VecDeque<ProcessLatencyTimestamp>,
+        results: VecDeque<Result<VmmData, VmmActionError>>,
+        events: Vec<LatencyProbeEvent>,
+    }
+
+    impl LatencyProbeVmm {
+        fn new(
+            timestamps_us: impl IntoIterator<Item = u64>,
+            results: impl IntoIterator<Item = Result<VmmData, VmmActionError>>,
+        ) -> Self {
+            Self {
+                timestamps: timestamps_us
+                    .into_iter()
+                    .map(Duration::from_micros)
+                    .map(ProcessLatencyTimestamp::from_duration)
+                    .collect(),
+                results: results.into_iter().collect(),
+                events: Vec::new(),
+            }
+        }
+
+        fn unsupported() -> Result<VmmData, VmmActionError> {
+            Err(VmmActionError::UnsupportedAction("latency probe"))
+        }
+    }
+
+    impl VmmRequestHandler for LatencyProbeVmm {
+        fn handle_action(&mut self, action: VmmAction) -> Result<VmmData, VmmActionError> {
+            self.events.push(LatencyProbeEvent::Action(action.name()));
+            self.results
+                .pop_front()
+                .expect("scripted VMM result should be available")
+        }
+
+        fn handle_get_request(
+            &mut self,
+            _request: GetApiRequest,
+        ) -> Result<VmmData, VmmActionError> {
+            Self::unsupported()
+        }
+
+        fn handle_patch_request(
+            &mut self,
+            _request: PatchApiRequest,
+        ) -> Result<VmmData, VmmActionError> {
+            Self::unsupported()
+        }
+
+        fn handle_put_request(
+            &mut self,
+            _request: PutApiRequest,
+        ) -> Result<VmmData, VmmActionError> {
+            Self::unsupported()
+        }
+
+        fn record_api_request_metric_effect(&mut self, _effect: ApiRequestMetricEffect) {}
+
+        fn handle_put_action_request(
+            &mut self,
+            _action: VmmAction,
+        ) -> Result<VmmData, VmmActionError> {
+            Self::unsupported()
+        }
+
+        fn log_api_request(&mut self, _method: LoggerHttpMethod, _route: LoggerApiRoute) -> bool {
+            true
+        }
+
+        fn log_api_control(&mut self, outcome: LoggerApiControlOutcome) -> bool {
+            self.events.push(LatencyProbeEvent::Control(outcome));
+            true
+        }
+
+        fn log_api_result(&mut self, _outcome: LoggerApiResultOutcome) -> bool {
+            true
+        }
+
+        fn log_process_startup(&mut self, _outcome: ProcessStartupOutcome) -> bool {
+            true
+        }
+
+        fn process_latency_timestamp(&mut self) -> ProcessLatencyTimestamp {
+            self.events.push(LatencyProbeEvent::Timestamp);
+            self.timestamps
+                .pop_front()
+                .expect("scripted process latency timestamp should be available")
+        }
+
+        fn record_process_latency_us(
+            &mut self,
+            operation: ProcessLatencyOperation,
+            boundary: ProcessLatencyBoundary,
+            duration_us: u64,
+        ) {
+            self.events
+                .push(LatencyProbeEvent::Record(operation, boundary, duration_us));
+        }
+    }
+
+    #[test]
+    fn controlled_outer_process_latencies_cover_all_operations_and_ignore_failures() {
+        let mut vmm = LatencyProbeVmm::new(
+            [
+                10, 110, 200, 260, 300, 360, 400, 470, 500, 580, 900, 1_000, 1_100,
+            ],
+            [
+                Ok(VmmData::Empty),
+                Ok(VmmData::Empty),
+                Ok(VmmData::Empty),
+                Ok(VmmData::Empty),
+                Ok(VmmData::Empty),
+                Err(VmmActionError::SnapshotUnsupported),
+                Ok(VmmData::VmmVersion("unexpected".to_owned())),
+            ],
+        );
+        let requests = [
+            request_with_body("PATCH", "/vm", r#"{"state":"Paused"}"#),
+            request_with_body("PATCH", "/vm", r#"{"state":"Resumed"}"#),
+            request_with_body(
+                "PUT",
+                "/snapshot/create",
+                r#"{"snapshot_path":"private-full-state","mem_file_path":"private-full-memory"}"#,
+            ),
+            request_with_body(
+                "PUT",
+                "/snapshot/create",
+                r#"{"snapshot_type":"Diff","snapshot_path":"private-diff-state","mem_file_path":"private-diff-memory"}"#,
+            ),
+            request_with_body(
+                "PUT",
+                "/snapshot/load",
+                r#"{"snapshot_path":"private-load-state","mem_backend":{"backend_path":"private-load-memory","backend_type":"File"}}"#,
+            ),
+        ];
+        for request in requests {
+            assert_eq!(
+                handle_request_bytes(request.as_bytes(), &mut vmm).status(),
+                StatusCode::NoContent
+            );
+        }
+
+        let recorded = vmm
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                LatencyProbeEvent::Record(operation, boundary, duration_us) => {
+                    Some((*operation, *boundary, *duration_us))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            recorded,
+            [
+                (
+                    ProcessLatencyOperation::PauseVm,
+                    ProcessLatencyBoundary::OuterApi,
+                    100,
+                ),
+                (
+                    ProcessLatencyOperation::ResumeVm,
+                    ProcessLatencyBoundary::OuterApi,
+                    60,
+                ),
+                (
+                    ProcessLatencyOperation::FullCreateSnapshot,
+                    ProcessLatencyBoundary::OuterApi,
+                    60,
+                ),
+                (
+                    ProcessLatencyOperation::DiffCreateSnapshot,
+                    ProcessLatencyBoundary::OuterApi,
+                    70,
+                ),
+                (
+                    ProcessLatencyOperation::LoadSnapshot,
+                    ProcessLatencyBoundary::OuterApi,
+                    80,
+                ),
+            ]
+        );
+
+        let failed = request_with_body(
+            "PUT",
+            "/snapshot/create",
+            r#"{"snapshot_path":"private-failed-state","mem_file_path":"private-failed-memory"}"#,
+        );
+        assert_eq!(
+            handle_request_bytes(failed.as_bytes(), &mut vmm).status(),
+            StatusCode::BadRequest
+        );
+        let unexpected = request_with_body("PATCH", "/vm", r#"{"state":"Paused"}"#);
+        assert_eq!(
+            handle_request_bytes(unexpected.as_bytes(), &mut vmm).status(),
+            StatusCode::BadRequest
+        );
+        let malformed = request_with_body("PATCH", "/vm", r#"{"state":"Running"}"#);
+        assert_eq!(
+            handle_request_bytes(malformed.as_bytes(), &mut vmm).status(),
+            StatusCode::BadRequest
+        );
+        assert_eq!(
+            vmm.events
+                .iter()
+                .filter(|event| matches!(event, LatencyProbeEvent::Record(..)))
+                .count(),
+            5,
+            "action, response, and parser failures must retain the five successful stores"
+        );
+        assert!(vmm.timestamps.is_empty());
+        assert!(vmm.results.is_empty());
+
+        let event_text = format!("{:?}", vmm.events);
+        for private_value in [
+            "private-full-state",
+            "private-full-memory",
+            "private-diff-state",
+            "private-diff-memory",
+            "private-load-state",
+            "private-load-memory",
+            "private-failed-state",
+            "private-failed-memory",
+        ] {
+            assert!(!event_text.contains(private_value));
+        }
+        for record_index in [4_usize, 9, 14, 19, 24] {
+            assert!(matches!(
+                vmm.events.get(record_index.wrapping_sub(2)),
+                Some(LatencyProbeEvent::Control(
+                    LoggerApiControlOutcome::RequestCompleted
+                ))
+            ));
+            assert!(matches!(
+                vmm.events.get(record_index.wrapping_sub(1)),
+                Some(LatencyProbeEvent::Timestamp)
+            ));
+            assert!(matches!(
+                vmm.events.get(record_index),
+                Some(LatencyProbeEvent::Record(..))
+            ));
+        }
+    }
+
     fn put_action_over_socket(
         vmm: &mut impl VmmRequestHandler,
         socket_name: &str,
@@ -4360,26 +4611,18 @@ mod tests {
             self.inner.log_process_startup(outcome)
         }
 
-        fn record_pause_vm_latency_us(&mut self, duration_us: u64) {
-            self.inner.record_pause_vm_latency_us(duration_us);
+        fn process_latency_timestamp(&mut self) -> ProcessLatencyTimestamp {
+            self.inner.process_latency_timestamp()
         }
 
-        fn record_resume_vm_latency_us(&mut self, duration_us: u64) {
-            self.inner.record_resume_vm_latency_us(duration_us);
-        }
-
-        fn record_full_create_snapshot_latency_us(&mut self, duration_us: u64) {
+        fn record_process_latency_us(
+            &mut self,
+            operation: ProcessLatencyOperation,
+            boundary: ProcessLatencyBoundary,
+            duration_us: u64,
+        ) {
             self.inner
-                .record_full_create_snapshot_latency_us(duration_us);
-        }
-
-        fn record_diff_create_snapshot_latency_us(&mut self, duration_us: u64) {
-            self.inner
-                .record_diff_create_snapshot_latency_us(duration_us);
-        }
-
-        fn record_load_snapshot_latency_us(&mut self, duration_us: u64) {
-            self.inner.record_load_snapshot_latency_us(duration_us);
+                .record_process_latency_us(operation, boundary, duration_us);
         }
 
         fn metrics_session_epoch(&self) -> Option<Instant> {
@@ -9066,6 +9309,7 @@ mod tests {
         assert!(flush.starts_with("HTTP/1.1 204 No Content\r\n"));
         let metrics = read_metrics_json(&metrics_path);
         assert_latency_metric_present(&metrics, "full_create_snapshot");
+        assert_latency_metric_present(&metrics, "vmm_full_create_snapshot");
         let raw_metrics =
             fs::read_to_string(&metrics_path).expect("metrics should remain readable");
         assert!(!raw_metrics.contains(state_path.to_string_lossy().as_ref()));
@@ -9080,6 +9324,7 @@ mod tests {
         assert!(fault_flush.starts_with("HTTP/1.1 204 No Content\r\n"));
         let fault_metrics = read_metrics_json(&metrics_path);
         assert_latency_metric_present(&fault_metrics, "full_create_snapshot");
+        assert_latency_metric_present(&fault_metrics, "vmm_full_create_snapshot");
         assert_eq!(
             fs::read(&state_path).expect("state should remain readable"),
             state_before
@@ -9203,6 +9448,7 @@ mod tests {
             .collect::<Vec<serde_json::Value>>();
         assert_eq!(metrics_lines.len(), 2);
         assert_latency_metric_present(&metrics_lines[0], "load_snapshot");
+        assert_latency_metric_present(&metrics_lines[0], "vmm_load_snapshot");
         assert!(!raw_metrics.contains(resumed_state.to_string_lossy().as_ref()));
         assert!(!raw_metrics.contains(resumed_memory.to_string_lossy().as_ref()));
 
@@ -10449,6 +10695,20 @@ mod tests {
                 .is_some(),
             "resume_vm latency should be present"
         );
+        assert!(
+            latencies
+                .get("vmm_pause_vm")
+                .and_then(serde_json::Value::as_u64)
+                .is_some(),
+            "vmm_pause_vm latency should be present"
+        );
+        assert!(
+            latencies
+                .get("vmm_resume_vm")
+                .and_then(serde_json::Value::as_u64)
+                .is_some(),
+            "vmm_resume_vm latency should be present"
+        );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
     }
@@ -10497,6 +10757,7 @@ mod tests {
         );
         let resumed_metrics = read_metrics_json(&metrics_path);
         assert_latency_metric_present(&resumed_metrics, "resume_vm");
+        assert_latency_metric_present(&resumed_metrics, "vmm_resume_vm");
         let resumed_latency = resumed_metrics
             .get("latencies_us")
             .and_then(|latencies| latencies.get("resume_vm"))
@@ -10525,6 +10786,7 @@ mod tests {
         );
         let paused_metrics = read_metrics_json(&metrics_path);
         assert_latency_metric_present(&paused_metrics, "pause_vm");
+        assert_latency_metric_present(&paused_metrics, "vmm_pause_vm");
         assert_eq!(
             paused_metrics
                 .get("latencies_us")
@@ -10584,12 +10846,14 @@ mod tests {
         let metrics = read_metrics_json(&metrics_path);
         assert_eq!(metrics["latencies_us"]["pause_vm"], 0);
         assert_eq!(metrics["latencies_us"]["resume_vm"], 0);
+        assert_eq!(metrics["latencies_us"]["vmm_pause_vm"], 0);
+        assert_eq!(metrics["latencies_us"]["vmm_resume_vm"], 0);
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
     }
 
     #[test]
-    fn configured_metrics_records_snapshot_create_latencies_on_snapshot_fault() {
+    fn configured_metrics_do_not_record_snapshot_create_latencies_on_snapshot_fault() {
         let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
         let metrics_path = unique_socket_path("scl").with_extension("metrics");
         let metrics_body = format!(r#"{{"metrics_path":"{}"}}"#, metrics_path.to_string_lossy());
@@ -10656,8 +10920,10 @@ mod tests {
             "{flush_response}"
         );
         let metrics = read_metrics_json(&metrics_path);
-        assert_latency_metric_present(&metrics, "full_create_snapshot");
-        assert_latency_metric_present(&metrics, "diff_create_snapshot");
+        assert_eq!(metrics["latencies_us"]["full_create_snapshot"], 0);
+        assert_eq!(metrics["latencies_us"]["diff_create_snapshot"], 0);
+        assert_eq!(metrics["latencies_us"]["vmm_full_create_snapshot"], 0);
+        assert_eq!(metrics["latencies_us"]["vmm_diff_create_snapshot"], 0);
         assert!(
             metrics
                 .get("latencies_us")
@@ -10685,7 +10951,7 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn configured_metrics_records_snapshot_load_latency_on_execution_fault() {
+    fn configured_metrics_do_not_record_snapshot_load_latency_on_execution_fault() {
         let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
         let (state_path, memory_path) = native_v2_snapshot_fixture("metrics-load-fault");
         let state_text = state_path.to_string_lossy().into_owned();
@@ -10742,7 +11008,8 @@ mod tests {
             "{flush_response}"
         );
         let metrics = read_metrics_json(&metrics_path);
-        assert_latency_metric_present(&metrics, "load_snapshot");
+        assert_eq!(metrics["latencies_us"]["load_snapshot"], 0);
+        assert_eq!(metrics["latencies_us"]["vmm_load_snapshot"], 0);
         assert!(
             metrics
                 .get("latencies_us")

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -2724,7 +2724,7 @@ mod tests {
     use bangbang_runtime::memory_hotplug::MemoryHotplugConfigInput;
     use bangbang_runtime::metrics::{
         MetricsConfigError, MetricsConfigInput, MetricsDiagnostics, MetricsFlushError,
-        SharedSignalMetrics,
+        ProcessLatencyBoundary, ProcessLatencyOperation, SharedSignalMetrics,
     };
     use bangbang_runtime::mmds::MmdsDataStoreError;
     use bangbang_runtime::network::NetworkInterfaceConfigInput;
@@ -2747,9 +2747,9 @@ mod tests {
     use crate::vmm::{
         GetApiRequest, InstanceStartError, InstanceStartExecutor,
         NativeV1SnapshotCaptureCancellation, NativeV1SnapshotLoadError,
-        NativeV1SnapshotPublicationError, PatchApiRequest, ProcessSessionDiagnostics,
-        ProcessSessionExitStatus, ProcessVmm, PutApiRequest, SnapshotV1LoadSuccess,
-        VmmRequestHandler,
+        NativeV1SnapshotPublicationError, PatchApiRequest, ProcessLatencyTimestamp,
+        ProcessSessionDiagnostics, ProcessSessionExitStatus, ProcessVmm, PutApiRequest,
+        SnapshotV1LoadSuccess, VmmRequestHandler,
     };
 
     use super::{
@@ -3115,26 +3115,18 @@ mod tests {
             self.inner.log_process_startup(outcome)
         }
 
-        fn record_pause_vm_latency_us(&mut self, duration_us: u64) {
-            self.inner.record_pause_vm_latency_us(duration_us);
+        fn process_latency_timestamp(&mut self) -> ProcessLatencyTimestamp {
+            self.inner.process_latency_timestamp()
         }
 
-        fn record_resume_vm_latency_us(&mut self, duration_us: u64) {
-            self.inner.record_resume_vm_latency_us(duration_us);
-        }
-
-        fn record_full_create_snapshot_latency_us(&mut self, duration_us: u64) {
+        fn record_process_latency_us(
+            &mut self,
+            operation: ProcessLatencyOperation,
+            boundary: ProcessLatencyBoundary,
+            duration_us: u64,
+        ) {
             self.inner
-                .record_full_create_snapshot_latency_us(duration_us);
-        }
-
-        fn record_diff_create_snapshot_latency_us(&mut self, duration_us: u64) {
-            self.inner
-                .record_diff_create_snapshot_latency_us(duration_us);
-        }
-
-        fn record_load_snapshot_latency_us(&mut self, duration_us: u64) {
-            self.inner.record_load_snapshot_latency_us(duration_us);
+                .record_process_latency_us(operation, boundary, duration_us);
         }
 
         fn metrics_session_epoch(&self) -> Option<Instant> {

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -149,10 +149,11 @@ use bangbang_runtime::metrics::{
     BootRunLoopMetricStatus, MetricsConfigInput, MetricsDiagnostics, MmdsMetrics,
     NetworkInterfaceMetrics, NetworkInterfaceMetricsCaptureError,
     NetworkInterfaceMetricsCaptureState, NetworkInterfaceMetricsLease,
-    NetworkInterfaceMetricsRegistryError, SharedBalloonDeviceMetrics,
-    SharedBlockDeviceMetricsRegistry, SharedEntropyDeviceMetrics, SharedMemoryHotplugDeviceMetrics,
-    SharedMmdsMetrics, SharedNetworkInterfaceMetricsRegistry, SharedPmemDeviceMetricsRegistry,
-    SharedRtcDeviceMetrics, SharedSignalMetrics, SharedVsockDeviceMetrics,
+    NetworkInterfaceMetricsRegistryError, ProcessLatencyBoundary, ProcessLatencyOperation,
+    SharedBalloonDeviceMetrics, SharedBlockDeviceMetricsRegistry, SharedEntropyDeviceMetrics,
+    SharedMemoryHotplugDeviceMetrics, SharedMmdsMetrics, SharedNetworkInterfaceMetricsRegistry,
+    SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics, SharedSignalMetrics,
+    SharedVsockDeviceMetrics,
 };
 use bangbang_runtime::mmds::{
     MmdsConfig, MmdsConfigError, MmdsConfigInput, MmdsContentInput, MmdsState, MmdsStateHandle,
@@ -5445,6 +5446,44 @@ fn record_api_request_failure(controller: &mut VmmController, endpoint: ApiReque
     }
 }
 
+/// One value-only process-local monotonic timestamp used by latency producers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProcessLatencyTimestamp(Duration);
+
+impl ProcessLatencyTimestamp {
+    #[cfg(test)]
+    pub(crate) const fn from_duration(timestamp: Duration) -> Self {
+        Self(timestamp)
+    }
+
+    pub(crate) fn elapsed_us_since(self, started: Self) -> u64 {
+        u64::try_from(self.0.saturating_sub(started.0).as_micros()).unwrap_or(u64::MAX)
+    }
+}
+
+pub(crate) trait ProcessLatencyClock: fmt::Debug + Send {
+    fn timestamp(&mut self) -> ProcessLatencyTimestamp;
+}
+
+#[derive(Debug)]
+struct SystemProcessLatencyClock {
+    origin: Instant,
+}
+
+impl Default for SystemProcessLatencyClock {
+    fn default() -> Self {
+        Self {
+            origin: Instant::now(),
+        }
+    }
+}
+
+impl ProcessLatencyClock for SystemProcessLatencyClock {
+    fn timestamp(&mut self) -> ProcessLatencyTimestamp {
+        ProcessLatencyTimestamp(self.origin.elapsed())
+    }
+}
+
 pub(crate) trait VmmRequestHandler {
     fn handle_action(&mut self, action: VmmAction) -> Result<VmmData, VmmActionError>;
 
@@ -5471,15 +5510,14 @@ pub(crate) trait VmmRequestHandler {
     #[track_caller]
     fn log_process_startup(&mut self, outcome: ProcessStartupOutcome) -> bool;
 
-    fn record_pause_vm_latency_us(&mut self, duration_us: u64);
+    fn process_latency_timestamp(&mut self) -> ProcessLatencyTimestamp;
 
-    fn record_resume_vm_latency_us(&mut self, duration_us: u64);
-
-    fn record_full_create_snapshot_latency_us(&mut self, duration_us: u64);
-
-    fn record_diff_create_snapshot_latency_us(&mut self, duration_us: u64);
-
-    fn record_load_snapshot_latency_us(&mut self, duration_us: u64);
+    fn record_process_latency_us(
+        &mut self,
+        operation: ProcessLatencyOperation,
+        boundary: ProcessLatencyBoundary,
+        duration_us: u64,
+    );
 
     fn metrics_session_epoch(&self) -> Option<Instant> {
         None
@@ -5686,6 +5724,7 @@ where
     terminal_logger_attempted: bool,
     terminal_metrics_attempted: bool,
     process_metrics_diagnostics: MetricsDiagnostics,
+    process_latency_clock: Box<dyn ProcessLatencyClock>,
     process_signal_metrics: Option<SharedSignalMetrics>,
     process_stdout: Option<ProcessStdoutLogger>,
     snapshot_capture_cancellation: NativeV1SnapshotCaptureCancellation,
@@ -5802,6 +5841,7 @@ where
             terminal_logger_attempted: false,
             terminal_metrics_attempted: false,
             process_metrics_diagnostics: MetricsDiagnostics::default(),
+            process_latency_clock: Box::<SystemProcessLatencyClock>::default(),
             process_signal_metrics: None,
             process_stdout: None,
             snapshot_capture_cancellation: NativeV1SnapshotCaptureCancellation::default(),
@@ -5843,6 +5883,15 @@ where
         diagnostics: MetricsDiagnostics,
     ) -> Self {
         self.process_metrics_diagnostics = diagnostics;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_process_latency_clock(
+        mut self,
+        clock: impl ProcessLatencyClock + 'static,
+    ) -> Self {
+        self.process_latency_clock = Box::new(clock);
         self
     }
 
@@ -6149,26 +6198,27 @@ where
         self.controller.log_process_startup(outcome)
     }
 
-    fn record_pause_vm_latency_us(&mut self, duration_us: u64) {
-        self.controller.record_pause_vm_latency_us(duration_us);
+    fn process_latency_timestamp(&mut self) -> ProcessLatencyTimestamp {
+        self.process_latency_clock.timestamp()
     }
 
-    fn record_resume_vm_latency_us(&mut self, duration_us: u64) {
-        self.controller.record_resume_vm_latency_us(duration_us);
-    }
-
-    fn record_full_create_snapshot_latency_us(&mut self, duration_us: u64) {
+    fn record_process_latency_us(
+        &mut self,
+        operation: ProcessLatencyOperation,
+        boundary: ProcessLatencyBoundary,
+        duration_us: u64,
+    ) {
         self.controller
-            .record_full_create_snapshot_latency_us(duration_us);
+            .record_process_latency_us(operation, boundary, duration_us);
     }
 
-    fn record_diff_create_snapshot_latency_us(&mut self, duration_us: u64) {
-        self.controller
-            .record_diff_create_snapshot_latency_us(duration_us);
-    }
-
-    fn record_load_snapshot_latency_us(&mut self, duration_us: u64) {
-        self.controller.record_load_snapshot_latency_us(duration_us);
+    fn record_inner_process_latency_since(
+        &mut self,
+        operation: ProcessLatencyOperation,
+        started: ProcessLatencyTimestamp,
+    ) {
+        let elapsed_us = self.process_latency_timestamp().elapsed_us_since(started);
+        self.record_process_latency_us(operation, ProcessLatencyBoundary::InnerVmm, elapsed_us);
     }
 
     #[cfg(target_os = "macos")]
@@ -7181,6 +7231,7 @@ where
     }
 
     fn pause_instance(&mut self) -> Result<VmmData, VmmActionError> {
+        let latency_started = self.process_latency_timestamp();
         let transition = match self.controller.preflight_pause_instance() {
             Ok(transition) => transition,
             Err(error) => {
@@ -7200,6 +7251,10 @@ where
         };
 
         if transition == VmStateTransition::AlreadyInTargetState {
+            self.record_inner_process_latency_since(
+                ProcessLatencyOperation::PauseVm,
+                latency_started,
+            );
             let _ = self
                 .controller
                 .log_lifecycle(LoggerLifecycleOutcome::VmPauseUnchanged);
@@ -7212,6 +7267,12 @@ where
             return Err(VmmActionError::Lifecycle(error));
         }
         let result = self.controller.pause_instance();
+        if result.is_ok() {
+            self.record_inner_process_latency_since(
+                ProcessLatencyOperation::PauseVm,
+                latency_started,
+            );
+        }
         let outcome = if result.is_ok() {
             LoggerLifecycleOutcome::VmPauseSucceeded
         } else {
@@ -7222,12 +7283,14 @@ where
     }
 
     fn resume_instance(&mut self) -> Result<VmmData, VmmActionError> {
-        self.resume_instance_with_lifecycle_log(true)
+        let latency_started = self.process_latency_timestamp();
+        self.resume_instance_with_lifecycle_log(true, Some(latency_started))
     }
 
     fn resume_instance_with_lifecycle_log(
         &mut self,
         log_lifecycle: bool,
+        latency_started: Option<ProcessLatencyTimestamp>,
     ) -> Result<VmmData, VmmActionError> {
         let transition = match self.controller.preflight_resume_instance() {
             Ok(transition) => transition,
@@ -7252,6 +7315,12 @@ where
         };
 
         if transition == VmStateTransition::AlreadyInTargetState {
+            if let Some(latency_started) = latency_started {
+                self.record_inner_process_latency_since(
+                    ProcessLatencyOperation::ResumeVm,
+                    latency_started,
+                );
+            }
             if log_lifecycle {
                 let _ = self
                     .controller
@@ -7268,6 +7337,14 @@ where
             return Err(VmmActionError::Lifecycle(error));
         }
         let result = self.controller.resume_instance();
+        if result.is_ok()
+            && let Some(latency_started) = latency_started
+        {
+            self.record_inner_process_latency_since(
+                ProcessLatencyOperation::ResumeVm,
+                latency_started,
+            );
+        }
         if log_lifecycle {
             let outcome = if result.is_ok() {
                 LoggerLifecycleOutcome::VmResumeSucceeded
@@ -7280,6 +7357,11 @@ where
     }
 
     fn create_snapshot(&mut self, input: SnapshotCreateInput) -> Result<VmmData, VmmActionError> {
+        let latency_started = self.process_latency_timestamp();
+        let latency_operation = match input.snapshot_type() {
+            SnapshotType::Full => ProcessLatencyOperation::FullCreateSnapshot,
+            SnapshotType::Diff => ProcessLatencyOperation::DiffCreateSnapshot,
+        };
         let publication = match input.snapshot_type() {
             SnapshotType::Full => self.publish_native_v2_snapshot(&input),
             SnapshotType::Diff => self.publish_native_v2_diff_snapshot(&input),
@@ -7292,11 +7374,15 @@ where
         let result = publication
             .map_err(native_v2_snapshot_publication_action_error)
             .map(|_| VmmData::Empty);
+        if result.is_ok() {
+            self.record_inner_process_latency_since(latency_operation, latency_started);
+        }
         let _ = self.controller.log_snapshot(outcome);
         result
     }
 
     fn load_snapshot(&mut self, input: SnapshotLoadInput) -> Result<VmmData, VmmActionError> {
+        let latency_started = self.process_latency_timestamp();
         let resume_requested = match self.restore_native_snapshot(&input) {
             Ok(resume_requested) => resume_requested,
             Err(error) => {
@@ -7306,13 +7392,18 @@ where
                 return Err(error);
             }
         };
-        if resume_requested && let Err(error) = self.resume_instance_with_lifecycle_log(false) {
+        if resume_requested && let Err(error) = self.resume_instance_with_lifecycle_log(false, None)
+        {
             let error = native_v1_snapshot_resume_action_error(error);
             let _ = self
                 .controller
                 .log_snapshot(LoggerSnapshotOutcome::LoadFailed);
             return Err(error);
         }
+        self.record_inner_process_latency_since(
+            ProcessLatencyOperation::LoadSnapshot,
+            latency_started,
+        );
         let _ = self
             .controller
             .log_snapshot(LoggerSnapshotOutcome::LoadSucceeded);
@@ -7856,7 +7947,7 @@ where
         if !resume_requested {
             return Ok(false);
         }
-        self.resume_instance_with_lifecycle_log(false)
+        self.resume_instance_with_lifecycle_log(false, None)
             .map_err(|error| {
                 let source = match error {
                     VmmActionError::Lifecycle(source) => source,
@@ -10765,24 +10856,17 @@ where
         ProcessVmm::log_process_startup(self, outcome)
     }
 
-    fn record_pause_vm_latency_us(&mut self, duration_us: u64) {
-        ProcessVmm::record_pause_vm_latency_us(self, duration_us);
+    fn process_latency_timestamp(&mut self) -> ProcessLatencyTimestamp {
+        ProcessVmm::process_latency_timestamp(self)
     }
 
-    fn record_resume_vm_latency_us(&mut self, duration_us: u64) {
-        ProcessVmm::record_resume_vm_latency_us(self, duration_us);
-    }
-
-    fn record_full_create_snapshot_latency_us(&mut self, duration_us: u64) {
-        ProcessVmm::record_full_create_snapshot_latency_us(self, duration_us);
-    }
-
-    fn record_diff_create_snapshot_latency_us(&mut self, duration_us: u64) {
-        ProcessVmm::record_diff_create_snapshot_latency_us(self, duration_us);
-    }
-
-    fn record_load_snapshot_latency_us(&mut self, duration_us: u64) {
-        ProcessVmm::record_load_snapshot_latency_us(self, duration_us);
+    fn record_process_latency_us(
+        &mut self,
+        operation: ProcessLatencyOperation,
+        boundary: ProcessLatencyBoundary,
+        duration_us: u64,
+    ) {
+        ProcessVmm::record_process_latency_us(self, operation, boundary, duration_us);
     }
 
     fn process_exit_wakeup_fd(&self) -> Option<RawFd> {
@@ -36999,23 +37083,24 @@ mod tests {
         NativeV2SnapshotPublicationRequest, NativeV2SnapshotRootCaptureError,
         NativeV2SnapshotStorageCaptureError, NativeV2SnapshotVsockCaptureError,
         NetworkPacketIoRunLoopSession, NoopProcessNetworkTxPacketSink, PreparedNativeSnapshotLoad,
-        ProcessCaptureReadyNetworkError, ProcessHvfBootSession, ProcessMmdsPacketDetourConfig,
-        ProcessNetworkPacketIoProvider, ProcessNetworkPacketIoProviderBuildError,
-        ProcessNetworkPacketIoRegistry, ProcessNetworkPacketIoRegistryError,
-        ProcessNetworkPacketIoStopError, ProcessRuntimeNetworkPacketIoProvider,
-        ProcessSessionDiagnostics, ProcessSessionExitStatus, ProcessSessionShutdownStatus,
-        ProcessSnapshotV2BalloonLoadRequest, ProcessSnapshotV2DiffLoadRequest,
-        ProcessSnapshotV2EntropyLoadRequest, ProcessSnapshotV2MemoryHotplugLoadRequest,
-        ProcessSnapshotV2MultiBlockLoadRequest, ProcessSnapshotV2MultiBlockLoadSuccess,
-        ProcessSnapshotV2NetworkLoadRequest, ProcessSnapshotV2NetworkRestorePlanError,
-        ProcessSnapshotV2RootLoadCompletion, ProcessSnapshotV2RootLoadRequest,
-        ProcessSnapshotV2RootLoadSuccess, ProcessSnapshotV2SerialLoadRequest,
-        ProcessSnapshotV2StorageLoadRequest, ProcessSnapshotV2StorageLoadSuccess,
-        ProcessSnapshotV2VsockLoadRequest, ProcessVmm, ProcessVmnetAuthority,
-        ProcessVmnetPacketIoBackendFactory, SerialGrantState, SnapshotCreateSession,
-        SnapshotV1LoadSuccess, SnapshotV2LoadSuccess, default_hvf_boot_run_loop_step_limit,
-        default_hvf_boot_session_config, native_snapshot_load_logger_outcome,
-        native_v2_platform_capture_is_terminal, prepare_process_snapshot_v2_network_restore_plan,
+        ProcessCaptureReadyNetworkError, ProcessHvfBootSession, ProcessLatencyClock,
+        ProcessLatencyTimestamp, ProcessMmdsPacketDetourConfig, ProcessNetworkPacketIoProvider,
+        ProcessNetworkPacketIoProviderBuildError, ProcessNetworkPacketIoRegistry,
+        ProcessNetworkPacketIoRegistryError, ProcessNetworkPacketIoStopError,
+        ProcessRuntimeNetworkPacketIoProvider, ProcessSessionDiagnostics, ProcessSessionExitStatus,
+        ProcessSessionShutdownStatus, ProcessSnapshotV2BalloonLoadRequest,
+        ProcessSnapshotV2DiffLoadRequest, ProcessSnapshotV2EntropyLoadRequest,
+        ProcessSnapshotV2MemoryHotplugLoadRequest, ProcessSnapshotV2MultiBlockLoadRequest,
+        ProcessSnapshotV2MultiBlockLoadSuccess, ProcessSnapshotV2NetworkLoadRequest,
+        ProcessSnapshotV2NetworkRestorePlanError, ProcessSnapshotV2RootLoadCompletion,
+        ProcessSnapshotV2RootLoadRequest, ProcessSnapshotV2RootLoadSuccess,
+        ProcessSnapshotV2SerialLoadRequest, ProcessSnapshotV2StorageLoadRequest,
+        ProcessSnapshotV2StorageLoadSuccess, ProcessSnapshotV2VsockLoadRequest, ProcessVmm,
+        ProcessVmnetAuthority, ProcessVmnetPacketIoBackendFactory, SerialGrantState,
+        SnapshotCreateSession, SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
+        default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
+        native_snapshot_load_logger_outcome, native_v2_platform_capture_is_terminal,
+        prepare_process_snapshot_v2_network_restore_plan,
         prepare_process_snapshot_v2_vsock_candidate, require_native_v1_composite_record,
         snapshot_destination_machine_config, vsock_capture_error_from_boot_run_loop_command,
     };
@@ -37027,6 +37112,62 @@ mod tests {
     };
 
     static NEXT_TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug)]
+    struct ScriptedProcessLatencyClock {
+        timestamps: VecDeque<ProcessLatencyTimestamp>,
+    }
+
+    impl ScriptedProcessLatencyClock {
+        fn new(timestamps: impl IntoIterator<Item = Duration>) -> Self {
+            Self {
+                timestamps: timestamps
+                    .into_iter()
+                    .map(ProcessLatencyTimestamp::from_duration)
+                    .collect(),
+            }
+        }
+    }
+
+    impl ProcessLatencyClock for ScriptedProcessLatencyClock {
+        fn timestamp(&mut self) -> ProcessLatencyTimestamp {
+            self.timestamps
+                .pop_front()
+                .expect("scripted process latency timestamp should be available")
+        }
+    }
+
+    #[test]
+    fn process_latency_timestamps_convert_monotonically_and_saturate() {
+        let start = ProcessLatencyTimestamp::from_duration(Duration::from_micros(10));
+        assert_eq!(
+            ProcessLatencyTimestamp::from_duration(Duration::from_micros(52))
+                .elapsed_us_since(start),
+            42
+        );
+        assert_eq!(
+            ProcessLatencyTimestamp::from_duration(Duration::from_micros(9))
+                .elapsed_us_since(start),
+            0
+        );
+        assert_eq!(
+            ProcessLatencyTimestamp::from_duration(Duration::MAX)
+                .elapsed_us_since(ProcessLatencyTimestamp::from_duration(Duration::ZERO)),
+            u64::MAX
+        );
+
+        let mut vmm = ProcessVmm::with_starter(
+            "latency-clock",
+            "0.1.0",
+            "bangbang",
+            FakeStarter::success(1),
+        )
+        .with_process_latency_clock(ScriptedProcessLatencyClock::new([Duration::from_micros(7)]));
+        assert_eq!(
+            vmm.process_latency_timestamp(),
+            ProcessLatencyTimestamp::from_duration(Duration::from_micros(7))
+        );
+    }
 
     fn contained_vmnet_authority(authority: VmnetAuthority) -> ProcessVmnetAuthority {
         contained_vmnet_authority_for_session(0x5a, authority)
@@ -65454,6 +65595,144 @@ mod tests {
             values[0]["api_server"]["process_startup_time_cpu_us"],
             3_000
         );
+    }
+
+    #[test]
+    fn controlled_inner_vm_state_latencies_record_success_and_ignore_failure() {
+        let metrics = TempFilePath::create("controlled-inner-vm-state-latencies");
+        let mut vmm = configured_vmm(FakeStarter::success(201)).with_process_latency_clock(
+            ScriptedProcessLatencyClock::new([
+                Duration::from_micros(10),
+                Duration::from_micros(40),
+                Duration::from_micros(50),
+                Duration::from_micros(90),
+                Duration::from_micros(100),
+            ]),
+        );
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics.path(),
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("instance should start");
+        vmm.handle_action(VmmAction::Pause)
+            .expect("instance should pause");
+        vmm.handle_action(VmmAction::Resume)
+            .expect("instance should resume");
+
+        vmm.started_session = None;
+        assert_eq!(
+            vmm.handle_action(VmmAction::Pause),
+            Err(VmmActionError::Lifecycle(BackendError::InvalidState(
+                "active session unavailable"
+            )))
+        );
+        vmm.handle_action(VmmAction::FlushMetrics)
+            .expect("metrics should flush after the failed action");
+
+        let values = read_canonical_metrics_lines(metrics.path(), 1);
+        let latencies = &values[0]["latencies_us"];
+        assert_eq!(latencies["vmm_pause_vm"], 30);
+        assert_eq!(latencies["vmm_resume_vm"], 40);
+        assert_eq!(latencies["pause_vm"], 0);
+        assert_eq!(latencies["resume_vm"], 0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn controlled_inner_snapshot_latencies_cover_create_and_auto_resumed_load() {
+        let create_metrics = TempFilePath::create("controlled-inner-create-latencies");
+        let full_directory = TempSnapshotDirectory::new("controlled-inner-full-create");
+        let full_paths = full_directory.paths();
+        let diff_directory = TempSnapshotDirectory::new("controlled-inner-diff-create");
+        let diff_paths = diff_directory.paths();
+        let mut source = snapshot_profile_vmm(FakeStarter::success(202))
+            .with_process_latency_clock(ScriptedProcessLatencyClock::new([
+                Duration::from_micros(10),
+                Duration::from_micros(20),
+                Duration::from_micros(100),
+                Duration::from_micros(140),
+                Duration::from_micros(200),
+                Duration::from_micros(270),
+                Duration::from_micros(300),
+            ]));
+        source
+            .handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+                create_metrics.path(),
+            )))
+            .expect("create metrics should configure");
+        source
+            .handle_action(VmmAction::InstanceStart)
+            .expect("snapshot source should start");
+        source
+            .handle_action(VmmAction::Pause)
+            .expect("snapshot source should pause");
+        source
+            .handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
+                SnapshotType::Full,
+                full_paths.state(),
+                full_paths.memory(),
+            )))
+            .expect("full snapshot should publish");
+        source
+            .handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
+                SnapshotType::Diff,
+                diff_paths.state(),
+                diff_paths.memory(),
+            )))
+            .expect("diff snapshot should publish");
+        assert!(
+            source
+                .handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
+                    SnapshotType::Full,
+                    full_paths.state(),
+                    full_paths.memory(),
+                )))
+                .is_err(),
+            "publication collision should fail"
+        );
+        source
+            .handle_action(VmmAction::FlushMetrics)
+            .expect("create metrics should flush");
+
+        let create_values = read_canonical_metrics_lines(create_metrics.path(), 1);
+        let create_latencies = &create_values[0]["latencies_us"];
+        assert_eq!(create_latencies["vmm_full_create_snapshot"], 40);
+        assert_eq!(create_latencies["vmm_diff_create_snapshot"], 70);
+        assert_eq!(create_latencies["full_create_snapshot"], 0);
+        assert_eq!(create_latencies["diff_create_snapshot"], 0);
+
+        let load_metrics = TempFilePath::create("controlled-inner-load-latency");
+        let (_snapshot, load) =
+            native_v2_snapshot_load_fixture("controlled-inner-auto-resumed-load", true);
+        let mut destination = ProcessVmm::with_starter(
+            "controlled-inner-load",
+            "0.1.0",
+            "bangbang",
+            FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::Success),
+        )
+        .with_process_latency_clock(ScriptedProcessLatencyClock::new([
+            Duration::from_micros(400),
+            Duration::from_micros(490),
+        ]));
+        destination
+            .handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+                load_metrics.path(),
+            )))
+            .expect("load metrics should configure");
+        destination
+            .handle_action(VmmAction::LoadSnapshot(load))
+            .expect("snapshot should load and resume");
+        destination
+            .handle_action(VmmAction::FlushMetrics)
+            .expect("load metrics should flush");
+
+        let load_values = read_canonical_metrics_lines(load_metrics.path(), 1);
+        let load_latencies = &load_values[0]["latencies_us"];
+        assert_eq!(load_latencies["vmm_load_snapshot"], 90);
+        assert_eq!(load_latencies["load_snapshot"], 0);
+        assert_eq!(load_latencies["vmm_resume_vm"], 0);
+        assert_eq!(destination.instance_info().state, InstanceState::Running);
     }
 
     #[test]

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -1220,7 +1220,7 @@ mod macos_arm64 {
             Some(
                 r#"{"balloon_count":3,"hotplug_memory_count":0,"instance_info_count":9,"machine_cfg_count":0,"mmds_count":2,"vmm_version_count":0}"#,
             ),
-            r#"{"actions_count":2,"actions_fails":0,"balloon_count":1,"balloon_fails":1,"boot_source_count":2,"boot_source_fails":1,"cpu_cfg_count":1,"cpu_cfg_fails":1,"drive_count":3,"drive_fails":1,"hotplug_memory_count":0,"hotplug_memory_fails":0,"logger_count":2,"logger_fails":1,"machine_cfg_count":1,"machine_cfg_fails":0,"metrics_count":2,"metrics_fails":1,"mmds_count":2,"mmds_fails":1,"network_count":1,"network_fails":1,"pmem_count":0,"pmem_fails":0,"serial_count":2,"serial_fails":1,"vsock_count":2,"vsock_fails":1}"#,
+            r#"{"actions_count":2,"actions_fails":0,"balloon_count":1,"balloon_fails":1,"boot_source_count":2,"boot_source_fails":0,"cpu_cfg_count":1,"cpu_cfg_fails":0,"drive_count":3,"drive_fails":0,"hotplug_memory_count":0,"hotplug_memory_fails":0,"logger_count":2,"logger_fails":0,"machine_cfg_count":1,"machine_cfg_fails":0,"metrics_count":2,"metrics_fails":0,"mmds_count":2,"mmds_fails":0,"network_count":1,"network_fails":0,"pmem_count":0,"pmem_fails":0,"serial_count":2,"serial_fails":0,"vsock_count":2,"vsock_fails":0}"#,
             Some(
                 r#"{"balloon_count":4,"balloon_fails":4,"drive_count":2,"drive_fails":0,"hotplug_memory_count":0,"hotplug_memory_fails":0,"machine_cfg_count":0,"machine_cfg_fails":0,"mmds_count":1,"mmds_fails":0,"network_count":0,"network_fails":0,"pmem_count":0,"pmem_fails":0}"#,
             ),
@@ -1705,7 +1705,7 @@ mod macos_arm64 {
         assert_metrics_output(
             &metrics_path,
             None,
-            r#"{"actions_count":2,"actions_fails":1,"balloon_count":0,"balloon_fails":0,"boot_source_count":0,"boot_source_fails":0,"cpu_cfg_count":0,"cpu_cfg_fails":0,"drive_count":0,"drive_fails":0,"hotplug_memory_count":0,"hotplug_memory_fails":0,"logger_count":0,"logger_fails":0,"machine_cfg_count":1,"machine_cfg_fails":1,"metrics_count":0,"metrics_fails":0,"mmds_count":0,"mmds_fails":0,"network_count":0,"network_fails":0,"pmem_count":0,"pmem_fails":0,"serial_count":0,"serial_fails":0,"vsock_count":0,"vsock_fails":0}"#,
+            r#"{"actions_count":2,"actions_fails":0,"balloon_count":0,"balloon_fails":0,"boot_source_count":0,"boot_source_fails":0,"cpu_cfg_count":0,"cpu_cfg_fails":0,"drive_count":0,"drive_fails":0,"hotplug_memory_count":0,"hotplug_memory_fails":0,"logger_count":0,"logger_fails":0,"machine_cfg_count":1,"machine_cfg_fails":0,"metrics_count":0,"metrics_fails":0,"mmds_count":0,"mmds_fails":0,"network_count":0,"network_fails":0,"pmem_count":0,"pmem_fails":0,"serial_count":0,"serial_fails":0,"vsock_count":0,"vsock_fails":0}"#,
             None,
         );
         assert_logger_output(&logger_path, LoggerPrefixExpectation::None);

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1794,27 +1794,14 @@ impl VmmController {
         self.metrics_state.record_deprecated_api_call();
     }
 
-    pub fn record_pause_vm_latency_us(&mut self, duration_us: u64) {
-        self.metrics_state.record_pause_vm_latency_us(duration_us);
-    }
-
-    pub fn record_resume_vm_latency_us(&mut self, duration_us: u64) {
-        self.metrics_state.record_resume_vm_latency_us(duration_us);
-    }
-
-    pub fn record_full_create_snapshot_latency_us(&mut self, duration_us: u64) {
+    pub fn record_process_latency_us(
+        &mut self,
+        operation: metrics::ProcessLatencyOperation,
+        boundary: metrics::ProcessLatencyBoundary,
+        duration_us: u64,
+    ) {
         self.metrics_state
-            .record_full_create_snapshot_latency_us(duration_us);
-    }
-
-    pub fn record_diff_create_snapshot_latency_us(&mut self, duration_us: u64) {
-        self.metrics_state
-            .record_diff_create_snapshot_latency_us(duration_us);
-    }
-
-    pub fn record_load_snapshot_latency_us(&mut self, duration_us: u64) {
-        self.metrics_state
-            .record_load_snapshot_latency_us(duration_us);
+            .record_process_latency_us(operation, boundary, duration_us);
     }
 
     pub fn record_patch_drive_request(&mut self) {

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -46,6 +46,30 @@ pub const FIRECRACKER_METRICS_MAX_IDENTITY_BYTES: usize =
 pub const FIRECRACKER_METRICS_MAX_LINE_BYTES: usize =
     firecracker::FIRECRACKER_METRICS_MAX_LINE_BYTES;
 
+/// A Firecracker operation with distinct outer API and inner VMM latency stores.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessLatencyOperation {
+    /// Create a full snapshot.
+    FullCreateSnapshot,
+    /// Create a differential snapshot.
+    DiffCreateSnapshot,
+    /// Load a snapshot.
+    LoadSnapshot,
+    /// Pause the VM.
+    PauseVm,
+    /// Resume the VM.
+    ResumeVm,
+}
+
+/// The semantic owner of one process-operation latency measurement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessLatencyBoundary {
+    /// The complete successful API operation before response publication.
+    OuterApi,
+    /// The corresponding successful VMM action before outcome logging.
+    InnerVmm,
+}
+
 const fn incremental_delta(current: u64, previous: u64) -> u64 {
     if current >= previous {
         current - previous
@@ -328,24 +352,13 @@ impl MetricsState {
         self.deprecated_api.record_deprecated_http_api_call();
     }
 
-    pub(crate) fn record_pause_vm_latency_us(&mut self, duration_us: u64) {
-        self.latencies_us.record_pause_vm(duration_us);
-    }
-
-    pub(crate) fn record_resume_vm_latency_us(&mut self, duration_us: u64) {
-        self.latencies_us.record_resume_vm(duration_us);
-    }
-
-    pub(crate) fn record_full_create_snapshot_latency_us(&mut self, duration_us: u64) {
-        self.latencies_us.record_full_create_snapshot(duration_us);
-    }
-
-    pub(crate) fn record_diff_create_snapshot_latency_us(&mut self, duration_us: u64) {
-        self.latencies_us.record_diff_create_snapshot(duration_us);
-    }
-
-    pub(crate) fn record_load_snapshot_latency_us(&mut self, duration_us: u64) {
-        self.latencies_us.record_load_snapshot(duration_us);
+    pub(crate) fn record_process_latency_us(
+        &mut self,
+        operation: ProcessLatencyOperation,
+        boundary: ProcessLatencyBoundary,
+        duration_us: u64,
+    ) {
+        self.latencies_us.record(operation, boundary, duration_us);
     }
 
     pub(crate) fn record_put_actions_request(&mut self) {
@@ -691,27 +704,53 @@ struct LatencyMetrics {
     load_snapshot: Option<u64>,
     pause_vm: Option<u64>,
     resume_vm: Option<u64>,
+    vmm_full_create_snapshot: Option<u64>,
+    vmm_diff_create_snapshot: Option<u64>,
+    vmm_load_snapshot: Option<u64>,
+    vmm_pause_vm: Option<u64>,
+    vmm_resume_vm: Option<u64>,
 }
 
 impl LatencyMetrics {
-    fn record_full_create_snapshot(&mut self, duration_us: u64) {
-        self.full_create_snapshot = Some(duration_us);
-    }
-
-    fn record_diff_create_snapshot(&mut self, duration_us: u64) {
-        self.diff_create_snapshot = Some(duration_us);
-    }
-
-    fn record_load_snapshot(&mut self, duration_us: u64) {
-        self.load_snapshot = Some(duration_us);
-    }
-
-    fn record_pause_vm(&mut self, duration_us: u64) {
-        self.pause_vm = Some(duration_us);
-    }
-
-    fn record_resume_vm(&mut self, duration_us: u64) {
-        self.resume_vm = Some(duration_us);
+    fn record(
+        &mut self,
+        operation: ProcessLatencyOperation,
+        boundary: ProcessLatencyBoundary,
+        duration_us: u64,
+    ) {
+        let destination = match (operation, boundary) {
+            (ProcessLatencyOperation::FullCreateSnapshot, ProcessLatencyBoundary::OuterApi) => {
+                &mut self.full_create_snapshot
+            }
+            (ProcessLatencyOperation::DiffCreateSnapshot, ProcessLatencyBoundary::OuterApi) => {
+                &mut self.diff_create_snapshot
+            }
+            (ProcessLatencyOperation::LoadSnapshot, ProcessLatencyBoundary::OuterApi) => {
+                &mut self.load_snapshot
+            }
+            (ProcessLatencyOperation::PauseVm, ProcessLatencyBoundary::OuterApi) => {
+                &mut self.pause_vm
+            }
+            (ProcessLatencyOperation::ResumeVm, ProcessLatencyBoundary::OuterApi) => {
+                &mut self.resume_vm
+            }
+            (ProcessLatencyOperation::FullCreateSnapshot, ProcessLatencyBoundary::InnerVmm) => {
+                &mut self.vmm_full_create_snapshot
+            }
+            (ProcessLatencyOperation::DiffCreateSnapshot, ProcessLatencyBoundary::InnerVmm) => {
+                &mut self.vmm_diff_create_snapshot
+            }
+            (ProcessLatencyOperation::LoadSnapshot, ProcessLatencyBoundary::InnerVmm) => {
+                &mut self.vmm_load_snapshot
+            }
+            (ProcessLatencyOperation::PauseVm, ProcessLatencyBoundary::InnerVmm) => {
+                &mut self.vmm_pause_vm
+            }
+            (ProcessLatencyOperation::ResumeVm, ProcessLatencyBoundary::InnerVmm) => {
+                &mut self.vmm_resume_vm
+            }
+        };
+        *destination = Some(duration_us);
     }
 }
 
@@ -7273,14 +7312,14 @@ mod tests {
         MetricsFlushError, MetricsOutput, MetricsState, MmdsMetrics, NetworkInterfaceMetrics,
         NetworkInterfaceMetricsByInterface, NetworkInterfaceMetricsCaptureError,
         NetworkInterfaceMetricsRegistryError, PatchApiRequestMetrics, PmemDeviceMetrics,
-        PmemDeviceMetricsByDevice, PmemDeviceMetricsRegistryError, PutApiRequestMetrics,
-        RtcDeviceMetrics, SharedBalloonDeviceMetrics, SharedBlockDeviceMetrics,
-        SharedBlockDeviceMetricsRegistry, SharedEntropyDeviceMetrics,
-        SharedMemoryHotplugDeviceMetrics, SharedMemoryHotplugLatencyMetricsInner,
-        SharedMmdsMetrics, SharedNetworkInterfaceMetrics, SharedNetworkInterfaceMetricsRegistry,
-        SharedPmemDeviceMetrics, SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics,
-        SharedSignalMetrics, SharedVsockDeviceMetrics, SignalMetrics,
-        VirtioNetworkLatencyAggregate, VsockDeviceMetrics,
+        PmemDeviceMetricsByDevice, PmemDeviceMetricsRegistryError, ProcessLatencyBoundary,
+        ProcessLatencyOperation, PutApiRequestMetrics, RtcDeviceMetrics,
+        SharedBalloonDeviceMetrics, SharedBlockDeviceMetrics, SharedBlockDeviceMetricsRegistry,
+        SharedEntropyDeviceMetrics, SharedMemoryHotplugDeviceMetrics,
+        SharedMemoryHotplugLatencyMetricsInner, SharedMmdsMetrics, SharedNetworkInterfaceMetrics,
+        SharedNetworkInterfaceMetricsRegistry, SharedPmemDeviceMetrics,
+        SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics, SharedSignalMetrics,
+        SharedVsockDeviceMetrics, SignalMetrics, VirtioNetworkLatencyAggregate, VsockDeviceMetrics,
     };
     use crate::block::VirtioBlockLatencyAggregate;
     use crate::logger::SharedLoggerMetrics;
@@ -7742,11 +7781,60 @@ mod tests {
 
     fn record_all_process_metrics(state: &mut MetricsState) {
         state.record_deprecated_api_call();
-        state.record_pause_vm_latency_us(101);
-        state.record_resume_vm_latency_us(102);
-        state.record_full_create_snapshot_latency_us(103);
-        state.record_diff_create_snapshot_latency_us(104);
-        state.record_load_snapshot_latency_us(105);
+        for (operation, boundary, value) in [
+            (
+                ProcessLatencyOperation::PauseVm,
+                ProcessLatencyBoundary::OuterApi,
+                101,
+            ),
+            (
+                ProcessLatencyOperation::ResumeVm,
+                ProcessLatencyBoundary::OuterApi,
+                102,
+            ),
+            (
+                ProcessLatencyOperation::FullCreateSnapshot,
+                ProcessLatencyBoundary::OuterApi,
+                103,
+            ),
+            (
+                ProcessLatencyOperation::DiffCreateSnapshot,
+                ProcessLatencyBoundary::OuterApi,
+                104,
+            ),
+            (
+                ProcessLatencyOperation::LoadSnapshot,
+                ProcessLatencyBoundary::OuterApi,
+                105,
+            ),
+            (
+                ProcessLatencyOperation::PauseVm,
+                ProcessLatencyBoundary::InnerVmm,
+                106,
+            ),
+            (
+                ProcessLatencyOperation::ResumeVm,
+                ProcessLatencyBoundary::InnerVmm,
+                107,
+            ),
+            (
+                ProcessLatencyOperation::FullCreateSnapshot,
+                ProcessLatencyBoundary::InnerVmm,
+                108,
+            ),
+            (
+                ProcessLatencyOperation::DiffCreateSnapshot,
+                ProcessLatencyBoundary::InnerVmm,
+                109,
+            ),
+            (
+                ProcessLatencyOperation::LoadSnapshot,
+                ProcessLatencyBoundary::InnerVmm,
+                110,
+            ),
+        ] {
+            state.record_process_latency_us(operation, boundary, value);
+        }
         state.record_put_actions_request();
         state.record_put_actions_failure();
         state.record_put_balloon_request();
@@ -10646,32 +10734,64 @@ mod tests {
     }
 
     #[test]
-    fn writes_pause_resume_latency_metrics_when_recorded() {
-        let path = unique_metrics_path("latencies-us");
+    fn writes_every_outer_and_inner_process_latency_when_recorded() {
+        let path = unique_metrics_path("process-latencies-us");
         let mut state = MetricsState::default();
 
-        state.record_pause_vm_latency_us(0);
-        state.record_resume_vm_latency_us(42);
-        state
-            .configure(MetricsConfigInput::new(&path))
-            .expect("metrics should configure");
-        assert_eq!(state.flush(), Ok(true));
-
-        let value = only_metrics_value_from_file(&path);
-        assert_eq!(value["latencies_us"]["pause_vm"], 0);
-        assert_eq!(value["latencies_us"]["resume_vm"], 42);
-
-        fs::remove_file(path).expect("fixture should clean up");
-    }
-
-    #[test]
-    fn writes_snapshot_latency_metrics_when_recorded() {
-        let path = unique_metrics_path("snapshot-latencies-us");
-        let mut state = MetricsState::default();
-
-        state.record_full_create_snapshot_latency_us(1);
-        state.record_diff_create_snapshot_latency_us(2);
-        state.record_load_snapshot_latency_us(3);
+        for (operation, boundary, value) in [
+            (
+                ProcessLatencyOperation::FullCreateSnapshot,
+                ProcessLatencyBoundary::OuterApi,
+                1,
+            ),
+            (
+                ProcessLatencyOperation::DiffCreateSnapshot,
+                ProcessLatencyBoundary::OuterApi,
+                2,
+            ),
+            (
+                ProcessLatencyOperation::LoadSnapshot,
+                ProcessLatencyBoundary::OuterApi,
+                3,
+            ),
+            (
+                ProcessLatencyOperation::PauseVm,
+                ProcessLatencyBoundary::OuterApi,
+                4,
+            ),
+            (
+                ProcessLatencyOperation::ResumeVm,
+                ProcessLatencyBoundary::OuterApi,
+                5,
+            ),
+            (
+                ProcessLatencyOperation::FullCreateSnapshot,
+                ProcessLatencyBoundary::InnerVmm,
+                6,
+            ),
+            (
+                ProcessLatencyOperation::DiffCreateSnapshot,
+                ProcessLatencyBoundary::InnerVmm,
+                7,
+            ),
+            (
+                ProcessLatencyOperation::LoadSnapshot,
+                ProcessLatencyBoundary::InnerVmm,
+                8,
+            ),
+            (
+                ProcessLatencyOperation::PauseVm,
+                ProcessLatencyBoundary::InnerVmm,
+                9,
+            ),
+            (
+                ProcessLatencyOperation::ResumeVm,
+                ProcessLatencyBoundary::InnerVmm,
+                10,
+            ),
+        ] {
+            state.record_process_latency_us(operation, boundary, value);
+        }
         state
             .configure(MetricsConfigInput::new(&path))
             .expect("metrics should configure");
@@ -10681,6 +10801,13 @@ mod tests {
         assert_eq!(value["latencies_us"]["full_create_snapshot"], 1);
         assert_eq!(value["latencies_us"]["diff_create_snapshot"], 2);
         assert_eq!(value["latencies_us"]["load_snapshot"], 3);
+        assert_eq!(value["latencies_us"]["pause_vm"], 4);
+        assert_eq!(value["latencies_us"]["resume_vm"], 5);
+        assert_eq!(value["latencies_us"]["vmm_full_create_snapshot"], 6);
+        assert_eq!(value["latencies_us"]["vmm_diff_create_snapshot"], 7);
+        assert_eq!(value["latencies_us"]["vmm_load_snapshot"], 8);
+        assert_eq!(value["latencies_us"]["vmm_pause_vm"], 9);
+        assert_eq!(value["latencies_us"]["vmm_resume_vm"], 10);
 
         fs::remove_file(path).expect("fixture should clean up");
     }

--- a/crates/runtime/src/metrics/firecracker.rs
+++ b/crates/runtime/src/metrics/firecracker.rs
@@ -849,7 +849,17 @@ pub(super) fn build_metrics_line(
             load_snapshot: interval.latencies_us.load_snapshot.unwrap_or_default(),
             pause_vm: interval.latencies_us.pause_vm.unwrap_or_default(),
             resume_vm: interval.latencies_us.resume_vm.unwrap_or_default(),
-            ..LatencyMetrics::default()
+            vmm_full_create_snapshot: interval
+                .latencies_us
+                .vmm_full_create_snapshot
+                .unwrap_or_default(),
+            vmm_diff_create_snapshot: interval
+                .latencies_us
+                .vmm_diff_create_snapshot
+                .unwrap_or_default(),
+            vmm_load_snapshot: interval.latencies_us.vmm_load_snapshot.unwrap_or_default(),
+            vmm_pause_vm: interval.latencies_us.vmm_pause_vm.unwrap_or_default(),
+            vmm_resume_vm: interval.latencies_us.vmm_resume_vm.unwrap_or_default(),
         },
         logger: LoggerMetrics {
             missed_metrics_count: interval.logger_metrics.missed_metrics_count,

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -671,6 +671,19 @@ summed while aggregate `min_us` and `max_us` remain zero, matching the pinned
 construction. `*_bytes` fields are bytes, `*_us` fields are microseconds, and
 count/failure/event fields count the named events.
 
+The five process operation latencies have paired outer API and `vmm_*` stores
+for pause, resume, Full snapshot create, Diff snapshot create, and snapshot
+load. A single injectable process-local monotonic clock supplies both layers.
+The outer boundary begins at typed request handling entry after the bounded
+socket read and commits after the complete operation, successful control-log
+attempt, and response construction. The inner boundary covers the functional
+VMM action and commits before lifecycle or snapshot outcome logging. Only
+successful operations replace these stores; parser, preflight, backend,
+publication, restore, and response failures preserve the prior values. An
+automatic resume requested by snapshot load remains inside `vmm_load_snapshot`
+and does not write `vmm_resume_vm`. The values describe distinct boundaries,
+so no `outer >= inner` relationship is promised.
+
 Bangbang-only extensions are not part of this strict line. In particular,
 `vmm.metrics_flush_count`, string boot-run-loop status, `pmem_*` roots, vmnet
 fields, newer balloon API/device fields, extra UART fields, and the ordinary

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1541,7 +1541,8 @@ arm64 static roots and 243 static scalar paths, plus configured block/network/
 vhost-user field populations of 24/29/5. The separate human-owned
 `metrics-process-producer-audit.json` is an exact incremental mapping of the 69
 fields assigned to the process profile; it records 44 implemented #1827
-request/deprecation fields and 25 planned fields owned by #1828–#1830. Run the
+request/deprecation fields, 12 implemented #1828 startup/latency fields, and 13
+planned fields owned by #1829–#1830. Run the
 schema and process-audit focused local mutations with:
 
 ```sh

--- a/tools/firecracker-capability-audit/src/metrics_process_validate.rs
+++ b/tools/firecracker-capability-audit/src/metrics_process_validate.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 const EXPECTED_PROCESS_FIELDS: usize = 69;
-const COMPLETED_DELIVERY_ISSUES: &[&str] = &["#1827"];
+const COMPLETED_DELIVERY_ISSUES: &[&str] = &["#1827", "#1828"];
 
 /// Validate exact process-producer authority against the resolved metrics schema.
 pub fn validate_metrics_process_producers(
@@ -184,11 +184,11 @@ fn validate_record(
             record.field_id
         ));
     }
-    if delivery_issue == "#1827"
+    if matches!(delivery_issue, "#1827" | "#1828")
         && record.disposition != MetricsProcessProducerDisposition::Implemented
     {
         errors.push(format!(
-            "API metrics producer must be implemented, not neutral or zero: {}",
+            "completed process metrics producer must be implemented, not neutral or zero: {}",
             record.field_id
         ));
     }
@@ -346,13 +346,13 @@ fn expected_rationale(
             "Pinned Firecracker increments this counter only after typed parsing accepts a deprecated API value; Bangbang records the redacted parse effect once."
         }
         ("#1828", MetricsProcessProducerBoundary::ProcessStartup) => {
-            "Delivery child #1828 owns the exact process startup clock boundary and remains unresolved in this audit slice."
+            "Bangbang samples one process monotonic clock and one process CPU clock at startup, uses saturating elapsed arithmetic, and adds optional parent CPU time before storing the canonical values."
         }
         ("#1828", MetricsProcessProducerBoundary::SuccessfulOuterApiOperation) => {
-            "Delivery child #1828 owns the successful outer API operation latency boundary and remains unresolved in this audit slice."
+            "Pinned Firecracker stores this latency only after the complete typed API operation succeeds; Bangbang measures from bounded request entry through successful response construction and leaves the prior value unchanged on failure."
         }
         ("#1828", MetricsProcessProducerBoundary::SuccessfulInnerVmmOperation) => {
-            "Delivery child #1828 owns the successful inner VMM operation latency boundary and remains unresolved in this audit slice."
+            "Pinned Firecracker stores this latency only after the corresponding VMM operation succeeds; Bangbang commits at the functional action boundary before outcome logging and folds automatic snapshot-load resume into load."
         }
         ("#1829", MetricsProcessProducerBoundary::LoggerLifecycle) => {
             "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice."

--- a/tools/firecracker-capability-audit/tests/metrics_schema.rs
+++ b/tools/firecracker-capability-audit/tests/metrics_schema.rs
@@ -101,7 +101,7 @@ fn checked_process_producer_audit_is_canonical_and_exact() {
                 record.disposition == MetricsProcessProducerDisposition::Implemented
             })
             .count(),
-        44
+        56
     );
     assert_eq!(
         audit
@@ -109,7 +109,7 @@ fn checked_process_producer_audit_is_canonical_and_exact() {
             .iter()
             .filter(|record| record.disposition == MetricsProcessProducerDisposition::Planned)
             .count(),
-        25
+        13
     );
 
     let error = validate_metrics_process_producers(&audit, &authority, &root, AuditMode::Final)
@@ -167,13 +167,26 @@ fn process_producer_audit_rejects_boundary_child_and_completion_drift() {
     api.validation.clear();
     let error = process_validation_error(&completed);
     assert!(error.contains("completed metrics process producer slice must be terminal"));
-    assert!(error.contains("API metrics producer must be implemented"));
+    assert!(error.contains("completed process metrics producer must be implemented"));
+
+    let mut completed_latency = checked_process_audit();
+    let latency = completed_latency
+        .records
+        .iter_mut()
+        .find(|record| record.delivery_issue == "#1828")
+        .expect("latency record must exist");
+    latency.disposition = MetricsProcessProducerDisposition::Planned;
+    latency.implementation.clear();
+    latency.validation.clear();
+    let error = process_validation_error(&completed_latency);
+    assert!(error.contains("completed metrics process producer slice must be terminal"));
+    assert!(error.contains("completed process metrics producer must be implemented"));
 
     let mut premature = checked_process_audit();
     let downstream = premature
         .records
         .iter_mut()
-        .find(|record| record.delivery_issue == "#1828")
+        .find(|record| record.delivery_issue == "#1829")
         .expect("downstream record must exist");
     downstream.disposition = MetricsProcessProducerDisposition::Implemented;
     downstream.implementation.push(Reference::Local {
@@ -197,7 +210,8 @@ fn process_producer_audit_rejects_neutral_aliases_and_bad_evidence() {
         .expect("API record must exist");
     api.disposition = MetricsProcessProducerDisposition::SourceNeutral;
     assert!(
-        process_validation_error(&neutral).contains("must be implemented, not neutral or zero")
+        process_validation_error(&neutral)
+            .contains("completed process metrics producer must be implemented")
     );
 
     let mut missing = checked_process_audit();


### PR DESCRIPTION
## Summary

- add one typed five-operation × outer/inner latency store and serialize all ten Firecracker fields
- measure outer API success through response construction and inner VMM functional success before outcome logging
- keep parser/action failures from replacing prior values and keep snapshot-load auto-resume out of `vmm_resume_vm`
- promote the 12 #1828 process-producer rows to evidence-backed `implemented` and update the 56/13 audit totals and contracts
- align two signed async-block expectations with #1827's parser-only `*_fails` semantics discovered by the full signed run

## Scope exclusions

- does not implement #1829/#1830 asynchronous process producers
- does not promote the parent process-schema policy or claim an outer/inner duration ordering

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker /Users/liangyou/github/firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple-target signed-integration Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` (all non-executable groups green; found two stale #1827 expectations)
- `scripts/run-integration-tests.sh --test executable_hvf_e2e` (80/80 green after correcting those expectations)

Closes #1828
