### PR TITLE
feat: make process metrics snapshots generation-consistent

### DIFF
--- a/compat/firecracker/v1.16.0/metrics-contract.md
+++ b/compat/firecracker/v1.16.0/metrics-contract.md
@@ -90,11 +90,12 @@ fixed: #1827 owns 44 API request and deprecation fields, #1828 owns two startup
 and ten successful outer/inner operation-latency fields, #1829 owns four logger
 fields plus SIGPIPE, and #1830 owns six fatal-signal fields plus panic and
 seccomp.
-Only a completed child may use the `implemented` disposition and carry
-resolvable production and validation evidence. #1827 and #1828 are complete,
-so 56 records are `implemented`; the remaining 13 records stay `planned` until
-their #1829 or #1830 pull requests land. `source-neutral` and `platform-zero`
-are terminal policy choices, not aliases for an undelivered feasible producer.
+Only a completed child may use a terminal disposition and carry resolvable
+production and validation evidence. #1827 through #1829 are complete, so 60
+records are `implemented`, `logger.metrics_fails` is the sole
+`source-neutral` record, and the eight #1830 records remain `planned`.
+`source-neutral` and `platform-zero` are terminal policy choices, not aliases
+for an undelivered feasible producer.
 
 For #1827, request metrics are created as a typed, value-free effect only after
 the HTTP request passes admission. The effect is applied exactly once before
@@ -135,6 +136,27 @@ resume is part of `vmm_load_snapshot` and does not write `vmm_resume_vm`;
 explicit `PATCH /vm` resume does. Both layers use the same injectable
 process-local monotonic clock, but no ordering relationship between the two
 reported durations is promised.
+
+For #1829, one controller-owned `SharedProcessMetrics` identity supplies narrow
+logger and SIGPIPE facades plus the collection authority. Missed-log,
+rate-limited-log, and SIGPIPE producers use monotonic saturating `SeqCst`
+atomics. They never reset or wait for collection; the SIGPIPE handler performs
+only its atomic value operation and returns. The collector reads the fixed
+three-value vector twice in the same order with a `SeqCst` fence between the
+scans. If the vectors are equal, every first load precedes the fence and every
+second load follows it in the global order. Monotonicity therefore proves that
+the complete vector existed at the fence, which is the cut's linearization
+point. An update that is already saturated at `u64::MAX` is fully represented.
+
+A changed vector retries. Sixty-four changed vectors fail closed as a redacted
+busy attempt without advancing a generation or consuming an event. Every
+stable cut receives the next checked owner-local generation; exhaustion fails
+closed rather than aliasing two cuts. Control-owned `missed_metrics_count` and
+constant source-neutral `logger.metrics_fails = 0` then join that immutable
+snapshot. Pinned Firecracker has producers at logger loss, logger limiter
+denial, metrics-write failure, and SIGPIPE, but exact pinned-source search has
+no producer for `logger.metrics_fails`; Bangbang therefore never aliases a
+sink failure into that field.
 
 ## Exact Arm64 Shape
 
@@ -279,13 +301,16 @@ path redaction remain governed by the existing direct/contained process
 contract.
 
 Bangbang uses a stronger publication transaction than pinned Firecracker. One
-flush attempt must snapshot all producers before serialization. Interval values
-are computed from the last completely successful publication, and that
-baseline advances only after the entire newline-terminated line is accepted.
-A failed write retains the baseline and replays the interval. If a writer
-exposed a prefix before returning failure, observers may see an ambiguous
-partial attempt followed by an at-least-once replay; the contract does not
-claim durable or exactly-once output.
+flush attempt must snapshot all producers before serialization. The shared
+process cut above is frozen first; events ordered before its successful fence
+belong to that generation, while later events remain in monotonic totals for a
+later attempt. Interval values are computed from the last completely successful
+publication, and that baseline advances only after the entire
+newline-terminated line is accepted. A busy cut, exhausted generation, failed
+build, or failed output records one missed metrics attempt and retains the
+baseline. If a writer exposed a prefix before returning failure, observers may
+see an ambiguous partial attempt followed by an at-least-once replay; the
+contract does not claim durable or exactly-once output.
 
 Initial, periodic, explicit, and terminal flush paths must share that immutable
 attempt transaction. Producer events arriving after the snapshot belong to a

--- a/compat/firecracker/v1.16.0/metrics-process-producer-audit.json
+++ b/compat/firecracker/v1.16.0/metrics-process-producer-audit.json
@@ -647,38 +647,136 @@
     {
       "field_id": "static:logger.metrics_fails",
       "boundary": "logger-lifecycle",
-      "disposition": "planned",
+      "disposition": "source-neutral",
       "delivery_issue": "#1829",
-      "rationale": "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker v1.16.0 defines logger.metrics_fails but has no producer; Bangbang keeps the canonical field source-neutral at zero and records every metrics publication failure only in missed_metrics_count.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/metrics-contract.md",
+          "anchor": "pinned source-neutral logger metrics evidence"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "canonical source-neutral logger metrics mapping"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "all metrics failure stages preserve source-neutral metrics_fails"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1829 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:logger.missed_log_count",
       "boundary": "logger-lifecycle",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1829",
-      "rationale": "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker increments this counter when logger delivery fails; Bangbang records actual bounded-queue, timeout, writer, emergency, and batch-loss stages and freezes the monotonic total in the shared process cut.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "saturating missed-log producer facade"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "generation-consistent shared process cut"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "actual logger loss-stage tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "process cut race contention and retry tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1829 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:logger.missed_metrics_count",
       "boundary": "logger-lifecycle",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1829",
-      "rationale": "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker increments this counter when metrics publication fails; Bangbang records each failed stable-cut, build, or output attempt and advances its prior successful baseline only after complete line flush.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "success-only process metrics publication transaction"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "stable-cut and output failure replay tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1829 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:logger.rate_limited_log_count",
       "boundary": "logger-lifecycle",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1829",
-      "rationale": "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker increments this counter when logger rate limiting rejects a record; Bangbang records limiter denial or contention fallback and freezes the monotonic total in the shared process cut.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "saturating rate-limited-log producer facade"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger/rate_limiter.rs",
+          "anchor": "closed limiter denial and contention outcomes"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "generation-consistent shared process cut"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/logger.rs",
+          "anchor": "rate limiter denial and contention tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "process cut race contention and retry tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1829 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:patch_api_requests.drive_count",
@@ -2087,11 +2185,38 @@
     {
       "field_id": "static:signals.sigpipe",
       "boundary": "signal-lifecycle",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1829",
-      "rationale": "Delivery child #1829 owns the generation-consistent SIGPIPE capture boundary and remains unresolved in this audit slice.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker increments SIGPIPE and returns from its handler; Bangbang performs one atomic-only saturating update and freezes it with logger totals in the shared process cut.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/main.rs",
+          "anchor": "atomic-only returning SIGPIPE handler"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "generation-consistent shared process cut"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed live SIGPIPE generation validation"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "SIGPIPE race saturation and retry tests"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1829 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:signals.sigsegv",

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -305,7 +305,6 @@ fn run(
                 .metrics_diagnostics()
                 .map_err(ProcessError::StartupTime)?;
 
-            let signal_metrics = SharedSignalMetrics::default();
             let vmm = ProcessVmm::new(
                 id,
                 env!("CARGO_PKG_VERSION"),
@@ -316,10 +315,10 @@ fn run(
             .with_pci_enabled(enable_pci)
             .with_process_serial_stdio()
             .with_process_metrics_diagnostics(process_metrics_diagnostics)
-            .with_process_signal_metrics(signal_metrics.clone())
             .with_snapshot_capture_cancellation(snapshot_cancellation.clone())
             .with_grant_authority(grant_authority.clone())
             .with_vmnet_authority(vmnet_authority);
+            let signal_metrics = vmm.process_signal_metrics();
             #[cfg(target_os = "macos")]
             let mut vmm = vmm
                 .with_pager_grant_authority(pager_grant_authority)
@@ -2724,7 +2723,7 @@ mod tests {
     use bangbang_runtime::memory_hotplug::MemoryHotplugConfigInput;
     use bangbang_runtime::metrics::{
         MetricsConfigError, MetricsConfigInput, MetricsDiagnostics, MetricsFlushError,
-        ProcessLatencyBoundary, ProcessLatencyOperation, SharedSignalMetrics,
+        ProcessLatencyBoundary, ProcessLatencyOperation,
     };
     use bangbang_runtime::mmds::MmdsDataStoreError;
     use bangbang_runtime::network::NetworkInterfaceConfigInput;
@@ -5536,14 +5535,13 @@ mod tests {
     fn no_api_periodic_metrics_failure_reschedules_and_retries_delta() {
         let mut metrics_fifo = MetricsFifo::create("periodic-retry");
         let logger_path = unique_logger_path("periodic-retry");
-        let signal_metrics = SharedSignalMetrics::default();
         let mut vmm = ProcessVmm::with_starter(
             "demo-1",
             env!("CARGO_PKG_VERSION"),
             "bangbang",
             TestInstanceStarter,
-        )
-        .with_process_signal_metrics(signal_metrics.clone());
+        );
+        let signal_metrics = vmm.process_signal_metrics();
         vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
             metrics_fifo.path(),
         )))

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -5725,7 +5725,6 @@ where
     terminal_metrics_attempted: bool,
     process_metrics_diagnostics: MetricsDiagnostics,
     process_latency_clock: Box<dyn ProcessLatencyClock>,
-    process_signal_metrics: Option<SharedSignalMetrics>,
     process_stdout: Option<ProcessStdoutLogger>,
     snapshot_capture_cancellation: NativeV1SnapshotCaptureCancellation,
     terminal_snapshot_load_failure: bool,
@@ -5842,7 +5841,6 @@ where
             terminal_metrics_attempted: false,
             process_metrics_diagnostics: MetricsDiagnostics::default(),
             process_latency_clock: Box::<SystemProcessLatencyClock>::default(),
-            process_signal_metrics: None,
             process_stdout: None,
             snapshot_capture_cancellation: NativeV1SnapshotCaptureCancellation::default(),
             terminal_snapshot_load_failure: false,
@@ -5895,9 +5893,8 @@ where
         self
     }
 
-    pub(crate) fn with_process_signal_metrics(mut self, metrics: SharedSignalMetrics) -> Self {
-        self.process_signal_metrics = Some(metrics);
-        self
+    pub(crate) fn process_signal_metrics(&self) -> SharedSignalMetrics {
+        self.controller.process_signal_metrics()
     }
 
     pub(crate) fn install_process_stdout_logger(
@@ -7872,14 +7869,8 @@ where
             .map(ProcessSessionDiagnostics::metrics_diagnostics)
             .or_else(|| self.terminal_session_metrics.clone())
             .unwrap_or_default();
-        let signal_diagnostics = self
-            .process_signal_metrics
-            .as_ref()
-            .map(|metrics| MetricsDiagnostics::new().with_signal_metrics(metrics.snapshot()))
-            .unwrap_or_default();
         self.process_metrics_diagnostics
             .clone()
-            .merged_with(signal_diagnostics)
             .merged_with(self.starter.metrics_diagnostics())
             .merged_with(session_diagnostics)
     }
@@ -36875,8 +36866,8 @@ mod tests {
         PmemDeviceMetrics, PmemDeviceMetricsByDevice, RtcDeviceMetrics, SharedBalloonDeviceMetrics,
         SharedBlockDeviceMetricsRegistry, SharedEntropyDeviceMetrics,
         SharedMemoryHotplugDeviceMetrics, SharedMmdsMetrics, SharedNetworkInterfaceMetricsRegistry,
-        SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics, SharedSignalMetrics,
-        SharedVsockDeviceMetrics, VsockDeviceMetrics,
+        SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics, SharedVsockDeviceMetrics,
+        VsockDeviceMetrics,
     };
     use bangbang_runtime::mmds::{
         DEFAULT_MMDS_IPV4_ADDRESS, DEFAULT_MMDS_MAC_ADDRESS, MMDS_GUEST_TCP_PORT, MmdsConfig,
@@ -65786,14 +65777,13 @@ mod tests {
     #[test]
     fn flush_metrics_includes_process_signal_metrics() {
         let metrics = TempFilePath::create("metrics");
-        let signal_metrics = SharedSignalMetrics::default();
         let mut vmm = ProcessVmm::with_starter(
             "demo-1",
             "0.1.0",
             "bangbang",
             DiagnosticStarter::new(BootRunLoopMetricStatus::Running),
-        )
-        .with_process_signal_metrics(signal_metrics.clone());
+        );
+        let signal_metrics = vmm.process_signal_metrics();
         vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
             metrics.path(),
         )))
@@ -65808,9 +65798,12 @@ mod tests {
         signal_metrics.record_sigpipe();
         vmm.handle_action(VmmAction::FlushMetrics)
             .expect("metrics should flush");
+        vmm.handle_action(VmmAction::FlushMetrics)
+            .expect("the next metrics generation should flush");
 
-        let values = read_canonical_metrics_lines(metrics.path(), 1);
+        let values = read_canonical_metrics_lines(metrics.path(), 2);
         assert_eq!(values[0]["signals"]["sigpipe"], 1);
+        assert_eq!(values[1]["signals"]["sigpipe"], 0);
     }
 
     #[test]

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -18302,14 +18302,17 @@ mod macos_arm64 {
                 path.display()
             )
         });
-        assert!(
-            output.lines().any(|line| {
-                serde_json::from_str::<serde_json::Value>(line)
-                    .ok()
-                    .and_then(|value| value.pointer("/signals/sigpipe")?.as_u64())
-                    .is_some_and(|count| count > 0)
-            }),
-            "metrics output should include SIGPIPE signal metrics; output:\n{output}"
+        let latest = output
+            .lines()
+            .last()
+            .and_then(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .unwrap_or_else(|| panic!("metrics output should end in canonical JSON: {output}"));
+        assert_eq!(
+            latest
+                .pointer("/signals/sigpipe")
+                .and_then(|value| value.as_u64()),
+            Some(1),
+            "the first generation after SIGPIPE should report it exactly once; output:\n{output}"
         );
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -625,7 +625,7 @@ impl VmmController {
         mmds_data_store_limit_bytes: usize,
     ) -> Self {
         let instance_id = instance_id.into();
-        let shared_logger_metrics = logger::SharedLoggerMetrics::default();
+        let shared_process_metrics = metrics::SharedProcessMetrics::default();
         Self {
             instance_info: InstanceInfo::new(
                 instance_id.clone(),
@@ -645,8 +645,12 @@ impl VmmController {
             balloon_config: None,
             pmem_configs: pmem::PmemConfigs::new(),
             serial_config: serial::SerialConfig::default(),
-            logger_state: logger::LoggerState::with_shared_metrics(shared_logger_metrics.clone()),
-            metrics_state: metrics::MetricsState::with_shared_logger_metrics(shared_logger_metrics),
+            logger_state: logger::LoggerState::with_shared_metrics(
+                shared_process_metrics.logger_metrics(),
+            ),
+            metrics_state: metrics::MetricsState::with_shared_process_metrics(
+                shared_process_metrics,
+            ),
             mmds_state: mmds::MmdsStateHandle::new(mmds::MmdsState::with_instance_id(
                 mmds_data_store_limit_bytes,
                 instance_id,
@@ -657,6 +661,11 @@ impl VmmController {
 
     pub fn instance_info(&self) -> &InstanceInfo {
         &self.instance_info
+    }
+
+    /// Returns the atomic-only SIGPIPE metrics facade owned by this controller.
+    pub fn process_signal_metrics(&self) -> metrics::SharedSignalMetrics {
+        self.metrics_state.signal_metrics()
     }
 
     pub fn drive_configs(&self) -> &[block::DriveConfig] {

--- a/crates/runtime/src/logger.rs
+++ b/crates/runtime/src/logger.rs
@@ -281,13 +281,13 @@ pub(crate) struct SharedLoggerMetrics {
 impl SharedLoggerMetrics {
     fn record_saturating_by(counter: &AtomicU64, amount: usize) {
         let amount = u64::try_from(amount).unwrap_or(u64::MAX);
-        let mut current = counter.load(Ordering::Relaxed);
+        let mut current = counter.load(Ordering::SeqCst);
         while current != u64::MAX {
             match counter.compare_exchange_weak(
                 current,
                 current.saturating_add(amount),
-                Ordering::Relaxed,
-                Ordering::Relaxed,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
             ) {
                 Ok(_) => return,
                 Err(actual) => current = actual,
@@ -311,11 +311,21 @@ impl SharedLoggerMetrics {
     }
 
     pub(crate) fn missed_log_count(&self) -> u64 {
-        self.inner.missed_log_count.load(Ordering::Relaxed)
+        self.inner.missed_log_count.load(Ordering::SeqCst)
     }
 
     pub(crate) fn rate_limited_log_count(&self) -> u64 {
-        self.inner.rate_limited_log_count.load(Ordering::Relaxed)
+        self.inner.rate_limited_log_count.load(Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_counts_for_test(&self, missed_log_count: u64, rate_limited_log_count: u64) {
+        self.inner
+            .missed_log_count
+            .store(missed_log_count, Ordering::SeqCst);
+        self.inner
+            .rate_limited_log_count
+            .store(rate_limited_log_count, Ordering::SeqCst);
     }
 }
 

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -4,7 +4,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, LineWriter, Write};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering, fence};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::balloon::{VirtioBalloonDeviceNotificationDispatch, VirtioBalloonDiscardOutcome};
@@ -45,6 +45,9 @@ pub const FIRECRACKER_METRICS_MAX_IDENTITY_BYTES: usize =
 /// Maximum byte length of one complete newline-terminated Firecracker metrics record.
 pub const FIRECRACKER_METRICS_MAX_LINE_BYTES: usize =
     firecracker::FIRECRACKER_METRICS_MAX_LINE_BYTES;
+
+/// Bounds collection work without making a producer wait for the collector.
+const PROCESS_METRICS_SNAPSHOT_ATTEMPTS: usize = 64;
 
 /// A Firecracker operation with distinct outer API and inner VMM latency stores.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -177,6 +180,8 @@ impl std::error::Error for MetricsConfigError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MetricsFlushError {
+    ProcessSnapshotBusy,
+    ProcessGenerationExhausted,
     Clock,
     ConfiguredDevices,
     Allocation,
@@ -190,6 +195,12 @@ pub enum MetricsFlushError {
 impl fmt::Display for MetricsFlushError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::ProcessSnapshotBusy => {
+                f.write_str("failed to flush metrics: process snapshot remained busy")
+            }
+            Self::ProcessGenerationExhausted => {
+                f.write_str("failed to flush metrics: process generation exhausted")
+            }
             Self::Clock => f.write_str("failed to flush metrics: clock unavailable"),
             Self::ConfiguredDevices => {
                 f.write_str("failed to flush metrics: configured device inventory is invalid")
@@ -225,6 +236,7 @@ impl From<firecracker::MetricsLineBuildError> for MetricsFlushError {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct MetricsSnapshot {
+    generation: u64,
     diagnostics: MetricsDiagnostics,
     deprecated_api: DeprecatedApiMetrics,
     get_api_requests: GetApiRequestMetrics,
@@ -237,6 +249,7 @@ struct MetricsSnapshot {
 impl MetricsSnapshot {
     fn delta_since(&self, previous: &Self) -> Self {
         Self {
+            generation: self.generation,
             diagnostics: self.diagnostics.delta_since(&previous.diagnostics),
             deprecated_api: self.deprecated_api.delta_since(previous.deprecated_api),
             get_api_requests: self.get_api_requests.delta_since(previous.get_api_requests),
@@ -258,9 +271,10 @@ pub struct MetricsState {
     get_api_requests: GetApiRequestMetrics,
     latencies_us: LatencyMetrics,
     logger_metrics: LoggerMetrics,
+    process_generation: u64,
     previous_successful: MetricsSnapshot,
     serializer: Box<dyn firecracker::MetricsLineSerializer>,
-    shared_logger_metrics: SharedLoggerMetrics,
+    shared_process_metrics: SharedProcessMetrics,
     patch_api_requests: PatchApiRequestMetrics,
     put_api_requests: PutApiRequestMetrics,
 }
@@ -274,9 +288,10 @@ impl Default for MetricsState {
             get_api_requests: GetApiRequestMetrics::default(),
             latencies_us: LatencyMetrics::default(),
             logger_metrics: LoggerMetrics::default(),
+            process_generation: 0,
             previous_successful: MetricsSnapshot::default(),
             serializer: Box::<firecracker::SystemMetricsLineSerializer>::default(),
-            shared_logger_metrics: SharedLoggerMetrics::default(),
+            shared_process_metrics: SharedProcessMetrics::default(),
             patch_api_requests: PatchApiRequestMetrics::default(),
             put_api_requests: PutApiRequestMetrics::default(),
         }
@@ -298,11 +313,17 @@ impl fmt::Debug for PreparedMetricsConfig {
 }
 
 impl MetricsState {
-    pub(crate) fn with_shared_logger_metrics(shared_logger_metrics: SharedLoggerMetrics) -> Self {
+    pub(crate) fn with_shared_process_metrics(
+        shared_process_metrics: SharedProcessMetrics,
+    ) -> Self {
         Self {
-            shared_logger_metrics,
+            shared_process_metrics,
             ..Self::default()
         }
+    }
+
+    pub(crate) fn signal_metrics(&self) -> SharedSignalMetrics {
+        self.shared_process_metrics.signal_metrics()
     }
 
     pub fn configure(&mut self, input: MetricsConfigInput) -> Result<(), MetricsConfigError> {
@@ -571,14 +592,29 @@ impl MetricsState {
         if self.sink.is_none() {
             return Ok(false);
         }
+        let Some(generation) = self.process_generation.checked_add(1) else {
+            self.logger_metrics.record_missed_metrics();
+            return Err(MetricsFlushError::ProcessGenerationExhausted);
+        };
+        let process_metrics = match self.shared_process_metrics.stable_snapshot() {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                self.logger_metrics.record_missed_metrics();
+                return Err(error);
+            }
+        };
+        self.process_generation = generation;
         let current = MetricsSnapshot {
-            diagnostics: diagnostics.clone(),
+            generation,
+            diagnostics: diagnostics.clone().merged_with(
+                MetricsDiagnostics::new().with_signal_metrics(process_metrics.signal_metrics),
+            ),
             deprecated_api: self.deprecated_api,
             get_api_requests: self.get_api_requests,
             latencies_us: self.latencies_us,
             logger_metrics: self.logger_metrics.with_log_counts(
-                self.shared_logger_metrics.missed_log_count(),
-                self.shared_logger_metrics.rate_limited_log_count(),
+                process_metrics.missed_log_count,
+                process_metrics.rate_limited_log_count,
             ),
             patch_api_requests: self.patch_api_requests,
             put_api_requests: self.put_api_requests,
@@ -788,17 +824,97 @@ pub struct SharedSignalMetrics {
 
 impl SharedSignalMetrics {
     pub fn record_sigpipe(&self) {
-        record_atomic_metric(&self.inner.sigpipe, 1);
+        record_atomic_metric_seq_cst(&self.inner.sigpipe, 1);
     }
 
     pub fn snapshot(&self) -> SignalMetrics {
-        SignalMetrics::new(self.inner.sigpipe.load(Ordering::Relaxed))
+        SignalMetrics::new(self.inner.sigpipe.load(Ordering::SeqCst))
+    }
+
+    #[cfg(test)]
+    fn set_sigpipe_for_test(&self, sigpipe: u64) {
+        self.inner.sigpipe.store(sigpipe, Ordering::SeqCst);
     }
 }
 
 #[derive(Debug, Default)]
 struct SharedSignalMetricsInner {
     sigpipe: AtomicU64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SharedProcessMetricsSnapshot {
+    missed_log_count: u64,
+    rate_limited_log_count: u64,
+    signal_metrics: SignalMetrics,
+}
+
+#[cfg(test)]
+type ProcessMetricsScanHook = Arc<dyn Fn(usize) + Send + Sync>;
+
+#[derive(Clone, Default)]
+pub(crate) struct SharedProcessMetrics {
+    logger_metrics: SharedLoggerMetrics,
+    signal_metrics: SharedSignalMetrics,
+    #[cfg(test)]
+    scan_hook: Option<ProcessMetricsScanHook>,
+}
+
+impl fmt::Debug for SharedProcessMetrics {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SharedProcessMetrics")
+            .field("logger_metrics", &"<shared>")
+            .field("signal_metrics", &"<shared>")
+            .finish()
+    }
+}
+
+impl SharedProcessMetrics {
+    pub(crate) fn logger_metrics(&self) -> SharedLoggerMetrics {
+        self.logger_metrics.clone()
+    }
+
+    pub(crate) fn signal_metrics(&self) -> SharedSignalMetrics {
+        self.signal_metrics.clone()
+    }
+
+    fn read_snapshot(&self) -> SharedProcessMetricsSnapshot {
+        SharedProcessMetricsSnapshot {
+            missed_log_count: self.logger_metrics.missed_log_count(),
+            rate_limited_log_count: self.logger_metrics.rate_limited_log_count(),
+            signal_metrics: self.signal_metrics.snapshot(),
+        }
+    }
+
+    fn stable_snapshot(&self) -> Result<SharedProcessMetricsSnapshot, MetricsFlushError> {
+        for _attempt in 0..PROCESS_METRICS_SNAPSHOT_ATTEMPTS {
+            let first = self.read_snapshot();
+            #[cfg(test)]
+            if let Some(hook) = &self.scan_hook {
+                hook(_attempt);
+            }
+            // Every producer update and both fixed-order scans are SeqCst. Equal monotonic
+            // vectors therefore prove that all three values existed together at this fence.
+            fence(Ordering::SeqCst);
+            let second = self.read_snapshot();
+            if first == second {
+                return Ok(second);
+            }
+        }
+
+        Err(MetricsFlushError::ProcessSnapshotBusy)
+    }
+
+    #[cfg(test)]
+    fn set_scan_hook(&mut self, hook: impl Fn(usize) + Send + Sync + 'static) {
+        self.scan_hook = Some(Arc::new(hook));
+    }
+
+    #[cfg(test)]
+    fn clear_scan_hook(&mut self) {
+        self.scan_hook = None;
+    }
 }
 
 impl GetApiRequestMetrics {
@@ -6701,6 +6817,21 @@ fn record_atomic_metric(metric: &AtomicU64, increment: u64) {
     record_atomic_metric_with_ordering(metric, increment, Ordering::Relaxed);
 }
 
+fn record_atomic_metric_seq_cst(metric: &AtomicU64, increment: u64) {
+    let mut current = metric.load(Ordering::SeqCst);
+    while current != u64::MAX {
+        match metric.compare_exchange_weak(
+            current,
+            current.saturating_add(increment),
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => return,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
 fn record_atomic_metric_release(metric: &AtomicU64, increment: u64) {
     record_atomic_metric_with_ordering(metric, increment, Ordering::Release);
 }
@@ -7298,8 +7429,8 @@ mod tests {
     use std::fs::{self, OpenOptions};
     use std::io::{self, ErrorKind};
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier, Mutex};
     use std::thread;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -7318,11 +7449,11 @@ mod tests {
         SharedEntropyDeviceMetrics, SharedMemoryHotplugDeviceMetrics,
         SharedMemoryHotplugLatencyMetricsInner, SharedMmdsMetrics, SharedNetworkInterfaceMetrics,
         SharedNetworkInterfaceMetricsRegistry, SharedPmemDeviceMetrics,
-        SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics, SharedSignalMetrics,
-        SharedVsockDeviceMetrics, SignalMetrics, VirtioNetworkLatencyAggregate, VsockDeviceMetrics,
+        SharedPmemDeviceMetricsRegistry, SharedProcessMetrics, SharedRtcDeviceMetrics,
+        SharedSignalMetrics, SharedVsockDeviceMetrics, SignalMetrics,
+        VirtioNetworkLatencyAggregate, VsockDeviceMetrics,
     };
     use crate::block::VirtioBlockLatencyAggregate;
-    use crate::logger::SharedLoggerMetrics;
     use crate::network::NetworkInterfaceConfigInput;
     use crate::network::VirtioNetworkBackendMetrics;
     use crate::serial::SerialOutputMetrics;
@@ -7591,6 +7722,25 @@ mod tests {
     impl super::firecracker::MetricsClock for CountingFixedClock {
         fn now(&self) -> SystemTime {
             self.calls.fetch_add(1, Ordering::Relaxed);
+            self.now
+        }
+    }
+
+    #[derive(Debug)]
+    struct ProcessEventClock {
+        now: SystemTime,
+        fired: Arc<AtomicBool>,
+        logger_metrics: crate::logger::SharedLoggerMetrics,
+        signal_metrics: SharedSignalMetrics,
+    }
+
+    impl super::firecracker::MetricsClock for ProcessEventClock {
+        fn now(&self) -> SystemTime {
+            if !self.fired.swap(true, Ordering::SeqCst) {
+                self.logger_metrics.record_missed_log();
+                self.logger_metrics.record_rate_limited_log();
+                self.signal_metrics.record_sigpipe();
+            }
             self.now
         }
     }
@@ -7909,6 +8059,7 @@ mod tests {
 
         assert_eq!(state.flush(), Ok(false));
         assert!(!state.is_configured());
+        assert_eq!(state.process_generation, 0);
 
         let output = TestMetricsOutput::default();
         state.sink = Some(super::MetricsSink::new(Box::new(output.clone())));
@@ -7947,8 +8098,7 @@ mod tests {
     fn repeated_flushes_emit_all_increment_fields_and_preserve_stores() {
         let output = TestMetricsOutput::default();
         let mut state = MetricsState::with_test_output(output.clone());
-        let shared_logger_metrics = SharedLoggerMetrics::default();
-        state.shared_logger_metrics = shared_logger_metrics.clone();
+        let shared_logger_metrics = state.shared_process_metrics.logger_metrics();
         let first = diagnostics_with_all_fields();
         let next = first
             .clone()
@@ -8105,11 +8255,12 @@ mod tests {
     fn independent_metrics_states_do_not_consume_each_others_deltas() {
         let first_output = TestMetricsOutput::default();
         let second_output = TestMetricsOutput::default();
-        let shared_logger_metrics = SharedLoggerMetrics::default();
+        let shared_process_metrics = SharedProcessMetrics::default();
+        let shared_logger_metrics = shared_process_metrics.logger_metrics();
         let mut first = MetricsState::with_test_output(first_output.clone());
         let mut second = MetricsState::with_test_output(second_output.clone());
-        first.shared_logger_metrics = shared_logger_metrics.clone();
-        second.shared_logger_metrics = shared_logger_metrics.clone();
+        first.shared_process_metrics = shared_process_metrics.clone();
+        second.shared_process_metrics = shared_process_metrics;
 
         shared_logger_metrics.record_missed_log();
         assert_eq!(first.flush(), Ok(true));
@@ -8413,11 +8564,300 @@ mod tests {
     }
 
     #[test]
+    fn stable_process_snapshot_retries_a_racing_event_into_one_generation() {
+        let output = TestMetricsOutput::default();
+        let mut state = MetricsState::with_test_output(output.clone());
+        let logger_metrics = state.shared_process_metrics.logger_metrics();
+        let signal_metrics = state.shared_process_metrics.signal_metrics();
+        let hook_calls = Arc::new(AtomicUsize::new(0));
+        state.shared_process_metrics.set_scan_hook({
+            let logger_metrics = logger_metrics.clone();
+            let signal_metrics = signal_metrics.clone();
+            let hook_calls = Arc::clone(&hook_calls);
+            move |attempt| {
+                hook_calls.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    logger_metrics.record_missed_log();
+                    logger_metrics.record_rate_limited_log();
+                    signal_metrics.record_sigpipe();
+                }
+            }
+        });
+
+        assert_eq!(state.flush(), Ok(true));
+
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(state.process_generation, 1);
+        assert_eq!(state.previous_successful.generation, 1);
+        let value = only_metrics_value(&output);
+        assert_eq!(value["logger"]["missed_log_count"], 1);
+        assert_eq!(value["logger"]["rate_limited_log_count"], 1);
+        assert_eq!(value["logger"]["metrics_fails"], 0);
+        assert_eq!(value["signals"]["sigpipe"], 1);
+    }
+
+    #[test]
+    fn process_snapshot_preserves_exact_totals_under_producer_contention() {
+        const PRODUCERS: usize = 4;
+        const EVENTS_PER_PRODUCER: usize = 5_000;
+
+        let output = TestMetricsOutput::default();
+        let mut state = MetricsState::with_test_output(output.clone());
+        let logger_metrics = state.shared_process_metrics.logger_metrics();
+        let signal_metrics = state.shared_process_metrics.signal_metrics();
+        let release = Arc::new(Barrier::new(PRODUCERS + 1));
+        let finished = Arc::new(AtomicUsize::new(0));
+        let handles = (0..PRODUCERS)
+            .map(|_| {
+                let logger_metrics = logger_metrics.clone();
+                let signal_metrics = signal_metrics.clone();
+                let release = Arc::clone(&release);
+                let finished = Arc::clone(&finished);
+                thread::spawn(move || {
+                    release.wait();
+                    for _ in 0..EVENTS_PER_PRODUCER {
+                        logger_metrics.record_missed_log();
+                        logger_metrics.record_rate_limited_log();
+                        signal_metrics.record_sigpipe();
+                    }
+                    finished.fetch_add(1, Ordering::SeqCst);
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let hook_calls = Arc::new(AtomicUsize::new(0));
+        state.shared_process_metrics.set_scan_hook({
+            let release = Arc::clone(&release);
+            let finished = Arc::clone(&finished);
+            let hook_calls = Arc::clone(&hook_calls);
+            move |attempt| {
+                hook_calls.fetch_add(1, Ordering::SeqCst);
+                if attempt == 0 {
+                    release.wait();
+                    while finished.load(Ordering::SeqCst) != PRODUCERS {
+                        std::hint::spin_loop();
+                    }
+                }
+            }
+        });
+
+        assert_eq!(state.flush(), Ok(true));
+        for handle in handles {
+            handle.join().expect("metrics producer should finish");
+        }
+
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 2);
+        let expected = u64::try_from(PRODUCERS * EVENTS_PER_PRODUCER)
+            .expect("test event count should fit u64");
+        let value = only_metrics_value(&output);
+        assert_eq!(value["logger"]["missed_log_count"], expected);
+        assert_eq!(value["logger"]["rate_limited_log_count"], expected);
+        assert_eq!(value["signals"]["sigpipe"], expected);
+    }
+
+    #[test]
+    fn saturated_process_events_are_already_represented_by_a_stable_cut() {
+        let output = TestMetricsOutput::default();
+        let mut state = MetricsState::with_test_output(output.clone());
+        let logger_metrics = state.shared_process_metrics.logger_metrics();
+        let signal_metrics = state.shared_process_metrics.signal_metrics();
+        logger_metrics.set_counts_for_test(u64::MAX, u64::MAX);
+        signal_metrics.set_sigpipe_for_test(u64::MAX);
+        state.shared_process_metrics.set_scan_hook({
+            let logger_metrics = logger_metrics.clone();
+            let signal_metrics = signal_metrics.clone();
+            move |_| {
+                logger_metrics.record_missed_log();
+                logger_metrics.record_rate_limited_log();
+                signal_metrics.record_sigpipe();
+            }
+        });
+
+        assert_eq!(state.flush(), Ok(true));
+
+        let value = only_metrics_value(&output);
+        assert_eq!(value["logger"]["missed_log_count"], u64::MAX);
+        assert_eq!(value["logger"]["rate_limited_log_count"], u64::MAX);
+        assert_eq!(value["signals"]["sigpipe"], u64::MAX);
+        assert_eq!(state.process_generation, 1);
+    }
+
+    #[test]
+    fn busy_process_snapshot_retains_events_and_successful_baseline_for_retry() {
+        let output = TestMetricsOutput::default();
+        let mut state = MetricsState::with_test_output(output.clone());
+        let logger_metrics = state.shared_process_metrics.logger_metrics();
+        let signal_metrics = state.shared_process_metrics.signal_metrics();
+        let hook_calls = Arc::new(AtomicUsize::new(0));
+        state.shared_process_metrics.set_scan_hook({
+            let logger_metrics = logger_metrics.clone();
+            let signal_metrics = signal_metrics.clone();
+            let hook_calls = Arc::clone(&hook_calls);
+            move |_| {
+                hook_calls.fetch_add(1, Ordering::SeqCst);
+                logger_metrics.record_missed_log();
+                logger_metrics.record_rate_limited_log();
+                signal_metrics.record_sigpipe();
+            }
+        });
+
+        let error = state
+            .flush()
+            .expect_err("continuous process changes must exhaust the bounded scan");
+        assert_eq!(error, MetricsFlushError::ProcessSnapshotBusy);
+        assert_eq!(
+            error.to_string(),
+            "failed to flush metrics: process snapshot remained busy"
+        );
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 64);
+        assert!(output.lines().is_empty());
+        assert_eq!(state.process_generation, 0);
+        assert_eq!(state.previous_successful.generation, 0);
+        assert_eq!(state.logger_metrics.missed_metrics_count, 1);
+
+        state.shared_process_metrics.clear_scan_hook();
+        assert_eq!(state.flush(), Ok(true));
+
+        assert_eq!(state.process_generation, 1);
+        assert_eq!(state.previous_successful.generation, 1);
+        let value = only_metrics_value(&output);
+        assert_eq!(value["logger"]["missed_log_count"], 64);
+        assert_eq!(value["logger"]["missed_metrics_count"], 1);
+        assert_eq!(value["logger"]["rate_limited_log_count"], 64);
+        assert_eq!(value["logger"]["metrics_fails"], 0);
+        assert_eq!(value["signals"]["sigpipe"], 64);
+    }
+
+    #[test]
+    fn exhausted_process_generation_fails_closed_without_aliasing_a_cut() {
+        let output = TestMetricsOutput::default();
+        let mut state = MetricsState::with_test_output(output.clone());
+        state.process_generation = u64::MAX;
+
+        let error = state
+            .flush()
+            .expect_err("an exhausted generation must fail closed");
+
+        assert_eq!(error, MetricsFlushError::ProcessGenerationExhausted);
+        assert_eq!(
+            error.to_string(),
+            "failed to flush metrics: process generation exhausted"
+        );
+        assert!(output.lines().is_empty());
+        assert_eq!(state.process_generation, u64::MAX);
+        assert_eq!(state.previous_successful.generation, 0);
+        assert_eq!(state.logger_metrics.missed_metrics_count, 1);
+    }
+
+    #[test]
+    fn events_after_a_frozen_process_cut_enter_the_next_generation() {
+        let output = TestMetricsOutput::default();
+        let mut state = MetricsState::with_test_output(output.clone());
+        let logger_metrics = state.shared_process_metrics.logger_metrics();
+        let signal_metrics = state.shared_process_metrics.signal_metrics();
+        state.clock = Box::new(ProcessEventClock {
+            now: UNIX_EPOCH + Duration::from_millis(1),
+            fired: Arc::new(AtomicBool::new(false)),
+            logger_metrics,
+            signal_metrics,
+        });
+
+        assert_eq!(state.flush(), Ok(true));
+        assert_eq!(state.flush(), Ok(true));
+
+        let values = metrics_values(&output);
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0]["logger"]["missed_log_count"], 0);
+        assert_eq!(values[0]["logger"]["rate_limited_log_count"], 0);
+        assert_eq!(values[0]["signals"]["sigpipe"], 0);
+        assert_eq!(values[1]["logger"]["missed_log_count"], 1);
+        assert_eq!(values[1]["logger"]["rate_limited_log_count"], 1);
+        assert_eq!(values[1]["signals"]["sigpipe"], 1);
+        assert_eq!(state.process_generation, 2);
+        assert_eq!(state.previous_successful.generation, 2);
+    }
+
+    #[test]
+    fn failed_output_retries_post_cut_events_from_the_prior_successful_generation() {
+        let output = TestMetricsOutput::default();
+        output.fail_next_write();
+        let mut state = MetricsState::with_test_output(output.clone());
+        let logger_metrics = state.shared_process_metrics.logger_metrics();
+        let signal_metrics = state.shared_process_metrics.signal_metrics();
+        state.clock = Box::new(ProcessEventClock {
+            now: UNIX_EPOCH + Duration::from_millis(1),
+            fired: Arc::new(AtomicBool::new(false)),
+            logger_metrics,
+            signal_metrics,
+        });
+
+        assert_eq!(
+            state.flush(),
+            Err(MetricsFlushError::Write(ErrorKind::BrokenPipe))
+        );
+        assert_eq!(state.process_generation, 1);
+        assert_eq!(state.previous_successful.generation, 0);
+        assert_eq!(state.flush(), Ok(true));
+
+        let value = only_metrics_value(&output);
+        assert_eq!(value["logger"]["missed_log_count"], 1);
+        assert_eq!(value["logger"]["missed_metrics_count"], 1);
+        assert_eq!(value["logger"]["rate_limited_log_count"], 1);
+        assert_eq!(value["logger"]["metrics_fails"], 0);
+        assert_eq!(value["signals"]["sigpipe"], 1);
+        assert_eq!(state.process_generation, 2);
+        assert_eq!(state.previous_successful.generation, 2);
+    }
+
+    #[test]
+    fn every_metrics_failure_stage_keeps_logger_metrics_fails_source_neutral() {
+        enum FailureStage {
+            Serialization,
+            Write,
+            AcceptedWrite,
+            Newline,
+            Flush,
+        }
+
+        for stage in [
+            FailureStage::Serialization,
+            FailureStage::Write,
+            FailureStage::AcceptedWrite,
+            FailureStage::Newline,
+            FailureStage::Flush,
+        ] {
+            let output = TestMetricsOutput::default();
+            let mut state = MetricsState::with_test_output(output.clone());
+            match stage {
+                FailureStage::Serialization => {
+                    state.serializer = Box::new(FailingMetricsLineSerializer(
+                        super::firecracker::MetricsLineBuildError::Serialization,
+                    ));
+                }
+                FailureStage::Write => output.fail_next_write(),
+                FailureStage::AcceptedWrite => output.accept_next_write_then_fail(),
+                FailureStage::Newline => output.fail_next_newline(),
+                FailureStage::Flush => output.fail_next_flush(),
+            }
+
+            assert!(state.flush().is_err());
+            state.serializer = Box::<super::firecracker::SystemMetricsLineSerializer>::default();
+            assert_eq!(state.flush(), Ok(true));
+
+            let values = metrics_values(&output);
+            let value = values
+                .last()
+                .expect("successful retry should publish a metrics line");
+            assert_eq!(value["logger"]["missed_metrics_count"], 1);
+            assert_eq!(value["logger"]["metrics_fails"], 0);
+        }
+    }
+
+    #[test]
     fn logger_metrics_include_delivery_and_rate_limit_counts() {
         let output = TestMetricsOutput::default();
         let mut state = MetricsState::with_test_output(output.clone());
-        let shared_logger_metrics = SharedLoggerMetrics::default();
-        state.shared_logger_metrics = shared_logger_metrics.clone();
+        let shared_logger_metrics = state.shared_process_metrics.logger_metrics();
 
         shared_logger_metrics.record_missed_log();
         shared_logger_metrics.record_rate_limited_log();

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -690,23 +690,33 @@ fields, newer balloon API/device fields, extra UART fields, and the ordinary
 block configuration-change value remain internal or are discarded at the
 public boundary. Adding an extension requires a separately versioned schema.
 
-One flush snapshots all producers and captures the Unix-millisecond clock once.
-It serializes that immutable value first into a counting writer and then into
+One flush first freezes missed-log, rate-limited-log, and SIGPIPE totals through
+two fixed-order `SeqCst` scans separated by a `SeqCst` fence. Equal monotonic
+vectors establish that fence as a common process cut; a racing update forces a
+retry, and 64 mismatches fail closed without resetting or consuming producer
+state. A stable cut receives a checked internal generation, joins
+control-owned missed-metrics state, and captures the Unix-millisecond clock
+once. Logger and SIGPIPE producers remain lock-free, collector-independent,
+and saturating; the signal handler performs no allocation, lock, I/O,
+collection, or unwind.
+
+The immutable value is serialized first into a counting writer and then into
 an exactly reserved fixed-capacity buffer. A complete JSON-plus-newline record
-may be at most 64 MiB. Count, allocation, serialization, or size failure occurs
-before sink access. Publication then writes all JSON bytes, exactly one newline,
-and flushes. The typed previous-successful baseline advances only after all
-three stages succeed; every failure increments `logger.missed_metrics_count`
-and retains the old baseline. A sink may accept a prefix before reporting an
-error, so a later success intentionally replays the interval with at-least-once,
-not exactly-once or durable, semantics.
+may be at most 64 MiB. Busy/generation, count, allocation, serialization, or
+size failure occurs before sink access. Publication then writes all JSON bytes,
+exactly one newline, and flushes. The typed previous-successful baseline
+advances only after all three stages succeed; every failed attempt increments
+`logger.missed_metrics_count` and retains the old baseline. A sink may accept a
+prefix before reporting an error, so a later success intentionally replays the
+interval with at-least-once, not exactly-once or durable, semantics.
 
 Issue #717 remains `NOT_PLANNED` because Firecracker exposes no
 `GET /vm/config` request metric field, so its absence from the schema is not
 filled with a Bangbang extension. Issue #738 remains `NOT_PLANNED` because
 Firecracker's write-failure path increments `missed_metrics_count`, not
-`logger.metrics_fails`; the required `logger.metrics_fails` field is emitted as
-zero until an exact producer exists.
+`logger.metrics_fails`; exact pinned v1.16.0 source has no producer for the
+latter, so Bangbang terminally classifies the required field as source-neutral
+zero rather than inventing a duplicate sink-failure counter.
 
 ### Metrics triggers and errors
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2546,6 +2546,19 @@ failure increments `missed_metrics_count`; ambiguous accepted prefixes replay
 at least once. Tests also require closed Display/Debug errors to omit paths,
 configured IDs, fragments, and values.
 
+Process-cut tests place missed-log, rate-limited-log, and SIGPIPE events between
+two `SeqCst` scans without sleeps, force all 64 busy retries, then require a
+later stable generation to contain every event plus one missed attempt. They
+also inject events after a frozen cut, combine that race with accepted-prefix,
+write, newline, flush, and serialization failures, exercise exact sums under
+multi-threaded contention and `u64::MAX` saturation, and prove checked
+generation exhaustion cannot alias a cut. Every failure-stage retry keeps
+`logger.metrics_fails` source-neutral zero. Process/VMM and signed executable
+coverage obtain the SIGPIPE facade from the same controller as metrics,
+and publish one live signal in the first following generation while the handler
+remains atomic-only. Deterministic Process/VMM coverage additionally publishes
+a zero SIGPIPE interval in the next successful generation.
+
 Process-lifecycle tests cover configuration-origin-independent initial output,
 preboot scheduler dormancy, a session-epoch deadline, Running and Paused
 periodic output, due work that is not starved by ready API clients, periodic

--- a/tools/firecracker-capability-audit/src/metrics_process_validate.rs
+++ b/tools/firecracker-capability-audit/src/metrics_process_validate.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 const EXPECTED_PROCESS_FIELDS: usize = 69;
-const COMPLETED_DELIVERY_ISSUES: &[&str] = &["#1827", "#1828"];
+const COMPLETED_DELIVERY_ISSUES: &[&str] = &["#1827", "#1828", "#1829"];
 
 /// Validate exact process-producer authority against the resolved metrics schema.
 pub fn validate_metrics_process_producers(
@@ -192,6 +192,19 @@ fn validate_record(
             record.field_id
         ));
     }
+    if delivery_issue == "#1829" {
+        let expected = if path == "logger.metrics_fails" {
+            MetricsProcessProducerDisposition::SourceNeutral
+        } else {
+            MetricsProcessProducerDisposition::Implemented
+        };
+        if record.disposition != expected {
+            errors.push(format!(
+                "completed #1829 process metric has the wrong exact disposition: {}",
+                record.field_id
+            ));
+        }
+    }
 
     match record.disposition {
         MetricsProcessProducerDisposition::Planned => {
@@ -354,11 +367,28 @@ fn expected_rationale(
         ("#1828", MetricsProcessProducerBoundary::SuccessfulInnerVmmOperation) => {
             "Pinned Firecracker stores this latency only after the corresponding VMM operation succeeds; Bangbang commits at the functional action boundary before outcome logging and folds automatic snapshot-load resume into load."
         }
-        ("#1829", MetricsProcessProducerBoundary::LoggerLifecycle) => {
-            "Delivery child #1829 owns generation-consistent logger lifecycle capture and remains unresolved in this audit slice."
+        ("#1829", MetricsProcessProducerBoundary::LoggerLifecycle)
+            if path == "logger.metrics_fails" =>
+        {
+            "Pinned Firecracker v1.16.0 defines logger.metrics_fails but has no producer; Bangbang keeps the canonical field source-neutral at zero and records every metrics publication failure only in missed_metrics_count."
+        }
+        ("#1829", MetricsProcessProducerBoundary::LoggerLifecycle)
+            if path == "logger.missed_log_count" =>
+        {
+            "Pinned Firecracker increments this counter when logger delivery fails; Bangbang records actual bounded-queue, timeout, writer, emergency, and batch-loss stages and freezes the monotonic total in the shared process cut."
+        }
+        ("#1829", MetricsProcessProducerBoundary::LoggerLifecycle)
+            if path == "logger.missed_metrics_count" =>
+        {
+            "Pinned Firecracker increments this counter when metrics publication fails; Bangbang records each failed stable-cut, build, or output attempt and advances its prior successful baseline only after complete line flush."
+        }
+        ("#1829", MetricsProcessProducerBoundary::LoggerLifecycle)
+            if path == "logger.rate_limited_log_count" =>
+        {
+            "Pinned Firecracker increments this counter when logger rate limiting rejects a record; Bangbang records limiter denial or contention fallback and freezes the monotonic total in the shared process cut."
         }
         ("#1829", MetricsProcessProducerBoundary::SignalLifecycle) => {
-            "Delivery child #1829 owns the generation-consistent SIGPIPE capture boundary and remains unresolved in this audit slice."
+            "Pinned Firecracker increments SIGPIPE and returns from its handler; Bangbang performs one atomic-only saturating update and freezes it with logger totals in the shared process cut."
         }
         ("#1830", MetricsProcessProducerBoundary::SignalLifecycle) => {
             "Delivery child #1830 owns fatal process-signal classification and remains unresolved in this audit slice."

--- a/tools/firecracker-capability-audit/tests/metrics_schema.rs
+++ b/tools/firecracker-capability-audit/tests/metrics_schema.rs
@@ -101,7 +101,17 @@ fn checked_process_producer_audit_is_canonical_and_exact() {
                 record.disposition == MetricsProcessProducerDisposition::Implemented
             })
             .count(),
-        56
+        60
+    );
+    assert_eq!(
+        audit
+            .records
+            .iter()
+            .filter(|record| {
+                record.disposition == MetricsProcessProducerDisposition::SourceNeutral
+            })
+            .count(),
+        1
     );
     assert_eq!(
         audit
@@ -109,8 +119,20 @@ fn checked_process_producer_audit_is_canonical_and_exact() {
             .iter()
             .filter(|record| record.disposition == MetricsProcessProducerDisposition::Planned)
             .count(),
-        13
+        8
     );
+    for record in audit
+        .records
+        .iter()
+        .filter(|record| record.delivery_issue == "#1829")
+    {
+        let expected = if record.field_id == "static:logger.metrics_fails" {
+            MetricsProcessProducerDisposition::SourceNeutral
+        } else {
+            MetricsProcessProducerDisposition::Implemented
+        };
+        assert_eq!(record.disposition, expected, "{}", record.field_id);
+    }
 
     let error = validate_metrics_process_producers(&audit, &authority, &root, AuditMode::Final)
         .expect_err("planned downstream process producers must fail global final mode")
@@ -186,7 +208,7 @@ fn process_producer_audit_rejects_boundary_child_and_completion_drift() {
     let downstream = premature
         .records
         .iter_mut()
-        .find(|record| record.delivery_issue == "#1829")
+        .find(|record| record.delivery_issue == "#1830")
         .expect("downstream record must exist");
     downstream.disposition = MetricsProcessProducerDisposition::Implemented;
     downstream.implementation.push(Reference::Local {
@@ -212,6 +234,30 @@ fn process_producer_audit_rejects_neutral_aliases_and_bad_evidence() {
     assert!(
         process_validation_error(&neutral)
             .contains("completed process metrics producer must be implemented")
+    );
+
+    let mut fabricated_metrics_fails_producer = checked_process_audit();
+    fabricated_metrics_fails_producer
+        .records
+        .iter_mut()
+        .find(|record| record.field_id == "static:logger.metrics_fails")
+        .expect("logger metrics_fails record must exist")
+        .disposition = MetricsProcessProducerDisposition::Implemented;
+    assert!(
+        process_validation_error(&fabricated_metrics_fails_producer)
+            .contains("completed #1829 process metric has the wrong exact disposition")
+    );
+
+    let mut neutral_missed_log = checked_process_audit();
+    neutral_missed_log
+        .records
+        .iter_mut()
+        .find(|record| record.field_id == "static:logger.missed_log_count")
+        .expect("missed log record must exist")
+        .disposition = MetricsProcessProducerDisposition::SourceNeutral;
+    assert!(
+        process_validation_error(&neutral_missed_log)
+            .contains("completed #1829 process metric has the wrong exact disposition")
     );
 
     let mut missing = checked_process_audit();


### PR DESCRIPTION
## Summary

- give each controller one shared process-metrics identity and freeze missed-log, rate-limited-log, and SIGPIPE totals with a bounded sequentially consistent stable cut
- assign checked internal generations, fail closed after 64 racing scans, and preserve the success-only publication baseline across every retryable failure
- keep `logger.metrics_fails` source-neutral, promote exactly the five #1829 audit records, and document/test the concurrency and retry contract

## Scope exclusions

- fatal signals, panic convergence, and seccomp accounting remain in #1830
- device producers and terminal corpus certification remain in #1789 and #1790

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate --metrics-schema-final`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target integration-test Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test hvf_lifecycle --test guest_boot --test native_v2_process`
- `scripts/run-integration-tests.sh --test app_sandbox`
- `scripts/run-integration-tests.sh --test production_bundle`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`

Closes #1829

Parent delivery context: #1788
