### PR TITLE
feat: add exact device metrics producer audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- validate
 cargo check --workspace --all-targets --all-features --locked
 ```
 
+The ordinary audit also validates the exact nonterminal 231-field device
+producer authority for #1789: 216 planned records and 15 provisional
+platform-zero records partitioned across its nine delivery children.
+
 The terminal 69-field API/process metrics producer scope has a separate
 fail-closed certification gate:
 

--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -35,6 +35,11 @@ For commands and test-layer selection, see the
   process producer profile. It records one closed producer boundary, delivery
   child, disposition, rationale, and evidence set per field without duplicating
   the schema or shared field policy.
+- [`metrics-device-producer-audit.json`](metrics-device-producer-audit.json) is
+  the human-owned delivery audit for the exact 231 fields assigned to device
+  producer profiles. It records a closed operation boundary and one of the nine
+  #1789 delivery children per field. Its 216 planned and 15 provisional
+  platform-zero records are intentionally nonterminal and carry no evidence.
 - Contract Markdown files are human-owned evidence ledgers. They define a
   selected capability family, its exact supported or excluded boundary, and
   the implementation and validation evidence for its dispositions.
@@ -75,7 +80,7 @@ reviewed delta.
 | [Snapshot Wave 6](snapshot-wave6-contract.md) | Exact 70-row load, artifact, version, device, tool, time/identity, portability, and downstream-owner certification |
 | [Observability, tools, and specification](observability-tools-specification-contract.md) | Exact Wave 7 ownership, core API certification, x86 CPUID/MSR platform exclusions, and retained downstream handoffs |
 | [Logger producers](logger-contract.md) | Certified 11-row logger aggregate with exact 468-invocation source closure, 24 implemented classes, 7 exact platform/developer exclusions, no planned producer classes, safe fields, and bounded default-stdout admission/forwarding policy |
-| [Metrics schema and process producers](metrics-contract.md) | Terminal twelve-row #1787 API/schema certification, exact 24-root/243-static-field arm64 line shape, 24/29/5 configured dynamic families, source fingerprints, closed units/reset/aggregation policy, and a terminal 69-field #1788 process audit with 64 implemented, one source-neutral, and four platform-zero records |
+| [Metrics schema and producer audits](metrics-contract.md) | Terminal twelve-row #1787 API/schema certification, exact 24-root/243-static-field arm64 line shape, 24/29/5 configured dynamic families, source fingerprints, closed units/reset/aggregation policy, a terminal 69-field #1788 process audit, and an exact nonterminal 231-field #1789 device audit |
 
 ## Dispositions
 
@@ -129,7 +134,7 @@ capability records as `implemented-and-verified`. It does not ignore a logger
 class or alter another capability's disposition. Repository-global
 `validate --final` remains the stronger all-capabilities completion gate and
 must continue to fail while any unrelated `audit-required` or
-`missing-platform-feasible` record remains.
+`missing-platform-feasible` record or device producer remains nonterminal.
 
 ## Scoped Metrics Schema Certification
 
@@ -169,6 +174,11 @@ platform-zero device profiles remain #1789-owned, while both aggregate rows
 remain `audit-required` for #1790; neither downstream scope is promoted by this
 gate.
 
+All existing scoped final commands also parse and validate the exact device
+audit in delivery mode. This prevents malformed membership, child routing, or
+provisional state from being ignored without treating any device producer as
+complete. The future device-final composition remains owned by #1847.
+
 ## Contributor Update Rule
 
 Every pull request that changes a Firecracker-facing capability must update all
@@ -183,4 +193,5 @@ normal repository checks using
 Review candidate identity changes before updating a machine-owned projection.
 Never use regeneration to alter `capabilities.json`,
 `logger-producer-audit.json`, `metrics-process-producer-audit.json`, or the
-human policy projections in `metrics-schema.json`.
+human policy projections in `metrics-schema.json`. The human-owned
+`metrics-device-producer-audit.json` likewise has no regeneration command.

--- a/compat/firecracker/v1.16.0/metrics-contract.md
+++ b/compat/firecracker/v1.16.0/metrics-contract.md
@@ -2,15 +2,15 @@
 
 This contract defines the checked public metrics-line authority used by
 Bangbang for the pinned Firecracker v1.16.0 arm64 target. It separates schema
-presence, shared producer policy, and exact producer certification. The
-machine-readable artifacts are [`metrics-schema.json`](metrics-schema.json)
-and
-[`metrics-process-producer-audit.json`](metrics-process-producer-audit.json);
+presence, shared producer policy, and exact producer certification. Its
+machine-readable artifacts are [`metrics-schema.json`](metrics-schema.json),
+[`metrics-process-producer-audit.json`](metrics-process-producer-audit.json),
+and [`metrics-device-producer-audit.json`](metrics-device-producer-audit.json);
 this document explains how to interpret and update them.
 
 ## Authority Boundary
 
-The checked contract has three layers:
+The checked contract has four layers:
 
 - `metrics-schema.json.source` is machine-derived from the pinned Rust serializers and
   `tests/host_tools/fcmetrics.py`. It owns inputs and Git blobs, exact roots,
@@ -26,6 +26,10 @@ The checked contract has three layers:
   field's closed production boundary, delivery child, current disposition,
   rationale, and evidence without copying source shape, unit, reset, or
   aggregation policy.
+- `metrics-device-producer-audit.json` is the human-owned delivery audit of the
+  exact fields selected by device producer profiles. It records each field's
+  closed operation boundary, concrete #1789 child, current disposition,
+  rationale, and eventual anchored evidence without copying schema policy.
 
 The policy mapping is an exact bijection over the source fields. Policy cannot
 create or remove schema identities, and source regeneration cannot manufacture
@@ -37,11 +41,11 @@ The runtime compiles this authority into the canonical serializer and an exact
 descriptor-equality test. #1823 certifies the bounded #1787 API/schema slice,
 including the schema-runtime timestamp producer. #1788 certifies the exact
 API, process, logger, signal, boot, and lifecycle producers through two
-implemented aggregate profiles and the field-level audit. #1789 still owns
-device, MMDS, vCPU, time/device, configured-key, and retained-neutral
-producers. `corpus:metrics` and the cross-producer aggregate semantic remain
-#1790-owned. A required zero therefore proves wire-shape completeness only,
-never producer completion.
+implemented aggregate profiles and the field-level process audit. The checked
+device audit now assigns every #1789 field to one concrete delivery child, but
+all records remain nonterminal. `corpus:metrics` and the cross-producer
+aggregate semantic remain #1790-owned. A required zero therefore proves
+wire-shape completeness only, never producer completion.
 
 ## Terminal API and Schema Certification
 
@@ -201,6 +205,34 @@ Linux `SYS_SECCOMP` SIGSYS faults, but macOS exposes no Linux seccomp filter
 installation or fault producer and Bangbang rejects both runtime seccomp CLI
 forms. The generic SIGSYS handler preserves exit-code compatibility only and
 must never be aliased into `seccomp.num_faults`.
+
+## Nonterminal Device Producer Audit
+
+The device audit is an exact, lexicographically sorted bijection over all 231
+schema fields owned by device producer profiles. Missing, duplicate, stale,
+reordered, or differently owned identities fail closed. Its delivery partition
+is fixed at 23 fields for #1838, 38 for #1839, 20 for #1840, 48 for #1841,
+five for #1842, 57 for #1843, 14 for #1844, 11 for #1845, and 15 for #1846.
+Static and configured identities remain distinct; exact suffix routing splits
+mapped network fields from tap-oriented gaps and applicable vCPU exits from
+retained PIO/KVM-clock fields.
+
+The initial audit contains 216 `planned` records and 15
+`provisional-platform-zero` records. Both dispositions are nonterminal, carry
+empty implementation and validation arrays, and have no platform exclusion.
+The provisional records are the six retained i8042 fields plus nine vCPU
+PIO/KVM-clock fields; this label does not claim that the terminal platform
+evidence required by #1846 already exists.
+
+Later producer children may replace only their exact records with terminal
+`implemented`, `source-neutral`, or `platform-zero` dispositions. Terminal
+records require sorted implementation and validation reference lists; each
+list must include local evidence whose anchors resolve in tracked regular
+files. Terminal platform-zero additionally requires the complete structured
+platform-exclusion evidence. Ordinary and all existing scoped validation modes
+consume this audit in delivery mode; repository-wide final mode rejects every
+nonterminal device record. A scoped device-final command and certification
+composer remain #1847 work.
 
 ## Exact Arm64 Shape
 
@@ -395,16 +427,17 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- validate --metric
 `validate --metrics-schema-final` runs repository delivery validation, the
 metrics authority delivery gate, the exact twelve-row #1787 certification, and
 the logger producer delivery gate needed by metrics collection. It validates
-the exact 69-field process audit in delivery mode. It permits only the
-completed process profiles, explicit #1789 device handoffs, and retained #1790
-aggregate rows.
+the exact 69-field process audit and 231-field device audit in delivery mode.
+It permits only the completed process profiles, explicit nonterminal #1789
+device handoffs, and retained #1790 aggregate rows.
 
 `validate --metrics-process-final` composes that schema certification with
 final-mode process-audit validation and logger delivery validation. It requires
 all 69 records to be terminal with their exact child, boundary, rationale,
 disposition, and tracked evidence: 64 implemented, one source-neutral, and four
 platform-zero. It does not require the ten planned or four platform-zero
-device profiles to complete and does not promote either #1790 aggregate.
+device profiles or their 231 field records to complete and does not promote
+either #1790 aggregate.
 Repository-global `validate --final` remains the stronger all-capability gate.
 
 With an explicit clean sibling at the pinned commit, compare every source
@@ -427,8 +460,9 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- \
 
 The destination must not exist and cannot directly, lexically, or through a
 symlink alias any checked inventory file. Review exact source changes, then
-manually reconcile them with human policy and, when process-profile membership
-changes, the process audit. Regeneration never writes either human-owned layer.
+manually reconcile them with human policy and, when producer-profile membership
+changes, the process and device audits. Regeneration never writes any
+human-owned producer audit.
 Never copy old policy onto a changed identity without reviewing its unit,
 reset, aggregation, architecture, cardinality, producer owner, disposition,
 rationale, boundary, delivery child, and evidence.

--- a/compat/firecracker/v1.16.0/metrics-device-producer-audit.json
+++ b/compat/firecracker/v1.16.0/metrics-device-producer-audit.json
@@ -1,0 +1,2089 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "version": "1.16.0",
+    "commit": "d83d72b710361a10294480131377b1b00b163af8",
+    "target": "aarch64-macos-hvf"
+  },
+  "records": [
+    {
+      "field_id": "dynamic:block_{drive_id}.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.activate_fails` is assigned to #1841 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.cfg_fails",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.cfg_fails` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.event_fails` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.execute_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.execute_fails` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.flush_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.flush_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.invalid_reqs_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.invalid_reqs_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.io_engine_throttled_events",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.io_engine_throttled_events` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.no_avail_buffer",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.no_avail_buffer` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.queue_event_count` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.rate_limiter_event_count",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.rate_limiter_event_count` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.rate_limiter_throttled_events",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.rate_limiter_throttled_events` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_agg.max_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_agg.min_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_agg.sum_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_bytes",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_bytes` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.read_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.remaining_reqs_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.remaining_reqs_count` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.update_count",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.update_count` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.update_fails",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.update_fails` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_agg.max_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_agg.min_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_agg.sum_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_bytes",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_bytes` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:block_{drive_id}.write_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.activate_fails` is assigned to #1843 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.cfg_fails",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.cfg_fails` is assigned to #1843 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.event_fails` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.mac_address_updates",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.mac_address_updates` is assigned to #1844 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.no_rx_avail_buffer",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.no_rx_avail_buffer` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.no_tx_avail_buffer",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.no_tx_avail_buffer` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_bytes_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.rx_bytes_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.rx_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_event_rate_limiter_count",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.rx_event_rate_limiter_count` is assigned to #1843 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.rx_fails` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_packets_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.rx_packets_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.rx_queue_event_count` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_rate_limiter_throttled",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.rx_rate_limiter_throttled` is assigned to #1843 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.rx_tap_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.rx_tap_event_count` is assigned to #1844 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_read_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tap_read_fails` is assigned to #1844 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_write_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tap_write_agg.max_us` is assigned to #1844 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_write_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tap_write_agg.min_us` is assigned to #1844 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_write_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tap_write_agg.sum_us` is assigned to #1844 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tap_write_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tap_write_fails` is assigned to #1844 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_bytes_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_bytes_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_fails` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_malformed_frames",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_malformed_frames` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_packets_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_packets_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_queue_event_count` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_rate_limiter_event_count",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_rate_limiter_event_count` is assigned to #1843 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_rate_limiter_throttled",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_rate_limiter_throttled` is assigned to #1843 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_remaining_reqs_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_remaining_reqs_count` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:net_{iface_id}.tx_spoofed_mac_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net_{iface_id}.tx_spoofed_mac_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1842",
+      "rationale": "Pinned Firecracker field `vhost_user_block_{drive_id}.activate_fails` is assigned to #1842 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.activate_time_us",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1842",
+      "rationale": "Pinned Firecracker field `vhost_user_block_{drive_id}.activate_time_us` is assigned to #1842 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.cfg_fails",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1842",
+      "rationale": "Pinned Firecracker field `vhost_user_block_{drive_id}.cfg_fails` is assigned to #1842 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.config_change_time_us",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1842",
+      "rationale": "Pinned Firecracker field `vhost_user_block_{drive_id}.config_change_time_us` is assigned to #1842 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "dynamic:vhost_user_block_{drive_id}.init_time_us",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1842",
+      "rationale": "Pinned Firecracker field `vhost_user_block_{drive_id}.init_time_us` is assigned to #1842 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.activate_fails` is assigned to #1839 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.deflate_count",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.deflate_count` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.event_fails` is assigned to #1839 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.free_page_hint_count",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.free_page_hint_count` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.free_page_hint_fails",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.free_page_hint_fails` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.free_page_hint_freed",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.free_page_hint_freed` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.free_page_report_count",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.free_page_report_count` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.free_page_report_fails",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.free_page_report_fails` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.free_page_report_freed",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.free_page_report_freed` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.inflate_count",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.inflate_count` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.stats_update_fails",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.stats_update_fails` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:balloon.stats_updates_count",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `balloon.stats_updates_count` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.activate_fails` is assigned to #1841 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.cfg_fails",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.cfg_fails` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.event_fails` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.execute_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.execute_fails` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.flush_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.flush_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.invalid_reqs_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.invalid_reqs_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.io_engine_throttled_events",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.io_engine_throttled_events` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.no_avail_buffer",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.no_avail_buffer` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.queue_event_count` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.rate_limiter_event_count",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.rate_limiter_event_count` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.rate_limiter_throttled_events",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.rate_limiter_throttled_events` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.read_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.read_agg.max_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.read_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.read_agg.min_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.read_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.read_agg.sum_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.read_bytes",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.read_bytes` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.read_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.read_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.remaining_reqs_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.remaining_reqs_count` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.update_count",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.update_count` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.update_fails",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.update_fails` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.write_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.write_agg.max_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.write_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.write_agg.min_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.write_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.write_agg.sum_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.write_bytes",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.write_bytes` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:block.write_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1841",
+      "rationale": "Pinned Firecracker field `block.write_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:entropy.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `entropy.activate_fails` is assigned to #1838 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:entropy.entropy_bytes",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `entropy.entropy_bytes` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:entropy.entropy_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `entropy.entropy_event_count` is assigned to #1838 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:entropy.entropy_event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `entropy.entropy_event_fails` is assigned to #1838 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:entropy.entropy_rate_limiter_throttled",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `entropy.entropy_rate_limiter_throttled` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:entropy.host_rng_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `entropy.host_rng_fails` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:entropy.rate_limiter_event_count",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `entropy.rate_limiter_event_count` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:i8042.error_count",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `i8042.error_count` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:i8042.missed_read_count",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `i8042.missed_read_count` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:i8042.missed_write_count",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `i8042.missed_write_count` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:i8042.read_count",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `i8042.read_count` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:i8042.reset_count",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `i8042.reset_count` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:i8042.write_count",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `i8042.write_count` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:interrupts.config_updates",
+      "boundary": "interrupt-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `interrupts.config_updates` is assigned to #1845 at the `interrupt-lifecycle` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:interrupts.triggers",
+      "boundary": "interrupt-lifecycle",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `interrupts.triggers` is assigned to #1845 at the `interrupt-lifecycle` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.activate_fails` is assigned to #1839 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.plug_agg.max_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.plug_agg.min_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.plug_agg.sum_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_bytes",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.plug_bytes` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_count",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.plug_count` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.plug_fails",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.plug_fails` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.queue_event_count` is assigned to #1839 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.queue_event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.queue_event_fails` is assigned to #1839 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.state_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.state_agg.max_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.state_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.state_agg.min_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.state_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.state_agg.sum_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.state_count",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.state_count` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.state_fails",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.state_fails` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_agg.max_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_agg.min_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_agg.sum_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_all_agg.max_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_all_agg.min_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_all_agg.sum_us` is assigned to #1839 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_count",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_all_count` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_all_fails",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_all_fails` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_bytes",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_bytes` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_count",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_count` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_discard_fails",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_discard_fails` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:memory_hotplug.unplug_fails",
+      "boundary": "device-state",
+      "disposition": "planned",
+      "delivery_issue": "#1839",
+      "rationale": "Pinned Firecracker field `memory_hotplug.unplug_fails` is assigned to #1839 at the `device-state` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.connections_created",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.connections_created` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.connections_destroyed",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.connections_destroyed` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.rx_accepted",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.rx_accepted` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.rx_accepted_err",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.rx_accepted_err` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.rx_accepted_unusual",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.rx_accepted_unusual` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.rx_bad_eth",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.rx_bad_eth` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.rx_count",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.rx_count` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.rx_invalid_token",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.rx_invalid_token` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.rx_no_token",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.rx_no_token` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.tx_bytes",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.tx_bytes` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.tx_count",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.tx_count` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.tx_errors",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.tx_errors` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:mmds.tx_frames",
+      "boundary": "mmds-data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `mmds.tx_frames` is assigned to #1843 at the `mmds-data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.activate_fails` is assigned to #1843 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.cfg_fails",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.cfg_fails` is assigned to #1843 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.event_fails` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.mac_address_updates",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net.mac_address_updates` is assigned to #1844 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.no_rx_avail_buffer",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.no_rx_avail_buffer` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.no_tx_avail_buffer",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.no_tx_avail_buffer` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.rx_bytes_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.rx_bytes_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.rx_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.rx_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.rx_event_rate_limiter_count",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.rx_event_rate_limiter_count` is assigned to #1843 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.rx_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.rx_fails` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.rx_packets_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.rx_packets_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.rx_queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.rx_queue_event_count` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.rx_rate_limiter_throttled",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.rx_rate_limiter_throttled` is assigned to #1843 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.rx_tap_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net.rx_tap_event_count` is assigned to #1844 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tap_read_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net.tap_read_fails` is assigned to #1844 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tap_write_agg.max_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net.tap_write_agg.max_us` is assigned to #1844 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tap_write_agg.min_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net.tap_write_agg.min_us` is assigned to #1844 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tap_write_agg.sum_us",
+      "boundary": "latency",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net.tap_write_agg.sum_us` is assigned to #1844 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tap_write_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1844",
+      "rationale": "Pinned Firecracker field `net.tap_write_fails` is assigned to #1844 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_bytes_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_bytes_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_fails` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_malformed_frames",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_malformed_frames` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_packets_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_packets_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_queue_event_count` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_rate_limiter_event_count",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_rate_limiter_event_count` is assigned to #1843 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_rate_limiter_throttled",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_rate_limiter_throttled` is assigned to #1843 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_remaining_reqs_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_remaining_reqs_count` is assigned to #1843 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:net.tx_spoofed_mac_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1843",
+      "rationale": "Pinned Firecracker field `net.tx_spoofed_mac_count` is assigned to #1843 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:pmem.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `pmem.activate_fails` is assigned to #1838 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:pmem.cfg_fails",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `pmem.cfg_fails` is assigned to #1838 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:pmem.event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `pmem.event_fails` is assigned to #1838 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:pmem.queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `pmem.queue_event_count` is assigned to #1838 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:pmem.rate_limiter_event_count",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `pmem.rate_limiter_event_count` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:pmem.rate_limiter_throttled_events",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `pmem.rate_limiter_throttled_events` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:rtc.error_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `rtc.error_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:rtc.missed_read_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `rtc.missed_read_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:rtc.missed_write_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `rtc.missed_write_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:uart.error_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `uart.error_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:uart.flush_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `uart.flush_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:uart.missed_read_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `uart.missed_read_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:uart.missed_write_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `uart.missed_write_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:uart.rate_limiter_dropped_bytes",
+      "boundary": "rate-limiter",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `uart.rate_limiter_dropped_bytes` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:uart.read_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `uart.read_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:uart.write_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1838",
+      "rationale": "Pinned Firecracker field `uart.write_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_io_in",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `vcpu.exit_io_in` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_io_in_agg.max_us",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `vcpu.exit_io_in_agg.max_us` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_io_in_agg.min_us",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `vcpu.exit_io_in_agg.min_us` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_io_in_agg.sum_us",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `vcpu.exit_io_in_agg.sum_us` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_io_out",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `vcpu.exit_io_out` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_io_out_agg.max_us",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `vcpu.exit_io_out_agg.max_us` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_io_out_agg.min_us",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `vcpu.exit_io_out_agg.min_us` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_io_out_agg.sum_us",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `vcpu.exit_io_out_agg.sum_us` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_read",
+      "boundary": "vcpu-exit",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `vcpu.exit_mmio_read` is assigned to #1845 at the `vcpu-exit` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_read_agg.max_us",
+      "boundary": "vcpu-exit",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `vcpu.exit_mmio_read_agg.max_us` is assigned to #1845 at the `vcpu-exit` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_read_agg.min_us",
+      "boundary": "vcpu-exit",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `vcpu.exit_mmio_read_agg.min_us` is assigned to #1845 at the `vcpu-exit` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_read_agg.sum_us",
+      "boundary": "vcpu-exit",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `vcpu.exit_mmio_read_agg.sum_us` is assigned to #1845 at the `vcpu-exit` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_write",
+      "boundary": "vcpu-exit",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `vcpu.exit_mmio_write` is assigned to #1845 at the `vcpu-exit` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_write_agg.max_us",
+      "boundary": "vcpu-exit",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `vcpu.exit_mmio_write_agg.max_us` is assigned to #1845 at the `vcpu-exit` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_write_agg.min_us",
+      "boundary": "vcpu-exit",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `vcpu.exit_mmio_write_agg.min_us` is assigned to #1845 at the `vcpu-exit` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.exit_mmio_write_agg.sum_us",
+      "boundary": "vcpu-exit",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `vcpu.exit_mmio_write_agg.sum_us` is assigned to #1845 at the `vcpu-exit` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.failures",
+      "boundary": "vcpu-failure",
+      "disposition": "planned",
+      "delivery_issue": "#1845",
+      "rationale": "Pinned Firecracker field `vcpu.failures` is assigned to #1845 at the `vcpu-failure` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vcpu.kvmclock_ctrl_fails",
+      "boundary": "architecture-retained",
+      "disposition": "provisional-platform-zero",
+      "delivery_issue": "#1846",
+      "rationale": "Pinned Firecracker field `vcpu.kvmclock_ctrl_fails` is assigned to #1846 at the `architecture-retained` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.activate_fails",
+      "boundary": "activation",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.activate_fails` is assigned to #1840 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.cfg_fails",
+      "boundary": "configuration",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.cfg_fails` is assigned to #1840 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.conn_event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.conn_event_fails` is assigned to #1840 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.conns_added",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.conns_added` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.conns_killed",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.conns_killed` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.conns_removed",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.conns_removed` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.ev_queue_event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.ev_queue_event_fails` is assigned to #1840 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.killq_resync",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.killq_resync` is assigned to #1840 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.muxer_event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.muxer_event_fails` is assigned to #1840 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.rx_bytes_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.rx_bytes_count` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.rx_packets_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.rx_packets_count` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.rx_queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.rx_queue_event_count` is assigned to #1840 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.rx_queue_event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.rx_queue_event_fails` is assigned to #1840 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.rx_read_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.rx_read_fails` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.tx_bytes_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.tx_bytes_count` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.tx_flush_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.tx_flush_fails` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.tx_packets_count",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.tx_packets_count` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.tx_queue_event_count",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.tx_queue_event_count` is assigned to #1840 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.tx_queue_event_fails",
+      "boundary": "queue-event",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.tx_queue_event_fails` is assigned to #1840 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    },
+    {
+      "field_id": "static:vsock.tx_write_fails",
+      "boundary": "data-path",
+      "disposition": "planned",
+      "delivery_issue": "#1840",
+      "rationale": "Pinned Firecracker field `vsock.tx_write_fails` is assigned to #1840 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+      "implementation": [],
+      "validation": []
+    }
+  ]
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1551,6 +1551,13 @@ schema and process-audit focused local mutations with:
 cargo test -p bangbang-firecracker-capability-audit --test metrics_schema --locked
 ```
 
+The adjacent human-owned `metrics-device-producer-audit.json` maps all 231
+device-owned fields to closed operation boundaries and the nine concrete #1789
+children. Its 216 planned and 15 provisional-platform-zero records are
+intentionally nonterminal and contain no evidence. The same focused test checks
+canonical bytes, exact membership and partition, suffix routing, provisional
+state, anchored-evidence rules, and final-mode rejection.
+
 The ordinary `compare` command rederives the source projection together with
 the general and logger manifests. To create a metrics source-only candidate:
 
@@ -1561,14 +1568,15 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- \
   --output codex-work/tmp/metrics-schema-source.candidate.json
 ```
 
-The command never emits or carries forward policy or a process-producer audit.
+The command never emits or carries forward policy or either producer audit.
 Review source identities,
 root/field order, Rust and fixture anchors, types/reset classes, dynamic
 grammar, architecture, reconciliations, and fingerprints before manually
 updating `metrics-schema.json`. Then review every affected unit, aggregation,
 producer owner/disposition, delivery issue, rationale, and evidence mapping.
-If process-profile membership changes, manually reconcile the exact audit
-membership and its boundary/child/evidence policy in the same pull request.
+If producer-profile membership changes, manually reconcile the exact process
+or device audit membership and its boundary/child/evidence policy in the same
+pull request.
 The destination must be a new non-alias of every checked JSON file. The exact
 shape and publication boundary are documented in the
 [metrics schema contract](../compat/firecracker/v1.16.0/metrics-contract.md).
@@ -1607,10 +1615,11 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- validate --metric
 
 Metrics-process-final composes metrics-schema-final's authority and downstream
 partition with final-mode validation of the exact process audit, while retaining
-logger validation in delivery mode. It requires the two implemented process
-profiles and all 69 field records to remain terminal at exactly 64 implemented,
-one source-neutral, and four platform-zero. Ten planned and four platform-zero
-device profiles remain #1789-owned, and the two aggregates remain #1790-owned.
+logger and device-audit validation in delivery mode. It requires the two
+implemented process profiles and all 69 field records to remain terminal at
+exactly 64 implemented, one source-neutral, and four platform-zero. Ten planned
+and four platform-zero device profiles and all 231 device audit records remain
+#1789-owned and nonterminal, and the two aggregates remain #1790-owned.
 The composed test mutates both a field record and an aggregate process profile;
 the lower-level suite separately exercises every membership, ordering,
 ownership, boundary, child, rationale, disposition, evidence, path, and baseline

--- a/tools/firecracker-capability-audit/src/lib.rs
+++ b/tools/firecracker-capability-audit/src/lib.rs
@@ -5,6 +5,8 @@ mod logger_model;
 mod logger_upstream;
 mod logger_validate;
 mod metrics_certify;
+mod metrics_device_model;
+mod metrics_device_validate;
 mod metrics_model;
 mod metrics_process_certify;
 mod metrics_process_model;
@@ -29,6 +31,11 @@ pub use metrics_certify::{
     METRICS_SCHEMA_COMPATIBILITY_CAPABILITY_IDS, RETAINED_METRICS_AGGREGATE_CAPABILITY_IDS,
     validate_metrics_schema_compatibility,
 };
+pub use metrics_device_model::{
+    MetricsDeviceProducerAudit, MetricsDeviceProducerBoundary, MetricsDeviceProducerDisposition,
+    MetricsDeviceProducerRecord,
+};
+pub use metrics_device_validate::validate_metrics_device_producers;
 pub use metrics_model::{
     MetricsAggregation, MetricsArchitecture, MetricsCardinality, MetricsDynamicFamily,
     MetricsFieldPolicy, MetricsJsonType, MetricsPolicyProfile, MetricsProducerDisposition,
@@ -75,6 +82,8 @@ pub const METRICS_SCHEMA_VERSION: u32 = 1;
 pub const METRICS_SCHEMA_GENERATOR_VERSION: u32 = 1;
 /// Current checked-in process-producer audit format.
 pub const METRICS_PROCESS_PRODUCER_AUDIT_SCHEMA_VERSION: u32 = 1;
+/// Current checked-in device-producer audit format.
+pub const METRICS_DEVICE_PRODUCER_AUDIT_SCHEMA_VERSION: u32 = 1;
 /// Repository-relative generated source manifest path.
 pub const SOURCE_MANIFEST_PATH: &str = "compat/firecracker/v1.16.0/source-manifest.json";
 /// Repository-relative human capability overlay path.
@@ -90,6 +99,9 @@ pub const METRICS_SCHEMA_AUTHORITY_PATH: &str = "compat/firecracker/v1.16.0/metr
 /// Repository-relative exact process-producer audit path.
 pub const METRICS_PROCESS_PRODUCER_AUDIT_PATH: &str =
     "compat/firecracker/v1.16.0/metrics-process-producer-audit.json";
+/// Repository-relative exact device-producer audit path.
+pub const METRICS_DEVICE_PRODUCER_AUDIT_PATH: &str =
+    "compat/firecracker/v1.16.0/metrics-device-producer-audit.json";
 
 /// Error produced while reading, parsing, or deriving an inventory.
 #[derive(Debug)]
@@ -172,6 +184,22 @@ pub fn read_metrics_process_producer_audit(
     })
 }
 
+/// Read and parse the checked device-producer audit.
+pub fn read_metrics_device_producer_audit(
+    path: &Path,
+) -> Result<MetricsDeviceProducerAudit, AuditError> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        AuditError::new(format!(
+            "failed to read metrics device producer audit: {error}"
+        ))
+    })?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        AuditError::new(format!(
+            "failed to parse metrics device producer audit: {error}"
+        ))
+    })
+}
+
 /// Serialize a generated source manifest using canonical pretty JSON.
 pub fn source_manifest_json(manifest: &SourceManifest) -> Result<Vec<u8>, AuditError> {
     let mut bytes = serde_json::to_vec_pretty(manifest).map_err(|error| {
@@ -224,6 +252,13 @@ pub fn metrics_process_producer_audit_json(
     audit: &MetricsProcessProducerAudit,
 ) -> Result<Vec<u8>, AuditError> {
     canonical_json(audit, "metrics process producer audit")
+}
+
+/// Serialize the human device-producer audit using canonical pretty JSON.
+pub fn metrics_device_producer_audit_json(
+    audit: &MetricsDeviceProducerAudit,
+) -> Result<Vec<u8>, AuditError> {
+    canonical_json(audit, "metrics device producer audit")
 }
 
 fn canonical_json<T: serde::Serialize>(value: &T, label: &str) -> Result<Vec<u8>, AuditError> {

--- a/tools/firecracker-capability-audit/src/main.rs
+++ b/tools/firecracker-capability-audit/src/main.rs
@@ -6,15 +6,16 @@ use std::process::{Command, ExitCode};
 
 use bangbang_firecracker_capability_audit::{
     AuditError, AuditMode, CAPABILITY_INVENTORY_PATH, LOGGER_PRODUCER_AUDIT_PATH,
-    LOGGER_PRODUCER_MANIFEST_PATH, METRICS_PROCESS_PRODUCER_AUDIT_PATH,
-    METRICS_SCHEMA_AUTHORITY_PATH, SOURCE_MANIFEST_PATH, derive_logger_producer_manifest,
-    derive_metrics_schema_source, derive_source_manifest, logger_producer_manifest_json,
-    metrics_schema_source_candidate_json, read_capability_inventory, read_logger_producer_audit,
-    read_logger_producer_manifest, read_metrics_process_producer_audit,
-    read_metrics_schema_authority, read_source_manifest, source_manifest_json, validate,
-    validate_logger_compatibility, validate_logger_producers,
-    validate_metrics_process_compatibility, validate_metrics_process_producers,
-    validate_metrics_schema, validate_metrics_schema_compatibility,
+    LOGGER_PRODUCER_MANIFEST_PATH, METRICS_DEVICE_PRODUCER_AUDIT_PATH,
+    METRICS_PROCESS_PRODUCER_AUDIT_PATH, METRICS_SCHEMA_AUTHORITY_PATH, SOURCE_MANIFEST_PATH,
+    derive_logger_producer_manifest, derive_metrics_schema_source, derive_source_manifest,
+    logger_producer_manifest_json, metrics_schema_source_candidate_json, read_capability_inventory,
+    read_logger_producer_audit, read_logger_producer_manifest, read_metrics_device_producer_audit,
+    read_metrics_process_producer_audit, read_metrics_schema_authority, read_source_manifest,
+    source_manifest_json, validate, validate_logger_compatibility, validate_logger_producers,
+    validate_metrics_device_producers, validate_metrics_process_compatibility,
+    validate_metrics_process_producers, validate_metrics_schema,
+    validate_metrics_schema_compatibility,
 };
 
 fn main() -> ExitCode {
@@ -82,6 +83,8 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
         read_metrics_schema_authority(&root.join(METRICS_SCHEMA_AUTHORITY_PATH))?;
     let metrics_process_audit =
         read_metrics_process_producer_audit(&root.join(METRICS_PROCESS_PRODUCER_AUDIT_PATH))?;
+    let metrics_device_audit =
+        read_metrics_device_producer_audit(&root.join(METRICS_DEVICE_PRODUCER_AUDIT_PATH))?;
     let audit_mode = match mode {
         ValidateMode::Delivery => AuditMode::Delivery,
         ValidateMode::Final => AuditMode::Final,
@@ -111,8 +114,19 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
                     "metrics process producer validation errors:\n{errors}"
                 ))
             })?;
+            validate_metrics_device_producers(
+                &metrics_device_audit,
+                &metrics_authority,
+                &root,
+                AuditMode::Delivery,
+            )
+            .map_err(|errors| {
+                AuditError::new(format!(
+                    "metrics device producer validation errors:\n{errors}"
+                ))
+            })?;
             return Ok(
-                "Firecracker capability inventory, logger producer audit, metrics schema authority, and process producer audit are valid for the terminal logger compatibility scope"
+                "Firecracker capability inventory, logger producer audit, metrics schema authority, process producer audit, and device producer audit are valid for the terminal logger compatibility scope"
                     .to_string(),
             );
         }
@@ -138,8 +152,19 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
                     "metrics process producer validation errors:\n{errors}"
                 ))
             })?;
+            validate_metrics_device_producers(
+                &metrics_device_audit,
+                &metrics_authority,
+                &root,
+                AuditMode::Delivery,
+            )
+            .map_err(|errors| {
+                AuditError::new(format!(
+                    "metrics device producer validation errors:\n{errors}"
+                ))
+            })?;
             return Ok(
-                "Firecracker capability inventory, logger producer audit, metrics schema authority, and process producer audit are valid for the terminal metrics API/schema compatibility scope"
+                "Firecracker capability inventory, logger producer audit, metrics schema authority, process producer audit, and device producer audit are valid for the terminal metrics API/schema compatibility scope"
                     .to_string(),
             );
         }
@@ -160,8 +185,19 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
                 .map_err(|errors| {
                     AuditError::new(format!("logger producer validation errors:\n{errors}"))
                 })?;
+            validate_metrics_device_producers(
+                &metrics_device_audit,
+                &metrics_authority,
+                &root,
+                AuditMode::Delivery,
+            )
+            .map_err(|errors| {
+                AuditError::new(format!(
+                    "metrics device producer validation errors:\n{errors}"
+                ))
+            })?;
             return Ok(
-                "Firecracker capability inventory, logger producer audit, metrics schema authority, and process producer audit are valid for the terminal process metrics compatibility scope"
+                "Firecracker capability inventory, logger producer audit, metrics schema authority, process producer audit, and device producer audit are valid for the terminal process metrics compatibility scope"
                     .to_string(),
             );
         }
@@ -188,6 +224,16 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
             "metrics process producer validation errors:\n{errors}"
         ));
     }
+    if let Err(errors) = validate_metrics_device_producers(
+        &metrics_device_audit,
+        &metrics_authority,
+        &root,
+        audit_mode,
+    ) {
+        failures.push(format!(
+            "metrics device producer validation errors:\n{errors}"
+        ));
+    }
     if !failures.is_empty() {
         return Err(AuditError::new(failures.join("\n")));
     }
@@ -196,7 +242,7 @@ fn run_validate(args: &[String]) -> Result<String, AuditError> {
         AuditMode::Final => "final",
     };
     Ok(format!(
-        "Firecracker capability inventory, logger producer audit, metrics schema authority, and process producer audit are valid in {mode_name} mode"
+        "Firecracker capability inventory, logger producer audit, metrics schema authority, process producer audit, and device producer audit are valid in {mode_name} mode"
     ))
 }
 
@@ -363,6 +409,7 @@ fn candidate_output_path(root: &Path, output: &Path) -> Result<PathBuf, AuditErr
     let logger_audit_path = root.join(LOGGER_PRODUCER_AUDIT_PATH);
     let metrics_schema_path = root.join(METRICS_SCHEMA_AUTHORITY_PATH);
     let metrics_process_audit_path = root.join(METRICS_PROCESS_PRODUCER_AUDIT_PATH);
+    let metrics_device_audit_path = root.join(METRICS_DEVICE_PRODUCER_AUDIT_PATH);
     let normalized_output = normalize_lexically(&output_path);
     let checked_paths = [
         &source_path,
@@ -371,6 +418,7 @@ fn candidate_output_path(root: &Path, output: &Path) -> Result<PathBuf, AuditErr
         &logger_audit_path,
         &metrics_schema_path,
         &metrics_process_audit_path,
+        &metrics_device_audit_path,
     ];
     if checked_paths
         .iter()
@@ -546,6 +594,19 @@ mod tests {
     }
 
     #[test]
+    fn completed_scoped_modes_consume_device_audit_in_delivery_mode() {
+        for flag in [
+            "--logger-final",
+            "--metrics-schema-final",
+            "--metrics-process-final",
+        ] {
+            let message = run_validate(&[flag.to_string()])
+                .expect("completed scoped validation must remain available");
+            assert!(message.contains("device producer audit"), "{flag}");
+        }
+    }
+
+    #[test]
     fn rejects_duplicate_options() {
         let error = required_options(
             &[
@@ -584,6 +645,7 @@ mod tests {
             LOGGER_PRODUCER_AUDIT_PATH,
             METRICS_SCHEMA_AUTHORITY_PATH,
             METRICS_PROCESS_PRODUCER_AUDIT_PATH,
+            METRICS_DEVICE_PRODUCER_AUDIT_PATH,
         ] {
             let error = candidate_output_path(root, Path::new(path))
                 .expect_err("checked inventory path should be refused");
@@ -601,6 +663,7 @@ mod tests {
             "compat/firecracker/v1.16.0/../v1.16.0/logger-producer-audit.json",
             "compat/firecracker/v1.16.0/./metrics-schema.json",
             "compat/firecracker/v1.16.0/./metrics-process-producer-audit.json",
+            "compat/firecracker/v1.16.0/./metrics-device-producer-audit.json",
         ] {
             let error = candidate_output_path(root, Path::new(path))
                 .expect_err("checked inventory alias should be refused");

--- a/tools/firecracker-capability-audit/src/metrics_device_model.rs
+++ b/tools/firecracker-capability-audit/src/metrics_device_model.rs
@@ -1,0 +1,144 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Baseline, PlatformExclusion, Reference};
+
+/// Closed semantic producer boundary for a device-owned metrics field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsDeviceProducerBoundary {
+    Activation,
+    ArchitectureRetained,
+    Configuration,
+    DataPath,
+    DeviceState,
+    InterruptLifecycle,
+    Latency,
+    MmdsDataPath,
+    QueueEvent,
+    RateLimiter,
+    VcpuExit,
+    VcpuFailure,
+}
+
+impl MetricsDeviceProducerBoundary {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Activation => "activation",
+            Self::ArchitectureRetained => "architecture-retained",
+            Self::Configuration => "configuration",
+            Self::DataPath => "data-path",
+            Self::DeviceState => "device-state",
+            Self::InterruptLifecycle => "interrupt-lifecycle",
+            Self::Latency => "latency",
+            Self::MmdsDataPath => "mmds-data-path",
+            Self::QueueEvent => "queue-event",
+            Self::RateLimiter => "rate-limiter",
+            Self::VcpuExit => "vcpu-exit",
+            Self::VcpuFailure => "vcpu-failure",
+        }
+    }
+}
+
+/// Terminal or unresolved state of one exact device producer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsDeviceProducerDisposition {
+    Planned,
+    ProvisionalPlatformZero,
+    Implemented,
+    SourceNeutral,
+    PlatformZero,
+}
+
+impl MetricsDeviceProducerDisposition {
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Implemented | Self::SourceNeutral | Self::PlatformZero
+        )
+    }
+}
+
+/// Reviewed producer authority for one canonical device metrics field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsDeviceProducerRecord {
+    pub field_id: String,
+    pub boundary: MetricsDeviceProducerBoundary,
+    pub disposition: MetricsDeviceProducerDisposition,
+    pub delivery_issue: String,
+    pub rationale: String,
+    #[serde(default)]
+    pub implementation: Vec<Reference>,
+    #[serde(default)]
+    pub validation: Vec<Reference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform_exclusion: Option<PlatformExclusion>,
+}
+
+/// Human-reviewed exact-field producer overlay for device-owned metrics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsDeviceProducerAudit {
+    pub schema_version: u32,
+    pub baseline: Baseline,
+    pub records: Vec<MetricsDeviceProducerRecord>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_unknown_device_audit_fields() {
+        let error = serde_json::from_str::<MetricsDeviceProducerAudit>(
+            r#"{
+                "schema_version":1,
+                "baseline":{"version":"1.16.0","commit":"c","target":"t"},
+                "records":[],
+                "typo":true
+            }"#,
+        )
+        .expect_err("unknown audit fields must fail");
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_open_ended_device_boundaries() {
+        let error = serde_json::from_str::<MetricsDeviceProducerRecord>(
+            r##"{
+                "field_id":"static:test.field",
+                "boundary":"somewhere",
+                "disposition":"planned",
+                "delivery_issue":"#1",
+                "rationale":"test"
+            }"##,
+        )
+        .expect_err("unknown boundaries must fail");
+        assert!(error.to_string().contains("unknown variant"));
+    }
+
+    #[test]
+    fn rejects_unknown_device_dispositions() {
+        let error = serde_json::from_str::<MetricsDeviceProducerRecord>(
+            r##"{
+                "field_id":"static:test.field",
+                "boundary":"data-path",
+                "disposition":"deferred",
+                "delivery_issue":"#1",
+                "rationale":"test"
+            }"##,
+        )
+        .expect_err("unknown dispositions must fail");
+        assert!(error.to_string().contains("unknown variant"));
+    }
+
+    #[test]
+    fn provisional_platform_zero_is_not_terminal() {
+        assert!(!MetricsDeviceProducerDisposition::Planned.is_terminal());
+        assert!(!MetricsDeviceProducerDisposition::ProvisionalPlatformZero.is_terminal());
+        assert!(MetricsDeviceProducerDisposition::Implemented.is_terminal());
+        assert!(MetricsDeviceProducerDisposition::SourceNeutral.is_terminal());
+        assert!(MetricsDeviceProducerDisposition::PlatformZero.is_terminal());
+    }
+}

--- a/tools/firecracker-capability-audit/src/metrics_device_validate.rs
+++ b/tools/firecracker-capability-audit/src/metrics_device_validate.rs
@@ -1,0 +1,704 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+
+use crate::validate::{tracked_repository_files, validate_exclusion, validate_reference};
+use crate::{
+    AuditMode, FIRECRACKER_COMMIT, FIRECRACKER_TARGET, FIRECRACKER_VERSION,
+    METRICS_DEVICE_PRODUCER_AUDIT_SCHEMA_VERSION, MetricsDeviceProducerAudit,
+    MetricsDeviceProducerBoundary, MetricsDeviceProducerDisposition, MetricsDeviceProducerRecord,
+    MetricsPolicyProfile, MetricsProducerDisposition, MetricsProducerOwner, MetricsSchemaAuthority,
+    MetricsSourceField, Reference, ValidationErrors,
+};
+
+const EXPECTED_DEVICE_FIELDS: usize = 231;
+const COMPLETED_DELIVERY_ISSUES: &[&str] = &[];
+
+/// Validate exact device-producer authority against the resolved metrics schema.
+pub fn validate_metrics_device_producers(
+    audit: &MetricsDeviceProducerAudit,
+    authority: &MetricsSchemaAuthority,
+    repository_root: &Path,
+    mode: AuditMode,
+) -> Result<(), ValidationErrors> {
+    let mut errors = Vec::new();
+    validate_baseline(audit, authority, &mut errors);
+
+    let profiles = authority
+        .policy_profiles
+        .iter()
+        .map(|profile| (profile.id.as_str(), profile))
+        .collect::<BTreeMap<_, _>>();
+    let source_fields = authority
+        .source
+        .fields
+        .iter()
+        .map(|field| (field.id.as_str(), field))
+        .collect::<BTreeMap<_, _>>();
+    let expected = authority
+        .field_policies
+        .iter()
+        .filter_map(|policy| {
+            let profile = profiles.get(policy.profile_id.as_str()).copied()?;
+            if profile.producer_owner != MetricsProducerOwner::Device {
+                return None;
+            }
+            source_fields
+                .get(policy.field_id.as_str())
+                .copied()
+                .map(|field| (policy.field_id.as_str(), (field, profile)))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    if expected.len() != EXPECTED_DEVICE_FIELDS {
+        errors.push(format!(
+            "metrics device producer schema set must contain {EXPECTED_DEVICE_FIELDS} fields, found {}",
+            expected.len()
+        ));
+    }
+    if audit.records.len() != EXPECTED_DEVICE_FIELDS {
+        errors.push(format!(
+            "metrics device producer audit must contain {EXPECTED_DEVICE_FIELDS} records, found {}",
+            audit.records.len()
+        ));
+    }
+
+    let tracked = tracked_repository_files(repository_root, &mut errors);
+    let context = RecordValidationContext {
+        repository_root,
+        tracked: &tracked,
+        mode,
+    };
+    let mut records = BTreeMap::new();
+    let mut previous = None;
+    for record in &audit.records {
+        if previous.is_some_and(|field_id| record.field_id.as_str() <= field_id) {
+            errors.push(
+                "metrics device producer records must be sorted and unique by field_id".to_string(),
+            );
+        }
+        previous = Some(record.field_id.as_str());
+        if records.insert(record.field_id.as_str(), record).is_some() {
+            errors.push(format!(
+                "duplicate metrics device producer record: {}",
+                record.field_id
+            ));
+        }
+
+        let Some((field, profile)) = expected.get(record.field_id.as_str()).copied() else {
+            errors.push(format!(
+                "stale or unowned metrics device producer record: {}",
+                record.field_id
+            ));
+            continue;
+        };
+        validate_record(record, field, profile, &context, &mut errors);
+    }
+    for field_id in expected.keys() {
+        if !records.contains_key(field_id) {
+            errors.push(format!(
+                "missing metrics device producer record: {field_id}"
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(ValidationErrors::from_messages(errors))
+    }
+}
+
+fn validate_baseline(
+    audit: &MetricsDeviceProducerAudit,
+    authority: &MetricsSchemaAuthority,
+    errors: &mut Vec<String>,
+) {
+    if audit.schema_version != METRICS_DEVICE_PRODUCER_AUDIT_SCHEMA_VERSION {
+        errors.push(format!(
+            "metrics device producer schema_version must be {METRICS_DEVICE_PRODUCER_AUDIT_SCHEMA_VERSION}, found {}",
+            audit.schema_version
+        ));
+    }
+    if audit.baseline != authority.baseline {
+        errors.push("metrics device producer and metrics schema baselines differ".to_string());
+    }
+    if audit.baseline.version != FIRECRACKER_VERSION
+        || audit.baseline.commit != FIRECRACKER_COMMIT
+        || audit.baseline.target != FIRECRACKER_TARGET
+    {
+        errors.push("metrics device producer baseline is not the pinned release".to_string());
+    }
+}
+
+struct RecordValidationContext<'a> {
+    repository_root: &'a Path,
+    tracked: &'a BTreeSet<PathBuf>,
+    mode: AuditMode,
+}
+
+fn validate_record(
+    record: &MetricsDeviceProducerRecord,
+    field: &MetricsSourceField,
+    profile: &MetricsPolicyProfile,
+    context: &RecordValidationContext<'_>,
+    errors: &mut Vec<String>,
+) {
+    let path = field.path.as_str();
+    let Some(delivery_issue) = expected_delivery_issue(path) else {
+        errors.push(format!(
+            "metrics device producer field has no closed delivery owner: {}",
+            record.field_id
+        ));
+        return;
+    };
+    if record.delivery_issue != delivery_issue {
+        errors.push(format!(
+            "metrics device producer has the wrong delivery issue: {}",
+            record.field_id
+        ));
+    }
+
+    let Some(boundary) = expected_boundary(path) else {
+        errors.push(format!(
+            "metrics device producer field has no closed boundary: {}",
+            record.field_id
+        ));
+        return;
+    };
+    if record.boundary != boundary {
+        errors.push(format!(
+            "metrics device producer has the wrong boundary: {}",
+            record.field_id
+        ));
+    }
+
+    let completed = COMPLETED_DELIVERY_ISSUES.contains(&delivery_issue);
+    let rationale = expected_rationale(path, delivery_issue, boundary, completed);
+    if record.rationale != rationale {
+        errors.push(format!(
+            "metrics device producer has a stale rationale: {}",
+            record.field_id
+        ));
+    }
+
+    let provisional = is_provisional_platform_zero(path);
+    if provisional != (profile.producer_disposition == MetricsProducerDisposition::PlatformZero) {
+        errors.push(format!(
+            "metrics device producer disagrees with the schema platform candidate: {}",
+            record.field_id
+        ));
+    }
+
+    let expected_disposition = if completed {
+        expected_terminal_disposition(path)
+    } else if provisional {
+        Some(MetricsDeviceProducerDisposition::ProvisionalPlatformZero)
+    } else if profile.producer_disposition == MetricsProducerDisposition::Planned {
+        Some(MetricsDeviceProducerDisposition::Planned)
+    } else {
+        None
+    };
+    let Some(expected_disposition) = expected_disposition else {
+        errors.push(format!(
+            "metrics device producer field has no closed current disposition: {}",
+            record.field_id
+        ));
+        return;
+    };
+    if record.disposition != expected_disposition {
+        errors.push(format!(
+            "metrics device producer has the wrong current disposition: {}",
+            record.field_id
+        ));
+    }
+
+    match record.disposition {
+        MetricsDeviceProducerDisposition::Planned
+        | MetricsDeviceProducerDisposition::ProvisionalPlatformZero => {
+            if !record.implementation.is_empty()
+                || !record.validation.is_empty()
+                || record.platform_exclusion.is_some()
+            {
+                errors.push(format!(
+                    "nonterminal metrics device producer must not claim terminal evidence: {}",
+                    record.field_id
+                ));
+            }
+            if context.mode == AuditMode::Final {
+                errors.push(format!(
+                    "final metrics device producer validation rejects nonterminal record: {}",
+                    record.field_id
+                ));
+            }
+        }
+        MetricsDeviceProducerDisposition::Implemented
+        | MetricsDeviceProducerDisposition::SourceNeutral
+        | MetricsDeviceProducerDisposition::PlatformZero => {
+            if record.implementation.is_empty() || record.validation.is_empty() {
+                errors.push(format!(
+                    "terminal metrics device producer needs implementation and validation evidence: {}",
+                    record.field_id
+                ));
+            }
+            validate_references(
+                &record.implementation,
+                "implementation",
+                &record.field_id,
+                context.repository_root,
+                context.tracked,
+                errors,
+            );
+            validate_references(
+                &record.validation,
+                "validation",
+                &record.field_id,
+                context.repository_root,
+                context.tracked,
+                errors,
+            );
+
+            match (record.disposition, &record.platform_exclusion) {
+                (MetricsDeviceProducerDisposition::PlatformZero, Some(exclusion)) => {
+                    validate_exclusion(
+                        &record.field_id,
+                        exclusion,
+                        context.repository_root,
+                        context.tracked,
+                        errors,
+                    );
+                    validate_exclusion_anchors(
+                        exclusion,
+                        &record.field_id,
+                        context.repository_root,
+                        errors,
+                    );
+                }
+                (MetricsDeviceProducerDisposition::PlatformZero, None) => errors.push(format!(
+                    "terminal platform-zero metrics device producer needs structured exclusion evidence: {}",
+                    record.field_id
+                )),
+                (_, Some(_)) => errors.push(format!(
+                    "non-platform metrics device producer forbids exclusion evidence: {}",
+                    record.field_id
+                )),
+                (_, None) => {}
+            }
+        }
+    }
+}
+
+fn validate_references(
+    references: &[Reference],
+    kind: &str,
+    field_id: &str,
+    repository_root: &Path,
+    tracked: &BTreeSet<PathBuf>,
+    errors: &mut Vec<String>,
+) {
+    if references.windows(2).any(|pair| {
+        let [previous, current] = pair else {
+            return false;
+        };
+        previous >= current
+    }) {
+        errors.push(format!(
+            "metrics device producer {kind} references must be sorted and unique: {field_id}"
+        ));
+    }
+    if !references
+        .iter()
+        .any(|reference| matches!(reference, Reference::Local { .. }))
+    {
+        errors.push(format!(
+            "metrics device producer {kind} needs anchored local evidence: {field_id}"
+        ));
+    }
+    for (index, reference) in references.iter().enumerate() {
+        validate_reference(
+            reference,
+            repository_root,
+            tracked,
+            &format!("metrics device producer {field_id} {kind}[{index}]"),
+            errors,
+        );
+        validate_local_anchor(
+            reference,
+            repository_root,
+            &format!("metrics device producer {field_id} {kind}[{index}]"),
+            errors,
+        );
+    }
+}
+
+fn validate_exclusion_anchors(
+    exclusion: &crate::PlatformExclusion,
+    field_id: &str,
+    repository_root: &Path,
+    errors: &mut Vec<String>,
+) {
+    for (group, references) in [
+        ("upstream_contract", &exclusion.upstream_contract),
+        ("platform_evidence", &exclusion.platform_evidence),
+        ("stable_behavior", &exclusion.stable_behavior),
+        ("focused_tests", &exclusion.focused_tests),
+        ("compatibility_docs", &exclusion.compatibility_docs),
+        ("security_docs", &exclusion.security_docs),
+    ] {
+        for (index, reference) in references.iter().enumerate() {
+            validate_local_anchor(
+                reference,
+                repository_root,
+                &format!("metrics device producer {field_id} exclusion.{group}[{index}]"),
+                errors,
+            );
+        }
+    }
+}
+
+fn validate_local_anchor(
+    reference: &Reference,
+    repository_root: &Path,
+    label: &str,
+    errors: &mut Vec<String>,
+) {
+    let Reference::Local { path, anchor } = reference else {
+        return;
+    };
+    let Some(anchor) = anchor.as_deref().filter(|anchor| !anchor.trim().is_empty()) else {
+        errors.push(format!("local reference needs a stable anchor: {label}"));
+        return;
+    };
+    let relative = Path::new(path);
+    if relative.is_absolute()
+        || relative.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return;
+    }
+    let joined = repository_root.join(relative);
+    let Ok(metadata) = std::fs::symlink_metadata(&joined) else {
+        return;
+    };
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return;
+    }
+    let (Ok(canonical_root), Ok(canonical)) =
+        (repository_root.canonicalize(), joined.canonicalize())
+    else {
+        return;
+    };
+    if !canonical.starts_with(canonical_root) {
+        return;
+    }
+    let Ok(contents) = std::fs::read_to_string(canonical) else {
+        errors.push(format!(
+            "local reference anchor file must be UTF-8: {label}"
+        ));
+        return;
+    };
+    if !contents.contains(anchor) {
+        errors.push(format!("local reference anchor does not resolve: {label}"));
+    }
+}
+
+fn expected_delivery_issue(path: &str) -> Option<&'static str> {
+    let (root, suffix) = path.split_once('.').unwrap_or((path, ""));
+    Some(match root {
+        "entropy" | "pmem" | "rtc" | "uart" => "#1838",
+        "balloon" | "memory_hotplug" => "#1839",
+        "vsock" => "#1840",
+        "block" | "block_{drive_id}" => "#1841",
+        "vhost_user_block_{drive_id}" => "#1842",
+        "mmds" => "#1843",
+        "net" | "net_{iface_id}" if is_tap_gap(suffix) => "#1844",
+        "net" | "net_{iface_id}" => "#1843",
+        "interrupts" => "#1845",
+        "vcpu" if is_provisional_vcpu_suffix(suffix) => "#1846",
+        "vcpu" => "#1845",
+        "i8042" => "#1846",
+        _ => return None,
+    })
+}
+
+fn expected_boundary(path: &str) -> Option<MetricsDeviceProducerBoundary> {
+    use MetricsDeviceProducerBoundary as Boundary;
+
+    let (root, suffix) = path.split_once('.')?;
+    match root {
+        "i8042" => return architecture_suffix(suffix).then_some(Boundary::ArchitectureRetained),
+        "interrupts" => {
+            return matches!(suffix, "config_updates" | "triggers")
+                .then_some(Boundary::InterruptLifecycle);
+        }
+        "mmds" => return mmds_suffix(suffix).then_some(Boundary::MmdsDataPath),
+        "vcpu" if is_provisional_vcpu_suffix(suffix) => {
+            return Some(Boundary::ArchitectureRetained);
+        }
+        "vcpu" if suffix == "failures" => return Some(Boundary::VcpuFailure),
+        "vcpu" => return vcpu_mmio_suffix(suffix).then_some(Boundary::VcpuExit),
+        _ => {}
+    }
+
+    if matches!(
+        suffix,
+        "activate_fails" | "activate_time_us" | "init_time_us"
+    ) {
+        return Some(Boundary::Activation);
+    }
+    if matches!(
+        suffix,
+        "cfg_fails"
+            | "config_change_time_us"
+            | "mac_address_updates"
+            | "update_count"
+            | "update_fails"
+    ) {
+        return Some(Boundary::Configuration);
+    }
+    if latency_suffix(suffix) {
+        return Some(Boundary::Latency);
+    }
+    if rate_limiter_suffix(suffix) {
+        return Some(Boundary::RateLimiter);
+    }
+    if queue_event_suffix(suffix) {
+        return Some(Boundary::QueueEvent);
+    }
+    if root == "balloon" && balloon_state_suffix(suffix) {
+        return Some(Boundary::DeviceState);
+    }
+    if root == "memory_hotplug" && memory_hotplug_state_suffix(suffix) {
+        return Some(Boundary::DeviceState);
+    }
+    data_path_suffix(suffix).then_some(Boundary::DataPath)
+}
+
+fn expected_terminal_disposition(_path: &str) -> Option<MetricsDeviceProducerDisposition> {
+    None
+}
+
+fn expected_rationale(
+    path: &str,
+    delivery_issue: &str,
+    boundary: MetricsDeviceProducerBoundary,
+    completed: bool,
+) -> String {
+    if completed {
+        format!(
+            "Pinned Firecracker field `{path}` is completed by {delivery_issue} at the `{}` boundary with exact implementation and validation evidence.",
+            boundary.as_str()
+        )
+    } else {
+        format!(
+            "Pinned Firecracker field `{path}` is assigned to {delivery_issue} at the `{}` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
+            boundary.as_str()
+        )
+    }
+}
+
+fn is_provisional_platform_zero(path: &str) -> bool {
+    let (root, suffix) = path.split_once('.').unwrap_or((path, ""));
+    root == "i8042" || (root == "vcpu" && is_provisional_vcpu_suffix(suffix))
+}
+
+fn is_tap_gap(suffix: &str) -> bool {
+    matches!(
+        suffix,
+        "mac_address_updates"
+            | "rx_tap_event_count"
+            | "tap_read_fails"
+            | "tap_write_agg.max_us"
+            | "tap_write_agg.min_us"
+            | "tap_write_agg.sum_us"
+            | "tap_write_fails"
+    )
+}
+
+fn is_provisional_vcpu_suffix(suffix: &str) -> bool {
+    suffix == "kvmclock_ctrl_fails"
+        || suffix == "exit_io_in"
+        || suffix.starts_with("exit_io_in_agg.")
+        || suffix == "exit_io_out"
+        || suffix.starts_with("exit_io_out_agg.")
+}
+
+fn architecture_suffix(suffix: &str) -> bool {
+    matches!(
+        suffix,
+        "error_count"
+            | "missed_read_count"
+            | "missed_write_count"
+            | "read_count"
+            | "reset_count"
+            | "write_count"
+    )
+}
+
+fn mmds_suffix(suffix: &str) -> bool {
+    matches!(
+        suffix,
+        "connections_created"
+            | "connections_destroyed"
+            | "rx_accepted"
+            | "rx_accepted_err"
+            | "rx_accepted_unusual"
+            | "rx_bad_eth"
+            | "rx_count"
+            | "rx_invalid_token"
+            | "rx_no_token"
+            | "tx_bytes"
+            | "tx_count"
+            | "tx_errors"
+            | "tx_frames"
+    )
+}
+
+fn vcpu_mmio_suffix(suffix: &str) -> bool {
+    suffix == "exit_mmio_read"
+        || suffix.starts_with("exit_mmio_read_agg.")
+        || suffix == "exit_mmio_write"
+        || suffix.starts_with("exit_mmio_write_agg.")
+}
+
+fn latency_suffix(suffix: &str) -> bool {
+    suffix.ends_with("_agg.max_us")
+        || suffix.ends_with("_agg.min_us")
+        || suffix.ends_with("_agg.sum_us")
+}
+
+fn rate_limiter_suffix(suffix: &str) -> bool {
+    matches!(
+        suffix,
+        "entropy_rate_limiter_throttled"
+            | "io_engine_throttled_events"
+            | "rate_limiter_dropped_bytes"
+            | "rate_limiter_event_count"
+            | "rate_limiter_throttled_events"
+            | "rx_event_rate_limiter_count"
+            | "rx_rate_limiter_throttled"
+            | "tx_rate_limiter_event_count"
+            | "tx_rate_limiter_throttled"
+    )
+}
+
+fn queue_event_suffix(suffix: &str) -> bool {
+    matches!(
+        suffix,
+        "conn_event_fails"
+            | "entropy_event_count"
+            | "entropy_event_fails"
+            | "ev_queue_event_fails"
+            | "event_fails"
+            | "killq_resync"
+            | "muxer_event_fails"
+            | "no_avail_buffer"
+            | "no_rx_avail_buffer"
+            | "no_tx_avail_buffer"
+            | "queue_event_count"
+            | "queue_event_fails"
+            | "remaining_reqs_count"
+            | "rx_queue_event_count"
+            | "rx_queue_event_fails"
+            | "rx_tap_event_count"
+            | "tx_queue_event_count"
+            | "tx_queue_event_fails"
+            | "tx_remaining_reqs_count"
+    )
+}
+
+fn balloon_state_suffix(suffix: &str) -> bool {
+    matches!(
+        suffix,
+        "deflate_count"
+            | "free_page_hint_count"
+            | "free_page_hint_fails"
+            | "free_page_hint_freed"
+            | "free_page_report_count"
+            | "free_page_report_fails"
+            | "free_page_report_freed"
+            | "inflate_count"
+            | "stats_update_fails"
+            | "stats_updates_count"
+    )
+}
+
+fn memory_hotplug_state_suffix(suffix: &str) -> bool {
+    matches!(
+        suffix,
+        "plug_bytes"
+            | "plug_count"
+            | "plug_fails"
+            | "state_count"
+            | "state_fails"
+            | "unplug_all_count"
+            | "unplug_all_fails"
+            | "unplug_bytes"
+            | "unplug_count"
+            | "unplug_discard_fails"
+            | "unplug_fails"
+    )
+}
+
+fn data_path_suffix(suffix: &str) -> bool {
+    matches!(
+        suffix,
+        "conns_added"
+            | "conns_killed"
+            | "conns_removed"
+            | "entropy_bytes"
+            | "error_count"
+            | "execute_fails"
+            | "flush_count"
+            | "host_rng_fails"
+            | "invalid_reqs_count"
+            | "missed_read_count"
+            | "missed_write_count"
+            | "read_bytes"
+            | "read_count"
+            | "rx_bytes_count"
+            | "rx_count"
+            | "rx_fails"
+            | "rx_packets_count"
+            | "rx_read_fails"
+            | "tap_read_fails"
+            | "tap_write_fails"
+            | "tx_bytes_count"
+            | "tx_count"
+            | "tx_fails"
+            | "tx_flush_fails"
+            | "tx_malformed_frames"
+            | "tx_packets_count"
+            | "tx_spoofed_mac_count"
+            | "tx_write_fails"
+            | "write_bytes"
+            | "write_count"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_every_materialized_child_count() {
+        let paths = [
+            ("entropy.entropy_bytes", "#1838"),
+            ("memory_hotplug.plug_count", "#1839"),
+            ("vsock.conns_added", "#1840"),
+            ("block_{drive_id}.read_count", "#1841"),
+            ("vhost_user_block_{drive_id}.init_time_us", "#1842"),
+            ("mmds.rx_count", "#1843"),
+            ("net.tap_read_fails", "#1844"),
+            ("vcpu.exit_mmio_read", "#1845"),
+            ("vcpu.exit_io_in", "#1846"),
+        ];
+        for (path, issue) in paths {
+            assert_eq!(expected_delivery_issue(path), Some(issue), "{path}");
+            assert!(expected_boundary(path).is_some(), "{path}");
+        }
+    }
+}

--- a/tools/firecracker-capability-audit/src/validate.rs
+++ b/tools/firecracker-capability-audit/src/validate.rs
@@ -552,7 +552,7 @@ fn forbid_delivery_and_exclusion(capability: &Capability, errors: &mut Vec<Strin
     }
 }
 
-fn validate_exclusion(
+pub(crate) fn validate_exclusion(
     id: &str,
     exclusion: &PlatformExclusion,
     repository_root: &Path,

--- a/tools/firecracker-capability-audit/tests/metrics_schema.rs
+++ b/tools/firecracker-capability-audit/tests/metrics_schema.rs
@@ -3,13 +3,16 @@
 use std::path::PathBuf;
 
 use bangbang_firecracker_capability_audit::{
-    AuditMode, METRICS_PROCESS_PRODUCER_AUDIT_PATH, METRICS_SCHEMA_AUTHORITY_PATH,
-    MetricsAggregation, MetricsArchitecture, MetricsProcessProducerAudit,
-    MetricsProcessProducerBoundary, MetricsProcessProducerDisposition, MetricsProducerDisposition,
-    MetricsProducerOwner, MetricsSchemaAuthority, MetricsUnit, MetricsValueKind, Reference,
-    SOURCE_MANIFEST_PATH, metrics_process_producer_audit_json, metrics_schema_authority_json,
+    AuditMode, METRICS_DEVICE_PRODUCER_AUDIT_PATH, METRICS_PROCESS_PRODUCER_AUDIT_PATH,
+    METRICS_SCHEMA_AUTHORITY_PATH, MetricsAggregation, MetricsArchitecture,
+    MetricsDeviceProducerAudit, MetricsDeviceProducerBoundary, MetricsDeviceProducerDisposition,
+    MetricsDeviceProducerRecord, MetricsProcessProducerAudit, MetricsProcessProducerBoundary,
+    MetricsProcessProducerDisposition, MetricsProducerDisposition, MetricsProducerOwner,
+    MetricsSchemaAuthority, MetricsUnit, MetricsValueKind, PlatformExclusion, Reference,
+    SOURCE_MANIFEST_PATH, metrics_device_producer_audit_json, metrics_process_producer_audit_json,
+    metrics_schema_authority_json, read_metrics_device_producer_audit,
     read_metrics_process_producer_audit, read_metrics_schema_authority, read_source_manifest,
-    validate_metrics_process_producers, validate_metrics_schema,
+    validate_metrics_device_producers, validate_metrics_process_producers, validate_metrics_schema,
 };
 
 fn repository_root() -> PathBuf {
@@ -31,6 +34,12 @@ fn checked_process_audit() -> MetricsProcessProducerAudit {
         .expect("checked metrics process producer audit must parse")
 }
 
+fn checked_device_audit() -> MetricsDeviceProducerAudit {
+    let root = repository_root();
+    read_metrics_device_producer_audit(&root.join(METRICS_DEVICE_PRODUCER_AUDIT_PATH))
+        .expect("checked metrics device producer audit must parse")
+}
+
 fn validation_error(authority: &MetricsSchemaAuthority) -> String {
     let root = repository_root();
     let manifest = read_source_manifest(&root.join(SOURCE_MANIFEST_PATH))
@@ -45,6 +54,34 @@ fn process_validation_error(audit: &MetricsProcessProducerAudit) -> String {
     validate_metrics_process_producers(audit, &checked_authority(), &root, AuditMode::Delivery)
         .expect_err("mutated metrics process producer audit must fail")
         .to_string()
+}
+
+fn device_validation_error(audit: &MetricsDeviceProducerAudit) -> String {
+    let root = repository_root();
+    validate_metrics_device_producers(audit, &checked_authority(), &root, AuditMode::Delivery)
+        .expect_err("mutated metrics device producer audit must fail")
+        .to_string()
+}
+
+fn anchored_local_reference() -> Reference {
+    Reference::Local {
+        path: "tools/firecracker-capability-audit/src/metrics_process_validate.rs".to_string(),
+        anchor: Some("pub fn validate_metrics_process_producers".to_string()),
+    }
+}
+
+fn make_device_record_terminal(
+    audit: &mut MetricsDeviceProducerAudit,
+) -> &mut MetricsDeviceProducerRecord {
+    let record = audit
+        .records
+        .iter_mut()
+        .find(|record| record.disposition == MetricsDeviceProducerDisposition::Planned)
+        .expect("planned device record must exist");
+    record.disposition = MetricsDeviceProducerDisposition::Implemented;
+    record.implementation.push(anchored_local_reference());
+    record.validation.push(anchored_local_reference());
+    record
 }
 
 #[test]
@@ -156,6 +193,353 @@ fn checked_process_producer_audit_is_canonical_and_exact() {
 
     validate_metrics_process_producers(&audit, &authority, &root, AuditMode::Final)
         .expect("all process producer records should now be terminal");
+}
+
+#[test]
+fn checked_device_producer_audit_is_canonical_and_exact() {
+    let root = repository_root();
+    let path = root.join(METRICS_DEVICE_PRODUCER_AUDIT_PATH);
+    let authority = checked_authority();
+    let audit = checked_device_audit();
+    validate_metrics_device_producers(&audit, &authority, &root, AuditMode::Delivery)
+        .expect("checked device producer audit must validate locally");
+    assert_eq!(
+        std::fs::read(path).expect("checked device producer audit must be readable"),
+        metrics_device_producer_audit_json(&audit)
+            .expect("device producer audit must serialize canonically")
+    );
+    assert_eq!(audit.records.len(), 231);
+    for (issue, count) in [
+        ("#1838", 23),
+        ("#1839", 38),
+        ("#1840", 20),
+        ("#1841", 48),
+        ("#1842", 5),
+        ("#1843", 57),
+        ("#1844", 14),
+        ("#1845", 11),
+        ("#1846", 15),
+    ] {
+        assert_eq!(
+            audit
+                .records
+                .iter()
+                .filter(|record| record.delivery_issue == issue)
+                .count(),
+            count,
+            "{issue}"
+        );
+    }
+    assert_eq!(
+        audit
+            .records
+            .iter()
+            .filter(|record| record.disposition == MetricsDeviceProducerDisposition::Planned)
+            .count(),
+        216
+    );
+    assert_eq!(
+        audit
+            .records
+            .iter()
+            .filter(|record| {
+                record.disposition == MetricsDeviceProducerDisposition::ProvisionalPlatformZero
+            })
+            .count(),
+        15
+    );
+    assert!(audit.records.iter().all(|record| {
+        record.implementation.is_empty()
+            && record.validation.is_empty()
+            && record.platform_exclusion.is_none()
+    }));
+
+    let error = validate_metrics_device_producers(&audit, &authority, &root, AuditMode::Final)
+        .expect_err("all device producer records must remain nonterminal")
+        .to_string();
+    assert_eq!(
+        error
+            .lines()
+            .filter(|line| line.contains("final metrics device producer validation rejects"))
+            .count(),
+        231
+    );
+}
+
+#[test]
+fn device_producer_audit_rejects_membership_and_order_drift() {
+    let mut missing = checked_device_audit();
+    let removed = missing.records.remove(0);
+    let error = device_validation_error(&missing);
+    assert!(error.contains("must contain 231 records"));
+    assert!(error.contains(&format!(
+        "missing metrics device producer record: {}",
+        removed.field_id
+    )));
+
+    let mut duplicate = checked_device_audit();
+    duplicate.records.push(duplicate.records[0].clone());
+    let error = device_validation_error(&duplicate);
+    assert!(error.contains("sorted and unique"));
+    assert!(error.contains("duplicate metrics device producer record"));
+
+    let mut stale = checked_device_audit();
+    stale.records[0].field_id = "static:not.device_owned".to_string();
+    let error = device_validation_error(&stale);
+    assert!(error.contains("stale or unowned"));
+    assert!(error.contains("missing metrics device producer record"));
+
+    let mut order = checked_device_audit();
+    order.records.swap(0, 1);
+    assert!(device_validation_error(&order).contains("sorted and unique"));
+
+    let mut static_for_dynamic = checked_device_audit();
+    let dynamic = static_for_dynamic
+        .records
+        .iter_mut()
+        .find(|record| record.field_id == "dynamic:block_{drive_id}.activate_fails")
+        .expect("configured block record must exist");
+    dynamic.field_id = "static:block.activate_fails".to_string();
+    let error = device_validation_error(&static_for_dynamic);
+    assert!(error.contains("duplicate metrics device producer record"));
+    assert!(error.contains(
+        "missing metrics device producer record: dynamic:block_{drive_id}.activate_fails"
+    ));
+}
+
+#[test]
+fn device_producer_audit_rejects_child_boundary_and_rationale_drift() {
+    let mut boundary = checked_device_audit();
+    boundary.records[0].boundary = MetricsDeviceProducerBoundary::VcpuFailure;
+    assert!(device_validation_error(&boundary).contains("wrong boundary"));
+
+    let mut rationale = checked_device_audit();
+    rationale.records[0].rationale.clear();
+    assert!(device_validation_error(&rationale).contains("stale rationale"));
+
+    for (field_id, wrong_issue) in [
+        ("static:entropy.entropy_bytes", "#1839"),
+        ("static:memory_hotplug.plug_count", "#1840"),
+        ("static:vsock.conns_added", "#1841"),
+        ("dynamic:block_{drive_id}.read_count", "#1842"),
+        ("dynamic:vhost_user_block_{drive_id}.init_time_us", "#1843"),
+        ("static:mmds.rx_count", "#1844"),
+        ("dynamic:net_{iface_id}.tx_count", "#1844"),
+        ("static:net.tap_read_fails", "#1843"),
+        ("static:vcpu.exit_mmio_read", "#1846"),
+        ("static:vcpu.exit_io_in", "#1845"),
+    ] {
+        let mut audit = checked_device_audit();
+        audit
+            .records
+            .iter_mut()
+            .find(|record| record.field_id == field_id)
+            .expect("representative device record must exist")
+            .delivery_issue = wrong_issue.to_string();
+        assert!(
+            device_validation_error(&audit).contains("wrong delivery issue"),
+            "{field_id}"
+        );
+    }
+}
+
+#[test]
+fn device_producer_audit_rejects_disposition_and_nonterminal_evidence_drift() {
+    let mut planned_as_provisional = checked_device_audit();
+    planned_as_provisional
+        .records
+        .iter_mut()
+        .find(|record| record.disposition == MetricsDeviceProducerDisposition::Planned)
+        .expect("planned device record must exist")
+        .disposition = MetricsDeviceProducerDisposition::ProvisionalPlatformZero;
+    assert!(device_validation_error(&planned_as_provisional).contains("wrong current disposition"));
+
+    let mut provisional_as_planned = checked_device_audit();
+    provisional_as_planned
+        .records
+        .iter_mut()
+        .find(|record| {
+            record.disposition == MetricsDeviceProducerDisposition::ProvisionalPlatformZero
+        })
+        .expect("provisional device record must exist")
+        .disposition = MetricsDeviceProducerDisposition::Planned;
+    assert!(device_validation_error(&provisional_as_planned).contains("wrong current disposition"));
+
+    let mut premature = checked_device_audit();
+    let record = premature
+        .records
+        .iter_mut()
+        .find(|record| record.disposition == MetricsDeviceProducerDisposition::Planned)
+        .expect("planned device record must exist");
+    record.disposition = MetricsDeviceProducerDisposition::Implemented;
+    record.implementation.push(anchored_local_reference());
+    record.validation.push(anchored_local_reference());
+    assert!(device_validation_error(&premature).contains("wrong current disposition"));
+
+    let mut evidence = checked_device_audit();
+    evidence.records[0]
+        .implementation
+        .push(anchored_local_reference());
+    assert!(device_validation_error(&evidence).contains("must not claim terminal evidence"));
+}
+
+#[test]
+fn device_producer_audit_rejects_bad_terminal_evidence() {
+    let mut missing = checked_device_audit();
+    make_device_record_terminal(&mut missing)
+        .implementation
+        .clear();
+    assert!(
+        device_validation_error(&missing).contains("needs implementation and validation evidence")
+    );
+
+    let mut duplicate = checked_device_audit();
+    let record = make_device_record_terminal(&mut duplicate);
+    record.implementation.push(anchored_local_reference());
+    assert!(
+        device_validation_error(&duplicate)
+            .contains("implementation references must be sorted and unique")
+    );
+
+    let mut unsorted = checked_device_audit();
+    make_device_record_terminal(&mut unsorted).implementation = vec![
+        Reference::Github {
+            url: "https://github.com/seven332/bangbang/issues/1837".to_string(),
+        },
+        anchored_local_reference(),
+    ];
+    assert!(
+        device_validation_error(&unsorted)
+            .contains("implementation references must be sorted and unique")
+    );
+
+    let mut unsafe_path = checked_device_audit();
+    make_device_record_terminal(&mut unsafe_path).implementation[0] = Reference::Local {
+        path: "../escape.rs".to_string(),
+        anchor: Some("anything".to_string()),
+    };
+    assert!(device_validation_error(&unsafe_path).contains("path escapes repository"));
+
+    let mut missing_anchor = checked_device_audit();
+    make_device_record_terminal(&mut missing_anchor).implementation[0] = Reference::Local {
+        path: "tools/firecracker-capability-audit/src/metrics_process_validate.rs".to_string(),
+        anchor: None,
+    };
+    assert!(device_validation_error(&missing_anchor).contains("needs a stable anchor"));
+
+    let mut unresolved_anchor = checked_device_audit();
+    make_device_record_terminal(&mut unresolved_anchor).implementation[0] = Reference::Local {
+        path: "tools/firecracker-capability-audit/src/metrics_process_validate.rs".to_string(),
+        anchor: Some("this symbol does not exist".to_string()),
+    };
+    assert!(device_validation_error(&unresolved_anchor).contains("anchor does not resolve"));
+
+    let mut invalid_urls = checked_device_audit();
+    make_device_record_terminal(&mut invalid_urls)
+        .implementation
+        .push(Reference::Github {
+            url: "http://example.invalid/not-github".to_string(),
+        });
+    assert!(device_validation_error(&invalid_urls).contains("GitHub reference must name an HTTPS"));
+
+    let mut invalid_authority = checked_device_audit();
+    make_device_record_terminal(&mut invalid_authority)
+        .implementation
+        .push(Reference::Authoritative {
+            url: "http://example.invalid/platform".to_string(),
+        });
+    assert!(
+        device_validation_error(&invalid_authority)
+            .contains("authoritative reference must name an HTTPS")
+    );
+}
+
+#[test]
+fn device_producer_audit_rejects_invalid_platform_exclusions() {
+    let empty_exclusion = || PlatformExclusion {
+        upstream_contract: Vec::new(),
+        platform_evidence: Vec::new(),
+        alternatives: Vec::new(),
+        stable_behavior: Vec::new(),
+        focused_tests: Vec::new(),
+        compatibility_docs: Vec::new(),
+        security_docs: Vec::new(),
+        challenge: Reference::Github {
+            url: "https://github.com/seven332/bangbang/issues/1837".to_string(),
+        },
+    };
+
+    let mut forbidden = checked_device_audit();
+    let record = forbidden
+        .records
+        .iter_mut()
+        .find(|record| record.disposition == MetricsDeviceProducerDisposition::Planned)
+        .expect("planned device record must exist");
+    record.platform_exclusion = Some(empty_exclusion());
+    assert!(device_validation_error(&forbidden).contains("must not claim terminal evidence"));
+
+    let mut non_platform_terminal = checked_device_audit();
+    make_device_record_terminal(&mut non_platform_terminal).platform_exclusion =
+        Some(empty_exclusion());
+    assert!(
+        device_validation_error(&non_platform_terminal)
+            .contains("non-platform metrics device producer forbids exclusion evidence")
+    );
+
+    let mut missing = checked_device_audit();
+    let record = missing
+        .records
+        .iter_mut()
+        .find(|record| {
+            record.disposition == MetricsDeviceProducerDisposition::ProvisionalPlatformZero
+        })
+        .expect("provisional platform device record must exist");
+    record.disposition = MetricsDeviceProducerDisposition::PlatformZero;
+    record.implementation.push(anchored_local_reference());
+    record.validation.push(anchored_local_reference());
+    assert!(device_validation_error(&missing).contains("needs structured exclusion evidence"));
+
+    let mut incomplete = checked_device_audit();
+    let record = incomplete
+        .records
+        .iter_mut()
+        .find(|record| {
+            record.disposition == MetricsDeviceProducerDisposition::ProvisionalPlatformZero
+        })
+        .expect("provisional platform device record must exist");
+    record.disposition = MetricsDeviceProducerDisposition::PlatformZero;
+    record.implementation.push(anchored_local_reference());
+    record.validation.push(anchored_local_reference());
+    record.platform_exclusion = Some(PlatformExclusion {
+        upstream_contract: Vec::new(),
+        platform_evidence: Vec::new(),
+        alternatives: Vec::new(),
+        stable_behavior: Vec::new(),
+        focused_tests: Vec::new(),
+        compatibility_docs: Vec::new(),
+        security_docs: Vec::new(),
+        challenge: Reference::Local {
+            path: "README.md".to_string(),
+            anchor: Some("Bangbang".to_string()),
+        },
+    });
+    let error = device_validation_error(&incomplete);
+    assert!(error.contains("platform exclusion upstream_contract must not be empty"));
+    assert!(error.contains("alternatives must contain reviewed reasons"));
+    assert!(error.contains("challenge must be a GitHub reference"));
+}
+
+#[test]
+fn device_producer_audit_rejects_schema_version_and_baseline_drift() {
+    let mut schema = checked_device_audit();
+    schema.schema_version += 1;
+    assert!(device_validation_error(&schema).contains("schema_version must be 1"));
+
+    let mut baseline = checked_device_audit();
+    baseline.baseline.commit = "0".repeat(40);
+    let error = device_validation_error(&baseline);
+    assert!(error.contains("baselines differ"));
+    assert!(error.contains("not the pinned release"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a human-owned, canonical audit for all 231 Firecracker v1.16.0 device metrics fields
- pin the exact nine-child delivery partition, closed producer boundaries, 216 planned records, and 15 nonterminal provisional platform-zero records
- validate membership, ordering, ownership, child routing, rationale, disposition, anchored terminal evidence, and structured platform exclusions fail-closed
- make ordinary and existing scoped validation commands consume the device audit without introducing device-final certification early

## Scope exclusions

- no runtime metrics producer, serializer, schema, or public JSON-line changes
- no terminal device producer or platform-zero claims
- no `--metrics-device-final` command; final device composition remains #1847

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate --logger-final`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate --metrics-schema-final`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate --metrics-process-final`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate --final` (expected failure, including exactly 231 nonterminal device records)
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo test -p bangbang-firecracker-capability-audit --all-targets --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `git diff --check`

Closes #1837

Parent delivery context: #1789

Program context: #1348
