### PR TITLE
feat: certify entropy, pmem, RTC, and UART metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ cargo run -p bangbang-firecracker-capability-audit --locked -- validate
 cargo check --workspace --all-targets --all-features --locked
 ```
 
-The ordinary audit also validates the exact nonterminal 231-field device
-producer authority for #1789: 216 planned records and 15 provisional
-platform-zero records partitioned across its nine delivery children.
+The ordinary audit also validates the exact 231-field device producer
+authority for #1789. The completed #1838 slice contributes 22 implemented
+entropy/pmem/RTC/UART records and one source-neutral UART record; 193 planned
+and 15 provisional platform-zero records remain across the later children.
 
 The terminal 69-field API/process metrics producer scope has a separate
 fail-closed certification gate:

--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -38,8 +38,9 @@ For commands and test-layer selection, see the
 - [`metrics-device-producer-audit.json`](metrics-device-producer-audit.json) is
   the human-owned delivery audit for the exact 231 fields assigned to device
   producer profiles. It records a closed operation boundary and one of the nine
-  #1789 delivery children per field. Its 216 planned and 15 provisional
-  platform-zero records are intentionally nonterminal and carry no evidence.
+  #1789 delivery children per field. After #1838 it contains 22 implemented,
+  one source-neutral, 193 planned, and 15 provisional platform-zero records;
+  only the latter two groups are nonterminal and carry no evidence.
 - Contract Markdown files are human-owned evidence ledgers. They define a
   selected capability family, its exact supported or excluded boundary, and
   the implementation and validation evidence for its dispositions.
@@ -80,7 +81,7 @@ reviewed delta.
 | [Snapshot Wave 6](snapshot-wave6-contract.md) | Exact 70-row load, artifact, version, device, tool, time/identity, portability, and downstream-owner certification |
 | [Observability, tools, and specification](observability-tools-specification-contract.md) | Exact Wave 7 ownership, core API certification, x86 CPUID/MSR platform exclusions, and retained downstream handoffs |
 | [Logger producers](logger-contract.md) | Certified 11-row logger aggregate with exact 468-invocation source closure, 24 implemented classes, 7 exact platform/developer exclusions, no planned producer classes, safe fields, and bounded default-stdout admission/forwarding policy |
-| [Metrics schema and producer audits](metrics-contract.md) | Terminal twelve-row #1787 API/schema certification, exact 24-root/243-static-field arm64 line shape, 24/29/5 configured dynamic families, source fingerprints, closed units/reset/aggregation policy, a terminal 69-field #1788 process audit, and an exact nonterminal 231-field #1789 device audit |
+| [Metrics schema and producer audits](metrics-contract.md) | Terminal twelve-row #1787 API/schema certification, exact 24-root/243-static-field arm64 line shape, 24/29/5 configured dynamic families, source fingerprints, closed units/reset/aggregation policy, a terminal 69-field #1788 process audit, and an incremental 231-field #1789 device audit with #1838 terminal |
 
 ## Dispositions
 

--- a/compat/firecracker/v1.16.0/entropy-contract.md
+++ b/compat/firecracker/v1.16.0/entropy-contract.md
@@ -63,8 +63,15 @@ native-v2 2.8 snapshot continuation and containment.
   zero-length host-source failure remains a consumed request.
 - The `entropy` metrics object exposes `activate_fails`, `entropy_event_fails`,
   `entropy_event_count`, `entropy_bytes`, `host_rng_fails`,
-  `entropy_rate_limiter_throttled`, and `rate_limiter_event_count`. Counts are
-  per device, saturating, and reported through the ordinary metrics pipeline.
+  `entropy_rate_limiter_throttled`, and `rate_limiter_event_count`. Event count
+  advances when a descriptor is popped, before parsing or limiter admission,
+  and is retained across throttle undo and later queue errors. Host RNG and its
+  paired event failure advance only when filling that popped request fails; a
+  pre-dispatch source-provider acquisition failure remains an internal
+  diagnostic. Counts are per device, saturating, owner-snapshot coherent, and
+  reported through the ordinary metrics pipeline. MMIO, PCI, and restored
+  devices attach the fresh session owner before publication, so activation
+  failures never leak between source, destination, or reused device owners.
 - Detached state contains external configuration, available and negotiated
   features, activation, exact one-queue geometry/ranges/cursors, limiter
   configuration and redacted budget/burst/refill-age state, the single pending

--- a/compat/firecracker/v1.16.0/metrics-contract.md
+++ b/compat/firecracker/v1.16.0/metrics-contract.md
@@ -42,10 +42,11 @@ descriptor-equality test. #1823 certifies the bounded #1787 API/schema slice,
 including the schema-runtime timestamp producer. #1788 certifies the exact
 API, process, logger, signal, boot, and lifecycle producers through two
 implemented aggregate profiles and the field-level process audit. The checked
-device audit now assigns every #1789 field to one concrete delivery child, but
-all records remain nonterminal. `corpus:metrics` and the cross-producer
-aggregate semantic remain #1790-owned. A required zero therefore proves
-wire-shape completeness only, never producer completion.
+device audit now assigns every #1789 field to one concrete delivery child and
+terminally certifies the 23 #1838 records; later child records remain
+nonterminal. `corpus:metrics` and the cross-producer aggregate semantic remain
+#1790-owned. A required zero therefore proves wire-shape completeness only,
+never producer completion unless its field audit is terminal.
 
 ## Terminal API and Schema Certification
 
@@ -206,7 +207,7 @@ installation or fault producer and Bangbang rejects both runtime seccomp CLI
 forms. The generic SIGSYS handler preserves exit-code compatibility only and
 must never be aliased into `seccomp.num_faults`.
 
-## Nonterminal Device Producer Audit
+## Incremental Device Producer Audit
 
 The device audit is an exact, lexicographically sorted bijection over all 231
 schema fields owned by device producer profiles. Missing, duplicate, stale,
@@ -217,12 +218,27 @@ Static and configured identities remain distinct; exact suffix routing splits
 mapped network fields from tap-oriented gaps and applicable vCPU exits from
 retained PIO/KVM-clock fields.
 
-The initial audit contains 216 `planned` records and 15
-`provisional-platform-zero` records. Both dispositions are nonterminal, carry
-empty implementation and validation arrays, and have no platform exclusion.
-The provisional records are the six retained i8042 fields plus nine vCPU
-PIO/KVM-clock fields; this label does not claim that the terminal platform
-evidence required by #1846 already exists.
+After #1838, the audit contains 193 `planned`, 15
+`provisional-platform-zero`, 22 `implemented`, and one `source-neutral`
+record. The 23 terminal records cover the complete pinned entropy, pmem, RTC,
+and UART roots. `uart.flush_count` is the source-neutral record because pinned
+Firecracker declares the field but has no producer; receive-FIFO clearing and
+other Bangbang-only serial diagnostics do not feed it. The remaining planned
+and provisional records are nonterminal, carry empty implementation and
+validation arrays, and have no platform exclusion. The provisional records
+are the six retained i8042 fields plus nine vCPU PIO/KVM-clock fields; this
+label does not claim that the terminal platform evidence required by #1846
+already exists.
+
+Entropy, pmem, RTC, and UART counters use one narrow owner-local value lock per
+immutable snapshot. A compound producer update and a snapshot therefore cannot
+expose a partially applied tuple. Pmem's aggregate and each current device
+generation are separate coherent owners; no cross-owner atomic cut is claimed.
+Entropy counts a request when its descriptor is popped, including parse,
+limiter, source, and publication failures, while a pre-dispatch host-source
+provider acquisition failure remains internal. RTC distinguishes missed
+register accesses from width/data bus failures. UART limiter drops count both
+the attempted write and the dropped byte.
 
 Later producer children may replace only their exact records with terminal
 `implemented`, `source-neutral`, or `platform-zero` dispositions. Terminal

--- a/compat/firecracker/v1.16.0/metrics-device-producer-audit.json
+++ b/compat/firecracker/v1.16.0/metrics-device-producer-audit.json
@@ -855,65 +855,289 @@
     {
       "field_id": "static:entropy.activate_fails",
       "boundary": "activation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `entropy.activate_fails` is assigned to #1838 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `entropy.activate_fails` is completed by #1838 at the `activation` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_entropy_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "pub struct VirtioRngQueueDispatch {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn entropy_queue_dispatch_metrics("
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_entropy_transport_metrics_bind_activation_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "fn entropy_metrics_record_notification_dispatch()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:entropy.entropy_bytes",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `entropy.entropy_bytes` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `entropy.entropy_bytes` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_entropy_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "pub struct VirtioRngQueueDispatch {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn entropy_queue_dispatch_metrics("
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_entropy_transport_metrics_bind_activation_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "fn entropy_metrics_record_notification_dispatch()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:entropy.entropy_event_count",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `entropy.entropy_event_count` is assigned to #1838 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `entropy.entropy_event_count` is completed by #1838 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_entropy_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "pub struct VirtioRngQueueDispatch {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn entropy_queue_dispatch_metrics("
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_entropy_transport_metrics_bind_activation_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "fn entropy_metrics_record_notification_dispatch()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:entropy.entropy_event_fails",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `entropy.entropy_event_fails` is assigned to #1838 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `entropy.entropy_event_fails` is completed by #1838 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_entropy_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "pub struct VirtioRngQueueDispatch {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn entropy_queue_dispatch_metrics("
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_entropy_transport_metrics_bind_activation_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "fn entropy_metrics_record_notification_dispatch()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:entropy.entropy_rate_limiter_throttled",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `entropy.entropy_rate_limiter_throttled` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `entropy.entropy_rate_limiter_throttled` is completed by #1838 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_entropy_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "pub struct VirtioRngQueueDispatch {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn entropy_queue_dispatch_metrics("
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_entropy_transport_metrics_bind_activation_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "fn entropy_metrics_record_notification_dispatch()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:entropy.host_rng_fails",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `entropy.host_rng_fails` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `entropy.host_rng_fails` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_entropy_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "pub struct VirtioRngQueueDispatch {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn entropy_queue_dispatch_metrics("
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_entropy_transport_metrics_bind_activation_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "fn entropy_metrics_record_notification_dispatch()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:entropy.rate_limiter_event_count",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `entropy.rate_limiter_event_count` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `entropy.rate_limiter_event_count` is completed by #1838 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_entropy_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "pub struct VirtioRngQueueDispatch {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn entropy_queue_dispatch_metrics("
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_entropy_transport_metrics_bind_activation_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/entropy.rs",
+          "anchor": "fn entropy_metrics_record_notification_dispatch()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:i8042.error_count",
@@ -1602,146 +1826,593 @@
     {
       "field_id": "static:pmem.activate_fails",
       "boundary": "activation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `pmem.activate_fails` is assigned to #1838 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `pmem.activate_fails` is completed by #1838 at the `activation` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_pmem_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct SharedPmemDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "struct VirtioPmemTransportMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_pmem_transport_metrics_bind_aggregate_and_device_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "fn pmem_config_metrics_record_only_pinned_out_of_bounds_reads()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:pmem.cfg_fails",
       "boundary": "configuration",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `pmem.cfg_fails` is assigned to #1838 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `pmem.cfg_fails` is completed by #1838 at the `configuration` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_pmem_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct SharedPmemDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "struct VirtioPmemTransportMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_pmem_transport_metrics_bind_aggregate_and_device_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "fn pmem_config_metrics_record_only_pinned_out_of_bounds_reads()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:pmem.event_fails",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `pmem.event_fails` is assigned to #1838 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `pmem.event_fails` is completed by #1838 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_pmem_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct SharedPmemDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "struct VirtioPmemTransportMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_pmem_transport_metrics_bind_aggregate_and_device_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "fn pmem_config_metrics_record_only_pinned_out_of_bounds_reads()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:pmem.queue_event_count",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `pmem.queue_event_count` is assigned to #1838 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `pmem.queue_event_count` is completed by #1838 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_pmem_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct SharedPmemDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "struct VirtioPmemTransportMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_pmem_transport_metrics_bind_aggregate_and_device_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "fn pmem_config_metrics_record_only_pinned_out_of_bounds_reads()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:pmem.rate_limiter_event_count",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `pmem.rate_limiter_event_count` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `pmem.rate_limiter_event_count` is completed by #1838 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_pmem_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct SharedPmemDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "struct VirtioPmemTransportMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_pmem_transport_metrics_bind_aggregate_and_device_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "fn pmem_config_metrics_record_only_pinned_out_of_bounds_reads()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:pmem.rate_limiter_throttled_events",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `pmem.rate_limiter_throttled_events` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `pmem.rate_limiter_throttled_events` is completed by #1838 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn bind_mmio_pmem_transport_metrics("
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct SharedPmemDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "struct VirtioPmemTransportMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn mmio_pmem_transport_metrics_bind_aggregate_and_device_at_source()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/pmem.rs",
+          "anchor": "fn pmem_config_metrics_record_only_pinned_out_of_bounds_reads()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:rtc.error_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `rtc.error_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `rtc.error_count` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct SharedRtcDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/rtc.rs",
+          "anchor": "impl<T: RtcTimeSource> MmioHandler for Pl031RtcDevice<T> {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/rtc.rs",
+          "anchor": "fn read_errors_distinguish_bus_failures_from_missed_registers()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:rtc.missed_read_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `rtc.missed_read_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `rtc.missed_read_count` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct SharedRtcDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/rtc.rs",
+          "anchor": "impl<T: RtcTimeSource> MmioHandler for Pl031RtcDevice<T> {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/rtc.rs",
+          "anchor": "fn read_errors_distinguish_bus_failures_from_missed_registers()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:rtc.missed_write_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `rtc.missed_write_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `rtc.missed_write_count` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct SharedRtcDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/rtc.rs",
+          "anchor": "impl<T: RtcTimeSource> MmioHandler for Pl031RtcDevice<T> {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/rtc.rs",
+          "anchor": "fn write_errors_distinguish_bus_failures_from_missed_registers()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:uart.error_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `uart.error_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `uart.error_count` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "Firecracker v1.16.0 declares this field but has no UART producer."
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "impl SharedSerialOutputMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_serial_output_diagnostics_when_uart_metrics_are_nonzero()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "fn shared_output_and_uart_core_publish_one_coherent_metric_generation()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:uart.flush_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "source-neutral",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `uart.flush_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `uart.flush_count` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "Firecracker v1.16.0 declares this field but has no UART producer."
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "impl SharedSerialOutputMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_serial_output_diagnostics_when_uart_metrics_are_nonzero()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "fn shared_output_and_uart_core_publish_one_coherent_metric_generation()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:uart.missed_read_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `uart.missed_read_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `uart.missed_read_count` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "Firecracker v1.16.0 declares this field but has no UART producer."
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "impl SharedSerialOutputMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_serial_output_diagnostics_when_uart_metrics_are_nonzero()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "fn shared_output_and_uart_core_publish_one_coherent_metric_generation()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:uart.missed_write_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `uart.missed_write_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `uart.missed_write_count` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "Firecracker v1.16.0 declares this field but has no UART producer."
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "impl SharedSerialOutputMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_serial_output_diagnostics_when_uart_metrics_are_nonzero()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "fn shared_output_and_uart_core_publish_one_coherent_metric_generation()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:uart.rate_limiter_dropped_bytes",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `uart.rate_limiter_dropped_bytes` is assigned to #1838 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `uart.rate_limiter_dropped_bytes` is completed by #1838 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "Firecracker v1.16.0 declares this field but has no UART producer."
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "impl SharedSerialOutputMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_serial_output_diagnostics_when_uart_metrics_are_nonzero()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "fn shared_output_and_uart_core_publish_one_coherent_metric_generation()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:uart.read_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `uart.read_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `uart.read_count` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "Firecracker v1.16.0 declares this field but has no UART producer."
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "impl SharedSerialOutputMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_serial_output_diagnostics_when_uart_metrics_are_nonzero()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "fn shared_output_and_uart_core_publish_one_coherent_metric_generation()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:uart.write_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1838",
-      "rationale": "Pinned Firecracker field `uart.write_count` is assigned to #1838 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `uart.write_count` is completed by #1838 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "Firecracker v1.16.0 declares this field but has no UART producer."
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "impl SharedSerialOutputMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_serial_output_diagnostics_when_uart_metrics_are_nonzero()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/serial.rs",
+          "anchor": "fn shared_output_and_uart_core_publish_one_coherent_metric_generation()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests"
+        }
+      ]
     },
     {
       "field_id": "static:vcpu.exit_io_in",

--- a/crates/bangbang/src/snapshot_serial_restore.rs
+++ b/crates/bangbang/src/snapshot_serial_restore.rs
@@ -1565,7 +1565,7 @@ mod tests {
             .output_mut()
             .write_byte(b'B')
             .expect("over-budget byte should be dropped without an endpoint error");
-        assert_eq!(serial.metrics().write_count(), 1);
+        assert_eq!(serial.metrics().write_count(), 2);
         assert_eq!(serial.metrics().rate_limiter_dropped_bytes(), 1);
         let mut byte = [0];
         output_reader

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -54000,8 +54000,8 @@ mod tests {
             supervisor.metrics_diagnostics().entropy_device_metrics(),
             Some(
                 EntropyDeviceMetrics::default()
-                    .with_entropy_event_fails(2)
-                    .with_host_rng_fails(1)
+                    .with_entropy_event_fails(1)
+                    .with_source_provider_fails(1)
             )
         );
 

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -2164,6 +2164,11 @@ mod macos_arm64 {
             Some(&serde_json::json!(0)),
             "serial stdin EOF must detach without recording an input error"
         );
+        assert_eq!(
+            metrics.pointer("/uart/flush_count"),
+            Some(&serde_json::json!(0)),
+            "receive FIFO lifecycle must not invent a pinned UART flush producer"
+        );
 
         let output = bangbang.terminate();
         assert!(output.stdout.contains(GUEST_SERIAL_RX_READY_MARKER));
@@ -2329,12 +2334,24 @@ mod macos_arm64 {
                 .expect("rate-limited serial metrics should contain a generation"),
         )
         .expect("rate-limited serial metrics generation should be JSON");
+        let dropped = metrics
+            .pointer("/uart/rate_limiter_dropped_bytes")
+            .and_then(serde_json::Value::as_u64)
+            .expect("serial limiter dropped-byte metric should be numeric");
+        assert!(
+            dropped > 0,
+            "serial stdout limiter must account for dropped guest bytes: {metrics}"
+        );
         assert!(
             metrics
-                .pointer("/uart/rate_limiter_dropped_bytes")
+                .pointer("/uart/write_count")
                 .and_then(serde_json::Value::as_u64)
-                .is_some_and(|dropped| dropped > 0),
-            "serial stdout limiter must account for dropped guest bytes: {metrics}"
+                .is_some_and(|writes| writes >= dropped),
+            "every limiter-dropped byte must also count as an attempted UART write: {metrics}"
+        );
+        assert_eq!(
+            metrics.pointer("/uart/flush_count"),
+            Some(&serde_json::json!(0))
         );
         assert_eq!(
             metrics.pointer("/uart/error_count"),
@@ -7055,6 +7072,10 @@ mod macos_arm64 {
         }
         assert_eq!(
             final_metrics.pointer("/uart/error_count"),
+            Some(&serde_json::json!(0)),
+        );
+        assert_eq!(
+            final_metrics.pointer("/uart/flush_count"),
             Some(&serde_json::json!(0)),
         );
         assert_clean_shutdown(

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -41,7 +41,7 @@ use bangbang_runtime::entropy::{
     VIRTIO_RNG_QUEUE_SIZES, VirtioRngDevice, VirtioRngDeviceNotificationError,
     VirtioRngEntropySource, VirtioRngEntropySourceError, VirtioRngMmioCaptureState,
     VirtioRngOsEntropySource, VirtioRngPciCaptureError, VirtioRngPciCaptureState,
-    VirtioRngRetryCaptureState,
+    VirtioRngRetryCaptureState, attach_entropy_metrics_to_mmio_handler,
 };
 use bangbang_runtime::fdt::{
     Arm64FdtCacheHierarchy, Arm64FdtError, Arm64FdtGuestMemoryWrite, Arm64FdtPciHost,
@@ -98,7 +98,7 @@ use bangbang_runtime::pmem::{
     PmemConfig, PmemFileBacking, PmemMmioDeviceRegistration, PmemMmioLayout,
     PmemRuntimeMutationError, PmemSnapshotPersistenceBinding, PmemUpdate, PmemUpdateError,
     PreparedPmemDevice, VIRTIO_PMEM_DEVICE_ID, VIRTIO_PMEM_QUEUE_SIZES, VirtioPmemConfigSpace,
-    VirtioPmemDevice, VirtioPmemFlushStatus,
+    VirtioPmemDevice, VirtioPmemFlushStatus, attach_pmem_metrics_to_mmio_handler,
 };
 use bangbang_runtime::pvtime::{
     ARM64_PVTIME_STOLEN_TIME_OFFSET, ARM64_PVTIME_STRUCTURE_SIZE, Arm64PvTimeLayout,
@@ -1731,16 +1731,19 @@ impl HvfArm64BootPciDataDevices {
         })?;
         let pmem_id = prepared.id().to_string();
         let guest_range = prepared.guest_range();
-        let config_space = prepared.config_space();
-        let device = VirtioPmemDevice::with_rate_limiter(
-            prepared.mapping().file_len(),
-            prepared.rate_limiter(),
-        );
         let prepared_metrics = metrics.prepare_device(pmem_id.clone()).map_err(|source| {
             PmemRuntimeMutationError::PrepareDevice {
                 message: source.to_string(),
             }
         })?;
+        let device_metrics = prepared_metrics.metrics();
+        let mut config_space = prepared.config_space();
+        config_space.attach_metrics(device_metrics.clone(), metrics.aggregate());
+        let mut device = VirtioPmemDevice::with_rate_limiter(
+            prepared.mapping().file_len(),
+            prepared.rate_limiter(),
+        );
+        device.attach_metrics(device_metrics, metrics.aggregate());
         let interrupts = self.shared_msi_registry().map_err(|source| {
             PmemRuntimeMutationError::TerminalInsertion {
                 message: source.to_string(),
@@ -19305,6 +19308,7 @@ impl OwnedHvfArm64BootSession {
                 block_device_metrics,
                 pmem_device_metrics,
                 network_interface_metrics,
+                entropy_device_metrics,
                 ..
             } = &mut session;
             prepare_pci_data_devices(
@@ -19314,6 +19318,7 @@ impl OwnedHvfArm64BootSession {
                 block_device_metrics,
                 network_interface_metrics,
                 pmem_device_metrics,
+                entropy_device_metrics,
             )
         };
         let pci_data_devices = match pci_data_devices {
@@ -23880,11 +23885,13 @@ impl OwnedHvfArm64BootSession {
 
     fn attach_snapshot_v2_entropy_mmio(
         mut session: OwnedHvfArm64BootSession,
-        entropy: PreparedSnapshotV2EntropyMmioHandler,
+        mut entropy: PreparedSnapshotV2EntropyMmioHandler,
         storage_configs: Option<CaptureReadyStorageConfigs>,
         inject_scheduler_failure: bool,
         source_factory: impl FnOnce() -> VirtioRngOsEntropySource,
     ) -> Result<RestoredHvfSnapshotV2EntropyMmioOwners, HvfSnapshotV2EntropyMmioRestoreError> {
+        let entropy_device_metrics = SharedEntropyDeviceMetrics::default();
+        entropy.attach_metrics(entropy_device_metrics.clone());
         let (config, _queue_ranges, _retry, retry_deadline, region, interrupt_line, handler) =
             entropy.into_parts();
         let owner_is_vacant = session.runtime_resources.entropy_device.is_none()
@@ -24023,7 +24030,7 @@ impl OwnedHvfArm64BootSession {
         });
         session.entropy_interrupt_line = Some(interrupt_line);
         session.entropy_source = source_factory();
-        session.entropy_device_metrics = SharedEntropyDeviceMetrics::default();
+        session.entropy_device_metrics = entropy_device_metrics;
         session.entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
 
         if inject_scheduler_failure {
@@ -24214,7 +24221,7 @@ impl OwnedHvfArm64BootSession {
     fn attach_snapshot_v2_entropy_pci(
         mut session: OwnedHvfArm64BootSession,
         endpoint_plan: HvfSnapshotV2EntropyPciEndpointPlan,
-        entropy: SnapshotV2EntropyRestorePlan,
+        mut entropy: SnapshotV2EntropyRestorePlan,
         storage_configs: Option<CaptureReadyStorageConfigs>,
         inject_scheduler_failure: bool,
         source_factory: impl FnOnce() -> VirtioRngOsEntropySource,
@@ -24255,6 +24262,9 @@ impl OwnedHvfArm64BootSession {
                 HvfSnapshotV2EntropyPciRestoreFailure::ResourcePlan,
             ));
         }
+
+        let entropy_device_metrics = SharedEntropyDeviceMetrics::default();
+        entropy.attach_metrics(entropy_device_metrics.clone());
 
         let mut interrupts = match session.pci_data_devices.as_ref() {
             Some(manager) => match manager.shared_msi_registry() {
@@ -24366,7 +24376,7 @@ impl OwnedHvfArm64BootSession {
         }
 
         session.entropy_source = source_factory();
-        session.entropy_device_metrics = SharedEntropyDeviceMetrics::default();
+        session.entropy_device_metrics = entropy_device_metrics;
         session.entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
         if inject_scheduler_failure {
             return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
@@ -25598,7 +25608,7 @@ impl OwnedHvfArm64BootSession {
                 block_interrupt_lines.push(interrupt_line);
             }
 
-            for (pmem_index, (record, planned)) in pmem_records
+            for (pmem_index, (mut record, planned)) in pmem_records
                 .into_iter()
                 .zip(planned_pmem_records)
                 .enumerate()
@@ -25606,6 +25616,11 @@ impl OwnedHvfArm64BootSession {
                 let registration_index = balloon_count
                     .saturating_add(block_count)
                     .saturating_add(pmem_index);
+                let device_metrics = pmem_device_metrics.per_device(record.pmem_id()).ok_or((
+                    HvfSnapshotV2StorageMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2StorageMmioRestoreFailure::ResourcePlan,
+                ))?;
+                record.attach_metrics(device_metrics, pmem_device_metrics.aggregate());
                 let (
                     _key,
                     _is_root_device,
@@ -26529,7 +26544,7 @@ impl OwnedHvfArm64BootSession {
                 metrics_lease,
             }));
         }
-        for (pmem_index, (record, planned)) in pmem_records
+        for (pmem_index, (mut record, planned)) in pmem_records
             .into_iter()
             .zip(pci_plan.pmem_records())
             .enumerate()
@@ -26549,6 +26564,14 @@ impl OwnedHvfArm64BootSession {
                     HvfSnapshotV2StoragePciRestoreFailure::PciData(source)
                 ),
             };
+            let device_metrics = match pmem_device_metrics.per_device(record.pmem_id()) {
+                Some(metrics) => metrics,
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            record.attach_metrics(device_metrics, pmem_device_metrics.aggregate());
             let endpoint =
                 match record.prepare_endpoint(planned.bar_region_id(), interrupts.registry()) {
                     Ok(endpoint) => endpoint,
@@ -35774,7 +35797,8 @@ pub enum HvfArm64BootSessionError {
     PciData {
         source: HvfArm64BootPciDataError,
     },
-    NetworkMetricsBinding {
+    DeviceMetricsBinding {
+        kind: &'static str,
         message: String,
     },
     MapGuestMemory {
@@ -35905,8 +35929,8 @@ impl fmt::Display for HvfArm64BootSessionError {
             Self::PciData { source } => {
                 write!(f, "failed to prepare PCI data devices: {source}")
             }
-            Self::NetworkMetricsBinding { message } => {
-                write!(f, "failed to bind network transport metrics: {message}")
+            Self::DeviceMetricsBinding { kind, message } => {
+                write!(f, "failed to bind {kind} transport metrics: {message}")
             }
             Self::MapGuestMemory { source } => {
                 write!(
@@ -35975,7 +35999,7 @@ impl std::error::Error for HvfArm64BootSessionError {
             Self::BackendAlreadyInitialized
             | Self::SerialInputWithoutDevice
             | Self::UnsupportedVcpuCount { .. }
-            | Self::NetworkMetricsBinding { .. }
+            | Self::DeviceMetricsBinding { .. }
             | Self::PvTimeAddressOverflow { .. }
             | Self::PowerTopology
             | Self::MissingPciValidationMsiSignaler
@@ -36790,6 +36814,9 @@ fn prepare_arm64_boot_session_parts_with_cache<'vm>(
     } else {
         SharedNetworkInterfaceMetricsRegistry::from_interface_ids(network_interface_ids)
     };
+    let entropy_device_metrics = SharedEntropyDeviceMetrics::default();
+    bind_mmio_entropy_transport_metrics(&runtime, &mmio_dispatcher, &entropy_device_metrics)?;
+    bind_mmio_pmem_transport_metrics(&runtime, &mmio_dispatcher, &pmem_device_metrics)?;
     bind_mmio_network_transport_metrics(&runtime, &mmio_dispatcher, &network_interface_metrics)?;
     let has_block_devices =
         !runtime.block_devices.is_empty() || !runtime.pci_block_devices.is_empty();
@@ -36802,6 +36829,7 @@ fn prepare_arm64_boot_session_parts_with_cache<'vm>(
         &block_device_metrics,
         &network_interface_metrics,
         &pmem_device_metrics,
+        &entropy_device_metrics,
     )
     .map_err(|source| HvfArm64BootSessionError::PciData { source })?;
     let memory_hotplug_device_metrics = runtime
@@ -36894,7 +36922,7 @@ fn prepare_arm64_boot_session_parts_with_cache<'vm>(
         memory_hotplug_device_metrics,
         network_interface_metrics,
         vsock_device_metrics: SharedVsockDeviceMetrics::default(),
-        entropy_device_metrics: SharedEntropyDeviceMetrics::default(),
+        entropy_device_metrics,
         gic,
         block_interrupt_lines: interrupt_lines.block,
         pmem_interrupt_lines: interrupt_lines.pmem,
@@ -37278,6 +37306,66 @@ fn preflight_pci_data_dispatcher(
     Ok(())
 }
 
+fn bind_mmio_entropy_transport_metrics(
+    runtime: &Arm64BootRuntimeResources,
+    dispatcher: &Arc<Mutex<MmioDispatcher>>,
+    metrics: &SharedEntropyDeviceMetrics,
+) -> Result<(), HvfArm64BootSessionError> {
+    let Some(device) = &runtime.entropy_device else {
+        return Ok(());
+    };
+    let mut dispatcher =
+        dispatcher
+            .lock()
+            .map_err(|_| HvfArm64BootSessionError::DeviceMetricsBinding {
+                kind: "entropy",
+                message: "MMIO dispatcher is unavailable".to_string(),
+            })?;
+    attach_entropy_metrics_to_mmio_handler(
+        &mut dispatcher,
+        device.registration.region_id(),
+        metrics.clone(),
+    )
+    .map_err(|source| HvfArm64BootSessionError::DeviceMetricsBinding {
+        kind: "entropy",
+        message: format!("failed to resolve MMIO entropy device: {source}"),
+    })
+}
+
+fn bind_mmio_pmem_transport_metrics(
+    runtime: &Arm64BootRuntimeResources,
+    dispatcher: &Arc<Mutex<MmioDispatcher>>,
+    metrics: &SharedPmemDeviceMetricsRegistry,
+) -> Result<(), HvfArm64BootSessionError> {
+    let mut dispatcher =
+        dispatcher
+            .lock()
+            .map_err(|_| HvfArm64BootSessionError::DeviceMetricsBinding {
+                kind: "pmem",
+                message: "MMIO dispatcher is unavailable".to_string(),
+            })?;
+    for device in &runtime.pmem_mmio_devices {
+        let pmem_id = device.registration.pmem_id();
+        let device_metrics = metrics.per_device(pmem_id).ok_or_else(|| {
+            HvfArm64BootSessionError::DeviceMetricsBinding {
+                kind: "pmem",
+                message: format!("missing metrics generation for MMIO pmem device {pmem_id}"),
+            }
+        })?;
+        attach_pmem_metrics_to_mmio_handler(
+            &mut dispatcher,
+            device.registration.region_id(),
+            device_metrics,
+            metrics.aggregate(),
+        )
+        .map_err(|source| HvfArm64BootSessionError::DeviceMetricsBinding {
+            kind: "pmem",
+            message: format!("failed to resolve MMIO pmem device {pmem_id}: {source}"),
+        })?;
+    }
+    Ok(())
+}
+
 fn bind_mmio_network_transport_metrics(
     runtime: &Arm64BootRuntimeResources,
     dispatcher: &Arc<Mutex<MmioDispatcher>>,
@@ -37286,13 +37374,15 @@ fn bind_mmio_network_transport_metrics(
     let mut dispatcher =
         dispatcher
             .lock()
-            .map_err(|_| HvfArm64BootSessionError::NetworkMetricsBinding {
+            .map_err(|_| HvfArm64BootSessionError::DeviceMetricsBinding {
+                kind: "network",
                 message: "MMIO dispatcher is unavailable".to_string(),
             })?;
     for device in &runtime.network_devices {
         let iface_id = device.registration.iface_id();
         let interface_metrics = metrics.per_interface(iface_id).ok_or_else(|| {
-            HvfArm64BootSessionError::NetworkMetricsBinding {
+            HvfArm64BootSessionError::DeviceMetricsBinding {
+                kind: "network",
                 message: format!("missing metrics generation for MMIO interface {iface_id}"),
             }
         })?;
@@ -37302,7 +37392,8 @@ fn bind_mmio_network_transport_metrics(
             interface_metrics,
             metrics.aggregate(),
         )
-        .map_err(|source| HvfArm64BootSessionError::NetworkMetricsBinding {
+        .map_err(|source| HvfArm64BootSessionError::DeviceMetricsBinding {
+            kind: "network",
             message: format!("failed to resolve MMIO interface {iface_id}: {source}"),
         })?;
     }
@@ -37316,6 +37407,7 @@ fn prepare_pci_data_devices(
     block_device_metrics: &SharedBlockDeviceMetricsRegistry,
     network_interface_metrics: &SharedNetworkInterfaceMetricsRegistry,
     pmem_device_metrics: &SharedPmemDeviceMetricsRegistry,
+    entropy_device_metrics: &SharedEntropyDeviceMetrics,
 ) -> Result<Option<HvfArm64BootPciDataDevices>, HvfArm64BootPciDataError> {
     let Some(validation) = runtime.pci_validation.as_ref() else {
         return Ok(None);
@@ -37676,6 +37768,11 @@ fn prepare_pci_data_devices(
 
         for prepared in &runtime.pmem_devices {
             let pmem_id = prepared.id().to_string();
+            let device_metrics = pmem_device_metrics.per_device(&pmem_id).ok_or_else(|| {
+                HvfArm64BootPciDataError::new(format!(
+                    "missing PCI pmem metrics generation for {pmem_id}"
+                ))
+            })?;
             let metrics_lease = if all_virtio {
                 Some(
                     pmem_device_metrics
@@ -37690,11 +37787,13 @@ fn prepare_pci_data_devices(
                 None
             };
             let guest_range = prepared.guest_range();
-            let config_space = prepared.config_space();
-            let device = VirtioPmemDevice::with_rate_limiter(
+            let mut config_space = prepared.config_space();
+            config_space.attach_metrics(device_metrics.clone(), pmem_device_metrics.aggregate());
+            let mut device = VirtioPmemDevice::with_rate_limiter(
                 prepared.mapping().file_len(),
                 prepared.rate_limiter(),
             );
+            device.attach_metrics(device_metrics, pmem_device_metrics.aggregate());
             let interrupts = manager.shared_msi_registry()?;
             let region_id = pci_data_region_id(endpoint_index)?;
             let published = {
@@ -37770,7 +37869,8 @@ fn prepare_pci_data_devices(
             endpoint_index += 1;
         }
 
-        if let Some(prepared) = entropy {
+        if let Some(mut prepared) = entropy {
+            prepared.attach_metrics(entropy_device_metrics.clone());
             let (config_space, device) = prepared.into_parts();
             let interrupts = manager.shared_msi_registry()?;
             let region_id = pci_data_region_id(endpoint_index)?;
@@ -42376,16 +42476,14 @@ mod tests {
 
         assert!(dispatch.detached);
         assert!(serial_input.is_none());
-        assert_eq!(
-            runtime
-                .serial_device
-                .as_ref()
-                .expect("serial device should exist")
-                .output
-                .metrics()
-                .error_count(),
-            1
-        );
+        let metrics = runtime
+            .serial_device
+            .as_ref()
+            .expect("serial device should exist")
+            .output
+            .metrics();
+        assert_eq!(metrics.error_count(), 0);
+        assert_eq!(metrics.host_input_fails(), 1);
     }
 
     #[test]
@@ -45569,6 +45667,90 @@ mod tests {
                 .with_entropy_event_fails(1)
                 .with_entropy_event_count(1)
                 .with_entropy_bytes(16)
+        );
+    }
+
+    #[test]
+    fn mmio_entropy_transport_metrics_bind_activation_at_source() {
+        let (_memory, mut runtime, dispatcher) = boot_runtime_with_entropy();
+        let metrics = SharedEntropyDeviceMetrics::default();
+        let dispatcher = Arc::new(Mutex::new(dispatcher));
+        super::bind_mmio_entropy_transport_metrics(&runtime, &dispatcher, &metrics)
+            .expect("MMIO entropy metrics should bind");
+
+        let mut dispatcher = dispatcher
+            .lock()
+            .expect("MMIO entropy dispatcher should remain available");
+        for status in [
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+            QUEUE_CONFIG_STATUS,
+        ] {
+            write_boot_entropy_mmio_u32(
+                &mut runtime,
+                &mut dispatcher,
+                VirtioMmioRegister::Status,
+                status,
+            );
+        }
+        let address = runtime
+            .entropy_device
+            .as_ref()
+            .expect("entropy device should exist")
+            .registration
+            .address()
+            .checked_add(VirtioMmioRegister::Status.offset())
+            .expect("entropy status address should not overflow");
+        let access = dispatcher
+            .lookup(address, 4)
+            .expect("entropy status access should resolve");
+        let data = MmioAccessBytes::new(&DRIVER_OK_STATUS.to_le_bytes())
+            .expect("entropy status bytes should build");
+        assert!(
+            dispatcher
+                .dispatch(MmioOperation::write(access, data).expect("status write should build"))
+                .is_err(),
+            "an entropy queue that is not ready should reject activation"
+        );
+
+        assert_eq!(
+            metrics.snapshot(),
+            EntropyDeviceMetrics::default().with_activate_fails(1)
+        );
+    }
+
+    #[test]
+    fn mmio_pmem_transport_metrics_bind_aggregate_and_device_at_source() {
+        let (_memory, runtime, dispatcher) = boot_runtime_with_pmem(&["pmem0", "pmem1"]);
+        let metrics = SharedPmemDeviceMetricsRegistry::from_device_ids(["pmem0", "pmem1"]);
+        let dispatcher = Arc::new(Mutex::new(dispatcher));
+        super::bind_mmio_pmem_transport_metrics(&runtime, &dispatcher, &metrics)
+            .expect("MMIO pmem metrics should bind");
+
+        let address = runtime.pmem_mmio_devices[1]
+            .registration
+            .address()
+            .checked_add(VIRTIO_MMIO_DEVICE_CONFIG_OFFSET + 17)
+            .expect("pmem config address should not overflow");
+        let mut dispatcher = dispatcher
+            .lock()
+            .expect("MMIO pmem dispatcher should remain available");
+        let access = dispatcher
+            .lookup(address, 1)
+            .expect("pmem config access should resolve");
+        assert!(
+            dispatcher
+                .dispatch(MmioOperation::read(access).expect("config read should build"))
+                .is_err(),
+            "a pmem config read starting after the pinned 16-byte source should fail"
+        );
+        drop(dispatcher);
+
+        let expected = PmemDeviceMetrics::default().with_cfg_fails(1);
+        assert_eq!(metrics.aggregate_snapshot(), expected);
+        assert_eq!(
+            metrics.per_device_snapshot(),
+            PmemDeviceMetricsByDevice::new().with_device_metrics("pmem1", expected)
         );
     }
 

--- a/crates/runtime/src/entropy.rs
+++ b/crates/runtime/src/entropy.rs
@@ -4,8 +4,10 @@ use std::time::{Duration, Instant};
 
 use crate::logger::{GuestLogger, LoggerDeviceKind, LoggerEntropyOutcome, LoggerTransportOutcome};
 use crate::memory::{GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError};
+use crate::metrics::SharedEntropyDeviceMetrics;
 use crate::mmio::{
-    MmioBusError, MmioDispatchError, MmioDispatcher, MmioHandlerError, MmioRegion, MmioRegionId,
+    MmioBusError, MmioDispatchError, MmioDispatcher, MmioHandlerError, MmioHandlerLookupError,
+    MmioRegion, MmioRegionId,
 };
 use crate::token_bucket::{
     PersistedTokenBucketState, PersistedTokenBucketStateError, TokenBucket, TokenBucketConfig,
@@ -193,6 +195,10 @@ impl PreparedEntropyDevice {
         Self {
             device: VirtioRngDevice::from_config(config),
         }
+    }
+
+    pub fn attach_metrics(&mut self, metrics: SharedEntropyDeviceMetrics) {
+        self.device.attach_metrics(metrics);
     }
 
     pub const fn device(&self) -> &VirtioRngDevice {
@@ -1281,6 +1287,7 @@ impl VirtioRngQueue {
                 });
             }
         } {
+            dispatch.record_attempted_request();
             let descriptor_head = match descriptor_chain_head(&chain) {
                 Some(descriptor_head) => descriptor_head,
                 None => {
@@ -1594,6 +1601,7 @@ pub struct VirtioRngDevice {
     active_queue: Option<VirtioRngQueue>,
     rate_limiter: Option<VirtioRngRateLimiter>,
     pending_rate_limited_queue: bool,
+    metrics: Option<SharedEntropyDeviceMetrics>,
     guest_logger: Option<GuestLogger>,
 }
 
@@ -1603,6 +1611,7 @@ impl VirtioRngDevice {
             active_queue: None,
             rate_limiter: None,
             pending_rate_limited_queue: false,
+            metrics: None,
             guest_logger: None,
         }
     }
@@ -1618,6 +1627,7 @@ impl VirtioRngDevice {
                 .rate_limiter()
                 .and_then(|rate_limiter| VirtioRngRateLimiter::new_at(rate_limiter, now)),
             pending_rate_limited_queue: false,
+            metrics: None,
             guest_logger: None,
         }
     }
@@ -1631,8 +1641,13 @@ impl VirtioRngDevice {
             active_queue,
             rate_limiter,
             pending_rate_limited_queue,
+            metrics: None,
             guest_logger: None,
         }
+    }
+
+    pub fn attach_metrics(&mut self, metrics: SharedEntropyDeviceMetrics) {
+        self.metrics = Some(metrics);
     }
 
     pub fn is_activated(&self) -> bool {
@@ -1856,6 +1871,10 @@ impl VirtioRngDevice {
 }
 
 impl VirtioMmioRegisterHandler<UnsupportedVirtioMmioDeviceConfig, VirtioRngDevice> {
+    pub fn attach_entropy_metrics(&mut self, metrics: SharedEntropyDeviceMetrics) {
+        self.activation_handler_mut().attach_metrics(metrics);
+    }
+
     pub fn capture_entropy_state_at(
         &self,
         config: EntropyConfig,
@@ -1921,6 +1940,17 @@ impl VirtioMmioRegisterHandler<UnsupportedVirtioMmioDeviceConfig, VirtioRngDevic
 
         dispatch
     }
+}
+
+pub fn attach_entropy_metrics_to_mmio_handler(
+    dispatcher: &mut MmioDispatcher,
+    region_id: MmioRegionId,
+    metrics: SharedEntropyDeviceMetrics,
+) -> Result<(), MmioHandlerLookupError> {
+    dispatcher
+        .handler_mut::<VirtioRngMmioHandler>(region_id)?
+        .attach_entropy_metrics(metrics);
+    Ok(())
 }
 
 impl VirtioPciEndpoint<UnsupportedVirtioMmioDeviceConfig, VirtioRngDevice> {
@@ -2013,7 +2043,13 @@ impl VirtioMmioDeviceActivationHandler for VirtioRngDevice {
         &mut self,
         activation: VirtioMmioDeviceActivation<'_>,
     ) -> Result<(), VirtioMmioDeviceActivationError> {
-        self.activate_rng(activation).map_err(Into::into)
+        let result = self.activate_rng(activation);
+        if result.is_err()
+            && let Some(metrics) = &self.metrics
+        {
+            metrics.record_activation_failure();
+        }
+        result.map_err(Into::into)
     }
 
     fn reset(&mut self) {
@@ -2251,6 +2287,7 @@ fn observe_entropy_notification_result(
 
 #[derive(Debug, Default)]
 pub struct VirtioRngQueueDispatch {
+    attempted_requests: usize,
     processed_requests: usize,
     successful_requests: usize,
     buffer_parse_failures: usize,
@@ -2265,6 +2302,11 @@ pub struct VirtioRngQueueDispatch {
 }
 
 impl VirtioRngQueueDispatch {
+    /// Descriptor chains popped before parsing, limiter admission, or publication.
+    pub const fn attempted_requests(&self) -> usize {
+        self.attempted_requests
+    }
+
     pub const fn processed_requests(&self) -> usize {
         self.processed_requests
     }
@@ -2307,6 +2349,10 @@ impl VirtioRngQueueDispatch {
 
     pub const fn needs_queue_interrupt(&self) -> bool {
         self.needs_queue_interrupt
+    }
+
+    fn record_attempted_request(&mut self) {
+        self.attempted_requests += 1;
     }
 
     fn record(
@@ -3692,6 +3738,33 @@ mod tests {
     }
 
     #[test]
+    fn entropy_activation_metrics_follow_the_attached_transport_owner() {
+        let queues = configured_mmio_queue(TEST_QUEUE_SIZE, true);
+        let device_registers = rng_device_registers();
+        let metrics = SharedEntropyDeviceMetrics::default();
+        let other = SharedEntropyDeviceMetrics::default();
+        let mut device = VirtioRngDevice::new();
+        device.attach_metrics(metrics.clone());
+
+        VirtioMmioDeviceActivationHandler::activate(
+            &mut device,
+            rng_device_activation(&device_registers, &queues),
+        )
+        .expect("first transport activation should succeed");
+        VirtioMmioDeviceActivationHandler::activate(
+            &mut device,
+            rng_device_activation(&device_registers, &queues),
+        )
+        .expect_err("duplicate transport activation should fail");
+
+        assert_eq!(
+            metrics.snapshot(),
+            EntropyDeviceMetrics::default().with_activate_fails(1)
+        );
+        assert_eq!(other.snapshot(), EntropyDeviceMetrics::default());
+    }
+
+    #[test]
     fn rng_device_notification_without_pending_queues_is_noop() {
         let mut memory = memory();
         let mut source = TestEntropySource::default();
@@ -4176,6 +4249,13 @@ mod tests {
             first
                 .queue_dispatch()
                 .expect("first queue dispatch should be present")
+                .attempted_requests(),
+            2
+        );
+        assert_eq!(
+            first
+                .queue_dispatch()
+                .expect("first queue dispatch should be present")
                 .rate_limiter_throttled_requests(),
             1
         );
@@ -4183,6 +4263,7 @@ mod tests {
             .queue_dispatch()
             .expect("retry queue dispatch should be present");
         assert_eq!(retry_dispatch.processed_requests(), 1);
+        assert_eq!(retry_dispatch.attempted_requests(), 1);
         assert_eq!(retry_dispatch.rate_limiter_events(), 1);
         assert_eq!(retry_dispatch.rate_limiter_throttled_requests(), 0);
         let metrics = SharedEntropyDeviceMetrics::default();
@@ -4191,7 +4272,7 @@ mod tests {
         assert_eq!(
             metrics.snapshot(),
             EntropyDeviceMetrics::default()
-                .with_entropy_event_count(2)
+                .with_entropy_event_count(3)
                 .with_entropy_bytes(8)
                 .with_entropy_rate_limiter_throttled(1)
                 .with_rate_limiter_event_count(1)
@@ -4574,6 +4655,7 @@ mod tests {
             .dispatch_with_source(&mut memory, &mut source, None)
             .expect("rng queue dispatch should succeed");
 
+        assert_eq!(dispatch.attempted_requests(), 1);
         assert_eq!(dispatch.processed_requests(), 1);
         assert_eq!(dispatch.successful_requests(), 1);
         assert_eq!(dispatch.buffer_parse_failures(), 0);
@@ -4600,6 +4682,7 @@ mod tests {
             .dispatch_with_source(&mut memory, &mut source, None)
             .expect("empty rng queue dispatch should succeed");
 
+        assert_eq!(dispatch.attempted_requests(), 0);
         assert_eq!(dispatch.processed_requests(), 0);
         assert_eq!(dispatch.successful_requests(), 0);
         assert_eq!(dispatch.bytes_written_to_guest(), 0);
@@ -4633,6 +4716,7 @@ mod tests {
             .dispatch_with_source_at(&mut memory, &mut source, Some(&mut limiter), now)
             .expect("throttled rng queue dispatch should succeed");
 
+        assert_eq!(dispatch.attempted_requests(), 2);
         assert_eq!(dispatch.processed_requests(), 1);
         assert_eq!(dispatch.successful_requests(), 1);
         assert_eq!(dispatch.rate_limiter_throttled_requests(), 1);
@@ -4856,6 +4940,7 @@ mod tests {
             .dispatch_with_source(&mut memory, &mut source, None)
             .expect("rng queue dispatch should succeed");
 
+        assert_eq!(dispatch.attempted_requests(), 1);
         assert_eq!(dispatch.processed_requests(), 1);
         assert_eq!(dispatch.successful_requests(), 1);
         assert_eq!(dispatch.bytes_written_to_guest(), 8);
@@ -5249,6 +5334,7 @@ mod tests {
             }
             other => panic!("expected used ring error, got {other:?}"),
         }
+        assert_eq!(error.completed_dispatch().attempted_requests(), 1);
         assert_eq!(error.completed_dispatch().processed_requests(), 0);
         assert_eq!(source.calls(), &[8]);
         assert_eq!(limiter.snapshot(), before);

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -2545,100 +2545,85 @@ impl PmemDeviceMetricsByDevice {
 
 #[derive(Debug, Clone, Default)]
 pub struct SharedPmemDeviceMetrics {
-    inner: Arc<SharedPmemDeviceMetricsInner>,
+    inner: Arc<Mutex<PmemDeviceMetrics>>,
 }
 
 impl SharedPmemDeviceMetrics {
     pub fn record_activation_failure(&self) {
-        record_atomic_metric(&self.inner.activate_fails, 1);
+        self.record(PmemDeviceMetrics::default().with_activate_fails(1));
     }
 
     pub fn record_config_failure(&self) {
-        record_atomic_metric(&self.inner.cfg_fails, 1);
+        self.record(PmemDeviceMetrics::default().with_cfg_fails(1));
     }
 
     pub fn record_notification_dispatch(&self, dispatch: &VirtioPmemDeviceNotificationDispatch) {
-        self.record_queue_events(usize_to_u64_saturating(
-            dispatch.drained_notifications().len(),
-        ));
+        let mut observation = PmemDeviceMetrics::default().with_queue_event_count(
+            usize_to_u64_saturating(dispatch.drained_notifications().len()),
+        );
         if let Some(queue_dispatch) = dispatch.queue_dispatch() {
-            self.record_queue_dispatch(queue_dispatch);
+            observation = observation.merged_with(pmem_queue_dispatch_metrics(queue_dispatch));
         }
+        self.record(observation);
     }
 
     pub fn record_notification_error(&self, source: &VirtioPmemDeviceNotificationError) {
-        self.record_queue_events(usize_to_u64_saturating(
-            source.drained_notifications().len(),
-        ));
-        self.record_event_failure();
+        let mut observation = PmemDeviceMetrics::default()
+            .with_queue_event_count(usize_to_u64_saturating(
+                source.drained_notifications().len(),
+            ))
+            .with_event_fails(1);
         if let Some(completed) = source.completed_dispatch() {
-            self.record_queue_dispatch(completed);
+            observation = observation.merged_with(pmem_queue_dispatch_metrics(completed));
         }
+        self.record(observation);
     }
 
     pub fn record_queue_dispatch(&self, dispatch: &VirtioPmemQueueDispatch) {
-        self.record_event_failures(usize_to_u64_saturating(
-            dispatch
-                .parse_failures()
-                .saturating_add(dispatch.status_write_failures()),
-        ));
-        self.record_rate_limiter_throttled_events(usize_to_u64_saturating(
-            dispatch.rate_limiter_throttled_events(),
-        ));
-        self.record_rate_limiter_events(usize_to_u64_saturating(dispatch.rate_limiter_events()));
+        self.record(pmem_queue_dispatch_metrics(dispatch));
     }
 
     pub fn record_queue_events(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.queue_event_count, count);
-        }
+        self.record(PmemDeviceMetrics::default().with_queue_event_count(count));
     }
 
     pub fn record_event_failure(&self) {
-        record_atomic_metric(&self.inner.event_fails, 1);
+        self.record(PmemDeviceMetrics::default().with_event_fails(1));
     }
 
     pub fn snapshot(&self) -> PmemDeviceMetrics {
-        PmemDeviceMetrics {
-            activate_fails: self.inner.activate_fails.load(Ordering::Relaxed),
-            cfg_fails: self.inner.cfg_fails.load(Ordering::Relaxed),
-            event_fails: self.inner.event_fails.load(Ordering::Relaxed),
-            queue_event_count: self.inner.queue_event_count.load(Ordering::Relaxed),
-            rate_limiter_throttled_events: self
-                .inner
-                .rate_limiter_throttled_events
-                .load(Ordering::Relaxed),
-            rate_limiter_event_count: self.inner.rate_limiter_event_count.load(Ordering::Relaxed),
-        }
+        *lock_pmem_device_metrics(&self.inner)
     }
 
-    fn record_event_failures(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.event_fails, count);
+    fn record(&self, observation: PmemDeviceMetrics) {
+        if observation.is_empty() {
+            return;
         }
-    }
-
-    fn record_rate_limiter_throttled_events(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.rate_limiter_throttled_events, count);
-        }
-    }
-
-    fn record_rate_limiter_events(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.rate_limiter_event_count, count);
-        }
+        let mut metrics = lock_pmem_device_metrics(&self.inner);
+        *metrics = metrics.merged_with(observation);
     }
 }
 
-#[derive(Debug, Default)]
-struct SharedPmemDeviceMetricsInner {
-    activate_fails: AtomicU64,
-    cfg_fails: AtomicU64,
-    event_fails: AtomicU64,
-    queue_event_count: AtomicU64,
-    rate_limiter_throttled_events: AtomicU64,
-    rate_limiter_event_count: AtomicU64,
+fn pmem_queue_dispatch_metrics(dispatch: &VirtioPmemQueueDispatch) -> PmemDeviceMetrics {
+    PmemDeviceMetrics::default()
+        .with_event_fails(usize_to_u64_saturating(
+            dispatch
+                .parse_failures()
+                .saturating_add(dispatch.status_write_failures()),
+        ))
+        .with_rate_limiter_throttled_events(usize_to_u64_saturating(
+            dispatch.rate_limiter_throttled_events(),
+        ))
+        .with_rate_limiter_event_count(usize_to_u64_saturating(dispatch.rate_limiter_events()))
+}
+
+fn lock_pmem_device_metrics(
+    metrics: &Mutex<PmemDeviceMetrics>,
+) -> MutexGuard<'_, PmemDeviceMetrics> {
+    match metrics.lock() {
+        Ok(metrics) => metrics,
+        Err(poisoned) => poisoned.into_inner(),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2707,6 +2692,10 @@ impl fmt::Debug for PmemDeviceMetricsLease {
 }
 
 impl PreparedPmemDeviceMetrics {
+    pub fn metrics(&self) -> SharedPmemDeviceMetrics {
+        self.metrics.clone()
+    }
+
     pub fn publish(mut self) -> PmemDeviceMetricsLease {
         let mut state = lock_pmem_metrics_registry(&self.registry.per_device);
         let reservation_count = state.reservations.len();
@@ -5541,6 +5530,7 @@ pub struct EntropyDeviceMetrics {
     host_rng_fails: u64,
     entropy_rate_limiter_throttled: u64,
     rate_limiter_event_count: u64,
+    source_provider_fails: u64,
 }
 
 impl_incremental_delta!(EntropyDeviceMetrics {
@@ -5551,6 +5541,7 @@ impl_incremental_delta!(EntropyDeviceMetrics {
     host_rng_fails,
     entropy_rate_limiter_throttled,
     rate_limiter_event_count,
+    source_provider_fails,
 });
 
 impl EntropyDeviceMetrics {
@@ -5562,6 +5553,7 @@ impl EntropyDeviceMetrics {
             && self.host_rng_fails == 0
             && self.entropy_rate_limiter_throttled == 0
             && self.rate_limiter_event_count == 0
+            && self.source_provider_fails == 0
     }
 
     pub const fn activate_fails(self) -> u64 {
@@ -5590,6 +5582,11 @@ impl EntropyDeviceMetrics {
 
     pub const fn rate_limiter_event_count(self) -> u64 {
         self.rate_limiter_event_count
+    }
+
+    /// Bangbang-only failures while acquiring a source before a descriptor is popped.
+    pub const fn source_provider_fails(self) -> u64 {
+        self.source_provider_fails
     }
 
     pub const fn with_activate_fails(mut self, activate_fails: u64) -> Self {
@@ -5630,6 +5627,11 @@ impl EntropyDeviceMetrics {
         self
     }
 
+    pub const fn with_source_provider_fails(mut self, source_provider_fails: u64) -> Self {
+        self.source_provider_fails = source_provider_fails;
+        self
+    }
+
     const fn merged_with(self, other: Self) -> Self {
         Self {
             activate_fails: self.activate_fails.saturating_add(other.activate_fails),
@@ -5647,122 +5649,89 @@ impl EntropyDeviceMetrics {
             rate_limiter_event_count: self
                 .rate_limiter_event_count
                 .saturating_add(other.rate_limiter_event_count),
+            source_provider_fails: self
+                .source_provider_fails
+                .saturating_add(other.source_provider_fails),
         }
     }
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct SharedEntropyDeviceMetrics {
-    inner: Arc<SharedEntropyDeviceMetricsInner>,
+    inner: Arc<Mutex<EntropyDeviceMetrics>>,
 }
 
 impl SharedEntropyDeviceMetrics {
     pub fn record_activation_failure(&self) {
-        record_atomic_metric(&self.inner.activate_fails, 1);
+        self.record(EntropyDeviceMetrics::default().with_activate_fails(1));
     }
 
     pub fn record_notification_dispatch(&self, dispatch: &VirtioRngDeviceNotificationDispatch) {
         if let Some(queue_dispatch) = dispatch.queue_dispatch() {
-            self.record_queue_dispatch(queue_dispatch);
+            self.record(entropy_queue_dispatch_metrics(queue_dispatch));
         }
     }
 
     pub fn record_notification_error(&self, source: &VirtioRngDeviceNotificationError) {
+        let mut observation = EntropyDeviceMetrics::default().with_entropy_event_fails(1);
         if let Some(completed) = source.completed_dispatch() {
-            self.record_queue_dispatch(completed);
+            observation = observation.merged_with(entropy_queue_dispatch_metrics(completed));
         }
-        self.record_event_failure();
+        self.record(observation);
     }
 
     pub fn record_entropy_source_provider_failure(&self) {
-        self.record_host_rng_failure();
-        self.record_event_failure();
+        self.record(EntropyDeviceMetrics::default().with_source_provider_fails(1));
     }
 
     pub fn record_event_failure(&self) {
-        record_atomic_metric(&self.inner.entropy_event_fails, 1);
+        self.record(EntropyDeviceMetrics::default().with_entropy_event_fails(1));
     }
 
     pub fn record_host_rng_failure(&self) {
-        record_atomic_metric(&self.inner.host_rng_fails, 1);
+        self.record(EntropyDeviceMetrics::default().with_host_rng_fails(1));
     }
 
     pub fn snapshot(&self) -> EntropyDeviceMetrics {
-        EntropyDeviceMetrics {
-            activate_fails: self.inner.activate_fails.load(Ordering::Relaxed),
-            entropy_event_fails: self.inner.entropy_event_fails.load(Ordering::Relaxed),
-            entropy_event_count: self.inner.entropy_event_count.load(Ordering::Relaxed),
-            entropy_bytes: self.inner.entropy_bytes.load(Ordering::Relaxed),
-            host_rng_fails: self.inner.host_rng_fails.load(Ordering::Relaxed),
-            entropy_rate_limiter_throttled: self
-                .inner
-                .entropy_rate_limiter_throttled
-                .load(Ordering::Relaxed),
-            rate_limiter_event_count: self.inner.rate_limiter_event_count.load(Ordering::Relaxed),
-        }
+        *lock_entropy_device_metrics(&self.inner)
     }
 
     pub fn record_queue_dispatch(&self, dispatch: &VirtioRngQueueDispatch) {
-        self.record_entropy_events(usize_to_u64_saturating(dispatch.processed_requests()));
-        self.record_entropy_bytes(dispatch.bytes_written_to_guest());
-        self.record_event_failures(usize_to_u64_saturating(
-            dispatch
-                .buffer_parse_failures()
-                .saturating_add(dispatch.source_failures()),
-        ));
-        self.record_host_rng_failures(usize_to_u64_saturating(dispatch.source_failures()));
-        self.record_rate_limiter_throttled(usize_to_u64_saturating(
-            dispatch.rate_limiter_throttled_requests(),
-        ));
-        self.record_rate_limiter_events(usize_to_u64_saturating(dispatch.rate_limiter_events()));
+        self.record(entropy_queue_dispatch_metrics(dispatch));
     }
 
-    fn record_entropy_events(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.entropy_event_count, count);
+    fn record(&self, observation: EntropyDeviceMetrics) {
+        if observation.is_empty() {
+            return;
         }
-    }
-
-    fn record_entropy_bytes(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.entropy_bytes, count);
-        }
-    }
-
-    fn record_event_failures(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.entropy_event_fails, count);
-        }
-    }
-
-    fn record_host_rng_failures(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.host_rng_fails, count);
-        }
-    }
-
-    fn record_rate_limiter_throttled(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.entropy_rate_limiter_throttled, count);
-        }
-    }
-
-    fn record_rate_limiter_events(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.rate_limiter_event_count, count);
-        }
+        let mut metrics = lock_entropy_device_metrics(&self.inner);
+        *metrics = metrics.merged_with(observation);
     }
 }
 
-#[derive(Debug, Default)]
-struct SharedEntropyDeviceMetricsInner {
-    activate_fails: AtomicU64,
-    entropy_event_fails: AtomicU64,
-    entropy_event_count: AtomicU64,
-    entropy_bytes: AtomicU64,
-    host_rng_fails: AtomicU64,
-    entropy_rate_limiter_throttled: AtomicU64,
-    rate_limiter_event_count: AtomicU64,
+fn entropy_queue_dispatch_metrics(dispatch: &VirtioRngQueueDispatch) -> EntropyDeviceMetrics {
+    EntropyDeviceMetrics::default()
+        .with_entropy_event_count(usize_to_u64_saturating(dispatch.attempted_requests()))
+        .with_entropy_bytes(dispatch.bytes_written_to_guest())
+        .with_entropy_event_fails(usize_to_u64_saturating(
+            dispatch
+                .buffer_parse_failures()
+                .saturating_add(dispatch.source_failures()),
+        ))
+        .with_host_rng_fails(usize_to_u64_saturating(dispatch.source_failures()))
+        .with_entropy_rate_limiter_throttled(usize_to_u64_saturating(
+            dispatch.rate_limiter_throttled_requests(),
+        ))
+        .with_rate_limiter_event_count(usize_to_u64_saturating(dispatch.rate_limiter_events()))
+}
+
+fn lock_entropy_device_metrics(
+    metrics: &Mutex<EntropyDeviceMetrics>,
+) -> MutexGuard<'_, EntropyDeviceMetrics> {
+    match metrics.lock() {
+        Ok(metrics) => metrics,
+        Err(poisoned) => poisoned.into_inner(),
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -5833,34 +5802,45 @@ impl RtcDeviceMetrics {
 
 #[derive(Debug, Clone, Default)]
 pub struct SharedRtcDeviceMetrics {
-    inner: Arc<SharedRtcDeviceMetricsInner>,
+    inner: Arc<Mutex<RtcDeviceMetrics>>,
 }
 
 impl SharedRtcDeviceMetrics {
+    pub fn record_access_error(&self) {
+        self.record(RtcDeviceMetrics::default().with_error_count(1));
+    }
+
     pub fn record_read_error(&self) {
-        record_atomic_metric(&self.inner.missed_read_count, 1);
-        record_atomic_metric(&self.inner.error_count, 1);
+        self.record(
+            RtcDeviceMetrics::default()
+                .with_error_count(1)
+                .with_missed_read_count(1),
+        );
     }
 
     pub fn record_write_error(&self) {
-        record_atomic_metric(&self.inner.missed_write_count, 1);
-        record_atomic_metric(&self.inner.error_count, 1);
+        self.record(
+            RtcDeviceMetrics::default()
+                .with_error_count(1)
+                .with_missed_write_count(1),
+        );
     }
 
     pub fn snapshot(&self) -> RtcDeviceMetrics {
-        RtcDeviceMetrics::new(
-            self.inner.error_count.load(Ordering::Relaxed),
-            self.inner.missed_read_count.load(Ordering::Relaxed),
-            self.inner.missed_write_count.load(Ordering::Relaxed),
-        )
+        *lock_rtc_device_metrics(&self.inner)
+    }
+
+    fn record(&self, observation: RtcDeviceMetrics) {
+        let mut metrics = lock_rtc_device_metrics(&self.inner);
+        *metrics = metrics.merged_with(observation);
     }
 }
 
-#[derive(Debug, Default)]
-struct SharedRtcDeviceMetricsInner {
-    error_count: AtomicU64,
-    missed_read_count: AtomicU64,
-    missed_write_count: AtomicU64,
+fn lock_rtc_device_metrics(metrics: &Mutex<RtcDeviceMetrics>) -> MutexGuard<'_, RtcDeviceMetrics> {
+    match metrics.lock() {
+        Ok(metrics) => metrics,
+        Err(poisoned) => poisoned.into_inner(),
+    }
 }
 
 /// Observable counters for one balloon host-discard source.
@@ -7938,6 +7918,7 @@ mod tests {
             .with_host_rng_fails(5)
             .with_entropy_rate_limiter_throttled(6)
             .with_rate_limiter_event_count(7)
+            .with_source_provider_fails(8)
     }
 
     fn serial_metrics_with_scale(scale: u64) -> SerialOutputMetrics {
@@ -9119,7 +9100,11 @@ mod tests {
         let diagnostics = MetricsDiagnostics::new().with_serial_output_metrics(
             SerialOutputMetrics::default()
                 .with_error_count(1)
+                .with_flush_count(99)
+                .with_host_input_fails(5)
                 .with_missed_write_count(2)
+                .with_receive_fifo_flush_count(6)
+                .with_state_fails(7)
                 .with_write_count(3)
                 .with_rate_limiter_dropped_bytes(4),
         );
@@ -9128,10 +9113,14 @@ mod tests {
 
         let value = only_metrics_value(&output);
         assert_eq!(value["uart"]["error_count"], 1);
+        assert_eq!(value["uart"]["flush_count"], 0);
         assert_eq!(value["uart"]["missed_write_count"], 2);
         assert_eq!(value["uart"]["rate_limiter_dropped_bytes"], 4);
         assert_eq!(value["uart"]["write_count"], 3);
         assert!(value["uart"].get("input_count").is_none());
+        assert!(value["uart"].get("host_input_fails").is_none());
+        assert!(value["uart"].get("receive_fifo_flush_count").is_none());
+        assert!(value["uart"].get("state_fails").is_none());
     }
 
     #[test]
@@ -9748,10 +9737,7 @@ mod tests {
     #[test]
     fn shared_pmem_metric_increment_saturates() {
         let metrics = SharedPmemDeviceMetrics::default();
-        metrics
-            .inner
-            .queue_event_count
-            .store(u64::MAX - 1, Ordering::Relaxed);
+        metrics.record(PmemDeviceMetrics::default().with_queue_event_count(u64::MAX - 1));
 
         metrics.record_queue_events(3);
 
@@ -10474,6 +10460,7 @@ mod tests {
         let value = only_metrics_value(&output);
         assert_eq!(value["entropy"]["activate_fails"], 1);
         assert_eq!(value["entropy"]["rate_limiter_event_count"], 7);
+        assert!(value["entropy"].get("source_provider_fails").is_none());
     }
 
     #[test]
@@ -10501,8 +10488,8 @@ mod tests {
             first.snapshot(),
             EntropyDeviceMetrics::default()
                 .with_activate_fails(1)
-                .with_entropy_event_fails(2)
-                .with_host_rng_fails(1)
+                .with_entropy_event_fails(1)
+                .with_source_provider_fails(1)
         );
         assert_eq!(second.snapshot(), EntropyDeviceMetrics::default());
     }
@@ -10510,12 +10497,8 @@ mod tests {
     #[test]
     fn entropy_metric_increment_saturates() {
         let metrics = SharedEntropyDeviceMetrics::default();
-        metrics
-            .inner
-            .entropy_event_count
-            .store(u64::MAX - 1, Ordering::Relaxed);
-
-        metrics.record_entropy_events(3);
+        metrics.record(EntropyDeviceMetrics::default().with_entropy_event_count(u64::MAX - 1));
+        metrics.record(EntropyDeviceMetrics::default().with_entropy_event_count(3));
 
         assert_eq!(metrics.snapshot().entropy_event_count(), u64::MAX);
     }
@@ -10546,6 +10529,7 @@ mod tests {
                     .with_host_rng_fails(u64::MAX)
                     .with_entropy_rate_limiter_throttled(u64::MAX)
                     .with_rate_limiter_event_count(u64::MAX)
+                    .with_source_provider_fails(8)
             )
         );
     }
@@ -10606,15 +10590,69 @@ mod tests {
     #[test]
     fn rtc_metric_increment_saturates() {
         let metrics = SharedRtcDeviceMetrics::default();
-        metrics
-            .inner
-            .error_count
-            .store(u64::MAX - 1, Ordering::Relaxed);
+        metrics.record(RtcDeviceMetrics::default().with_error_count(u64::MAX - 1));
 
         metrics.record_read_error();
         metrics.record_write_error();
 
         assert_eq!(metrics.snapshot().error_count(), u64::MAX);
+    }
+
+    #[test]
+    fn owner_local_device_snapshots_never_expose_partial_compound_updates() {
+        const WRITERS: usize = 4;
+        const UPDATES: usize = 2_000;
+
+        let entropy = SharedEntropyDeviceMetrics::default();
+        let pmem = SharedPmemDeviceMetrics::default();
+        let rtc = SharedRtcDeviceMetrics::default();
+        let remaining = Arc::new(AtomicUsize::new(WRITERS));
+
+        thread::scope(|scope| {
+            for _ in 0..WRITERS {
+                let entropy = entropy.clone();
+                let pmem = pmem.clone();
+                let rtc = rtc.clone();
+                let remaining = Arc::clone(&remaining);
+                scope.spawn(move || {
+                    for _ in 0..UPDATES {
+                        entropy.record(
+                            EntropyDeviceMetrics::default()
+                                .with_entropy_event_count(1)
+                                .with_entropy_event_fails(1)
+                                .with_host_rng_fails(1),
+                        );
+                        pmem.record(
+                            PmemDeviceMetrics::default()
+                                .with_event_fails(1)
+                                .with_queue_event_count(1)
+                                .with_rate_limiter_event_count(1),
+                        );
+                        rtc.record_read_error();
+                    }
+                    remaining.fetch_sub(1, Ordering::SeqCst);
+                });
+            }
+
+            while remaining.load(Ordering::SeqCst) != 0 {
+                let entropy = entropy.snapshot();
+                assert_eq!(entropy.entropy_event_count(), entropy.entropy_event_fails());
+                assert_eq!(entropy.entropy_event_fails(), entropy.host_rng_fails());
+
+                let pmem = pmem.snapshot();
+                assert_eq!(pmem.event_fails(), pmem.queue_event_count());
+                assert_eq!(pmem.queue_event_count(), pmem.rate_limiter_event_count());
+
+                let rtc = rtc.snapshot();
+                assert_eq!(rtc.error_count(), rtc.missed_read_count());
+                assert_eq!(rtc.missed_write_count(), 0);
+            }
+        });
+
+        let expected = u64::try_from(WRITERS * UPDATES).expect("test count should fit u64");
+        assert_eq!(entropy.snapshot().entropy_event_count(), expected);
+        assert_eq!(pmem.snapshot().queue_event_count(), expected);
+        assert_eq!(rtc.snapshot().error_count(), expected);
     }
 
     #[test]

--- a/crates/runtime/src/metrics/firecracker.rs
+++ b/crates/runtime/src/metrics/firecracker.rs
@@ -830,7 +830,8 @@ pub(super) fn build_metrics_line(
         },
         uart: UartMetrics {
             error_count: serial.error_count(),
-            flush_count: serial.flush_count(),
+            // Firecracker v1.16.0 declares this field but has no UART producer.
+            flush_count: 0,
             missed_read_count: serial.missed_read_count(),
             missed_write_count: serial.missed_write_count(),
             read_count: serial.read_count(),

--- a/crates/runtime/src/pmem.rs
+++ b/crates/runtime/src/pmem.rs
@@ -22,9 +22,10 @@ use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryLayout,
     GuestMemoryRange, aarch64,
 };
+use crate::metrics::SharedPmemDeviceMetrics;
 use crate::mmio::{
-    MmioAccessBytes, MmioAccessBytesError, MmioBusError, MmioDispatchError, MmioDispatcher,
-    MmioHandlerError, MmioRegion, MmioRegionId,
+    MAX_MMIO_ACCESS_BYTES, MmioAccessBytes, MmioAccessBytesError, MmioBusError, MmioDispatchError,
+    MmioDispatcher, MmioHandlerError, MmioHandlerLookupError, MmioRegion, MmioRegionId,
 };
 use crate::token_bucket::{
     PersistedTokenBucketState, PersistedTokenBucketStateError, TokenBucket, TokenBucketConfig,
@@ -75,26 +76,57 @@ pub const fn aligned_pmem_mapping_len(len: u64) -> Option<u64> {
 pub type VirtioPmemMmioHandler = VirtioMmioRegisterHandler<VirtioPmemConfigSpace, VirtioPmemDevice>;
 pub type VirtioPmemPciEndpoint = VirtioPciEndpoint<VirtioPmemConfigSpace, VirtioPmemDevice>;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone)]
+struct VirtioPmemTransportMetrics {
+    device: SharedPmemDeviceMetrics,
+    aggregate: SharedPmemDeviceMetrics,
+}
+
+impl VirtioPmemTransportMetrics {
+    fn record_activation_failure(&self) {
+        self.device.record_activation_failure();
+        self.aggregate.record_activation_failure();
+    }
+
+    fn record_config_failure(&self) {
+        self.device.record_config_failure();
+        self.aggregate.record_config_failure();
+    }
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct VirtioPmemConfigSpace {
     start: u64,
     size: u64,
+    metrics: Option<VirtioPmemTransportMetrics>,
 }
+
+impl PartialEq for VirtioPmemConfigSpace {
+    fn eq(&self, other: &Self) -> bool {
+        self.start == other.start && self.size == other.size
+    }
+}
+
+impl Eq for VirtioPmemConfigSpace {}
 
 impl VirtioPmemConfigSpace {
     pub const fn new(start: u64, size: u64) -> Self {
-        Self { start, size }
+        Self {
+            start,
+            size,
+            metrics: None,
+        }
     }
 
-    pub const fn start(self) -> u64 {
+    pub const fn start(&self) -> u64 {
         self.start
     }
 
-    pub const fn size(self) -> u64 {
+    pub const fn size(&self) -> u64 {
         self.size
     }
 
-    pub const fn available_features(self) -> u64 {
+    pub const fn available_features(&self) -> u64 {
         virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
     }
 
@@ -122,10 +154,11 @@ impl VirtioPmemConfigSpace {
                 start0, start1, start2, start3, start4, start5, start6, start7,
             ]),
             size: u64::from_le_bytes([size0, size1, size2, size3, size4, size5, size6, size7]),
+            metrics: None,
         }
     }
 
-    pub fn to_le_bytes(self) -> [u8; VIRTIO_PMEM_CONFIG_SPACE_SIZE] {
+    pub fn to_le_bytes(&self) -> [u8; VIRTIO_PMEM_CONFIG_SPACE_SIZE] {
         let [
             start0,
             start1,
@@ -143,6 +176,14 @@ impl VirtioPmemConfigSpace {
             size3, size4, size5, size6, size7,
         ]
     }
+
+    pub fn attach_metrics(
+        &mut self,
+        device: SharedPmemDeviceMetrics,
+        aggregate: SharedPmemDeviceMetrics,
+    ) {
+        self.metrics = Some(VirtioPmemTransportMetrics { device, aggregate });
+    }
 }
 
 impl VirtioMmioDeviceConfigHandler for VirtioPmemConfigSpace {
@@ -151,19 +192,21 @@ impl VirtioMmioDeviceConfigHandler for VirtioPmemConfigSpace {
         access: VirtioMmioDeviceConfigAccess,
     ) -> Result<MmioAccessBytes, VirtioMmioDeviceConfigError> {
         let bytes = self.to_le_bytes();
-        let bytes = read_virtio_pmem_config_bytes(&bytes, access)?;
-        MmioAccessBytes::new(bytes).map_err(config_bytes_error)
+        let result = read_virtio_pmem_config_bytes(&bytes, access);
+        if result.is_err()
+            && let Some(metrics) = &self.metrics
+        {
+            metrics.record_config_failure();
+        }
+        result
     }
 
     fn write_device_config(
         &mut self,
-        access: VirtioMmioDeviceConfigAccess,
+        _access: VirtioMmioDeviceConfigAccess,
         _data: MmioAccessBytes,
     ) -> Result<(), VirtioMmioDeviceConfigError> {
-        Err(VirtioMmioDeviceConfigError::UnsupportedWrite {
-            offset: access.offset(),
-            len: access.len(),
-        })
+        Ok(())
     }
 }
 
@@ -1172,8 +1215,8 @@ pub struct VirtioPmemDeviceCaptureState {
 }
 
 impl VirtioPmemDeviceCaptureState {
-    pub const fn config_space(&self) -> VirtioPmemConfigSpace {
-        self.config_space
+    pub fn config_space(&self) -> VirtioPmemConfigSpace {
+        self.config_space.clone()
     }
 
     pub const fn active_queue(&self) -> Option<VirtioPmemQueueState> {
@@ -1280,6 +1323,7 @@ pub struct VirtioPmemDevice {
     file_len: u64,
     rate_limiter: Option<VirtioPmemRateLimiter>,
     pending_rate_limited_queue: bool,
+    metrics: Option<VirtioPmemTransportMetrics>,
     guest_logger: Option<GuestLogger>,
 }
 
@@ -1290,6 +1334,7 @@ impl VirtioPmemDevice {
             file_len: 0,
             rate_limiter: None,
             pending_rate_limited_queue: false,
+            metrics: None,
             guest_logger: None,
         }
     }
@@ -1309,6 +1354,7 @@ impl VirtioPmemDevice {
             rate_limiter: rate_limiter
                 .and_then(|rate_limiter| VirtioPmemRateLimiter::new_at(rate_limiter, now)),
             pending_rate_limited_queue: false,
+            metrics: None,
             guest_logger: None,
         }
     }
@@ -1342,8 +1388,17 @@ impl VirtioPmemDevice {
             file_len,
             rate_limiter,
             pending_rate_limited_queue,
+            metrics: None,
             guest_logger: None,
         })
+    }
+
+    pub fn attach_metrics(
+        &mut self,
+        device: SharedPmemDeviceMetrics,
+        aggregate: SharedPmemDeviceMetrics,
+    ) {
+        self.metrics = Some(VirtioPmemTransportMetrics { device, aggregate });
     }
 
     pub fn is_activated(&self) -> bool {
@@ -1679,6 +1734,17 @@ impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioPmemDe
 }
 
 impl VirtioPmemMmioHandler {
+    pub fn attach_pmem_metrics(
+        &mut self,
+        device: SharedPmemDeviceMetrics,
+        aggregate: SharedPmemDeviceMetrics,
+    ) {
+        self.device_config_handler_mut()
+            .attach_metrics(device.clone(), aggregate.clone());
+        self.activation_handler_mut()
+            .attach_metrics(device, aggregate);
+    }
+
     pub fn has_pending_pmem_rate_limited_queue(&self) -> bool {
         self.activation_handler().has_pending_rate_limited_queue()
     }
@@ -1690,7 +1756,7 @@ impl VirtioPmemMmioHandler {
         now: Instant,
     ) -> Result<VirtioPmemDeviceCaptureState, VirtioPmemDeviceCaptureError> {
         self.activation_handler().capture_state_at(
-            *self.device_config_handler(),
+            self.device_config_handler().clone(),
             expected_file_len,
             rate_limiter_config,
             now,
@@ -1712,7 +1778,7 @@ impl VirtioPciEndpoint<VirtioPmemConfigSpace, VirtioPmemDevice> {
         let device = work
             .with_core_mut(|core| {
                 core.activation.capture_state_at(
-                    core.device_config,
+                    core.device_config.clone(),
                     expected_file_len,
                     rate_limiter_config,
                     now,
@@ -1796,6 +1862,18 @@ impl VirtioPciEndpoint<VirtioPmemConfigSpace, VirtioPmemDevice> {
     }
 }
 
+pub fn attach_pmem_metrics_to_mmio_handler(
+    dispatcher: &mut MmioDispatcher,
+    region_id: MmioRegionId,
+    device: SharedPmemDeviceMetrics,
+    aggregate: SharedPmemDeviceMetrics,
+) -> Result<(), MmioHandlerLookupError> {
+    dispatcher
+        .handler_mut::<VirtioPmemMmioHandler>(region_id)?
+        .attach_pmem_metrics(device, aggregate);
+    Ok(())
+}
+
 impl VirtioMmioDeviceActivationHandler for VirtioPmemDevice {
     fn attach_guest_logger(&mut self, logger: GuestLogger) {
         self.guest_logger = Some(logger);
@@ -1805,7 +1883,13 @@ impl VirtioMmioDeviceActivationHandler for VirtioPmemDevice {
         &mut self,
         activation: VirtioMmioDeviceActivation<'_>,
     ) -> Result<(), VirtioMmioDeviceActivationError> {
-        self.activate_pmem(activation).map_err(Into::into)
+        let result = self.activate_pmem(activation);
+        if result.is_err()
+            && let Some(metrics) = &self.metrics
+        {
+            metrics.record_activation_failure();
+        }
+        result.map_err(Into::into)
     }
 
     fn reset(&mut self) {
@@ -3809,6 +3893,14 @@ pub struct PreparedPmemDevice {
 }
 
 impl PreparedPmemDevice {
+    pub fn attach_metrics(
+        &mut self,
+        device: SharedPmemDeviceMetrics,
+        aggregate: SharedPmemDeviceMetrics,
+    ) {
+        self.config_space.attach_metrics(device, aggregate);
+    }
+
     pub(crate) fn from_snapshot_parts(
         parts: PreparedSnapshotPmemDeviceParts,
     ) -> Result<Self, PreparedSnapshotPmemDeviceError> {
@@ -3954,8 +4046,8 @@ impl PreparedPmemDevice {
         self.guest_range
     }
 
-    pub const fn config_space(&self) -> VirtioPmemConfigSpace {
-        self.config_space
+    pub fn config_space(&self) -> VirtioPmemConfigSpace {
+        self.config_space.clone()
     }
 
     pub const fn rate_limiter(&self) -> Option<PmemRateLimiterConfig> {
@@ -4457,8 +4549,8 @@ impl PmemMmioDeviceRegistration {
         self.region.range().start()
     }
 
-    pub const fn config_space(&self) -> VirtioPmemConfigSpace {
-        self.config_space
+    pub fn config_space(&self) -> VirtioPmemConfigSpace {
+        self.config_space.clone()
     }
 }
 
@@ -4507,7 +4599,7 @@ impl PmemMmioDevices {
                 VIRTIO_PMEM_DEVICE_ID,
                 config_space.available_features(),
                 &VIRTIO_PMEM_QUEUE_SIZES,
-                config_space,
+                config_space.clone(),
                 VirtioPmemDevice::with_rate_limiter(file_len, rate_limiter),
             )
             .map_err(|source| PmemMmioRegistrationError::BuildHandler {
@@ -5127,26 +5219,50 @@ const fn virtio_feature_bit(feature: u32) -> u64 {
 fn read_virtio_pmem_config_bytes(
     bytes: &[u8; VIRTIO_PMEM_CONFIG_SPACE_SIZE],
     access: VirtioMmioDeviceConfigAccess,
-) -> Result<&[u8], VirtioMmioDeviceConfigError> {
+) -> Result<MmioAccessBytes, VirtioMmioDeviceConfigError> {
     let offset = usize::try_from(access.offset()).map_err(|_| {
         VirtioMmioDeviceConfigError::UnsupportedRead {
             offset: access.offset(),
             len: access.len(),
         }
     })?;
-    let Some(end) = offset.checked_add(access.len()) else {
+    if offset > bytes.len() {
         return Err(VirtioMmioDeviceConfigError::UnsupportedRead {
             offset: access.offset(),
             len: access.len(),
         });
-    };
+    }
 
-    bytes
+    let mut result = [0_u8; MAX_MMIO_ACCESS_BYTES];
+    let available = bytes.len().saturating_sub(offset).min(access.len());
+    let end =
+        offset
+            .checked_add(available)
+            .ok_or(VirtioMmioDeviceConfigError::UnsupportedRead {
+                offset: access.offset(),
+                len: access.len(),
+            })?;
+    let source = bytes
         .get(offset..end)
         .ok_or(VirtioMmioDeviceConfigError::UnsupportedRead {
             offset: access.offset(),
             len: access.len(),
+        })?;
+    let destination = result.get_mut(..available).ok_or_else(|| {
+        config_bytes_error(MmioAccessBytesError::TooLarge {
+            len: access.len(),
+            max: MAX_MMIO_ACCESS_BYTES,
         })
+    })?;
+    destination.copy_from_slice(source);
+
+    let requested = result.get(..access.len()).ok_or_else(|| {
+        config_bytes_error(MmioAccessBytesError::TooLarge {
+            len: access.len(),
+            max: MAX_MMIO_ACCESS_BYTES,
+        })
+    })?;
+    MmioAccessBytes::new(requested).map_err(config_bytes_error)
 }
 
 fn config_bytes_error(source: MmioAccessBytesError) -> VirtioMmioDeviceConfigError {
@@ -5180,8 +5296,8 @@ mod tests {
     use crate::mmio::{MmioAccess, MmioAccessBytes, MmioBus, MmioOperation, MmioRegionId};
     use crate::virtio_mmio::{
         VIRTIO_MMIO_DEVICE_CONFIG_OFFSET, VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VIRTIO_MMIO_MAGIC_VALUE,
-        VirtioMmioAccess, VirtioMmioDeviceConfigError, VirtioMmioRegister,
-        decode_virtio_mmio_access,
+        VirtioMmioAccess, VirtioMmioDeviceConfigError, VirtioMmioDeviceRegisters,
+        VirtioMmioQueueRegisters, VirtioMmioRegister, decode_virtio_mmio_access,
     };
     use crate::virtio_queue::{
         VIRTQUEUE_DESC_F_NEXT, VIRTQUEUE_DESC_F_WRITE, VIRTQUEUE_DESCRIPTOR_SIZE,
@@ -5831,28 +5947,87 @@ mod tests {
     }
 
     #[test]
-    fn virtio_pmem_config_space_rejects_out_of_bounds_reads() {
-        let config = VirtioPmemConfigSpace::new(0, 0);
+    fn virtio_pmem_config_space_zero_fills_trailing_and_end_reads() {
+        let config = VirtioPmemConfigSpace::new(0, 0x1100_0000_0000_0000);
 
         assert_eq!(
-            read_pmem_config(&config, 16, 1),
-            Err(VirtioMmioDeviceConfigError::UnsupportedRead { offset: 16, len: 1 })
+            read_pmem_config(&config, 16, 1)
+                .expect("read at config end should succeed")
+                .as_slice(),
+            &[0]
         );
         assert_eq!(
-            read_pmem_config(&config, 15, 2),
-            Err(VirtioMmioDeviceConfigError::UnsupportedRead { offset: 15, len: 2 })
+            read_pmem_config(&config, 15, 2)
+                .expect("cross-boundary read should succeed")
+                .as_slice(),
+            &[0x11, 0]
+        );
+        assert_eq!(
+            read_pmem_config(&config, 17, 1),
+            Err(VirtioMmioDeviceConfigError::UnsupportedRead { offset: 17, len: 1 })
         );
     }
 
     #[test]
-    fn virtio_pmem_config_space_rejects_guest_writes() {
+    fn virtio_pmem_config_space_ignores_guest_writes() {
         let mut config = VirtioPmemConfigSpace::new(0, 0);
 
-        assert_eq!(
-            write_pmem_config(&mut config, 0, &[1, 2, 3, 4]),
-            Err(VirtioMmioDeviceConfigError::UnsupportedWrite { offset: 0, len: 4 })
-        );
+        assert_eq!(write_pmem_config(&mut config, 0, &[1, 2, 3, 4]), Ok(()));
         assert_eq!(config, VirtioPmemConfigSpace::new(0, 0));
+    }
+
+    #[test]
+    fn pmem_config_metrics_record_only_pinned_out_of_bounds_reads() {
+        let device_metrics = SharedPmemDeviceMetrics::default();
+        let aggregate_metrics = SharedPmemDeviceMetrics::default();
+        let mut config = VirtioPmemConfigSpace::new(0, 0x1100_0000_0000_0000);
+        config.attach_metrics(device_metrics.clone(), aggregate_metrics.clone());
+
+        assert_eq!(
+            read_pmem_config(&config, 15, 2)
+                .expect("cross-boundary read should zero-fill")
+                .as_slice(),
+            &[0x11, 0]
+        );
+        assert_eq!(
+            read_pmem_config(&config, 16, 1)
+                .expect("read at config end should zero-fill")
+                .as_slice(),
+            &[0]
+        );
+        write_pmem_config(&mut config, 0, &[1, 2, 3, 4])
+            .expect("pinned pmem config write should be ignored");
+        assert_eq!(device_metrics.snapshot(), PmemDeviceMetrics::default());
+        assert_eq!(aggregate_metrics.snapshot(), PmemDeviceMetrics::default());
+
+        assert!(matches!(
+            read_pmem_config(&config, 17, 1),
+            Err(VirtioMmioDeviceConfigError::UnsupportedRead { offset: 17, len: 1 })
+        ));
+        let expected = PmemDeviceMetrics::default().with_cfg_fails(1);
+        assert_eq!(device_metrics.snapshot(), expected);
+        assert_eq!(aggregate_metrics.snapshot(), expected);
+    }
+
+    #[test]
+    fn pmem_activation_metrics_follow_device_and_aggregate_owners() {
+        let device_metrics = SharedPmemDeviceMetrics::default();
+        let aggregate_metrics = SharedPmemDeviceMetrics::default();
+        let mut device = VirtioPmemDevice::new();
+        device.attach_metrics(device_metrics.clone(), aggregate_metrics.clone());
+        let registers = VirtioMmioDeviceRegisters::new(VIRTIO_PMEM_DEVICE_ID, 0);
+        let queues = VirtioMmioQueueRegisters::new(&VIRTIO_PMEM_QUEUE_SIZES)
+            .expect("pmem queue registers should build");
+
+        VirtioMmioDeviceActivationHandler::activate(
+            &mut device,
+            VirtioMmioDeviceActivation::new(&registers, &queues),
+        )
+        .expect_err("not-ready pmem queue should reject activation");
+
+        let expected = PmemDeviceMetrics::default().with_activate_fails(1);
+        assert_eq!(device_metrics.snapshot(), expected);
+        assert_eq!(aggregate_metrics.snapshot(), expected);
     }
 
     #[test]
@@ -6280,7 +6455,7 @@ mod tests {
 
         let captured = device
             .capture_state_at(
-                config_space,
+                config_space.clone(),
                 VIRTIO_PMEM_ALIGNMENT,
                 Some(rate_limiter),
                 now + Duration::from_millis(5),
@@ -6318,7 +6493,7 @@ mod tests {
         );
         assert_eq!(
             device.capture_state_at(
-                config_space,
+                config_space.clone(),
                 VIRTIO_PMEM_ALIGNMENT + 1,
                 Some(rate_limiter),
                 now,

--- a/crates/runtime/src/rtc.rs
+++ b/crates/runtime/src/rtc.rs
@@ -184,7 +184,11 @@ impl<T: RtcTimeSource> Pl031RtcDevice<T> {
 impl<T: RtcTimeSource> MmioHandler for Pl031RtcDevice<T> {
     fn read(&mut self, access: MmioAccess) -> Result<MmioAccessBytes, MmioHandlerError> {
         self.read_access(access).map_err(|err| {
-            self.metrics.record_read_error();
+            if matches!(&err, Pl031RtcError::InvalidRegisterOffset { .. }) {
+                self.metrics.record_read_error();
+            } else {
+                self.metrics.record_access_error();
+            }
             if let Some(logger) = &self.guest_logger {
                 logger.log_time_identity(LoggerTimeIdentityOutcome::RtcReadRejected);
             }
@@ -194,7 +198,15 @@ impl<T: RtcTimeSource> MmioHandler for Pl031RtcDevice<T> {
 
     fn write(&mut self, access: MmioAccess, data: MmioAccessBytes) -> Result<(), MmioHandlerError> {
         self.write_access(access, data).map_err(|err| {
-            self.metrics.record_write_error();
+            if matches!(
+                &err,
+                Pl031RtcError::InvalidRegisterOffset { .. }
+                    | Pl031RtcError::ReadOnlyRegisterWrite { .. }
+            ) {
+                self.metrics.record_write_error();
+            } else {
+                self.metrics.record_access_error();
+            }
             if let Some(logger) = &self.guest_logger {
                 logger.log_time_identity(LoggerTimeIdentityOutcome::RtcWriteRejected);
             }
@@ -570,7 +582,7 @@ mod tests {
     }
 
     #[test]
-    fn read_errors_record_missed_read_and_error_counts() {
+    fn read_errors_distinguish_bus_failures_from_missed_registers() {
         let mut device = Pl031RtcDevice::new(FixedRtcTimeSource::new(100));
         let metrics = device.shared_metrics();
 
@@ -585,12 +597,12 @@ mod tests {
             metrics.snapshot(),
             RtcDeviceMetrics::default()
                 .with_error_count(2)
-                .with_missed_read_count(2)
+                .with_missed_read_count(1)
         );
     }
 
     #[test]
-    fn write_errors_record_missed_write_and_error_counts() {
+    fn write_errors_distinguish_bus_failures_from_missed_registers() {
         let mut device = Pl031RtcDevice::new(FixedRtcTimeSource::new(100));
         let metrics = device.shared_metrics();
         let short_data = MmioAccessBytes::new(&[1, 2]).expect("test bytes should be valid");
@@ -606,7 +618,7 @@ mod tests {
             metrics.snapshot(),
             RtcDeviceMetrics::default()
                 .with_error_count(2)
-                .with_missed_write_count(2)
+                .with_missed_write_count(1)
         );
     }
 

--- a/crates/runtime/src/serial.rs
+++ b/crates/runtime/src/serial.rs
@@ -8,7 +8,6 @@ use std::mem::MaybeUninit;
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::logger::{GuestLogger, LoggerDeviceKind, LoggerSerialOutcome, LoggerTransportOutcome};
@@ -53,12 +52,15 @@ pub trait SerialOutput: fmt::Debug + Send {
 pub struct SerialOutputMetrics {
     error_count: u64,
     flush_count: u64,
+    host_input_fails: u64,
     input_count: u64,
     interrupt_count: u64,
     missed_read_count: u64,
     missed_write_count: u64,
     overrun_count: u64,
     read_count: u64,
+    receive_fifo_flush_count: u64,
+    state_fails: u64,
     write_count: u64,
     rate_limiter_dropped_bytes: u64,
 }
@@ -76,6 +78,10 @@ impl SerialOutputMetrics {
         Self {
             error_count: Self::incremental_delta(self.error_count, previous.error_count),
             flush_count: Self::incremental_delta(self.flush_count, previous.flush_count),
+            host_input_fails: Self::incremental_delta(
+                self.host_input_fails,
+                previous.host_input_fails,
+            ),
             input_count: Self::incremental_delta(self.input_count, previous.input_count),
             interrupt_count: Self::incremental_delta(
                 self.interrupt_count,
@@ -91,6 +97,11 @@ impl SerialOutputMetrics {
             ),
             overrun_count: Self::incremental_delta(self.overrun_count, previous.overrun_count),
             read_count: Self::incremental_delta(self.read_count, previous.read_count),
+            receive_fifo_flush_count: Self::incremental_delta(
+                self.receive_fifo_flush_count,
+                previous.receive_fifo_flush_count,
+            ),
+            state_fails: Self::incremental_delta(self.state_fails, previous.state_fails),
             write_count: Self::incremental_delta(self.write_count, previous.write_count),
             rate_limiter_dropped_bytes: Self::incremental_delta(
                 self.rate_limiter_dropped_bytes,
@@ -105,6 +116,11 @@ impl SerialOutputMetrics {
 
     pub const fn flush_count(self) -> u64 {
         self.flush_count
+    }
+
+    /// Bangbang-only failures before host input reaches the UART receive buffer.
+    pub const fn host_input_fails(self) -> u64 {
+        self.host_input_fails
     }
 
     pub const fn input_count(self) -> u64 {
@@ -131,6 +147,16 @@ impl SerialOutputMetrics {
         self.read_count
     }
 
+    /// Bangbang-only receive FIFO clears; pinned UART `flush_count` has no producer.
+    pub const fn receive_fifo_flush_count(self) -> u64 {
+        self.receive_fifo_flush_count
+    }
+
+    /// Bangbang-only capture or receive-state preparation failures.
+    pub const fn state_fails(self) -> u64 {
+        self.state_fails
+    }
+
     pub const fn write_count(self) -> u64 {
         self.write_count
     }
@@ -146,6 +172,11 @@ impl SerialOutputMetrics {
 
     pub const fn with_flush_count(mut self, flush_count: u64) -> Self {
         self.flush_count = flush_count;
+        self
+    }
+
+    pub const fn with_host_input_fails(mut self, host_input_fails: u64) -> Self {
+        self.host_input_fails = host_input_fails;
         self
     }
 
@@ -179,6 +210,16 @@ impl SerialOutputMetrics {
         self
     }
 
+    pub const fn with_receive_fifo_flush_count(mut self, receive_fifo_flush_count: u64) -> Self {
+        self.receive_fifo_flush_count = receive_fifo_flush_count;
+        self
+    }
+
+    pub const fn with_state_fails(mut self, state_fails: u64) -> Self {
+        self.state_fails = state_fails;
+        self
+    }
+
     pub const fn with_write_count(mut self, write_count: u64) -> Self {
         self.write_count = write_count;
         self
@@ -195,12 +236,15 @@ impl SerialOutputMetrics {
     pub const fn is_empty(self) -> bool {
         self.error_count == 0
             && self.flush_count == 0
+            && self.host_input_fails == 0
             && self.input_count == 0
             && self.interrupt_count == 0
             && self.missed_read_count == 0
             && self.missed_write_count == 0
             && self.overrun_count == 0
             && self.read_count == 0
+            && self.receive_fifo_flush_count == 0
+            && self.state_fails == 0
             && self.write_count == 0
             && self.rate_limiter_dropped_bytes == 0
     }
@@ -208,95 +252,97 @@ impl SerialOutputMetrics {
 
 #[derive(Debug, Clone, Default)]
 struct SharedSerialOutputMetrics {
-    inner: Arc<SharedSerialOutputMetricsInner>,
+    inner: Arc<Mutex<SerialOutputMetrics>>,
 }
 
 impl SharedSerialOutputMetrics {
-    fn record_error(&self) {
-        record_serial_metric(&self.inner.error_count, 1);
+    fn record_receive_fifo_flush(&self) {
+        self.mutate(|metrics| {
+            metrics.receive_fifo_flush_count = metrics.receive_fifo_flush_count.saturating_add(1);
+        });
     }
 
-    fn record_flush(&self) {
-        record_serial_metric(&self.inner.flush_count, 1);
+    fn record_host_input_failure(&self) {
+        self.mutate(|metrics| {
+            metrics.host_input_fails = metrics.host_input_fails.saturating_add(1);
+        });
     }
 
-    fn record_input(&self, bytes: u64) {
-        record_serial_metric(&self.inner.input_count, bytes);
-    }
-
-    fn record_interrupt(&self) {
-        record_serial_metric(&self.inner.interrupt_count, 1);
+    fn record_state_failure(&self) {
+        self.mutate(|metrics| {
+            metrics.state_fails = metrics.state_fails.saturating_add(1);
+        });
     }
 
     fn record_missed_read(&self) {
-        record_serial_metric(&self.inner.missed_read_count, 1);
+        self.mutate(|metrics| {
+            metrics.missed_read_count = metrics.missed_read_count.saturating_add(1);
+        });
     }
 
     fn record_missed_write(&self) {
-        record_serial_metric(&self.inner.missed_write_count, 1);
-    }
-
-    fn record_overrun(&self, bytes: u64) {
-        record_serial_metric(&self.inner.overrun_count, bytes);
+        self.mutate(|metrics| {
+            metrics.missed_write_count = metrics.missed_write_count.saturating_add(1);
+        });
     }
 
     fn record_read(&self) {
-        record_serial_metric(&self.inner.read_count, 1);
+        self.mutate(|metrics| {
+            metrics.read_count = metrics.read_count.saturating_add(1);
+        });
     }
 
     fn record_write(&self) {
-        record_serial_metric(&self.inner.write_count, 1);
+        self.mutate(|metrics| {
+            metrics.write_count = metrics.write_count.saturating_add(1);
+        });
     }
 
-    fn record_rate_limiter_dropped_bytes(&self, bytes: u64) {
-        record_serial_metric(&self.inner.rate_limiter_dropped_bytes, bytes);
+    fn record_output_failure(&self) {
+        self.mutate(|metrics| {
+            metrics.missed_write_count = metrics.missed_write_count.saturating_add(1);
+            metrics.error_count = metrics.error_count.saturating_add(1);
+        });
+    }
+
+    fn record_rate_limiter_drop(&self, bytes: u64) {
+        self.mutate(|metrics| {
+            metrics.write_count = metrics.write_count.saturating_add(bytes);
+            metrics.rate_limiter_dropped_bytes =
+                metrics.rate_limiter_dropped_bytes.saturating_add(bytes);
+        });
+    }
+
+    fn record_receive_injection(
+        &self,
+        accepted_bytes: u64,
+        rejected_bytes: u64,
+        published_interrupt: bool,
+    ) {
+        self.mutate(|metrics| {
+            metrics.input_count = metrics.input_count.saturating_add(accepted_bytes);
+            metrics.overrun_count = metrics.overrun_count.saturating_add(rejected_bytes);
+            if published_interrupt {
+                metrics.interrupt_count = metrics.interrupt_count.saturating_add(1);
+            }
+        });
     }
 
     fn snapshot(&self) -> SerialOutputMetrics {
-        SerialOutputMetrics {
-            error_count: self.inner.error_count.load(Ordering::Relaxed),
-            flush_count: self.inner.flush_count.load(Ordering::Relaxed),
-            input_count: self.inner.input_count.load(Ordering::Relaxed),
-            interrupt_count: self.inner.interrupt_count.load(Ordering::Relaxed),
-            missed_read_count: self.inner.missed_read_count.load(Ordering::Relaxed),
-            missed_write_count: self.inner.missed_write_count.load(Ordering::Relaxed),
-            overrun_count: self.inner.overrun_count.load(Ordering::Relaxed),
-            read_count: self.inner.read_count.load(Ordering::Relaxed),
-            write_count: self.inner.write_count.load(Ordering::Relaxed),
-            rate_limiter_dropped_bytes: self
-                .inner
-                .rate_limiter_dropped_bytes
-                .load(Ordering::Relaxed),
-        }
+        *lock_serial_metrics(&self.inner)
+    }
+
+    fn mutate(&self, mutate: impl FnOnce(&mut SerialOutputMetrics)) {
+        mutate(&mut lock_serial_metrics(&self.inner));
     }
 }
 
-#[derive(Debug, Default)]
-struct SharedSerialOutputMetricsInner {
-    error_count: AtomicU64,
-    flush_count: AtomicU64,
-    input_count: AtomicU64,
-    interrupt_count: AtomicU64,
-    missed_read_count: AtomicU64,
-    missed_write_count: AtomicU64,
-    overrun_count: AtomicU64,
-    read_count: AtomicU64,
-    write_count: AtomicU64,
-    rate_limiter_dropped_bytes: AtomicU64,
-}
-
-fn record_serial_metric(counter: &AtomicU64, value: u64) {
-    if value == 0 {
-        return;
-    }
-
-    let mut current = counter.load(Ordering::Relaxed);
-    loop {
-        let next = current.saturating_add(value);
-        match counter.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed) {
-            Ok(_) => return,
-            Err(observed) => current = observed,
-        }
+fn lock_serial_metrics(
+    metrics: &Mutex<SerialOutputMetrics>,
+) -> std::sync::MutexGuard<'_, SerialOutputMetrics> {
+    match metrics.lock() {
+        Ok(metrics) => metrics,
+        Err(poisoned) => poisoned.into_inner(),
     }
 }
 
@@ -589,8 +635,7 @@ impl<O: SerialOutput> SerialOutput for MeteredSerialOutput<O> {
                 Ok(())
             }
             Err(err) => {
-                self.metrics.record_missed_write();
-                self.metrics.record_error();
+                self.metrics.record_output_failure();
                 if let Some(logger) = &self.guest_logger {
                     logger.log_serial(LoggerSerialOutcome::OutputFailed);
                 }
@@ -648,7 +693,7 @@ impl SharedSerialOutput {
 
     /// Record one host-input lifecycle failure without changing UART state.
     pub fn record_host_input_error(&self) {
-        self.metrics.record_error();
+        self.metrics.record_host_input_failure();
     }
 }
 
@@ -668,8 +713,7 @@ impl SerialOutput for SharedSerialOutput {
 
     fn write_byte(&mut self, byte: u8) -> Result<(), SerialOutputError> {
         let mut output = self.output.lock().map_err(|_| {
-            self.metrics.record_missed_write();
-            self.metrics.record_error();
+            self.metrics.record_output_failure();
             if let Some(logger) = &self.guest_logger {
                 logger.log_serial(LoggerSerialOutcome::OutputFailed);
             }
@@ -725,7 +769,7 @@ impl<O: SerialOutput> SerialOutput for RateLimitedSerialOutput<O> {
         if self.bucket.reduce(1) {
             self.output.write_byte(byte)
         } else {
-            self.metrics.record_rate_limiter_dropped_bytes(1);
+            self.metrics.record_rate_limiter_drop(1);
             if let Some(logger) = &self.guest_logger {
                 logger.log_transport(LoggerTransportOutcome::RateLimiterRejected(
                     LoggerDeviceKind::Serial,
@@ -2178,7 +2222,7 @@ impl<O> SerialMmioDevice<O> {
     ) -> Result<SerialMmioCaptureState, SerialMmioCaptureError> {
         let mut receive_bytes = Vec::new();
         if let Err(source) = reserve(&mut receive_bytes, self.receive_fifo.len()) {
-            self.metrics.record_error();
+            self.metrics.record_state_failure();
             return Err(SerialMmioCaptureError::BufferAllocation { source });
         }
         receive_bytes.extend(self.receive_fifo.iter().copied());
@@ -2311,7 +2355,7 @@ impl<O> SerialMmioDevice<O> {
         if accepted_bytes != 0
             && let Err(source) = reserve(&mut self.receive_fifo, accepted_bytes)
         {
-            self.metrics.record_error();
+            self.metrics.record_state_failure();
             return Err(SerialReceiveInjectionError::BufferAllocation { source });
         }
 
@@ -2333,13 +2377,13 @@ impl<O> SerialMmioDevice<O> {
             self.interrupt_identification = SERIAL_INTERRUPT_IDENTIFICATION_RECEIVED_DATA_AVAILABLE;
         }
 
-        self.metrics
-            .record_input(saturating_usize_to_u64(accepted_bytes));
-        self.metrics
-            .record_overrun(saturating_usize_to_u64(rejected_bytes));
-        if should_publish_interrupt {
-            self.publish_receive_interrupt_intent();
-        }
+        let published_interrupt =
+            should_publish_interrupt && self.publish_receive_interrupt_intent();
+        self.metrics.record_receive_injection(
+            saturating_usize_to_u64(accepted_bytes),
+            saturating_usize_to_u64(rejected_bytes),
+            published_interrupt,
+        );
 
         Ok(SerialReceiveInjectionOutcome::new(
             accepted_bytes,
@@ -2348,10 +2392,12 @@ impl<O> SerialMmioDevice<O> {
         ))
     }
 
-    fn publish_receive_interrupt_intent(&mut self) {
+    fn publish_receive_interrupt_intent(&mut self) -> bool {
         if !self.receive_interrupt_intent_pending {
             self.receive_interrupt_intent_pending = true;
-            self.metrics.record_interrupt();
+            true
+        } else {
+            false
         }
     }
 
@@ -2398,7 +2444,7 @@ impl<O> SerialMmioDevice<O> {
         self.receive_fifo.clear();
         self.line_status &= !(SERIAL_LINE_STATUS_DATA_READY | SERIAL_LINE_STATUS_OVERRUN_ERROR);
         self.acknowledge_receive_interrupt();
-        self.metrics.record_flush();
+        self.metrics.record_receive_fifo_flush();
         if had_receive_data {
             self.publish_input_ready_intent();
         }
@@ -2694,8 +2740,9 @@ mod tests {
     use std::os::unix::ffi::OsStrExt as _;
     use std::os::unix::fs::OpenOptionsExt as _;
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+    use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::{
@@ -3387,7 +3434,8 @@ mod tests {
             device.take_input_ready_intent(),
             Some(SerialInputReadyIntent::ReceiveBufferEmpty)
         );
-        assert_eq!(device.metrics().flush_count(), 1);
+        assert_eq!(device.metrics().flush_count(), 0);
+        assert_eq!(device.metrics().receive_fifo_flush_count(), 1);
         assert_receive_invariants(&device);
     }
 
@@ -3579,7 +3627,8 @@ mod tests {
                 .expect("state should remain capturable"),
             before
         );
-        assert_eq!(device.metrics().error_count(), 2);
+        assert_eq!(device.metrics().error_count(), 0);
+        assert_eq!(device.metrics().state_fails(), 2);
     }
 
     #[test]
@@ -3799,7 +3848,7 @@ mod tests {
             .expect_err("read-only write should fail");
 
         let expected = SerialOutputMetrics::default()
-            .with_flush_count(1)
+            .with_receive_fifo_flush_count(1)
             .with_input_count(SERIAL_RECEIVE_FIFO_CAPACITY as u64)
             .with_interrupt_count(1)
             .with_missed_read_count(1)
@@ -4075,7 +4124,7 @@ mod tests {
         assert_eq!(
             output.metrics(),
             SerialOutputMetrics::default()
-                .with_write_count(1)
+                .with_write_count(3)
                 .with_rate_limiter_dropped_bytes(2)
         );
     }
@@ -4084,17 +4133,46 @@ mod tests {
     fn shared_serial_output_metrics_saturates_counters() {
         let metrics = SharedSerialOutputMetrics::default();
 
-        metrics.record_rate_limiter_dropped_bytes(u64::MAX - 1);
-        metrics.record_rate_limiter_dropped_bytes(2);
-        metrics.record_write();
+        metrics.record_rate_limiter_drop(u64::MAX - 1);
+        metrics.record_rate_limiter_drop(2);
         metrics.record_write();
 
         assert_eq!(
             metrics.snapshot(),
             SerialOutputMetrics::default()
-                .with_write_count(2)
+                .with_write_count(u64::MAX)
                 .with_rate_limiter_dropped_bytes(u64::MAX)
         );
+    }
+
+    #[test]
+    fn serial_owner_snapshot_never_exposes_partial_output_failure() {
+        const WRITERS: usize = 4;
+        const UPDATES: usize = 2_000;
+
+        let metrics = SharedSerialOutputMetrics::default();
+        let remaining = Arc::new(AtomicUsize::new(WRITERS));
+        thread::scope(|scope| {
+            for _ in 0..WRITERS {
+                let metrics = metrics.clone();
+                let remaining = Arc::clone(&remaining);
+                scope.spawn(move || {
+                    for _ in 0..UPDATES {
+                        metrics.record_output_failure();
+                    }
+                    remaining.fetch_sub(1, Ordering::SeqCst);
+                });
+            }
+
+            while remaining.load(Ordering::SeqCst) != 0 {
+                let snapshot = metrics.snapshot();
+                assert_eq!(snapshot.error_count(), snapshot.missed_write_count());
+            }
+        });
+
+        let expected = u64::try_from(WRITERS * UPDATES).expect("test count should fit u64");
+        assert_eq!(metrics.snapshot().error_count(), expected);
+        assert_eq!(metrics.snapshot().missed_write_count(), expected);
     }
 
     #[test]

--- a/crates/runtime/src/snapshot_device_v2_6.rs
+++ b/crates/runtime/src/snapshot_device_v2_6.rs
@@ -346,8 +346,8 @@ impl SnapshotV2PmemState {
     }
 
     /// Returns the exact guest-visible pmem config space.
-    pub const fn config_space(&self) -> VirtioPmemConfigSpace {
-        self.config_space
+    pub fn config_space(&self) -> VirtioPmemConfigSpace {
+        self.config_space.clone()
     }
 
     /// Returns the optional active queue cursors.

--- a/crates/runtime/src/snapshot_device_v2_6/restore.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/restore.rs
@@ -10,6 +10,7 @@ use crate::block::{BlockFileBacking, DriveConfigs};
 use crate::interrupt::GuestInterruptLine;
 use crate::memory::{GuestMemory, GuestMemoryRange};
 use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::metrics::SharedPmemDeviceMetrics;
 use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::PciSbdf;
 use crate::pmem::{
@@ -528,6 +529,16 @@ impl PreparedSnapshotV2PmemRecord {
         &self.device
     }
 
+    pub fn attach_metrics(
+        &mut self,
+        device: SharedPmemDeviceMetrics,
+        aggregate: SharedPmemDeviceMetrics,
+    ) {
+        self.prepared_device
+            .attach_metrics(device.clone(), aggregate.clone());
+        self.device.attach_metrics(device, aggregate);
+    }
+
     /// Consumes the complete detached pmem owner.
     pub fn into_parts(self) -> PreparedSnapshotV2PmemRecordParts {
         (
@@ -617,6 +628,16 @@ impl PreparedSnapshotV2StorageMmioPmemRecord {
         &self.handler
     }
 
+    pub fn attach_metrics(
+        &mut self,
+        device: SharedPmemDeviceMetrics,
+        aggregate: SharedPmemDeviceMetrics,
+    ) {
+        self.prepared_device
+            .attach_metrics(device.clone(), aggregate.clone());
+        self.handler.attach_pmem_metrics(device, aggregate);
+    }
+
     /// Consumes the unpublished handler and authoritative mapping owner.
     pub fn into_parts(self) -> PreparedSnapshotV2StorageMmioPmemRecordParts {
         (
@@ -692,6 +713,18 @@ impl PreparedSnapshotV2StoragePciPmemRecord {
 
     pub const fn prepared_device(&self) -> &PreparedPmemDevice {
         &self.prepared_device
+    }
+
+    pub fn attach_metrics(
+        &mut self,
+        device: SharedPmemDeviceMetrics,
+        aggregate: SharedPmemDeviceMetrics,
+    ) {
+        self.prepared_device
+            .attach_metrics(device.clone(), aggregate.clone());
+        self.config_space
+            .attach_metrics(device.clone(), aggregate.clone());
+        self.device.attach_metrics(device, aggregate);
     }
 
     /// Completes retained endpoint preparation against the destination's

--- a/crates/runtime/src/snapshot_entropy_v2_8.rs
+++ b/crates/runtime/src/snapshot_entropy_v2_8.rs
@@ -18,6 +18,7 @@ use crate::entropy::{
 use crate::interrupt::GuestInterruptLine;
 use crate::memory::{GuestMemory, GuestMemoryRange};
 use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::metrics::SharedEntropyDeviceMetrics;
 use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::PciSbdf;
 use crate::snapshot_device_v2::{
@@ -470,6 +471,18 @@ pub struct SnapshotV2EntropyRestorePlan {
 }
 
 impl SnapshotV2EntropyRestorePlan {
+    /// Binds one fresh destination-local metrics owner before transport materialization.
+    pub fn attach_metrics(&mut self, metrics: SharedEntropyDeviceMetrics) {
+        match &mut self.transport {
+            PreparedSnapshotV2EntropyTransport::Mmio(mmio) => {
+                mmio.device.attach_metrics(metrics);
+            }
+            PreparedSnapshotV2EntropyTransport::Pci(pci) => {
+                pci.device.attach_metrics(metrics);
+            }
+        }
+    }
+
     /// Validates and reconstructs one decoded entropy continuation at a
     /// destination-local monotonic-time sample.
     pub fn prepare(
@@ -860,6 +873,10 @@ impl PreparedSnapshotV2EntropyMmioHandler {
     /// Returns the fully restored, still-unpublished handler.
     pub const fn handler(&self) -> &VirtioRngMmioHandler {
         &self.handler
+    }
+
+    pub fn attach_metrics(&mut self, metrics: SharedEntropyDeviceMetrics) {
+        self.handler.attach_entropy_metrics(metrics);
     }
 
     /// Consumes the value into continuation, placement, and inert handler.

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -695,6 +695,17 @@ fields, newer balloon API/device fields, extra UART fields, and the ordinary
 block configuration-change value remain internal or are discarded at the
 public boundary. Adding an extension requires a separately versioned schema.
 
+The checked device-producer audit now terminally certifies all 23 #1838 fields:
+22 entropy, pmem, RTC, and UART fields are implemented, while
+`uart.flush_count` is source-neutral zero because pinned Firecracker has no
+producer for it. Each device owner publishes an immutable compound counter
+snapshot. Entropy counts popped requests before parse or throttling; pmem binds
+configuration and activation failures to both the exact current generation and
+the aggregate; RTC records missed counters only for invalid/read-only register
+accesses; UART limiter drops count an attempted write while FIFO clears and
+host-input/state failures stay internal. Later #1839–#1846 records remain
+nonterminal and repository-final certification remains gated on their delivery.
+
 One flush first freezes missed-log, rate-limited-log, and SIGPIPE totals through
 two fixed-order `SeqCst` scans separated by a `SeqCst` fence. Equal monotonic
 vectors establish that fence as a common process cut; a racing update forces a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1553,10 +1553,23 @@ cargo test -p bangbang-firecracker-capability-audit --test metrics_schema --lock
 
 The adjacent human-owned `metrics-device-producer-audit.json` maps all 231
 device-owned fields to closed operation boundaries and the nine concrete #1789
-children. Its 216 planned and 15 provisional-platform-zero records are
-intentionally nonterminal and contain no evidence. The same focused test checks
-canonical bytes, exact membership and partition, suffix routing, provisional
-state, anchored-evidence rules, and final-mode rejection.
+children. After #1838 it contains 22 implemented entropy/pmem/RTC/UART fields,
+one source-neutral `uart.flush_count`, 193 planned fields, and 15
+provisional-platform-zero fields. Only the latter two groups are nonterminal
+and evidence-free. The same focused test checks canonical bytes, exact
+membership and partition, completed-child regression, future-child premature
+promotion, the UART-flush disposition, suffix routing, provisional state,
+anchored-evidence rules, and final-mode rejection of the remaining 208 records.
+
+Focused #1838 producer coverage lives with the owning runtime modules. It
+checks entropy popped-descriptor accounting and owner attachment, exact pmem
+config reads/no-op writes plus aggregate/per-generation attachment, RTC bus
+versus missed-register classification, UART output/drop/FIFO boundaries, and
+owner-local compound snapshot coherence. The HVF library tests additionally
+drive registered MMIO entropy activation and pmem configuration failures into
+the bound session owners. The full signed wrapper remains required before a PR
+is submitted so the same MMIO/PCI startup, restore, and production boundaries
+are exercised on Apple Silicon.
 
 The ordinary `compare` command rederives the source projection together with
 the general and logger manifests. To create a metrics source-only candidate:
@@ -1618,8 +1631,9 @@ partition with final-mode validation of the exact process audit, while retaining
 logger and device-audit validation in delivery mode. It requires the two
 implemented process profiles and all 69 field records to remain terminal at
 exactly 64 implemented, one source-neutral, and four platform-zero. Ten planned
-and four platform-zero device profiles and all 231 device audit records remain
-#1789-owned and nonterminal, and the two aggregates remain #1790-owned.
+and four platform-zero device profiles remain #1789-owned; within the 231-field
+device audit, #1838's 23 records are terminal and the other 208 remain
+nonterminal. The two aggregates remain #1790-owned.
 The composed test mutates both a field record and an aggregate process profile;
 the lower-level suite separately exercises every membership, ordering,
 ownership, boundary, child, rationale, disposition, evidence, path, and baseline

--- a/tools/firecracker-capability-audit/src/metrics_device_validate.rs
+++ b/tools/firecracker-capability-audit/src/metrics_device_validate.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 const EXPECTED_DEVICE_FIELDS: usize = 231;
-const COMPLETED_DELIVERY_ISSUES: &[&str] = &[];
+const COMPLETED_DELIVERY_ISSUES: &[&str] = &["#1838"];
 
 /// Validate exact device-producer authority against the resolved metrics schema.
 pub fn validate_metrics_device_producers(
@@ -477,8 +477,12 @@ fn expected_boundary(path: &str) -> Option<MetricsDeviceProducerBoundary> {
     data_path_suffix(suffix).then_some(Boundary::DataPath)
 }
 
-fn expected_terminal_disposition(_path: &str) -> Option<MetricsDeviceProducerDisposition> {
-    None
+fn expected_terminal_disposition(path: &str) -> Option<MetricsDeviceProducerDisposition> {
+    if path == "uart.flush_count" {
+        return Some(MetricsDeviceProducerDisposition::SourceNeutral);
+    }
+    (expected_delivery_issue(path) == Some("#1838"))
+        .then_some(MetricsDeviceProducerDisposition::Implemented)
 }
 
 fn expected_rationale(

--- a/tools/firecracker-capability-audit/tests/metrics_schema.rs
+++ b/tools/firecracker-capability-audit/tests/metrics_schema.rs
@@ -236,7 +236,7 @@ fn checked_device_producer_audit_is_canonical_and_exact() {
             .iter()
             .filter(|record| record.disposition == MetricsDeviceProducerDisposition::Planned)
             .count(),
-        216
+        193
     );
     assert_eq!(
         audit
@@ -248,22 +248,97 @@ fn checked_device_producer_audit_is_canonical_and_exact() {
             .count(),
         15
     );
-    assert!(audit.records.iter().all(|record| {
-        record.implementation.is_empty()
-            && record.validation.is_empty()
-            && record.platform_exclusion.is_none()
-    }));
+    assert_eq!(
+        audit
+            .records
+            .iter()
+            .filter(|record| record.disposition == MetricsDeviceProducerDisposition::Implemented)
+            .count(),
+        22
+    );
+    assert_eq!(
+        audit
+            .records
+            .iter()
+            .filter(|record| {
+                record.disposition == MetricsDeviceProducerDisposition::SourceNeutral
+            })
+            .count(),
+        1
+    );
+    for record in audit
+        .records
+        .iter()
+        .filter(|record| record.delivery_issue == "#1838")
+    {
+        let expected = if record.field_id == "static:uart.flush_count" {
+            MetricsDeviceProducerDisposition::SourceNeutral
+        } else {
+            MetricsDeviceProducerDisposition::Implemented
+        };
+        assert_eq!(record.disposition, expected, "{}", record.field_id);
+        assert!(!record.implementation.is_empty(), "{}", record.field_id);
+        assert!(!record.validation.is_empty(), "{}", record.field_id);
+        assert!(record.platform_exclusion.is_none(), "{}", record.field_id);
+    }
+    assert!(
+        audit
+            .records
+            .iter()
+            .filter(|record| record.delivery_issue != "#1838")
+            .all(|record| {
+                record.implementation.is_empty()
+                    && record.validation.is_empty()
+                    && record.platform_exclusion.is_none()
+            })
+    );
 
     let error = validate_metrics_device_producers(&audit, &authority, &root, AuditMode::Final)
-        .expect_err("all device producer records must remain nonterminal")
+        .expect_err("later device producer records must remain nonterminal")
         .to_string();
     assert_eq!(
         error
             .lines()
             .filter(|line| line.contains("final metrics device producer validation rejects"))
             .count(),
-        231
+        208
     );
+}
+
+// exact #1838 disposition mutation tests
+#[test]
+fn device_producer_audit_rejects_completed_child_regression_and_future_promotion() {
+    let mut implemented_regression = checked_device_audit();
+    implemented_regression
+        .records
+        .iter_mut()
+        .find(|record| {
+            record.delivery_issue == "#1838"
+                && record.disposition == MetricsDeviceProducerDisposition::Implemented
+        })
+        .expect("implemented #1838 record must exist")
+        .disposition = MetricsDeviceProducerDisposition::Planned;
+    assert!(device_validation_error(&implemented_regression).contains("wrong current disposition"));
+
+    let mut source_neutral_drift = checked_device_audit();
+    source_neutral_drift
+        .records
+        .iter_mut()
+        .find(|record| record.field_id == "static:uart.flush_count")
+        .expect("UART flush record must exist")
+        .disposition = MetricsDeviceProducerDisposition::Implemented;
+    assert!(device_validation_error(&source_neutral_drift).contains("wrong current disposition"));
+
+    let mut future_promotion = checked_device_audit();
+    let record = future_promotion
+        .records
+        .iter_mut()
+        .find(|record| record.delivery_issue == "#1839")
+        .expect("future child record must exist");
+    record.disposition = MetricsDeviceProducerDisposition::Implemented;
+    record.implementation.push(anchored_local_reference());
+    record.validation.push(anchored_local_reference());
+    assert!(device_validation_error(&future_promotion).contains("wrong current disposition"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- certify all 23 Firecracker v1.16.0 entropy, pmem, RTC, and UART metric fields
- make compound device observations and immutable snapshots coherent through narrow owner-local locks
- bind fresh entropy and pmem metric owners across MMIO, PCI, runtime hotplug, and snapshot restore paths
- align entropy attempts, pmem config access, RTC error classes, and UART drop/flush semantics with pinned producers
- promote exactly 22 implemented records and one source-neutral UART flush record in the device audit

## Scope exclusions

Balloon, memory-hotplug, vsock, block, vhost-user, network/MMDS, vCPU/interrupt, platform-zero, and final device certification remain assigned to later #1789 children.

## Verification

- cargo fmt --all -- --check
- cargo run -p bangbang-firecracker-capability-audit --locked -- validate
- cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker
- schema-final and process-final audit gates
- generic final gate rejects exactly the remaining 208 device records
- cargo check --workspace --all-targets --all-features --locked
- unsupported launcher target check for aarch64-unknown-linux-musl
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy workspace and all documented signed Apple targets with warnings denied
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps --locked
- scripts/run-integration-tests.sh without allow-unsupported

Closes #1838
Parent: #1789