### PR TITLE
feat: complete Firecracker block metrics producers

### DIFF
--- a/compat/firecracker/v1.16.0/metrics-contract.md
+++ b/compat/firecracker/v1.16.0/metrics-contract.md
@@ -43,7 +43,7 @@ including the schema-runtime timestamp producer. #1788 certifies the exact
 API, process, logger, signal, boot, and lifecycle producers through two
 implemented aggregate profiles and the field-level process audit. The checked
 device audit now assigns every #1789 field to one concrete delivery child and
-terminally certifies the 81 records delivered by #1838–#1840; later child
+terminally certifies the 129 records delivered by #1838–#1841; later child
 records remain nonterminal. `corpus:metrics` and the cross-producer aggregate
 semantic remain #1790-owned. A required zero therefore proves wire-shape
 completeness only, never producer completion unless its field audit is
@@ -219,10 +219,11 @@ Static and configured identities remain distinct; exact suffix routing splits
 mapped network fields from tap-oriented gaps and applicable vCPU exits from
 retained PIO/KVM-clock fields.
 
-After #1840, the audit contains 135 `planned`, 15
-`provisional-platform-zero`, 80 `implemented`, and one `source-neutral`
-record. The 81 terminal records cover the complete pinned entropy, pmem, RTC,
-UART, balloon, memory-hotplug, and vsock roots. `uart.flush_count` is the
+After #1841, the audit contains 87 `planned`, 15
+`provisional-platform-zero`, 128 `implemented`, and one `source-neutral`
+record. The 129 terminal records cover the complete pinned entropy, pmem, RTC,
+UART, balloon, memory-hotplug, vsock, static block, and configured ordinary
+block roots. `uart.flush_count` is the
 source-neutral record because pinned Firecracker declares the field but has no
 producer; receive-FIFO clearing and other Bangbang-only serial diagnostics do
 not feed it. The remaining planned and provisional records are nonterminal,
@@ -242,6 +243,36 @@ Every metrics flush snapshots all 20 fields atomically and advances its
 success baseline only after the full JSON line is accepted, so first-zero,
 later-delta, failed-middle, and ambiguously accepted writes retain the same
 at-least-once contract as the other device roots.
+
+Ordinary block uses one coherent saturating owner per live drive generation.
+The same owner is attached to its configuration space and MMIO or PCI device;
+vhost-user devices reject that binding and remain exclusive to
+`vhost_user_block_{drive_id}`. Invalid ordinary configuration reads and every
+configuration write count in `cfg_fails`, while only failed ordinary
+activation attempts count in `activate_fails`. One nonempty notification call
+counts one `queue_event_count` regardless of kick multiplicity. An empty call
+that starts with retained limiter work counts one `rate_limiter_event_count`.
+Interrupt-delivery failures are attributed only to affected drives.
+
+Each successfully popped descriptor contributes the then-current available
+length to `remaining_reqs_count`. A completed queue pass that publishes no used
+element increments `no_avail_buffer`; an available- or used-ring failure that
+returns before that tail does not. Parse failures feed `execute_fails`; I/O,
+partial-transfer, and unsupported outcomes feed `invalid_reqs_count`. Partial
+read/write byte totals retain the actual prefix, but operation counts require
+full I/O success. A successful backing flush is counted before guest status
+publication, and read/write latency covers attempted host I/O even when it
+fails. Status-byte publication failure remains typed and logged without being
+misclassified as a parse failure.
+
+One registry capture freezes every current per-drive value and private
+generation, then derives static `block` from that same set. A removed and
+reinserted ID therefore starts a fresh interval rather than subtracting its
+predecessor. Snapshot state never persists metrics owners or generations, so a
+restored destination starts fresh. Dynamic latency retains min/max/sum; static
+latency sums `sum_us` and leaves min/max zero exactly as pinned Firecracker
+does. The baseline advances only after a complete accepted line, preserving
+whole-observation replay after failed or ambiguously accepted publication.
 
 Entropy, pmem, RTC, and UART counters use one narrow owner-local value lock per
 immutable snapshot. A compound producer update and a snapshot therefore cannot

--- a/compat/firecracker/v1.16.0/metrics-device-producer-audit.json
+++ b/compat/firecracker/v1.16.0/metrics-device-producer-audit.json
@@ -9,218 +9,1106 @@
     {
       "field_id": "dynamic:block_{drive_id}.activate_fails",
       "boundary": "activation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.activate_fails` is assigned to #1841 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.activate_fails` is completed by #1841 at the `activation` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "metrics.record_activation_failure();"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_activation_trait_error_is_generic_handler_error()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.cfg_fails",
       "boundary": "configuration",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.cfg_fails` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.cfg_fails` is completed by #1841 at the `configuration` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "metrics.record_config_failure();"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn ordinary_config_space_records_only_failed_accesses()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.event_fails",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.event_fails` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.event_fails` is completed by #1841 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "metrics.record_event_failure_for_drive(config.drive_id());"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn block_metrics_record_signal_failure()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.execute_fails",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.execute_fails` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.execute_fails` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.flush_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.flush_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.flush_count` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.invalid_reqs_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.invalid_reqs_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.invalid_reqs_count` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.io_engine_throttled_events",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.io_engine_throttled_events` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.io_engine_throttled_events` is completed by #1841 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_io_engine_throttled_event(&mut self) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.no_avail_buffer",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.no_avail_buffer` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.no_avail_buffer` is completed by #1841 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn finish_queue_pass(&mut self) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.queue_event_count",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.queue_event_count` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.queue_event_count` is completed by #1841 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "metrics.record_queue_events(1);"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.rate_limiter_event_count",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.rate_limiter_event_count` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.rate_limiter_event_count` is completed by #1841 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "metrics.record_rate_limiter_event();"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.rate_limiter_throttled_events",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.rate_limiter_throttled_events` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.rate_limiter_throttled_events` is completed by #1841 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_rate_limited_request(&mut self, retry_after: Duration) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.read_agg.max_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.read_agg.max_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_agg.max_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.read_agg.min_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.read_agg.min_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_agg.min_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.read_agg.sum_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.read_agg.sum_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_agg.sum_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.read_bytes",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.read_bytes` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_bytes` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.read_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.read_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.read_count` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.remaining_reqs_count",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.remaining_reqs_count` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.remaining_reqs_count` is completed by #1841 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_remaining_requests(&mut self, remaining: u16) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.update_count",
       "boundary": "configuration",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.update_count` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.update_count` is completed by #1841 at the `configuration` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "fn record_block_device_update(&self, drive_id: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_block_update_metrics_output(path: &Path) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.update_fails",
       "boundary": "configuration",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.update_fails` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.update_fails` is completed by #1841 at the `configuration` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "fn record_block_device_update_failure(&self, drive_id: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_block_update_metrics_output(path: &Path) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.write_agg.max_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.write_agg.max_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_agg.max_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.write_agg.min_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.write_agg.min_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_agg.min_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.write_agg.sum_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.write_agg.sum_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_agg.sum_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.write_bytes",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.write_bytes` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_bytes` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:block_{drive_id}.write_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block_{drive_id}.write_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block_{drive_id}.write_count` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "dynamic:net_{iface_id}.activate_fails",
@@ -1143,218 +2031,1106 @@
     {
       "field_id": "static:block.activate_fails",
       "boundary": "activation",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.activate_fails` is assigned to #1841 at the `activation` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.activate_fails` is completed by #1841 at the `activation` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "metrics.record_activation_failure();"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_activation_trait_error_is_generic_handler_error()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.cfg_fails",
       "boundary": "configuration",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.cfg_fails` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.cfg_fails` is completed by #1841 at the `configuration` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "metrics.record_config_failure();"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn ordinary_config_space_records_only_failed_accesses()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.event_fails",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.event_fails` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.event_fails` is completed by #1841 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "metrics.record_event_failure_for_drive(config.drive_id());"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/hvf/src/startup.rs",
+          "anchor": "fn block_metrics_record_signal_failure()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.execute_fails",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.execute_fails` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.execute_fails` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.flush_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.flush_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.flush_count` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.invalid_reqs_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.invalid_reqs_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.invalid_reqs_count` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.io_engine_throttled_events",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.io_engine_throttled_events` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.io_engine_throttled_events` is completed by #1841 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_io_engine_throttled_event(&mut self) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.no_avail_buffer",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.no_avail_buffer` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.no_avail_buffer` is completed by #1841 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn finish_queue_pass(&mut self) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.queue_event_count",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.queue_event_count` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.queue_event_count` is completed by #1841 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "metrics.record_queue_events(1);"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.rate_limiter_event_count",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.rate_limiter_event_count` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.rate_limiter_event_count` is completed by #1841 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "metrics.record_rate_limiter_event();"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.rate_limiter_throttled_events",
       "boundary": "rate-limiter",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.rate_limiter_throttled_events` is assigned to #1841 at the `rate-limiter` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.rate_limiter_throttled_events` is completed by #1841 at the `rate-limiter` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_rate_limited_request(&mut self, retry_after: Duration) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.read_agg.max_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.read_agg.max_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.read_agg.max_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.read_agg.min_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.read_agg.min_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.read_agg.min_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.read_agg.sum_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.read_agg.sum_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.read_agg.sum_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.read_bytes",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.read_bytes` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.read_bytes` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.read_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.read_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.read_count` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.remaining_reqs_count",
       "boundary": "queue-event",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.remaining_reqs_count` is assigned to #1841 at the `queue-event` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.remaining_reqs_count` is completed by #1841 at the `queue-event` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_remaining_requests(&mut self, remaining: u16) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_device_retries_rate_limited_sync_queue_without_another_notification()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.update_count",
       "boundary": "configuration",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.update_count` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.update_count` is completed by #1841 at the `configuration` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "fn record_block_device_update(&self, drive_id: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_block_update_metrics_output(path: &Path) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.update_fails",
       "boundary": "configuration",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.update_fails` is assigned to #1841 at the `configuration` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.update_fails` is completed by #1841 at the `configuration` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/vmm.rs",
+          "anchor": "fn record_block_device_update_failure(&self, drive_id: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_block_update_metrics_output(path: &Path) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.write_agg.max_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.write_agg.max_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.write_agg.max_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.write_agg.min_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.write_agg.min_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.write_agg.min_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.write_agg.sum_us",
       "boundary": "latency",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.write_agg.sum_us` is assigned to #1841 at the `latency` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.write_agg.sum_us` is completed by #1841 at the `latency` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_latency_sample(&mut self, sample: VirtioBlockRequestLatencySample) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_executes_read_and_publishes_used_element()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.write_bytes",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.write_bytes` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.write_bytes` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:block.write_count",
       "boundary": "data-path",
-      "disposition": "planned",
+      "disposition": "implemented",
       "delivery_issue": "#1841",
-      "rationale": "Pinned Firecracker field `block.write_count` is assigned to #1841 at the `data-path` boundary; terminal implementation and validation evidence is intentionally deferred until that child is completed.",
-      "implementation": [],
-      "validation": []
+      "rationale": "Pinned Firecracker field `block.write_count` is completed by #1841 at the `data-path` boundary with exact implementation and validation evidence.",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "pub struct BlockDeviceMetrics {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics/firecracker.rs",
+          "anchor": "fn add_block_metrics(aggregate: &mut BlockMetrics, metrics: &BlockMetrics) {"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/block.rs",
+          "anchor": "fn block_queue_dispatch_execution_failure_still_publishes_completion()"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/metrics.rs",
+          "anchor": "fn writes_block_device_metrics_when_provided()"
+        },
+        {
+          "kind": "local",
+          "path": "tools/firecracker-capability-audit/tests/metrics_schema.rs",
+          "anchor": "exact #1838 disposition mutation tests, extended through #1841"
+        }
+      ]
     },
     {
       "field_id": "static:entropy.activate_fails",

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -36283,9 +36283,10 @@ where
         let mut diagnostics =
             MetricsDiagnostics::new().with_boot_run_loop_status(self.metric_status());
         if let Some(metrics) = &self.block_device_metrics {
+            let (aggregate, per_drive) = metrics.capture().into_parts();
             diagnostics = diagnostics
-                .with_block_device_metrics(metrics.aggregate_snapshot())
-                .with_block_device_metrics_by_drive(metrics.per_drive_snapshot());
+                .with_block_device_metrics(aggregate)
+                .with_block_device_metrics_by_drive(per_drive);
         }
         if let Some(metrics) = &self.pmem_device_metrics {
             diagnostics = diagnostics
@@ -53777,12 +53778,14 @@ mod tests {
         assert_eq!(
             diagnostics.block_device_metrics_by_drive(),
             Some(
-                &BlockDeviceMetricsByDrive::new().with_drive_metrics(
-                    "rootfs",
-                    BlockDeviceMetrics::default()
-                        .with_event_fails(1)
-                        .with_queue_event_count(1),
-                )
+                &BlockDeviceMetricsByDrive::new()
+                    .with_drive_metrics(
+                        "rootfs",
+                        BlockDeviceMetrics::default()
+                            .with_event_fails(1)
+                            .with_queue_event_count(1),
+                    )
+                    .with_drive_metrics("data", BlockDeviceMetrics::default())
             )
         );
 

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -17241,10 +17241,164 @@ mod macos_arm64 {
         }
     }
 
+    const SNAPSHOT_BLOCK_METRIC_FIELDS: [&str; 20] = [
+        "activate_fails",
+        "cfg_fails",
+        "no_avail_buffer",
+        "event_fails",
+        "execute_fails",
+        "invalid_reqs_count",
+        "flush_count",
+        "queue_event_count",
+        "rate_limiter_event_count",
+        "update_count",
+        "update_fails",
+        "read_bytes",
+        "write_bytes",
+        "read_count",
+        "write_count",
+        "read_agg",
+        "write_agg",
+        "rate_limiter_throttled_events",
+        "io_engine_throttled_events",
+        "remaining_reqs_count",
+    ];
+    const SNAPSHOT_BLOCK_COUNTER_FIELDS: [&str; 18] = [
+        "activate_fails",
+        "cfg_fails",
+        "no_avail_buffer",
+        "event_fails",
+        "execute_fails",
+        "invalid_reqs_count",
+        "flush_count",
+        "queue_event_count",
+        "rate_limiter_event_count",
+        "update_count",
+        "update_fails",
+        "read_bytes",
+        "write_bytes",
+        "read_count",
+        "write_count",
+        "rate_limiter_throttled_events",
+        "io_engine_throttled_events",
+        "remaining_reqs_count",
+    ];
+
+    fn assert_snapshot_block_metric_shape(metric: &serde_json::Value, context: &str) {
+        let object = metric
+            .as_object()
+            .unwrap_or_else(|| panic!("{context} block metric should be an object"));
+        assert_eq!(
+            object.len(),
+            SNAPSHOT_BLOCK_METRIC_FIELDS.len(),
+            "{context} should contain exactly the 24 Firecracker block leaves"
+        );
+        for field in SNAPSHOT_BLOCK_METRIC_FIELDS {
+            assert!(
+                object.contains_key(field),
+                "{context} should contain block field {field}"
+            );
+        }
+        for field in SNAPSHOT_BLOCK_COUNTER_FIELDS {
+            assert!(
+                object.get(field).is_some_and(serde_json::Value::is_u64),
+                "{context}.{field} should be an unsigned counter"
+            );
+        }
+        for aggregate in ["read_agg", "write_agg"] {
+            let aggregate = object
+                .get(aggregate)
+                .and_then(serde_json::Value::as_object)
+                .unwrap_or_else(|| panic!("{context}.{aggregate} should be an object"));
+            assert_eq!(
+                aggregate.len(),
+                3,
+                "{context} latency shape should be exact"
+            );
+            for field in ["min_us", "max_us", "sum_us"] {
+                assert!(
+                    aggregate.get(field).is_some_and(serde_json::Value::is_u64),
+                    "{context} latency field {field} should be unsigned"
+                );
+            }
+        }
+    }
+
     fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {
         let output = fs::read_to_string(path).unwrap_or_else(|error| {
             panic!("{context} metrics {} should read: {error}", path.display())
         });
+        let values = output
+            .lines()
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line)
+                    .unwrap_or_else(|error| panic!("{context} metrics line should parse: {error}"))
+            })
+            .collect::<Vec<_>>();
+        assert!(!values.is_empty(), "{context} should emit metrics lines");
+        for (line_index, value) in values.iter().enumerate() {
+            let root = value.as_object().unwrap_or_else(|| {
+                panic!("{context} metrics line {line_index} should be an object")
+            });
+            let static_metric = root
+                .get("block")
+                .unwrap_or_else(|| panic!("{context} line {line_index} should contain block"));
+            assert_snapshot_block_metric_shape(
+                static_metric,
+                &format!("{context} line {line_index} block"),
+            );
+            for drive_id in ["primary", "data", "audit"] {
+                let key = format!("block_{drive_id}");
+                let metric = root
+                    .get(&key)
+                    .unwrap_or_else(|| panic!("{context} line {line_index} should contain {key}"));
+                assert_snapshot_block_metric_shape(
+                    metric,
+                    &format!("{context} line {line_index} {key}"),
+                );
+            }
+            for field in SNAPSHOT_BLOCK_COUNTER_FIELDS {
+                let expected = ["primary", "data", "audit"]
+                    .into_iter()
+                    .map(|drive_id| {
+                        root[&format!("block_{drive_id}")][field]
+                            .as_u64()
+                            .expect("validated block counter should remain unsigned")
+                    })
+                    .fold(0_u64, u64::saturating_add);
+                assert_eq!(
+                    static_metric[field].as_u64(),
+                    Some(expected),
+                    "{context} line {line_index} static {field} should derive from configured drives"
+                );
+            }
+            for aggregate in ["read_agg", "write_agg"] {
+                let expected_sum = ["primary", "data", "audit"]
+                    .into_iter()
+                    .map(|drive_id| {
+                        root[&format!("block_{drive_id}")][aggregate]["sum_us"]
+                            .as_u64()
+                            .expect("validated block latency should remain unsigned")
+                    })
+                    .fold(0_u64, u64::saturating_add);
+                assert_eq!(static_metric[aggregate]["min_us"], 0);
+                assert_eq!(static_metric[aggregate]["max_us"], 0);
+                assert_eq!(static_metric[aggregate]["sum_us"], expected_sum);
+            }
+            for field in [
+                "activate_fails",
+                "cfg_fails",
+                "event_fails",
+                "execute_fails",
+                "invalid_reqs_count",
+                "update_fails",
+            ] {
+                assert_eq!(
+                    static_metric[field], 0,
+                    "{context} successful signed workload should not report {field}"
+                );
+            }
+        }
         for (drive_id, expect_write) in [("primary", true), ("data", true), ("audit", false)] {
             assert!(
                 snapshot_block_metric_total(path, drive_id, "queue_event_count") > 0,

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -26,8 +26,8 @@ use bangbang_runtime::block::{
     DriveIoEngine, DriveLiveUpdateMode, DriveRateLimiterConfig, DriveRuntimeMutationError,
     DriveUpdateError, PreparedBlockDevice, RuntimeBlockDeviceResource, VIRTIO_BLOCK_DEVICE_ID,
     VIRTIO_BLOCK_QUEUE_SIZES, VhostUserBlockConfigSignalError, VirtioBlockBackendKind,
-    VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockDeviceNotificationError,
-    VirtioBlockLiveUpdateError, VirtioBlockSnapshotPersistenceBinding,
+    VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockLiveUpdateError,
+    VirtioBlockSnapshotPersistenceBinding, attach_block_metrics_to_mmio_handler,
 };
 use bangbang_runtime::boot::{
     BootSourceFiles, canonical_process_block_command_line,
@@ -1059,6 +1059,13 @@ impl HvfArm64BootPciDataDevices {
                 message: source.to_string(),
             }
         })?;
+        if prepared.device().backend_kind() == VirtioBlockBackendKind::File
+            && !prepared.attach_metrics(prepared_metrics.metrics())
+        {
+            return Err(DriveRuntimeMutationError::PrepareDevice {
+                message: "ordinary block metrics owner was rejected".to_string(),
+            });
+        }
         let interrupts = self.shared_msi_registry().map_err(|source| {
             DriveRuntimeMutationError::TerminalInsertion {
                 message: source.to_string(),
@@ -1353,7 +1360,7 @@ impl HvfArm64BootPciDataDevices {
         memory: &mut GuestMemory,
         update: HvfLiveBlockUpdate<'_>,
         async_runtime: &SharedBlockAsyncRuntime,
-        metrics: &SharedBlockDeviceMetricsRegistry,
+        _metrics: &SharedBlockDeviceMetricsRegistry,
     ) -> Result<(), DriveUpdateError> {
         let HvfLiveBlockUpdate {
             config,
@@ -1380,14 +1387,8 @@ impl HvfArm64BootPciDataDevices {
                 async_runtime,
             );
         match result {
-            Ok(dispatch) => {
-                metrics.record_queue_dispatch_for_drive(config.drive_id(), &dispatch);
-                Ok(())
-            }
+            Ok(_) => Ok(()),
             Err(source) => {
-                if let Some(dispatch) = source.completed_device_operation() {
-                    metrics.record_queue_dispatch_for_drive(config.drive_id(), dispatch);
-                }
                 let terminal = source.endpoint_error().is_some()
                     || source
                         .device_error()
@@ -1406,7 +1407,7 @@ impl HvfArm64BootPciDataDevices {
         &mut self,
         drive_id: &str,
         memory: &mut GuestMemory,
-        metrics: &SharedBlockDeviceMetricsRegistry,
+        _metrics: &SharedBlockDeviceMetricsRegistry,
     ) -> Result<(), DriveRuntimeMutationError> {
         if !self.runtime_hotplug {
             return Err(DriveRuntimeMutationError::PciNotEnabled);
@@ -1455,14 +1456,6 @@ impl HvfArm64BootPciDataDevices {
                 );
             }
             let retire = device.published.endpoint().retire_quiesced_async(memory);
-            match &retire {
-                Ok(dispatch) => metrics.record_queue_dispatch_for_drive(drive_id, dispatch),
-                Err(source) => {
-                    if let Some(dispatch) = source.completed_device_operation() {
-                        metrics.record_queue_dispatch_for_drive(drive_id, dispatch);
-                    }
-                }
-            }
             device
                 .published
                 .commit_prepared_teardown(&mut dispatcher, self.validation.bar_allocator_mut())
@@ -2058,7 +2051,7 @@ impl HvfArm64BootPciDataDevices {
     fn dispatch_block(
         &mut self,
         memory: &mut GuestMemory,
-        metrics: &SharedBlockDeviceMetricsRegistry,
+        _metrics: &SharedBlockDeviceMetricsRegistry,
     ) -> Option<Duration> {
         for device in &mut self.block {
             let mut retry_after = None;
@@ -2068,7 +2061,6 @@ impl HvfArm64BootPciDataDevices {
                 .dispatch_block_queue_notifications(memory);
             match &result {
                 Ok(dispatch) => {
-                    metrics.record_notification_dispatch_for_drive(&device.drive_id, dispatch);
                     retain_earliest_retry(
                         &mut retry_after,
                         dispatch
@@ -2080,7 +2072,6 @@ impl HvfArm64BootPciDataDevices {
                     }
                 }
                 Err(error) => {
-                    record_pci_block_operation_error(metrics, &device.drive_id, error);
                     if let Some(completed) = error.completed_device_operation() {
                         retain_earliest_retry(
                             &mut retry_after,
@@ -2916,7 +2907,6 @@ fn update_mmio_live_block_device(
             ),
         )?
     };
-    metrics.record_queue_dispatch_for_drive(config.drive_id(), &dispatch);
     let signaler = HvfGicSpiSignaler::from_metadata(gic).map_err(|source| {
         DriveUpdateError::TerminalActiveSessionCommand {
             message: source.to_string(),
@@ -3106,32 +3096,6 @@ fn pci_memory_hotplug_configuration_updated(
 fn retain_earliest_retry(retained: &mut Option<Duration>, candidate: Option<Duration>) {
     if let Some(candidate) = candidate {
         *retained = Some(retained.map_or(candidate, |retained| retained.min(candidate)));
-    }
-}
-
-fn record_pci_block_operation_error(
-    metrics: &SharedBlockDeviceMetricsRegistry,
-    drive_id: &str,
-    error: &VirtioPciDeviceOperationError<
-        VirtioBlockDeviceNotificationError,
-        bangbang_runtime::block::VirtioBlockDeviceNotificationDispatch,
-    >,
-) {
-    if let Some(completed) = error.completed_device_operation() {
-        metrics.record_notification_dispatch_for_drive(drive_id, completed);
-    }
-    if let Some(source) = error.device_error() {
-        metrics.record_queue_events_for_drive(
-            drive_id,
-            usize_to_u64_saturating(source.drained_notifications().len()),
-        );
-        metrics.record_event_failure_for_drive(drive_id);
-        if let Some(completed) = source.completed_dispatch() {
-            metrics.record_queue_dispatch_for_drive(drive_id, completed);
-        }
-    }
-    if error.endpoint_error().is_some() {
-        metrics.record_event_failure_for_drive(drive_id);
     }
 }
 
@@ -13113,17 +13077,6 @@ fn capture_ready_storage_transaction_at_with_cancel(
                         .completed_block_dispatch()
                         .is_some_and(|dispatch| dispatch.needs_queue_interrupt()),
                 };
-                match &publication {
-                    Ok(dispatch) => block_device_metrics
-                        .record_queue_dispatch_for_drive(config.drive_id(), dispatch),
-                    Err(error) => {
-                        if let Some(dispatch) = error.completed_block_dispatch() {
-                            block_device_metrics
-                                .record_queue_dispatch_for_drive(config.drive_id(), dispatch);
-                        }
-                        block_device_metrics.record_event_failure_for_drive(config.drive_id());
-                    }
-                }
                 if needs_queue_interrupt {
                     mmio_block_interrupts.push(CaptureReadyMmioBlockInterrupt {
                         config_index: async_owner.config_index,
@@ -13161,22 +13114,16 @@ fn capture_ready_storage_transaction_at_with_cancel(
                 let mut delivered = false;
                 match &publication {
                     Ok(dispatch) => {
-                        block_device_metrics
-                            .record_queue_dispatch_for_drive(config.drive_id(), dispatch);
                         delivered = dispatch.needs_queue_interrupt();
                     }
                     Err(error) => {
-                        if let Some(dispatch) = error.completed_device_operation() {
-                            block_device_metrics
-                                .record_queue_dispatch_for_drive(config.drive_id(), dispatch);
-                        } else if let Some(source) = error.device_error() {
+                        if error.completed_device_operation().is_none()
+                            && let Some(source) = error.device_error()
+                        {
                             let dispatch = source.completed_dispatch();
-                            block_device_metrics
-                                .record_queue_dispatch_for_drive(config.drive_id(), dispatch);
                             delivered = error.endpoint_error().is_none()
                                 && dispatch.needs_queue_interrupt();
                         }
-                        block_device_metrics.record_event_failure_for_drive(config.drive_id());
                     }
                 }
                 if delivered {
@@ -16527,13 +16474,16 @@ impl HvfArm64BootSession<'_> {
             match HvfGicSpiSignaler::from_metadata(&self.gic) {
                 Ok(signaler) => signal_block_queue_interrupts(dispatches, &signaler),
                 Err(source) => {
+                    record_block_unavailable_signal_metrics(
+                        &self.block_device_metrics,
+                        dispatches.as_slice(),
+                    );
                     Err(HvfArm64BootBlockNotificationDispatchError::CreateSignalSink { source })
                 }
             }
         };
-        match &result {
-            Ok(dispatches) => record_block_signal_metrics(&self.block_device_metrics, dispatches),
-            Err(_) => self.block_device_metrics.record_event_failure(),
+        if let Ok(dispatches) = &result {
+            record_block_signal_metrics(&self.block_device_metrics, dispatches);
         }
         observe_block_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
@@ -16995,8 +16945,15 @@ fn snapshot_v2_root_identity_and_retry_deadline(
 fn install_snapshot_v2_mmio_root(
     platform: &RestoredHvfSnapshotV2Platform,
     root: bangbang_runtime::snapshot_device_v2::PreparedSnapshotV2MmioRoot,
+    metrics: &SharedBlockDeviceMetricsRegistry,
 ) -> Result<Arm64BootBlockDevice, HvfSnapshotV2RootRestoreFailure> {
-    let (drive_id, _partuuid, _retry, region, interrupt_line, handler) = root.into_parts();
+    let (drive_id, _partuuid, _retry, region, interrupt_line, mut handler) = root.into_parts();
+    let device_metrics = metrics
+        .per_drive(&drive_id)
+        .ok_or(HvfSnapshotV2RootRestoreFailure::ResourcePlan)?;
+    if !handler.attach_block_metrics(device_metrics) {
+        return Err(HvfSnapshotV2RootRestoreFailure::ResourcePlan);
+    }
     let mut dispatcher = platform
         .mmio_dispatcher()
         .lock()
@@ -17021,7 +16978,7 @@ fn install_snapshot_v2_mmio_root(
 
 fn prepare_snapshot_v2_pci_root_owner(
     platform: &RestoredHvfSnapshotV2Platform,
-    root: PreparedSnapshotV2PciRoot,
+    mut root: PreparedSnapshotV2PciRoot,
     resources: HvfSnapshotV2RootResourcePlan,
     layout: &GuestMemoryLayout,
     block_device_metrics: &SharedBlockDeviceMetricsRegistry,
@@ -17140,6 +17097,12 @@ fn prepare_snapshot_v2_pci_root_owner(
         return Err(HvfSnapshotV2RootRestoreFailure::ResourcePlan);
     };
 
+    let root_metrics = block_device_metrics
+        .per_drive(root.drive_id())
+        .ok_or(HvfSnapshotV2RootRestoreFailure::ResourcePlan)?;
+    if !root.attach_metrics(root_metrics) {
+        return Err(HvfSnapshotV2RootRestoreFailure::ResourcePlan);
+    }
     let interrupts = manager
         .shared_msi_registry()
         .map_err(HvfSnapshotV2RootRestoreFailure::PciData)?;
@@ -17147,9 +17110,6 @@ fn prepare_snapshot_v2_pci_root_owner(
         .prepare_endpoint(bar_region_id, interrupts.registry())
         .map_err(HvfSnapshotV2RootRestoreFailure::PciEndpoint)?;
     let (drive_id, _partuuid, _retry, origin, endpoint) = endpoint.into_parts();
-    let metrics_lease = block_device_metrics
-        .claim_drive_lease(&drive_id)
-        .map_err(HvfSnapshotV2RootRestoreFailure::Metrics)?;
     let segment = manager.validation.segment().clone();
     let published = {
         let mut dispatcher = manager
@@ -17165,6 +17125,9 @@ fn prepare_snapshot_v2_pci_root_owner(
             )
             .map_err(HvfSnapshotV2RootRestoreFailure::PciPublication)?
     };
+    let metrics_lease = block_device_metrics
+        .claim_drive_lease(&drive_id)
+        .map_err(HvfSnapshotV2RootRestoreFailure::Metrics)?;
     manager.block.push(HvfArm64BootPciBlockDevice {
         drive_id,
         is_root_device: true,
@@ -24503,23 +24466,24 @@ impl OwnedHvfArm64BootSession {
         match transport {
             PreparedSnapshotV2RootTransport::Mmio(root) => {
                 let interrupt_line = root.interrupt_line();
-                let device = match install_snapshot_v2_mmio_root(&platform, root) {
-                    Ok(device) => device,
-                    Err(failure) => {
-                        let stage = match &failure {
-                            HvfSnapshotV2RootRestoreFailure::MmioRegion(_) => {
-                                HvfSnapshotV2RootRestoreStage::MmioRegion
-                            }
-                            _ => HvfSnapshotV2RootRestoreStage::MmioHandler,
-                        };
-                        return Err(failed_snapshot_v2_root_after_platform(
-                            platform,
-                            stage,
-                            failure,
-                            &mut pci_data_devices,
-                        ));
-                    }
-                };
+                let device =
+                    match install_snapshot_v2_mmio_root(&platform, root, &block_device_metrics) {
+                        Ok(device) => device,
+                        Err(failure) => {
+                            let stage = match &failure {
+                                HvfSnapshotV2RootRestoreFailure::MmioRegion(_) => {
+                                    HvfSnapshotV2RootRestoreStage::MmioRegion
+                                }
+                                _ => HvfSnapshotV2RootRestoreStage::MmioHandler,
+                            };
+                            return Err(failed_snapshot_v2_root_after_platform(
+                                platform,
+                                stage,
+                                failure,
+                                &mut pci_data_devices,
+                            ));
+                        }
+                    };
                 block_devices.push(device);
                 block_interrupt_lines.push(interrupt_line);
             }
@@ -24853,8 +24817,18 @@ impl OwnedHvfArm64BootSession {
                     region,
                     interrupt_line,
                     _async_generation,
-                    handler,
+                    mut handler,
                 ) = record.into_parts();
+                let device_metrics = block_device_metrics.per_drive(&drive_id).ok_or((
+                    HvfSnapshotV2MultiBlockMmioRestoreStage::Registration { index },
+                    HvfSnapshotV2MultiBlockMmioRestoreFailure::ResourcePlan,
+                ))?;
+                if !handler.attach_block_metrics(device_metrics) {
+                    return Err((
+                        HvfSnapshotV2MultiBlockMmioRestoreStage::Registration { index },
+                        HvfSnapshotV2MultiBlockMmioRestoreFailure::ResourcePlan,
+                    ));
+                }
                 let request = [MmioRegionRequest::new(
                     region.range().start(),
                     region.range().size(),
@@ -25561,8 +25535,22 @@ impl OwnedHvfArm64BootSession {
                     region,
                     interrupt_line,
                     _async_generation,
-                    handler,
+                    mut handler,
                 ) = record.into_parts();
+                let device_metrics = block_device_metrics.per_drive(&drive_id).ok_or((
+                    HvfSnapshotV2StorageMmioRestoreStage::Registration {
+                        index: registration_index,
+                    },
+                    HvfSnapshotV2StorageMmioRestoreFailure::ResourcePlan,
+                ))?;
+                if !handler.attach_block_metrics(device_metrics) {
+                    return Err((
+                        HvfSnapshotV2StorageMmioRestoreStage::Registration {
+                            index: registration_index,
+                        },
+                        HvfSnapshotV2StorageMmioRestoreFailure::ResourcePlan,
+                    ));
+                }
                 let request = [MmioRegionRequest::new(
                     region.range().start(),
                     region.range().size(),
@@ -26502,11 +26490,24 @@ impl OwnedHvfArm64BootSession {
             });
         }
 
-        for (index, (record, planned)) in block_records
+        for (index, (mut record, planned)) in block_records
             .into_iter()
             .zip(pci_plan.block_records())
             .enumerate()
         {
+            let device_metrics = match block_device_metrics.per_drive(record.drive_id()) {
+                Some(metrics) => metrics,
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            if !record.attach_metrics(device_metrics) {
+                fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                );
+            }
             let manager = match pci_data_devices.as_mut() {
                 Some(manager) => manager,
                 None => fail_after_platform!(
@@ -27769,9 +27770,19 @@ impl OwnedHvfArm64BootSession {
                 HvfSnapshotV2MultiBlockPciRestoreStage::PciRoutes,
                 HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
             ))?;
-            for (index, (record, planned)) in
+            for (index, (mut record, planned)) in
                 records.into_iter().zip(pci_plan.records()).enumerate()
             {
+                let device_metrics = block_device_metrics.per_drive(record.drive_id()).ok_or((
+                    HvfSnapshotV2MultiBlockPciRestoreStage::EndpointPreparation { index },
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+                ))?;
+                if !record.attach_metrics(device_metrics) {
+                    return Err((
+                        HvfSnapshotV2MultiBlockPciRestoreStage::EndpointPreparation { index },
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+                    ));
+                }
                 let mut interrupts = manager.shared_msi_registry().map_err(|source| {
                     (
                         HvfSnapshotV2MultiBlockPciRestoreStage::EndpointPreparation { index },
@@ -28092,7 +28103,7 @@ impl OwnedHvfArm64BootSession {
         );
 
         let InstalledSnapshotV1RuntimeParts {
-            mmio_dispatcher,
+            mut mmio_dispatcher,
             mut runtime_resources,
             drive_config,
             block_retry,
@@ -28309,6 +28320,35 @@ impl OwnedHvfArm64BootSession {
                     &mut backend,
                 ));
             }
+        }
+
+        let mut block_metrics_binding_failed = false;
+        for device in &runtime_resources.block_devices {
+            let drive_id = device.registration.drive_id();
+            let Some(device_metrics) = block_device_metrics.per_drive(drive_id) else {
+                block_metrics_binding_failed = true;
+                break;
+            };
+            match attach_block_metrics_to_mmio_handler(
+                &mut mmio_dispatcher,
+                device.registration.region_id(),
+                device_metrics,
+            ) {
+                Ok(true) => {}
+                Ok(false) | Err(_) => {
+                    block_metrics_binding_failed = true;
+                    break;
+                }
+            }
+        }
+        if block_metrics_binding_failed {
+            return Err(failed_snapshot_v1_restore_after_destination_commit(
+                HvfSnapshotV1RestoreStage::AssembleSession,
+                HvfSnapshotV1RestoreFailure::InvalidRuntime,
+                &mut block_retry_wakeup_scheduler,
+                &mut runner,
+                &mut backend,
+            ));
         }
 
         let runner = match runner.take() {
@@ -30552,13 +30592,16 @@ impl OwnedHvfArm64BootSession {
             match HvfGicSpiSignaler::from_metadata(&self.gic) {
                 Ok(signaler) => signal_block_queue_interrupts(dispatches, &signaler),
                 Err(source) => {
+                    record_block_unavailable_signal_metrics(
+                        &self.block_device_metrics,
+                        dispatches.as_slice(),
+                    );
                     Err(HvfArm64BootBlockNotificationDispatchError::CreateSignalSink { source })
                 }
             }
         };
-        match &result {
-            Ok(dispatches) => record_block_signal_metrics(&self.block_device_metrics, dispatches),
-            Err(_) => self.block_device_metrics.record_event_failure(),
+        if let Ok(dispatches) = &result {
+            record_block_signal_metrics(&self.block_device_metrics, dispatches);
         }
         observe_block_interrupt_delivery(&self.backend.guest_logger(), &result);
         result
@@ -34819,10 +34862,6 @@ fn balloon_update_error_from_display(source: impl fmt::Display) -> BalloonUpdate
     }
 }
 
-fn usize_to_u64_saturating(value: usize) -> u64 {
-    u64::try_from(value).unwrap_or(u64::MAX)
-}
-
 #[cfg(test)]
 fn record_block_dispatch_metrics(
     metrics: &SharedBlockDeviceMetricsRegistry,
@@ -34842,21 +34881,19 @@ fn record_block_runtime_dispatch_metrics<'a>(
 ) {
     for dispatch in dispatches {
         let drive_id = dispatch.device().registration.drive_id();
-        if let Some(dispatched) = dispatch.outcome().dispatched() {
-            metrics.record_notification_dispatch_for_drive(drive_id, dispatched);
-        }
-        if let Some(source) = dispatch.outcome().dispatch_error() {
-            metrics.record_queue_events_for_drive(
-                drive_id,
-                usize_to_u64_saturating(source.drained_notifications().len()),
-            );
-            metrics.record_event_failure_for_drive(drive_id);
-            if let Some(completed) = source.completed_dispatch() {
-                metrics.record_queue_dispatch_for_drive(drive_id, completed);
-            }
-        }
         if dispatch.outcome().handler_lookup_error().is_some() {
             metrics.record_event_failure_for_drive(drive_id);
+        }
+    }
+}
+
+fn record_block_unavailable_signal_metrics(
+    metrics: &SharedBlockDeviceMetricsRegistry,
+    dispatches: &[Arm64BootBlockNotificationDispatch],
+) {
+    for dispatch in dispatches {
+        if dispatch.needs_queue_interrupt() {
+            metrics.record_event_failure_for_drive(dispatch.device().registration.drive_id());
         }
     }
 }
@@ -36976,6 +37013,7 @@ fn prepare_arm64_boot_session_parts_with_cache<'vm>(
     let vsock_device_metrics = SharedVsockDeviceMetrics::default();
     let entropy_device_metrics = SharedEntropyDeviceMetrics::default();
     bind_mmio_balloon_transport_metrics(&runtime, &mmio_dispatcher, &balloon_device_metrics)?;
+    bind_mmio_block_transport_metrics(&runtime, &mmio_dispatcher, &block_device_metrics)?;
     bind_mmio_vsock_transport_metrics(&runtime, &mmio_dispatcher, &vsock_device_metrics)?;
     bind_mmio_entropy_transport_metrics(&runtime, &mmio_dispatcher, &entropy_device_metrics)?;
     bind_mmio_pmem_transport_metrics(&runtime, &mmio_dispatcher, &pmem_device_metrics)?;
@@ -37584,6 +37622,39 @@ fn bind_mmio_pmem_transport_metrics(
     Ok(())
 }
 
+fn bind_mmio_block_transport_metrics(
+    runtime: &Arm64BootRuntimeResources,
+    dispatcher: &Arc<Mutex<MmioDispatcher>>,
+    metrics: &SharedBlockDeviceMetricsRegistry,
+) -> Result<(), HvfArm64BootSessionError> {
+    let mut dispatcher =
+        dispatcher
+            .lock()
+            .map_err(|_| HvfArm64BootSessionError::DeviceMetricsBinding {
+                kind: "block",
+                message: "MMIO dispatcher is unavailable".to_string(),
+            })?;
+    for device in &runtime.block_devices {
+        let drive_id = device.registration.drive_id();
+        let device_metrics = metrics.per_drive(drive_id).ok_or_else(|| {
+            HvfArm64BootSessionError::DeviceMetricsBinding {
+                kind: "block",
+                message: format!("missing metrics generation for MMIO block device {drive_id}"),
+            }
+        })?;
+        attach_block_metrics_to_mmio_handler(
+            &mut dispatcher,
+            device.registration.region_id(),
+            device_metrics,
+        )
+        .map_err(|source| HvfArm64BootSessionError::DeviceMetricsBinding {
+            kind: "block",
+            message: format!("failed to resolve MMIO block device {drive_id}: {source}"),
+        })?;
+    }
+    Ok(())
+}
+
 fn bind_mmio_network_transport_metrics(
     runtime: &Arm64BootRuntimeResources,
     dispatcher: &Arc<Mutex<MmioDispatcher>>,
@@ -37882,21 +37953,23 @@ fn prepare_pci_data_devices(
             endpoint_index += 1;
         }
 
-        for prepared in blocks {
-            let (drive_id, is_root_device, config_space, device) = prepared.into_parts();
-            let metrics_lease = if all_virtio {
-                Some(
-                    block_device_metrics
-                        .claim_drive_lease(&drive_id)
-                        .map_err(|source| {
-                            HvfArm64BootPciDataError::new(format!(
-                                "failed to claim PCI block metrics ownership: {source}"
-                            ))
-                        })?,
-                )
-            } else {
-                None
-            };
+        for mut prepared in blocks {
+            let drive_id = prepared.drive_id().to_string();
+            if prepared.device().backend_kind() == VirtioBlockBackendKind::File {
+                let device_metrics =
+                    block_device_metrics.per_drive(&drive_id).ok_or_else(|| {
+                        HvfArm64BootPciDataError::new(format!(
+                            "missing PCI block metrics generation for {drive_id}"
+                        ))
+                    })?;
+                if !prepared.attach_metrics(device_metrics) {
+                    return Err(HvfArm64BootPciDataError::new(format!(
+                        "ordinary PCI block metrics owner was rejected for {drive_id}"
+                    )));
+                }
+            }
+            let (published_drive_id, is_root_device, config_space, device) = prepared.into_parts();
+            debug_assert_eq!(published_drive_id, drive_id);
             let interrupts = manager.shared_msi_registry()?;
             let region_id = pci_data_region_id(endpoint_index)?;
             let published = {
@@ -37922,6 +37995,19 @@ fn prepare_pci_data_devices(
                         "failed to publish PCI block endpoint {drive_id}: {source}"
                     ))
                 })?
+            };
+            let metrics_lease = if all_virtio {
+                Some(
+                    block_device_metrics
+                        .claim_drive_lease(&drive_id)
+                        .map_err(|source| {
+                            HvfArm64BootPciDataError::new(format!(
+                                "failed to claim PCI block metrics ownership: {source}"
+                            ))
+                        })?,
+                )
+            } else {
+                None
             };
             manager.block.push(HvfArm64BootPciBlockDevice {
                 drive_id,
@@ -42892,6 +42978,27 @@ mod tests {
         (parts.memory, parts.runtime, parts.mmio_dispatcher)
     }
 
+    fn bind_test_block_metrics(
+        runtime: &Arm64BootRuntimeResources,
+        dispatcher: &mut MmioDispatcher,
+        metrics: &SharedBlockDeviceMetricsRegistry,
+    ) {
+        for device in &runtime.block_devices {
+            let drive_id = device.registration.drive_id();
+            let owner = metrics
+                .per_drive(drive_id)
+                .expect("test block metrics owner should exist");
+            assert!(
+                super::attach_block_metrics_to_mmio_handler(
+                    dispatcher,
+                    device.registration.region_id(),
+                    owner,
+                )
+                .expect("test block handler should resolve")
+            );
+        }
+    }
+
     fn boot_runtime_with_pmem(
         devices: &[&str],
     ) -> (GuestMemory, Arm64BootRuntimeResources, MmioDispatcher) {
@@ -45338,6 +45445,8 @@ mod tests {
             ("rootfs", payload.as_slice(), true),
             ("data", payload.as_slice(), false),
         ]);
+        let metrics = SharedBlockDeviceMetricsRegistry::from_drive_ids(["rootfs", "data"]);
+        bind_test_block_metrics(&runtime, &mut mmio_dispatcher, &metrics);
         configure_boot_block_queue(&mut runtime, &mut mmio_dispatcher, 1, TEST_USED_RING);
         write_queued_read_request(&mut memory);
         notify_boot_block_queue(&mut runtime, &mut mmio_dispatcher, 1);
@@ -45346,8 +45455,6 @@ mod tests {
         let (_, sink) = RecordingSink::successful();
         let result = signal_block_queue_interrupts(dispatches, sink.as_ref())
             .expect("queued dispatch should collect");
-        let metrics = SharedBlockDeviceMetricsRegistry::from_drive_ids(["rootfs", "data"]);
-
         super::record_block_dispatch_metrics(&metrics, &result);
 
         let aggregate = metrics.aggregate_snapshot();
@@ -45363,14 +45470,16 @@ mod tests {
         );
         assert_eq!(
             metrics.per_drive_snapshot(),
-            BlockDeviceMetricsByDrive::new().with_drive_metrics(
-                "data",
-                BlockDeviceMetrics::default()
-                    .with_queue_event_count(1)
-                    .with_read_bytes(VIRTIO_BLOCK_SECTOR_SIZE)
-                    .with_read_count(1)
-                    .with_read_agg(read_agg),
-            )
+            BlockDeviceMetricsByDrive::new()
+                .with_drive_metrics("rootfs", BlockDeviceMetrics::default())
+                .with_drive_metrics(
+                    "data",
+                    BlockDeviceMetrics::default()
+                        .with_queue_event_count(1)
+                        .with_read_bytes(VIRTIO_BLOCK_SECTOR_SIZE)
+                        .with_read_count(1)
+                        .with_read_agg(read_agg),
+                )
         );
     }
 
@@ -45378,6 +45487,8 @@ mod tests {
     fn block_metrics_preserve_partial_dispatch_before_signal() {
         let (mut memory, mut runtime, mut mmio_dispatcher) =
             boot_runtime_with_drives(&[("rootfs", &[0x5a; 512], true)]);
+        let metrics = SharedBlockDeviceMetricsRegistry::from_drive_ids(["rootfs"]);
+        bind_test_block_metrics(&runtime, &mut mmio_dispatcher, &metrics);
         configure_boot_block_queue(&mut runtime, &mut mmio_dispatcher, 0, TEST_USED_RING);
         write_partially_invalid_queued_flush_request(&mut memory);
         notify_boot_block_queue(&mut runtime, &mut mmio_dispatcher, 0);
@@ -45386,25 +45497,23 @@ mod tests {
         let (_, sink) = RecordingSink::successful();
         let result = signal_block_queue_interrupts(dispatches, sink.as_ref())
             .expect("partial dispatch result should collect");
-        let metrics = SharedBlockDeviceMetricsRegistry::from_drive_ids(["rootfs"]);
-
         super::record_block_dispatch_metrics(&metrics, &result);
 
         assert_eq!(
             metrics.aggregate_snapshot(),
             BlockDeviceMetrics::default()
-                .with_event_fails(1)
                 .with_flush_count(1)
                 .with_queue_event_count(1)
+                .with_remaining_reqs_count(1)
         );
         assert_eq!(
             metrics.per_drive_snapshot(),
             BlockDeviceMetricsByDrive::new().with_drive_metrics(
                 "rootfs",
                 BlockDeviceMetrics::default()
-                    .with_event_fails(1)
                     .with_flush_count(1)
-                    .with_queue_event_count(1),
+                    .with_queue_event_count(1)
+                    .with_remaining_reqs_count(1),
             )
         );
     }
@@ -45414,6 +45523,8 @@ mod tests {
         let payload = vec![0x74; VIRTIO_BLOCK_SECTOR_SIZE as usize];
         let (mut memory, mut runtime, mut mmio_dispatcher) =
             boot_runtime_with_drives(&[("rootfs", payload.as_slice(), true)]);
+        let metrics = SharedBlockDeviceMetricsRegistry::from_drive_ids(["rootfs"]);
+        bind_test_block_metrics(&runtime, &mut mmio_dispatcher, &metrics);
         configure_boot_block_queue(&mut runtime, &mut mmio_dispatcher, 0, TEST_USED_RING);
         write_queued_read_request(&mut memory);
         notify_boot_block_queue(&mut runtime, &mut mmio_dispatcher, 0);
@@ -45422,8 +45533,6 @@ mod tests {
         let (_, sink) = RecordingSink::failing("injected signal failure");
         let result = signal_block_queue_interrupts(dispatches, sink.as_ref())
             .expect("signal failure should stay per-device");
-        let metrics = SharedBlockDeviceMetricsRegistry::from_drive_ids(["rootfs"]);
-
         super::record_block_dispatch_metrics(&metrics, &result);
 
         let aggregate = metrics.aggregate_snapshot();

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -20246,10 +20246,164 @@ fn wait_for_snapshot_pmem_throttle(
     }
 }
 
+const SNAPSHOT_BLOCK_METRIC_FIELDS: [&str; 20] = [
+    "activate_fails",
+    "cfg_fails",
+    "no_avail_buffer",
+    "event_fails",
+    "execute_fails",
+    "invalid_reqs_count",
+    "flush_count",
+    "queue_event_count",
+    "rate_limiter_event_count",
+    "update_count",
+    "update_fails",
+    "read_bytes",
+    "write_bytes",
+    "read_count",
+    "write_count",
+    "read_agg",
+    "write_agg",
+    "rate_limiter_throttled_events",
+    "io_engine_throttled_events",
+    "remaining_reqs_count",
+];
+const SNAPSHOT_BLOCK_COUNTER_FIELDS: [&str; 18] = [
+    "activate_fails",
+    "cfg_fails",
+    "no_avail_buffer",
+    "event_fails",
+    "execute_fails",
+    "invalid_reqs_count",
+    "flush_count",
+    "queue_event_count",
+    "rate_limiter_event_count",
+    "update_count",
+    "update_fails",
+    "read_bytes",
+    "write_bytes",
+    "read_count",
+    "write_count",
+    "rate_limiter_throttled_events",
+    "io_engine_throttled_events",
+    "remaining_reqs_count",
+];
+
+fn assert_snapshot_block_metric_shape(metric: &serde_json::Value, context: &str) {
+    let object = metric
+        .as_object()
+        .unwrap_or_else(|| panic!("{context} block metric should be an object"));
+    assert_eq!(
+        object.len(),
+        SNAPSHOT_BLOCK_METRIC_FIELDS.len(),
+        "{context} should contain exactly the 24 Firecracker block leaves"
+    );
+    for field in SNAPSHOT_BLOCK_METRIC_FIELDS {
+        assert!(
+            object.contains_key(field),
+            "{context} should contain block field {field}"
+        );
+    }
+    for field in SNAPSHOT_BLOCK_COUNTER_FIELDS {
+        assert!(
+            object.get(field).is_some_and(serde_json::Value::is_u64),
+            "{context}.{field} should be an unsigned counter"
+        );
+    }
+    for aggregate in ["read_agg", "write_agg"] {
+        let aggregate = object
+            .get(aggregate)
+            .and_then(serde_json::Value::as_object)
+            .unwrap_or_else(|| panic!("{context}.{aggregate} should be an object"));
+        assert_eq!(
+            aggregate.len(),
+            3,
+            "{context} latency shape should be exact"
+        );
+        for field in ["min_us", "max_us", "sum_us"] {
+            assert!(
+                aggregate.get(field).is_some_and(serde_json::Value::is_u64),
+                "{context} latency field {field} should be unsigned"
+            );
+        }
+    }
+}
+
 fn assert_snapshot_block_metrics(path: &Path, expect_limiter: bool, context: &str) {
     let output = fs::read_to_string(path).unwrap_or_else(|error| {
         panic!("{context} metrics {} should read: {error}", path.display())
     });
+    let values = output
+        .lines()
+        .map(|line| {
+            serde_json::from_str::<serde_json::Value>(line)
+                .unwrap_or_else(|error| panic!("{context} metrics line should parse: {error}"))
+        })
+        .collect::<Vec<_>>();
+    assert!(!values.is_empty(), "{context} should emit metrics lines");
+    for (line_index, value) in values.iter().enumerate() {
+        let root = value
+            .as_object()
+            .unwrap_or_else(|| panic!("{context} metrics line {line_index} should be an object"));
+        let static_metric = root
+            .get("block")
+            .unwrap_or_else(|| panic!("{context} line {line_index} should contain block"));
+        assert_snapshot_block_metric_shape(
+            static_metric,
+            &format!("{context} line {line_index} block"),
+        );
+        for drive_id in ["primary", "data", "audit"] {
+            let key = format!("block_{drive_id}");
+            let metric = root
+                .get(&key)
+                .unwrap_or_else(|| panic!("{context} line {line_index} should contain {key}"));
+            assert_snapshot_block_metric_shape(
+                metric,
+                &format!("{context} line {line_index} {key}"),
+            );
+        }
+        for field in SNAPSHOT_BLOCK_COUNTER_FIELDS {
+            let expected = ["primary", "data", "audit"]
+                .into_iter()
+                .map(|drive_id| {
+                    root[&format!("block_{drive_id}")][field]
+                        .as_u64()
+                        .expect("validated block counter should remain unsigned")
+                })
+                .fold(0_u64, u64::saturating_add);
+            assert_eq!(
+                static_metric[field].as_u64(),
+                Some(expected),
+                "{context} line {line_index} static {field} should derive from configured drives"
+            );
+        }
+        for aggregate in ["read_agg", "write_agg"] {
+            let expected_sum = ["primary", "data", "audit"]
+                .into_iter()
+                .map(|drive_id| {
+                    root[&format!("block_{drive_id}")][aggregate]["sum_us"]
+                        .as_u64()
+                        .expect("validated block latency should remain unsigned")
+                })
+                .fold(0_u64, u64::saturating_add);
+            assert_eq!(static_metric[aggregate]["min_us"], 0);
+            assert_eq!(static_metric[aggregate]["max_us"], 0);
+            assert_eq!(static_metric[aggregate]["sum_us"], expected_sum);
+        }
+        for field in [
+            "activate_fails",
+            "cfg_fails",
+            "event_fails",
+            "execute_fails",
+            "invalid_reqs_count",
+            "update_fails",
+        ] {
+            assert_eq!(
+                static_metric[field], 0,
+                "{context} successful signed workload should not report {field}"
+            );
+        }
+    }
     for (drive_id, expect_write) in [("primary", true), ("data", true), ("audit", false)] {
         assert!(
             snapshot_block_metric_total(path, drive_id, "queue_event_count") > 0,

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -30,9 +30,10 @@ use crate::memory::{
     GuestMemoryRange, GuestMemoryRegionBacking, GuestMemorySharedBacking,
     GuestMemorySharedBackingError,
 };
+use crate::metrics::SharedBlockDeviceMetrics;
 use crate::mmio::{
     MmioAccessBytes, MmioAccessBytesError, MmioBusError, MmioDispatchError, MmioDispatcher,
-    MmioHandlerError, MmioRegion, MmioRegionId,
+    MmioHandlerError, MmioHandlerLookupError, MmioRegion, MmioRegionId,
 };
 use crate::token_bucket::{
     PersistedTokenBucketState, PersistedTokenBucketStateError, TokenBucket, TokenBucketConfig,
@@ -1384,7 +1385,7 @@ impl std::error::Error for DriveRuntimeMutationError {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct VirtioBlockConfigSpace {
     bytes: [u8; VIRTIO_BLOCK_CONFIG_SIZE],
     len: u8,
@@ -1392,7 +1393,21 @@ pub struct VirtioBlockConfigSpace {
     is_read_only: bool,
     cache_type: DriveCacheType,
     available_features: u64,
+    metrics: Option<SharedBlockDeviceMetrics>,
 }
+
+impl PartialEq for VirtioBlockConfigSpace {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes == other.bytes
+            && self.len == other.len
+            && self.capacity_sectors == other.capacity_sectors
+            && self.is_read_only == other.is_read_only
+            && self.cache_type == other.cache_type
+            && self.available_features == other.available_features
+    }
+}
+
+impl Eq for VirtioBlockConfigSpace {}
 
 impl VirtioBlockConfigSpace {
     pub fn new(backing_len: u64, is_read_only: bool, cache_type: DriveCacheType) -> Self {
@@ -1418,6 +1433,7 @@ impl VirtioBlockConfigSpace {
             is_read_only,
             cache_type,
             available_features,
+            metrics: None,
         }
     }
 
@@ -1437,6 +1453,7 @@ impl VirtioBlockConfigSpace {
                 != 0,
             cache_type,
             available_features,
+            metrics: None,
         }
     }
 
@@ -1444,24 +1461,28 @@ impl VirtioBlockConfigSpace {
         Self::new(backing.len(), backing.is_read_only(), cache_type)
     }
 
-    pub const fn capacity_sectors(self) -> u64 {
+    pub const fn capacity_sectors(&self) -> u64 {
         self.capacity_sectors
     }
 
-    pub const fn is_read_only(self) -> bool {
+    pub const fn is_read_only(&self) -> bool {
         self.is_read_only
     }
 
-    pub const fn cache_type(self) -> DriveCacheType {
+    pub const fn cache_type(&self) -> DriveCacheType {
         self.cache_type
     }
 
-    pub const fn available_features(self) -> u64 {
+    pub const fn available_features(&self) -> u64 {
         self.available_features
     }
 
-    pub const fn config_len(self) -> usize {
+    pub const fn config_len(&self) -> usize {
         self.len as usize
+    }
+
+    pub(crate) fn attach_metrics(&mut self, metrics: SharedBlockDeviceMetrics) {
+        self.metrics = Some(metrics);
     }
 }
 
@@ -1470,14 +1491,22 @@ impl VirtioMmioDeviceConfigHandler for VirtioBlockConfigSpace {
         &self,
         access: VirtioMmioDeviceConfigAccess,
     ) -> Result<MmioAccessBytes, VirtioMmioDeviceConfigError> {
-        let config = self.bytes.get(..self.config_len()).ok_or(
-            VirtioMmioDeviceConfigError::UnsupportedRead {
-                offset: access.offset(),
-                len: access.len(),
-            },
-        )?;
-        let bytes = read_virtio_block_config_bytes(config, access)?;
-        MmioAccessBytes::new(bytes).map_err(config_bytes_error)
+        let result = (|| {
+            let config = self.bytes.get(..self.config_len()).ok_or(
+                VirtioMmioDeviceConfigError::UnsupportedRead {
+                    offset: access.offset(),
+                    len: access.len(),
+                },
+            )?;
+            let bytes = read_virtio_block_config_bytes(config, access)?;
+            MmioAccessBytes::new(bytes).map_err(config_bytes_error)
+        })();
+        if result.is_err()
+            && let Some(metrics) = &self.metrics
+        {
+            metrics.record_config_failure();
+        }
+        result
     }
 
     fn write_device_config(
@@ -1485,6 +1514,9 @@ impl VirtioMmioDeviceConfigHandler for VirtioBlockConfigSpace {
         access: VirtioMmioDeviceConfigAccess,
         _data: MmioAccessBytes,
     ) -> Result<(), VirtioMmioDeviceConfigError> {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_config_failure();
+        }
         Err(VirtioMmioDeviceConfigError::UnsupportedWrite {
             offset: access.offset(),
             len: access.len(),
@@ -1714,7 +1746,7 @@ impl VirtioBlockRequest {
         backing: &BlockFileBacking,
         device_id: VirtioBlockDeviceId,
     ) -> VirtioBlockRequestExecution {
-        let (status_code, bytes_written_to_guest, outcome, latency_sample) =
+        let (status_code, bytes_written_to_guest, outcome, latency_sample, mut metric_outcome) =
             match self.execute_side_effects(memory, backing, device_id) {
                 Ok(VirtioBlockRequestSideEffect::Completed {
                     bytes_written_to_guest,
@@ -1724,29 +1756,59 @@ impl VirtioBlockRequest {
                     bytes_written_to_guest,
                     VirtioBlockRequestExecutionOutcome::Ok,
                     latency_sample,
+                    VirtioBlockRequestMetricOutcome::new(
+                        self.request_type,
+                        match self.request_type {
+                            VirtioBlockRequestType::In | VirtioBlockRequestType::Out => {
+                                self.data.map_or(0, |data| u64::from(data.len()))
+                            }
+                            VirtioBlockRequestType::Flush
+                            | VirtioBlockRequestType::GetDeviceId
+                            | VirtioBlockRequestType::Unsupported(_) => 0,
+                        },
+                        VirtioBlockRequestMetricDisposition::Success,
+                        self.request_type == VirtioBlockRequestType::Flush,
+                    ),
                 ),
                 Ok(VirtioBlockRequestSideEffect::Unsupported { request_type }) => (
                     VIRTIO_BLOCK_STATUS_UNSUPPORTED,
                     0,
                     VirtioBlockRequestExecutionOutcome::Unsupported { request_type },
                     None,
+                    VirtioBlockRequestMetricOutcome::new(
+                        self.request_type,
+                        0,
+                        VirtioBlockRequestMetricDisposition::Unsupported,
+                        false,
+                    ),
                 ),
                 Err(error) => (
                     VIRTIO_BLOCK_STATUS_IOERR,
                     0,
                     VirtioBlockRequestExecutionOutcome::IoError { error: error.error },
                     error.latency_sample,
+                    VirtioBlockRequestMetricOutcome::new(
+                        self.request_type,
+                        0,
+                        VirtioBlockRequestMetricDisposition::IoError,
+                        false,
+                    ),
                 ),
             };
 
         let (status_code, bytes_written_to_guest, outcome) =
             normalize_completion_status(status_code, bytes_written_to_guest, outcome);
+        if matches!(outcome, VirtioBlockRequestExecutionOutcome::IoError { .. }) {
+            metric_outcome.disposition = VirtioBlockRequestMetricDisposition::IoError;
+            metric_outcome.flush_succeeded = false;
+        }
         self.finish_execution(
             memory,
             status_code,
             bytes_written_to_guest,
             outcome,
             latency_sample,
+            metric_outcome,
         )
     }
 
@@ -1964,6 +2026,12 @@ impl VirtioBlockRequest {
                 error: VirtioBlockRequestExecutionError::AsyncOperation { source },
             },
             latency_sample,
+            VirtioBlockRequestMetricOutcome::new(
+                self.request_type,
+                0,
+                VirtioBlockRequestMetricDisposition::IoError,
+                false,
+            ),
         )
     }
 
@@ -1974,6 +2042,7 @@ impl VirtioBlockRequest {
         bytes_written_to_guest: u32,
         outcome: VirtioBlockRequestExecutionOutcome,
         latency_sample: Option<VirtioBlockRequestLatencySample>,
+        metric_outcome: VirtioBlockRequestMetricOutcome,
     ) -> VirtioBlockRequestExecution {
         match write_request_status(memory, self.status, status_code) {
             Ok(()) => {
@@ -1986,6 +2055,7 @@ impl VirtioBlockRequest {
                     status_code,
                     outcome,
                     latency_sample,
+                    metric_outcome,
                 )
             }
             Err(source) => {
@@ -1998,6 +2068,7 @@ impl VirtioBlockRequest {
                         source,
                     },
                     latency_sample,
+                    metric_outcome,
                 )
             }
         }
@@ -2187,12 +2258,53 @@ impl VirtioBlockRequestLatencySample {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VirtioBlockRequestMetricDisposition {
+    Success,
+    IoError,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VirtioBlockRequestMetricOutcome {
+    request_type: VirtioBlockRequestType,
+    transferred_bytes: u64,
+    disposition: VirtioBlockRequestMetricDisposition,
+    flush_succeeded: bool,
+}
+
+impl VirtioBlockRequestMetricOutcome {
+    const fn new(
+        request_type: VirtioBlockRequestType,
+        transferred_bytes: u64,
+        disposition: VirtioBlockRequestMetricDisposition,
+        flush_succeeded: bool,
+    ) -> Self {
+        Self {
+            request_type,
+            transferred_bytes,
+            disposition,
+            flush_succeeded,
+        }
+    }
+
+    const fn empty() -> Self {
+        Self::new(
+            VirtioBlockRequestType::GetDeviceId,
+            0,
+            VirtioBlockRequestMetricDisposition::Success,
+            false,
+        )
+    }
+}
+
 #[derive(Debug)]
 pub struct VirtioBlockRequestExecution {
     completion: VirtioBlockRequestCompletion,
     status_code: u8,
     outcome: VirtioBlockRequestExecutionOutcome,
     latency_sample: Option<VirtioBlockRequestLatencySample>,
+    metric_outcome: VirtioBlockRequestMetricOutcome,
 }
 
 impl VirtioBlockRequestExecution {
@@ -2201,7 +2313,13 @@ impl VirtioBlockRequestExecution {
         status_code: u8,
         outcome: VirtioBlockRequestExecutionOutcome,
     ) -> Self {
-        Self::new_with_latency(completion, status_code, outcome, None)
+        Self::new_with_latency(
+            completion,
+            status_code,
+            outcome,
+            None,
+            VirtioBlockRequestMetricOutcome::empty(),
+        )
     }
 
     const fn new_with_latency(
@@ -2209,12 +2327,14 @@ impl VirtioBlockRequestExecution {
         status_code: u8,
         outcome: VirtioBlockRequestExecutionOutcome,
         latency_sample: Option<VirtioBlockRequestLatencySample>,
+        metric_outcome: VirtioBlockRequestMetricOutcome,
     ) -> Self {
         Self {
             completion,
             status_code,
             outcome,
             latency_sample,
+            metric_outcome,
         }
     }
 
@@ -2232,6 +2352,10 @@ impl VirtioBlockRequestExecution {
 
     const fn latency_sample(&self) -> Option<VirtioBlockRequestLatencySample> {
         self.latency_sample
+    }
+
+    const fn metric_outcome(&self) -> VirtioBlockRequestMetricOutcome {
+        self.metric_outcome
     }
 }
 
@@ -2611,7 +2735,7 @@ impl std::error::Error for VirtioBlockSnapshotPersistenceError {
 }
 
 /// Detached, value-redacted block state retained for later persistence.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct VirtioBlockDeviceCaptureState {
     config_space: VirtioBlockConfigSpace,
     device_id: VirtioBlockDeviceId,
@@ -2622,27 +2746,27 @@ pub struct VirtioBlockDeviceCaptureState {
 }
 
 impl VirtioBlockDeviceCaptureState {
-    pub const fn config_space(self) -> VirtioBlockConfigSpace {
-        self.config_space
+    pub fn config_space(&self) -> VirtioBlockConfigSpace {
+        self.config_space.clone()
     }
 
-    pub const fn device_id(self) -> VirtioBlockDeviceId {
+    pub const fn device_id(&self) -> VirtioBlockDeviceId {
         self.device_id
     }
 
-    pub const fn backing(self) -> BlockFileBackingIdentity {
+    pub const fn backing(&self) -> BlockFileBackingIdentity {
         self.backing
     }
 
-    pub const fn active_queue(self) -> Option<VirtioBlockQueueState> {
+    pub const fn active_queue(&self) -> Option<VirtioBlockQueueState> {
         self.active_queue
     }
 
-    pub const fn rate_limiter(self) -> VirtioBlockRateLimiterState {
+    pub const fn rate_limiter(&self) -> VirtioBlockRateLimiterState {
         self.rate_limiter
     }
 
-    pub const fn io_engine(self) -> BlockCaptureIoEngine {
+    pub const fn io_engine(&self) -> BlockCaptureIoEngine {
         self.io_engine
     }
 }
@@ -3152,6 +3276,14 @@ impl VirtioBlockQueue {
                 source,
             })?
         {
+            let remaining =
+                self.available
+                    .available_descriptor_count(memory)
+                    .map_err(|source| VirtioBlockQueueDispatchError::AvailableRing {
+                        completed_dispatch: Box::new(dispatch.clone()),
+                        source,
+                    })?;
+            dispatch.record_remaining_requests(remaining);
             let descriptor_head = descriptor_chain_head(&chain).ok_or_else(|| {
                 VirtioBlockQueueDispatchError::EmptyDescriptorChain {
                     completed_dispatch: Box::new(dispatch.clone()),
@@ -3190,6 +3322,7 @@ impl VirtioBlockQueue {
                     ),
                 };
 
+            dispatch.record_outcome(outcome);
             let notification_suppression =
                 self.notification_suppression(memory).map_err(|source| {
                     VirtioBlockQueueDispatchError::AvailableRing {
@@ -3211,9 +3344,10 @@ impl VirtioBlockQueue {
                     bytes_written_to_guest: completion.bytes_written_to_guest(),
                     source,
                 })?;
-            dispatch.record(outcome, publication);
+            dispatch.record_publication(publication);
         }
 
+        dispatch.finish_queue_pass();
         Ok(dispatch)
     }
 
@@ -3242,6 +3376,7 @@ impl VirtioBlockQueue {
             }
         })? {
             dispatch.record_io_engine_throttled_event();
+            dispatch.finish_queue_pass();
             return Ok(dispatch);
         }
 
@@ -3255,6 +3390,14 @@ impl VirtioBlockQueue {
                 source,
             })?
         {
+            let remaining =
+                self.available
+                    .available_descriptor_count(memory)
+                    .map_err(|source| VirtioBlockQueueDispatchError::AvailableRing {
+                        completed_dispatch: Box::new(dispatch.clone()),
+                        source,
+                    })?;
+            dispatch.record_remaining_requests(remaining);
             let descriptor_head = descriptor_chain_head(&chain).ok_or_else(|| {
                 VirtioBlockQueueDispatchError::EmptyDescriptorChain {
                     completed_dispatch: Box::new(dispatch.clone()),
@@ -3360,6 +3503,7 @@ impl VirtioBlockQueue {
             };
             self.publish_completion(memory, completion, outcome, &mut dispatch)?;
         }
+        dispatch.finish_queue_pass();
         Ok(dispatch)
     }
 
@@ -3395,47 +3539,53 @@ impl VirtioBlockQueue {
             .then(|| {
                 VirtioBlockRequestLatencySample::new(request_type, completion.total_latency_us())
             });
-            let (status_code, bytes_written_to_guest, outcome) = match completion.status() {
+            let transferred_bytes = completion.bytes_transferred();
+            let mut metric_outcome = VirtioBlockRequestMetricOutcome::new(
+                request_type,
+                transferred_bytes,
+                match completion.status() {
+                    BlockAsyncOperationStatus::Success => {
+                        VirtioBlockRequestMetricDisposition::Success
+                    }
+                    BlockAsyncOperationStatus::Failed(_) => {
+                        VirtioBlockRequestMetricDisposition::IoError
+                    }
+                },
+                completion.kind() == BlockAsyncOperationKind::Flush
+                    && completion.status() == BlockAsyncOperationStatus::Success,
+            );
+            let (mut status_code, mut bytes_written_to_guest) = match completion.status() {
                 BlockAsyncOperationStatus::Success => {
-                    let data_len = u32::try_from(completion.bytes_transferred()).map_err(|_| {
+                    let data_len = u32::try_from(transferred_bytes).map_err(|_| {
                         VirtioBlockQueueDispatchError::AsyncRuntime {
                             completed_dispatch: Box::new(dispatch.clone()),
                             source: BlockAsyncRuntimeError::ExecutorInvariant,
                         }
                     })?;
-                    let bytes_written_to_guest =
+                    (
+                        VIRTIO_BLOCK_STATUS_OK,
                         if completion.kind() == BlockAsyncOperationKind::Read {
                             data_len
                         } else {
                             0
-                        };
-                    (
-                        VIRTIO_BLOCK_STATUS_OK,
-                        bytes_written_to_guest,
-                        VirtioBlockQueueDispatchOutcome::Ok {
-                            request_type,
-                            data_len,
-                            latency_sample,
                         },
                     )
                 }
-                BlockAsyncOperationStatus::Failed(_) => (
-                    VIRTIO_BLOCK_STATUS_IOERR,
-                    0,
-                    VirtioBlockQueueDispatchOutcome::IoError { latency_sample },
-                ),
+                BlockAsyncOperationStatus::Failed(_) => (VIRTIO_BLOCK_STATUS_IOERR, 0),
             };
-            let (status_code, bytes_written_to_guest, outcome) = if bytes_written_to_guest
+            if bytes_written_to_guest
                 .checked_add(VIRTIO_BLOCK_STATUS_SIZE)
-                .is_some()
+                .is_none()
             {
-                (status_code, bytes_written_to_guest, outcome)
-            } else {
-                (
-                    VIRTIO_BLOCK_STATUS_IOERR,
-                    0,
-                    VirtioBlockQueueDispatchOutcome::IoError { latency_sample },
-                )
+                status_code = VIRTIO_BLOCK_STATUS_IOERR;
+                bytes_written_to_guest = 0;
+                metric_outcome.disposition = VirtioBlockRequestMetricDisposition::IoError;
+                metric_outcome.flush_succeeded = false;
+            }
+            let outcome = VirtioBlockQueueDispatchOutcome::Request {
+                metric_outcome,
+                latency_sample,
+                status_write_failed: false,
             };
             let status = VirtioBlockStatusDescriptor {
                 index: u16::MAX,
@@ -3448,8 +3598,11 @@ impl VirtioBlockQueue {
                     bytes_written_to_guest + VIRTIO_BLOCK_STATUS_SIZE,
                 ),
                 Err(_) => {
-                    let outcome =
-                        VirtioBlockQueueDispatchOutcome::StatusWriteFailed { latency_sample };
+                    let outcome = VirtioBlockQueueDispatchOutcome::Request {
+                        metric_outcome,
+                        latency_sample,
+                        status_write_failed: true,
+                    };
                     self.publish_completion(
                         memory,
                         VirtioBlockRequestCompletion::new(identity.descriptor_head(), 0),
@@ -3471,6 +3624,7 @@ impl VirtioBlockQueue {
         outcome: VirtioBlockQueueDispatchOutcome,
         dispatch: &mut VirtioBlockQueueDispatch,
     ) -> Result<(), VirtioBlockQueueDispatchError> {
+        dispatch.record_outcome(outcome);
         let notification_suppression = self.notification_suppression(memory).map_err(|source| {
             VirtioBlockQueueDispatchError::AvailableRing {
                 completed_dispatch: Box::new(dispatch.clone()),
@@ -3491,7 +3645,7 @@ impl VirtioBlockQueue {
                 bytes_written_to_guest: completion.bytes_written_to_guest(),
                 source,
             })?;
-        dispatch.record(outcome, publication);
+        dispatch.record_publication(publication);
         Ok(())
     }
 
@@ -3514,6 +3668,7 @@ impl VirtioBlockQueue {
 pub struct VirtioBlockQueueDispatch {
     processed_requests: usize,
     successful_requests: usize,
+    published_used_elements: u64,
     read_count: usize,
     write_count: usize,
     flush_count: usize,
@@ -3527,6 +3682,8 @@ pub struct VirtioBlockQueueDispatch {
     status_write_failures: usize,
     rate_limiter_throttled_requests: usize,
     io_engine_throttled_events: usize,
+    no_avail_buffer: u64,
+    remaining_reqs_count: u64,
     rate_limiter_retry_after: Option<Duration>,
     first_parse_failure: Option<VirtioBlockRequestError>,
     needs_queue_interrupt: bool,
@@ -3597,6 +3754,14 @@ impl VirtioBlockQueueDispatch {
         self.io_engine_throttled_events
     }
 
+    pub const fn no_avail_buffer(&self) -> u64 {
+        self.no_avail_buffer
+    }
+
+    pub const fn remaining_reqs_count(&self) -> u64 {
+        self.remaining_reqs_count
+    }
+
     pub const fn rate_limiter_retry_after(&self) -> Option<Duration> {
         self.rate_limiter_retry_after
     }
@@ -3605,59 +3770,93 @@ impl VirtioBlockQueueDispatch {
         self.needs_queue_interrupt
     }
 
-    fn record(
-        &mut self,
-        outcome: VirtioBlockQueueDispatchOutcome,
-        publication: VirtqueueUsedRingPublication,
-    ) {
-        self.processed_requests += 1;
-        self.needs_queue_interrupt |= publication.needs_queue_interrupt();
+    fn record_outcome(&mut self, outcome: VirtioBlockQueueDispatchOutcome) {
+        self.processed_requests = self.processed_requests.saturating_add(1);
         if let Some(latency_sample) = outcome.latency_sample() {
             self.record_latency_sample(latency_sample);
         }
         match outcome {
-            VirtioBlockQueueDispatchOutcome::Ok {
-                request_type,
-                data_len,
+            VirtioBlockQueueDispatchOutcome::Request {
+                metric_outcome,
+                status_write_failed,
                 ..
             } => {
-                self.successful_requests += 1;
-                match request_type {
+                if metric_outcome.disposition == VirtioBlockRequestMetricDisposition::Success
+                    && !status_write_failed
+                {
+                    self.successful_requests = self.successful_requests.saturating_add(1);
+                }
+                match metric_outcome.request_type {
                     VirtioBlockRequestType::In => {
-                        self.read_count += 1;
-                        self.read_bytes = self.read_bytes.saturating_add(u64::from(data_len));
+                        self.read_bytes = self
+                            .read_bytes
+                            .saturating_add(metric_outcome.transferred_bytes);
+                        if metric_outcome.disposition
+                            == VirtioBlockRequestMetricDisposition::Success
+                        {
+                            self.read_count = self.read_count.saturating_add(1);
+                        }
                     }
                     VirtioBlockRequestType::Out => {
-                        self.write_count += 1;
-                        self.write_bytes = self.write_bytes.saturating_add(u64::from(data_len));
+                        self.write_bytes = self
+                            .write_bytes
+                            .saturating_add(metric_outcome.transferred_bytes);
+                        if metric_outcome.disposition
+                            == VirtioBlockRequestMetricDisposition::Success
+                        {
+                            self.write_count = self.write_count.saturating_add(1);
+                        }
                     }
                     VirtioBlockRequestType::Flush => {
-                        self.flush_count += 1;
+                        if metric_outcome.flush_succeeded {
+                            self.flush_count = self.flush_count.saturating_add(1);
+                        }
                     }
                     VirtioBlockRequestType::GetDeviceId
                     | VirtioBlockRequestType::Unsupported(_) => {}
                 }
+                match metric_outcome.disposition {
+                    VirtioBlockRequestMetricDisposition::Success => {}
+                    VirtioBlockRequestMetricDisposition::IoError => {
+                        self.io_errors = self.io_errors.saturating_add(1);
+                    }
+                    VirtioBlockRequestMetricDisposition::Unsupported => {
+                        self.unsupported_requests = self.unsupported_requests.saturating_add(1);
+                    }
+                }
+                if status_write_failed {
+                    self.status_write_failures = self.status_write_failures.saturating_add(1);
+                }
             }
             VirtioBlockQueueDispatchOutcome::ParseError(source) => {
-                self.parse_failures += 1;
+                self.parse_failures = self.parse_failures.saturating_add(1);
                 if self.first_parse_failure.is_none() {
                     self.first_parse_failure = Some(source);
                 }
             }
-            VirtioBlockQueueDispatchOutcome::IoError { .. } => {
-                self.io_errors += 1;
-            }
-            VirtioBlockQueueDispatchOutcome::Unsupported => {
-                self.unsupported_requests += 1;
-            }
-            VirtioBlockQueueDispatchOutcome::StatusWriteFailed { .. } => {
-                self.status_write_failures += 1;
-            }
+        }
+    }
+
+    fn record_publication(&mut self, publication: VirtqueueUsedRingPublication) {
+        self.published_used_elements = self.published_used_elements.saturating_add(1);
+        self.needs_queue_interrupt |= publication.needs_queue_interrupt();
+    }
+
+    fn record_remaining_requests(&mut self, remaining: u16) {
+        self.remaining_reqs_count = self
+            .remaining_reqs_count
+            .saturating_add(u64::from(remaining));
+    }
+
+    fn finish_queue_pass(&mut self) {
+        if self.published_used_elements == 0 {
+            self.no_avail_buffer = self.no_avail_buffer.saturating_add(1);
         }
     }
 
     fn record_rate_limited_request(&mut self, retry_after: Duration) {
-        self.rate_limiter_throttled_requests += 1;
+        self.rate_limiter_throttled_requests =
+            self.rate_limiter_throttled_requests.saturating_add(1);
         self.rate_limiter_retry_after = Some(match self.rate_limiter_retry_after {
             Some(existing) => existing.min(retry_after),
             None => retry_after,
@@ -3693,53 +3892,33 @@ impl VirtioBlockQueueDispatch {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum VirtioBlockQueueDispatchOutcome {
-    Ok {
-        request_type: VirtioBlockRequestType,
-        data_len: u32,
+    Request {
+        metric_outcome: VirtioBlockRequestMetricOutcome,
         latency_sample: Option<VirtioBlockRequestLatencySample>,
+        status_write_failed: bool,
     },
     ParseError(VirtioBlockRequestError),
-    IoError {
-        latency_sample: Option<VirtioBlockRequestLatencySample>,
-    },
-    Unsupported,
-    StatusWriteFailed {
-        latency_sample: Option<VirtioBlockRequestLatencySample>,
-    },
 }
 
 impl VirtioBlockQueueDispatchOutcome {
     const fn from_request_execution(
-        request: &VirtioBlockRequest,
+        _request: &VirtioBlockRequest,
         execution: &VirtioBlockRequestExecution,
     ) -> Self {
-        match execution.outcome() {
-            VirtioBlockRequestExecutionOutcome::Ok => Self::Ok {
-                request_type: request.request_type(),
-                data_len: match request.data() {
-                    Some(data) => data.len(),
-                    None => 0,
-                },
-                latency_sample: execution.latency_sample(),
-            },
-            VirtioBlockRequestExecutionOutcome::IoError { .. } => Self::IoError {
-                latency_sample: execution.latency_sample(),
-            },
-            VirtioBlockRequestExecutionOutcome::Unsupported { .. } => Self::Unsupported,
-            VirtioBlockRequestExecutionOutcome::StatusWriteFailed { .. } => {
-                Self::StatusWriteFailed {
-                    latency_sample: execution.latency_sample(),
-                }
-            }
+        Self::Request {
+            metric_outcome: execution.metric_outcome(),
+            latency_sample: execution.latency_sample(),
+            status_write_failed: matches!(
+                execution.outcome(),
+                VirtioBlockRequestExecutionOutcome::StatusWriteFailed { .. }
+            ),
         }
     }
 
     const fn latency_sample(&self) -> Option<VirtioBlockRequestLatencySample> {
         match self {
-            Self::Ok { latency_sample, .. }
-            | Self::IoError { latency_sample }
-            | Self::StatusWriteFailed { latency_sample } => *latency_sample,
-            Self::ParseError(_) | Self::Unsupported => None,
+            Self::Request { latency_sample, .. } => *latency_sample,
+            Self::ParseError(_) => None,
         }
     }
 }
@@ -6024,6 +6203,7 @@ pub struct VirtioBlockDevice {
     device_id: VirtioBlockDeviceId,
     pending_rate_limited_queue: bool,
     guest_logger: Option<GuestLogger>,
+    metrics: Option<SharedBlockDeviceMetrics>,
 }
 
 impl VirtioBlockDevice {
@@ -6038,6 +6218,7 @@ impl VirtioBlockDevice {
             device_id,
             pending_rate_limited_queue: false,
             guest_logger: None,
+            metrics: None,
         }
     }
 
@@ -6064,6 +6245,7 @@ impl VirtioBlockDevice {
             device_id,
             pending_rate_limited_queue: false,
             guest_logger: None,
+            metrics: None,
         })
     }
 
@@ -6095,7 +6277,16 @@ impl VirtioBlockDevice {
             device_id,
             pending_rate_limited_queue,
             guest_logger: None,
+            metrics: None,
         }
+    }
+
+    pub(crate) fn attach_metrics(&mut self, metrics: SharedBlockDeviceMetrics) -> bool {
+        if !matches!(self.backend, VirtioBlockBackend::File { .. }) {
+            return false;
+        }
+        self.metrics = Some(metrics);
+        true
     }
 
     pub fn backing(&self) -> Option<&BlockFileBacking> {
@@ -6675,8 +6866,29 @@ impl VirtioBlockDevice {
         drained_notifications: Vec<usize>,
     ) -> Result<VirtioBlockDeviceNotificationDispatch, VirtioBlockDeviceNotificationError> {
         let had_pending_rate_limited_queue = self.pending_rate_limited_queue;
+        if let Some(metrics) = &self.metrics {
+            if !drained_notifications.is_empty() {
+                metrics.record_queue_events(1);
+            } else if had_pending_rate_limited_queue {
+                metrics.record_rate_limiter_event();
+            }
+        }
         let result =
             self.dispatch_drained_queue_notifications_unobserved(memory, drained_notifications);
+        if let Some(metrics) = &self.metrics {
+            match &result {
+                Ok(dispatch) => {
+                    if let Some(queue_dispatch) = dispatch.queue_dispatch() {
+                        metrics.record_queue_dispatch(queue_dispatch);
+                    }
+                }
+                Err(error) => {
+                    if let Some(queue_dispatch) = error.completed_dispatch() {
+                        metrics.record_queue_dispatch(queue_dispatch);
+                    }
+                }
+            }
+        }
         self.observe_notification_result(&result, had_pending_rate_limited_queue);
         result
     }
@@ -7278,6 +7490,16 @@ impl VirtioBlockLiveUpdateError {
     pub const fn terminal(&self) -> bool {
         matches!(self, Self::AsyncTerminal(_) | Self::Queue(_))
     }
+
+    pub const fn completed_dispatch(&self) -> Option<&VirtioBlockQueueDispatch> {
+        match self {
+            Self::Queue(source) => Some(source.completed_dispatch()),
+            Self::UnsupportedBackend
+            | Self::MissingReplacementBacking
+            | Self::AsyncPreparation(_)
+            | Self::AsyncTerminal(_) => None,
+        }
+    }
 }
 
 impl fmt::Display for VirtioBlockLiveUpdateError {
@@ -7464,7 +7686,7 @@ impl PreparedBlockDevice {
             rate_limiter,
             pending_rate_limited_queue,
         } = parts;
-        Self::validate_snapshot_backing(&backing, config_space)?;
+        Self::validate_snapshot_backing(&backing, config_space.clone())?;
         let device = VirtioBlockDevice::from_snapshot_parts(
             backing,
             device_id,
@@ -7534,8 +7756,8 @@ impl PreparedBlockDevice {
         self.is_root_device
     }
 
-    pub const fn config_space(&self) -> VirtioBlockConfigSpace {
-        self.config_space
+    pub fn config_space(&self) -> VirtioBlockConfigSpace {
+        self.config_space.clone()
     }
 
     pub const fn io_engine(&self) -> Option<DriveIoEngine> {
@@ -7552,6 +7774,18 @@ impl PreparedBlockDevice {
 
     pub fn device_mut(&mut self) -> &mut VirtioBlockDevice {
         &mut self.device
+    }
+
+    /// Attaches one coherent owner to both ordinary block metric sources.
+    ///
+    /// Vhost-user block devices intentionally retain their separate metric
+    /// family and reject an ordinary owner.
+    pub fn attach_metrics(&mut self, metrics: SharedBlockDeviceMetrics) -> bool {
+        if !self.device.attach_metrics(metrics.clone()) {
+            return false;
+        }
+        self.config_space.attach_metrics(metrics);
+        true
     }
 
     pub fn bind_async_runtime(
@@ -8347,9 +8581,17 @@ impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioBlockD
         &mut self,
         memory: &mut GuestMemory,
     ) -> Result<VirtioBlockQueueDispatch, VirtioBlockQueueDispatchError> {
-        let dispatch = self
-            .activation_handler_mut()
-            .publish_quiesced_async_completions(memory);
+        let dispatch = {
+            let activation = self.activation_handler_mut();
+            let dispatch = activation.publish_quiesced_async_completions(memory);
+            if let Some(metrics) = &activation.metrics {
+                match &dispatch {
+                    Ok(completed) => metrics.record_queue_dispatch(completed),
+                    Err(source) => metrics.record_queue_dispatch(source.completed_dispatch()),
+                }
+            }
+            dispatch
+        };
         let needs_queue_interrupt = match &dispatch {
             Ok(dispatch) => dispatch.needs_queue_interrupt(),
             Err(error) => error.completed_dispatch().needs_queue_interrupt(),
@@ -8362,6 +8604,21 @@ impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioBlockD
 }
 
 impl VirtioBlockMmioHandler {
+    /// Attaches one ordinary per-drive metrics owner to both source objects.
+    ///
+    /// Returns `false` for vhost-user block so its separate metric family
+    /// cannot accidentally populate ordinary `block_{drive_id}` values.
+    pub fn attach_block_metrics(&mut self, metrics: SharedBlockDeviceMetrics) -> bool {
+        if !self
+            .activation_handler_mut()
+            .attach_metrics(metrics.clone())
+        {
+            return false;
+        }
+        self.device_config_handler_mut().attach_metrics(metrics);
+        true
+    }
+
     pub fn block_backend_kind(&self) -> VirtioBlockBackendKind {
         self.activation_handler().backend_kind()
     }
@@ -8375,7 +8632,7 @@ impl VirtioBlockMmioHandler {
         config: &DriveConfig,
     ) -> Result<VirtioBlockSnapshotPersistenceBinding, VirtioBlockSnapshotPersistenceError> {
         self.activation_handler()
-            .snapshot_persistence_binding(*self.device_config_handler(), config)
+            .snapshot_persistence_binding(self.device_config_handler().clone(), config)
     }
 
     pub fn persist_block_snapshot_backing(
@@ -8383,7 +8640,7 @@ impl VirtioBlockMmioHandler {
         config: &DriveConfig,
     ) -> Result<(), VirtioBlockSnapshotPersistenceError> {
         self.activation_handler()
-            .persist_snapshot_backing(*self.device_config_handler(), config)
+            .persist_snapshot_backing(self.device_config_handler().clone(), config)
     }
 
     pub fn block_async_binding(
@@ -8397,12 +8654,29 @@ impl VirtioBlockMmioHandler {
         config: &DriveConfig,
         now: Instant,
     ) -> Result<VirtioBlockDeviceCaptureState, VirtioBlockDeviceCaptureError> {
-        self.activation_handler()
-            .capture_state_at(*self.device_config_handler(), config, now)
+        self.activation_handler().capture_state_at(
+            self.device_config_handler().clone(),
+            config,
+            now,
+        )
     }
 }
 
 impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
+    pub fn attach_block_metrics(
+        &self,
+        metrics: SharedBlockDeviceMetrics,
+    ) -> Result<bool, VirtioPciEndpointError> {
+        let work = self.admit_device_work()?;
+        work.with_core_mut(|core| {
+            if !core.activation.attach_metrics(metrics.clone()) {
+                return false;
+            }
+            core.device_config.attach_metrics(metrics);
+            true
+        })
+    }
+
     pub fn block_backend_kind(&self) -> Result<VirtioBlockBackendKind, VirtioPciEndpointError> {
         let work = self.admit_device_work()?;
         work.with_core_mut(|core| core.activation.backend_kind())
@@ -8417,7 +8691,7 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
             .map_err(VirtioBlockPciSnapshotPersistenceError::Endpoint)?;
         work.with_core_mut(|core| {
             core.activation
-                .snapshot_persistence_binding(core.device_config, config)
+                .snapshot_persistence_binding(core.device_config.clone(), config)
         })
         .map_err(VirtioBlockPciSnapshotPersistenceError::Endpoint)?
         .map_err(VirtioBlockPciSnapshotPersistenceError::Persistence)
@@ -8432,7 +8706,7 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
             .map_err(VirtioBlockPciSnapshotPersistenceError::Endpoint)?;
         work.with_core_mut(|core| {
             core.activation
-                .persist_snapshot_backing(core.device_config, config)
+                .persist_snapshot_backing(core.device_config.clone(), config)
         })
         .map_err(VirtioBlockPciSnapshotPersistenceError::Endpoint)?
         .map_err(VirtioBlockPciSnapshotPersistenceError::Persistence)
@@ -8458,7 +8732,7 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
         let device = work
             .with_core_mut(|core| {
                 core.activation
-                    .capture_state_at(core.device_config, config, now)
+                    .capture_state_at(core.device_config.clone(), config, now)
             })
             .map_err(VirtioBlockPciCaptureError::Endpoint)?
             .map_err(VirtioBlockPciCaptureError::Device)?;
@@ -8482,6 +8756,12 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
         let dispatch = work
             .with_core_mut(|core| {
                 let dispatch = core.activation.publish_quiesced_async_completions(memory);
+                if let Some(metrics) = &core.activation.metrics {
+                    match &dispatch {
+                        Ok(completed) => metrics.record_queue_dispatch(completed),
+                        Err(source) => metrics.record_queue_dispatch(source.completed_dispatch()),
+                    }
+                }
                 let needs_queue_interrupt = match &dispatch {
                     Ok(dispatch) => dispatch.needs_queue_interrupt(),
                     Err(error) => error.completed_dispatch().needs_queue_interrupt(),
@@ -8495,6 +8775,9 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
         let endpoint = work.drain_interrupt_intents();
         if endpoint.is_err() {
             let _ = work.with_core_mut(|core| {
+                if let Some(metrics) = &core.activation.metrics {
+                    metrics.record_event_failure();
+                }
                 if let Some(logger) = &core.activation.guest_logger {
                     logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
                 }
@@ -8552,6 +8835,9 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
         let endpoint = work.drain_interrupt_intents();
         if endpoint.is_err() {
             let _ = work.with_core_mut(|core| {
+                if let Some(metrics) = &core.activation.metrics {
+                    metrics.record_event_failure();
+                }
                 if let Some(logger) = &core.activation.guest_logger {
                     logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
                 }
@@ -8570,8 +8856,11 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
         let backing_changed = backing.is_some();
         work.with_core_mut(|core| {
             if let Some(backing) = backing {
-                let config_space =
+                let mut config_space =
                     VirtioBlockConfigSpace::from_backing(&backing, config.cache_type());
+                if let Some(metrics) = &core.activation.metrics {
+                    config_space.attach_metrics(metrics.clone());
+                }
                 core.activation
                     .refresh_backing(backing)
                     .map_err(|_| VirtioPciEndpointError::UnsupportedDeviceOperation)?;
@@ -8590,6 +8879,9 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
             let endpoint = work.drain_interrupt_intents();
             if endpoint.is_err() {
                 let _ = work.with_core_mut(|core| {
+                    if let Some(metrics) = &core.activation.metrics {
+                        metrics.record_event_failure();
+                    }
                     if let Some(logger) = &core.activation.guest_logger {
                         logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
                     }
@@ -8621,18 +8913,33 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
         let file_state_changed = config_space.is_some() || mode == DriveLiveUpdateMode::Replacement;
         let update = work
             .with_core_mut(|core| {
-                let dispatch = core.activation.update_file_backend_with_opened(
+                let update = core.activation.update_file_backend_with_opened(
                     memory,
                     config,
                     backing,
                     rate_limiter_update,
                     mode,
                     shared_runtime,
-                )?;
+                );
+                if let Some(metrics) = &core.activation.metrics {
+                    match &update {
+                        Ok(dispatch) => metrics.record_queue_dispatch(dispatch),
+                        Err(source) => {
+                            if let Some(dispatch) = source.completed_dispatch() {
+                                metrics.record_queue_dispatch(dispatch);
+                            }
+                        }
+                    }
+                }
+                let dispatch = update?;
                 if dispatch.needs_queue_interrupt() {
                     core.record_interrupt_intent(VirtioInterruptIntent::Queue { queue_index: 0 });
                 }
                 if let Some(config_space) = config_space {
+                    let mut config_space = config_space;
+                    if let Some(metrics) = &core.activation.metrics {
+                        config_space.attach_metrics(metrics.clone());
+                    }
                     core.device_config = config_space;
                     core.device.increment_config_generation();
                     core.record_interrupt_intent(VirtioInterruptIntent::Configuration);
@@ -8648,6 +8955,9 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
             };
         if endpoint.is_err() {
             let _ = work.with_core_mut(|core| {
+                if let Some(metrics) = &core.activation.metrics {
+                    metrics.record_event_failure();
+                }
                 if let Some(logger) = &core.activation.guest_logger {
                     logger.log_block(LoggerBlockOutcome::InterruptDeliveryFailed);
                 }
@@ -8665,9 +8975,22 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
         VirtioBlockQueueDispatch,
         VirtioPciDeviceOperationError<VirtioBlockLiveUpdateError, VirtioBlockQueueDispatch>,
     > {
-        self.with_quiesced_core_mut(|core| core.activation.retire_async(memory))
-            .map_err(VirtioPciDeviceOperationError::Endpoint)?
-            .map_err(|source| VirtioPciDeviceOperationError::Device(Box::new(source)))
+        self.with_quiesced_core_mut(|core| {
+            let result = core.activation.retire_async(memory);
+            if let Some(metrics) = &core.activation.metrics {
+                match &result {
+                    Ok(dispatch) => metrics.record_queue_dispatch(dispatch),
+                    Err(source) => {
+                        if let Some(dispatch) = source.completed_dispatch() {
+                            metrics.record_queue_dispatch(dispatch);
+                        }
+                    }
+                }
+            }
+            result
+        })
+        .map_err(VirtioPciDeviceOperationError::Endpoint)?
+        .map_err(|source| VirtioPciDeviceOperationError::Device(Box::new(source)))
     }
 
     pub fn refresh_vhost_user_block_config(
@@ -8687,7 +9010,7 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
                     .map_err(|source| DriveUpdateError::ActiveSessionCommand {
                         message: source.to_string(),
                     })?;
-                let snapshot = (core.device, core.device_config);
+                let snapshot = (core.device, core.device_config.clone());
                 core.device_config = config_space;
                 core.device.increment_config_generation();
                 core.record_interrupt_intent(VirtioInterruptIntent::Configuration);
@@ -8760,7 +9083,7 @@ impl VirtioMmioRegisterHandler<VirtioBlockConfigSpace, VirtioBlockDevice> {
                 message: source.to_string(),
             })?;
         let transport_snapshot = self.transport_state();
-        let config_snapshot = *self.device_config_handler();
+        let config_snapshot = self.device_config_handler().clone();
         *self.device_config_handler_mut() = config_space;
         self.increment_config_generation();
         self.mark_config_interrupt_pending();
@@ -8799,7 +9122,10 @@ impl VirtioMmioRegisterHandler<VirtioBlockConfigSpace, VirtioBlockDevice> {
         config: &DriveConfig,
         backing: BlockFileBacking,
     ) -> Result<(), DriveUpdateError> {
-        let config_space = VirtioBlockConfigSpace::from_backing(&backing, config.cache_type());
+        let mut config_space = VirtioBlockConfigSpace::from_backing(&backing, config.cache_type());
+        if let Some(metrics) = &self.activation_handler().metrics {
+            config_space.attach_metrics(metrics.clone());
+        }
 
         self.activation_handler_mut()
             .refresh_backing(backing)
@@ -8831,7 +9157,7 @@ impl VirtioMmioRegisterHandler<VirtioBlockConfigSpace, VirtioBlockDevice> {
         let config_space = backing
             .as_ref()
             .map(|backing| VirtioBlockConfigSpace::from_backing(backing, config.cache_type()));
-        let dispatch = self
+        let update = self
             .activation_handler_mut()
             .update_file_backend_with_opened(
                 memory,
@@ -8840,17 +9166,41 @@ impl VirtioMmioRegisterHandler<VirtioBlockConfigSpace, VirtioBlockDevice> {
                 rate_limiter_update,
                 mode,
                 shared_runtime,
-            )?;
+            );
+        if let Some(metrics) = &self.activation_handler().metrics {
+            match &update {
+                Ok(dispatch) => metrics.record_queue_dispatch(dispatch),
+                Err(source) => {
+                    if let Some(dispatch) = source.completed_dispatch() {
+                        metrics.record_queue_dispatch(dispatch);
+                    }
+                }
+            }
+        }
+        let dispatch = update?;
         if dispatch.needs_queue_interrupt() {
             self.mark_queue_interrupt_pending(0);
         }
-        if let Some(config_space) = config_space {
+        if let Some(mut config_space) = config_space {
+            if let Some(metrics) = &self.activation_handler().metrics {
+                config_space.attach_metrics(metrics.clone());
+            }
             *self.device_config_handler_mut() = config_space;
             self.increment_config_generation();
             self.mark_config_interrupt_pending();
         }
         Ok(dispatch)
     }
+}
+
+pub fn attach_block_metrics_to_mmio_handler(
+    dispatcher: &mut MmioDispatcher,
+    region_id: MmioRegionId,
+    metrics: SharedBlockDeviceMetrics,
+) -> Result<bool, MmioHandlerLookupError> {
+    Ok(dispatcher
+        .handler_mut::<VirtioBlockMmioHandler>(region_id)?
+        .attach_block_metrics(metrics))
 }
 
 impl VirtioMmioDeviceActivationHandler for VirtioBlockDevice {
@@ -8862,7 +9212,13 @@ impl VirtioMmioDeviceActivationHandler for VirtioBlockDevice {
         &mut self,
         activation: VirtioMmioDeviceActivation<'_>,
     ) -> Result<(), VirtioMmioDeviceActivationError> {
-        self.activate_block(activation).map_err(Into::into)
+        let result = self.activate_block(activation).map_err(Into::into);
+        if result.is_err()
+            && let Some(metrics) = &self.metrics
+        {
+            metrics.record_activation_failure();
+        }
+        result
     }
 
     fn reset(&mut self) {
@@ -9779,6 +10135,7 @@ mod tests {
         thread::JoinHandle<()>,
     ) {
         let (config_space, device, memory, peer) = vhost_user_refresh_device(refreshed_config);
+        let guest_features = config_space.available_features() & !VHOST_USER_F_PROTOCOL_FEATURES;
         let mut handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
             VIRTIO_BLOCK_DEVICE_ID,
             config_space.available_features(),
@@ -9787,7 +10144,6 @@ mod tests {
             device,
         )
         .expect("vhost-user block handler should build");
-        let guest_features = config_space.available_features() & !VHOST_USER_F_PROTOCOL_FEATURES;
         handler
             .write_register(VirtioMmioRegister::Status, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE)
             .expect("vhost-user refresh handler should accept ACKNOWLEDGE");
@@ -9983,7 +10339,7 @@ mod tests {
         endpoint
             .admit_device_work()
             .expect("test PCI endpoint work should admit")
-            .with_core_mut(|core| (core.device.config_generation(), core.device_config))
+            .with_core_mut(|core| (core.device.config_generation(), core.device_config.clone()))
             .expect("test PCI endpoint state should remain available")
     }
 
@@ -10306,11 +10662,11 @@ mod tests {
     }
 
     fn read_block_config(
-        config: VirtioBlockConfigSpace,
+        config: &VirtioBlockConfigSpace,
         offset: u64,
         len: u64,
     ) -> Result<MmioAccessBytes, VirtioMmioRegisterHandlerError> {
-        block_config_handler(config).read_access(virtio_mmio_access(
+        block_config_handler(config.clone()).read_access(virtio_mmio_access(
             VIRTIO_MMIO_DEVICE_CONFIG_OFFSET + offset,
             len,
         ))
@@ -11528,6 +11884,33 @@ mod tests {
         let rendered = error.to_string();
         assert!(!rendered.contains(sensitive_id));
         assert!(!rendered.contains("private-runtime-backing-1420"));
+    }
+
+    #[test]
+    fn prepared_file_block_attaches_one_metrics_owner_to_both_sources() {
+        let file = temp_file("prepared-block-metrics-owner.img", &[0; 512]);
+        let config = DriveConfigInput::new("rootfs", "rootfs", file.as_path(), true)
+            .validate()
+            .expect("file-backed drive config should validate");
+        let mut prepared = PreparedBlockDevice::from_config_with_backing(&config, None)
+            .expect("file-backed block device should prepare");
+        let metrics = SharedBlockDeviceMetrics::default();
+
+        assert!(prepared.attach_metrics(metrics.clone()));
+
+        let config_metrics = prepared
+            .config_space
+            .metrics
+            .as_ref()
+            .expect("ordinary config source should retain the metrics owner");
+        let device_metrics = prepared
+            .device
+            .metrics
+            .as_ref()
+            .expect("ordinary device source should retain the metrics owner");
+        assert!(metrics.shares_state_with(config_metrics));
+        assert!(metrics.shares_state_with(device_metrics));
+        assert!(config_metrics.shares_state_with(device_metrics));
     }
 
     #[test]
@@ -13064,6 +13447,22 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_config_space_records_only_failed_accesses() {
+        let metrics = SharedBlockDeviceMetrics::default();
+        let mut config = VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe);
+        config.attach_metrics(metrics.clone());
+
+        assert!(read_block_config(&config, 0, 8).is_ok());
+        assert!(read_block_config(&config, 8, 1).is_err());
+        assert!(write_block_config_after_driver(config, 0, &[0]).is_err());
+
+        assert_eq!(
+            metrics.snapshot(),
+            BlockDeviceMetrics::default().with_cfg_fails(2)
+        );
+    }
+
+    #[test]
     fn block_handler_refresh_updates_backing_config_generation_and_interrupt() {
         let first = temp_file("refresh-first.img", &[0; 512]);
         let second = temp_file("refresh-second.img", &[0; 1024]);
@@ -13215,7 +13614,7 @@ mod tests {
     fn vhost_user_block_handler_refresh_failure_preserves_config_and_generation() {
         let (mut handler, _memory, peer) =
             vhost_user_refresh_handler(TestVhostUserConfigReply::Malformed);
-        let original = *handler.device_config_handler();
+        let original = handler.device_config_handler().clone();
 
         let error = handler
             .refresh_vhost_user_block_config(DriveCacheType::Unsafe)
@@ -13242,7 +13641,7 @@ mod tests {
         let (mut handler, _memory, peer) =
             vhost_user_refresh_handler(TestVhostUserConfigReply::Exact(refreshed));
         let original_transport = handler.transport_state();
-        let original_config = *handler.device_config_handler();
+        let original_config = handler.device_config_handler().clone();
 
         let error = handler
             .refresh_vhost_user_block_config_with_signal(DriveCacheType::Unsafe, || {
@@ -13422,19 +13821,19 @@ mod tests {
         let expected = sectors.to_le_bytes();
 
         assert_eq!(
-            read_block_config(config, 0, 8)
+            read_block_config(&config, 0, 8)
                 .expect("full capacity read should succeed")
                 .as_slice(),
             expected.as_slice()
         );
         assert_eq!(
-            read_block_config(config, 1, 2)
+            read_block_config(&config, 1, 2)
                 .expect("partial capacity read should succeed")
                 .as_slice(),
             &[0x03, 0x02]
         );
         assert_eq!(
-            read_block_config(config, 4, 4)
+            read_block_config(&config, 4, 4)
                 .expect("high capacity word read should succeed")
                 .as_slice(),
             &[0, 0, 0, 0]
@@ -13447,13 +13846,13 @@ mod tests {
         let expected = config.capacity_sectors().to_le_bytes();
 
         assert_eq!(
-            read_block_config(config, 7, 1)
+            read_block_config(&config, 7, 1)
                 .expect("last capacity byte should read")
                 .as_slice(),
             expected.get(7..8).expect("test slice should exist")
         );
         assert_eq!(
-            read_block_config(config, 4, 4)
+            read_block_config(&config, 4, 4)
                 .expect("read ending at capacity boundary should succeed")
                 .as_slice(),
             expected.get(4..8).expect("test slice should exist")
@@ -13465,11 +13864,11 @@ mod tests {
         let config = VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe);
 
         assert!(matches!(
-            read_block_config(config, 8, 1),
+            read_block_config(&config, 8, 1),
             Err(VirtioMmioRegisterHandlerError::UnsupportedDeviceConfigRead { offset: 8, len: 1 })
         ));
         assert!(matches!(
-            read_block_config(config, 7, 2),
+            read_block_config(&config, 7, 2),
             Err(VirtioMmioRegisterHandlerError::UnsupportedDeviceConfigRead { offset: 7, len: 2 })
         ));
     }
@@ -14486,8 +14885,14 @@ mod tests {
                 )
                 .expect("test online memory view should insert");
         }
-        let prepared = PreparedBlockDevice::from_config_with_vhost_user(&config, frontend, &memory)
-            .expect("vhost-user block should prepare with shared memory");
+        let mut prepared =
+            PreparedBlockDevice::from_config_with_vhost_user(&config, frontend, &memory)
+                .expect("vhost-user block should prepare with shared memory");
+        let ordinary_metrics = SharedBlockDeviceMetrics::default();
+        assert!(!prepared.attach_metrics(ordinary_metrics.clone()));
+        assert_eq!(ordinary_metrics.snapshot(), BlockDeviceMetrics::default());
+        assert!(prepared.config_space.metrics.is_none());
+        assert!(prepared.device.metrics.is_none());
         assert_eq!(prepared.drive_id(), "vhost");
         assert!(prepared.is_root_device());
         assert_eq!(
@@ -15123,6 +15528,8 @@ mod tests {
         let file = temp_file("block-device-trait-error.img", &sector_payload(0x66));
         let backing = open_backing(file.as_path(), false).expect("backing should open");
         let mut device = VirtioBlockDevice::new(backing, TEST_DEVICE_ID);
+        let metrics = SharedBlockDeviceMetrics::default();
+        assert!(device.attach_metrics(metrics.clone()));
         let queues = configured_mmio_queue(TEST_QUEUE_SIZE, false);
         let registers = block_device_registers();
 
@@ -15141,6 +15548,10 @@ mod tests {
             }
         }
         assert!(device.active_queue().is_none());
+        assert_eq!(
+            metrics.snapshot(),
+            BlockDeviceMetrics::default().with_activate_fails(1)
+        );
     }
 
     #[test]
@@ -16130,7 +16541,12 @@ mod tests {
         else {
             panic!("partial publication should report an uncertain used-ring write");
         };
-        assert_eq!(*completed_dispatch, VirtioBlockQueueDispatch::default());
+        assert_eq!(completed_dispatch.processed_requests(), 1);
+        assert_eq!(completed_dispatch.successful_requests(), 1);
+        assert_eq!(completed_dispatch.read_count(), 1);
+        assert_eq!(completed_dispatch.read_bytes(), VIRTIO_BLOCK_SECTOR_SIZE);
+        assert_eq!(completed_dispatch.published_used_elements, 0);
+        assert!(completed_dispatch.read_latency_aggregate().is_some());
         assert_eq!(descriptor_head, 0);
         assert_eq!(
             bytes_written_to_guest,
@@ -16236,7 +16652,7 @@ mod tests {
         assert_eq!(completed.processed_requests(), 1);
         assert_eq!(completed.successful_requests(), 0);
         assert_eq!(completed.read_count(), 0);
-        assert_eq!(completed.read_bytes(), 0);
+        assert_eq!(completed.read_bytes(), 128);
         assert_eq!(completed.io_errors(), 1);
         assert!(completed.read_latency_aggregate().is_some());
         assert!(completed.needs_queue_interrupt());
@@ -16427,7 +16843,10 @@ mod tests {
         metrics.record_queue_dispatch(&dispatch);
         assert_eq!(
             metrics.snapshot(),
-            BlockDeviceMetrics::default().with_io_engine_throttled_events(1)
+            BlockDeviceMetrics::default()
+                .with_no_avail_buffer(1)
+                .with_io_engine_throttled_events(1)
+                .with_remaining_reqs_count(1)
         );
 
         release_sender
@@ -16737,6 +17156,8 @@ mod tests {
         .expect("rate limiter should be enabled");
         let mut device =
             VirtioBlockDevice::new(backing, TEST_DEVICE_ID).with_rate_limiter(rate_limiter);
+        let metrics = SharedBlockDeviceMetrics::default();
+        assert!(device.attach_metrics(metrics.clone()));
         let VirtioBlockBackend::File { active_queue, .. } = &mut device.backend else {
             panic!("test device should use a file backend");
         };
@@ -16751,6 +17172,10 @@ mod tests {
         assert_eq!(first_queue.processed_requests(), 1);
         assert!(first_queue.rate_limiter_retry_after().is_some());
         assert!(device.has_pending_rate_limited_queue());
+        let first_metrics = metrics.snapshot();
+        assert_eq!(first_metrics.queue_event_count(), 1);
+        assert_eq!(first_metrics.rate_limiter_event_count(), 0);
+        assert_eq!(first_metrics.flush_count(), 1);
 
         let retry = device
             .dispatch_drained_queue_notifications(&mut memory, Vec::new())
@@ -16763,6 +17188,10 @@ mod tests {
         assert!(retry_queue.rate_limiter_retry_after().is_some());
         assert!(device.has_pending_rate_limited_queue());
         assert_eq!(read_used_index(&memory), 1);
+        let retry_metrics = metrics.snapshot();
+        assert_eq!(retry_metrics.queue_event_count(), 1);
+        assert_eq!(retry_metrics.rate_limiter_event_count(), 1);
+        assert_eq!(retry_metrics.flush_count(), 1);
     }
 
     #[test]
@@ -17131,7 +17560,8 @@ mod tests {
         assert_eq!(dispatch.processed_requests(), 1);
         assert_eq!(dispatch.status_write_failures(), 1);
         assert_eq!(dispatch.successful_requests(), 0);
-        assert_eq!(dispatch.read_count(), 0);
+        assert_eq!(dispatch.read_count(), 1);
+        assert_eq!(dispatch.read_bytes(), VIRTIO_BLOCK_SECTOR_SIZE);
         assert_eq!(dispatch.write_count(), 0);
         assert_eq!(dispatch.flush_count(), 0);
         assert_eq!(dispatch.io_errors(), 0);
@@ -17144,7 +17574,8 @@ mod tests {
         assert_eq!(
             metrics.snapshot(),
             BlockDeviceMetrics::default()
-                .with_execute_fails(1)
+                .with_read_bytes(VIRTIO_BLOCK_SECTOR_SIZE)
+                .with_read_count(1)
                 .with_read_agg(read_agg)
         );
         assert_eq!(

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -6429,7 +6429,7 @@ impl VirtioBlockDevice {
     /// Captures a regular-file device after any Async generation is drained.
     pub fn capture_state_at(
         &self,
-        config_space: VirtioBlockConfigSpace,
+        mut config_space: VirtioBlockConfigSpace,
         config: &DriveConfig,
         now: Instant,
     ) -> Result<VirtioBlockDeviceCaptureState, VirtioBlockDeviceCaptureError> {
@@ -6479,6 +6479,7 @@ impl VirtioBlockDevice {
                 return Err(VirtioBlockDeviceCaptureError::ConfigurationMismatch);
             }
         };
+        config_space.metrics = None;
         Ok(VirtioBlockDeviceCaptureState {
             config_space,
             device_id: self.device_id,
@@ -11911,6 +11912,24 @@ mod tests {
         assert!(metrics.shares_state_with(config_metrics));
         assert!(metrics.shares_state_with(device_metrics));
         assert!(config_metrics.shares_state_with(device_metrics));
+    }
+
+    #[test]
+    fn block_capture_detaches_the_live_metrics_owner() {
+        let file = temp_file("capture-metrics-owner.img", &[0; 512]);
+        let config = DriveConfigInput::new("rootfs", "rootfs", file.as_path(), true)
+            .validate()
+            .expect("file-backed drive config should validate");
+        let mut prepared = PreparedBlockDevice::from_config_with_backing(&config, None)
+            .expect("file-backed block device should prepare");
+        assert!(prepared.attach_metrics(SharedBlockDeviceMetrics::default()));
+
+        let captured = prepared
+            .device()
+            .capture_state_at(prepared.config_space(), &config, Instant::now())
+            .expect("ordinary block state should capture");
+
+        assert!(captured.config_space.metrics.is_none());
     }
 
     #[test]

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -1626,10 +1626,19 @@ impl PartialEq for BlockDeviceMetricsByDrive {
 
 impl Eq for BlockDeviceMetricsByDrive {}
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
 struct BlockDeviceMetricsByDriveEntry {
     generation: u64,
     metrics: BlockDeviceMetrics,
+}
+
+impl fmt::Debug for BlockDeviceMetricsByDriveEntry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BlockDeviceMetricsByDriveEntry")
+            .field("metrics", &self.metrics)
+            .finish()
+    }
 }
 
 impl BlockDeviceMetricsByDrive {
@@ -9017,6 +9026,10 @@ mod tests {
         let replacement = replacement.publish();
 
         let current = registry.capture();
+        assert!(
+            !format!("{current:?}").contains("generation"),
+            "private block metrics generations must stay out of Debug output"
+        );
         let delta = current.per_drive().delta_since(Some(original.per_drive()));
         assert_eq!(
             delta,

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -4,7 +4,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, LineWriter, Write};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering, fence};
+use std::sync::atomic::{AtomicU64, Ordering, fence};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::balloon::{VirtioBalloonDeviceNotificationDispatch, VirtioBalloonDiscardOutcome};
@@ -1275,6 +1275,9 @@ impl PutApiRequestMetrics {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BlockDeviceMetrics {
     config_change_time_us: Option<u64>,
+    activate_fails: u64,
+    cfg_fails: u64,
+    no_avail_buffer: u64,
     event_fails: u64,
     execute_fails: u64,
     invalid_reqs_count: u64,
@@ -1291,6 +1294,7 @@ pub struct BlockDeviceMetrics {
     write_count: u64,
     read_agg: VirtioBlockLatencyAggregate,
     write_agg: VirtioBlockLatencyAggregate,
+    remaining_reqs_count: u64,
 }
 
 impl BlockDeviceMetrics {
@@ -1301,6 +1305,9 @@ impl BlockDeviceMetrics {
             } else {
                 self.config_change_time_us
             },
+            activate_fails: incremental_delta(self.activate_fails, previous.activate_fails),
+            cfg_fails: incremental_delta(self.cfg_fails, previous.cfg_fails),
+            no_avail_buffer: incremental_delta(self.no_avail_buffer, previous.no_avail_buffer),
             event_fails: incremental_delta(self.event_fails, previous.event_fails),
             execute_fails: incremental_delta(self.execute_fails, previous.execute_fails),
             invalid_reqs_count: incremental_delta(
@@ -1332,11 +1339,18 @@ impl BlockDeviceMetrics {
             write_count: incremental_delta(self.write_count, previous.write_count),
             read_agg: block_latency_delta(self.read_agg, previous.read_agg),
             write_agg: block_latency_delta(self.write_agg, previous.write_agg),
+            remaining_reqs_count: incremental_delta(
+                self.remaining_reqs_count,
+                previous.remaining_reqs_count,
+            ),
         }
     }
 
     pub const fn is_empty(self) -> bool {
         self.config_change_time_us.is_none()
+            && self.activate_fails == 0
+            && self.cfg_fails == 0
+            && self.no_avail_buffer == 0
             && self.event_fails == 0
             && self.execute_fails == 0
             && self.invalid_reqs_count == 0
@@ -1353,10 +1367,23 @@ impl BlockDeviceMetrics {
             && self.write_count == 0
             && self.read_agg.is_empty()
             && self.write_agg.is_empty()
+            && self.remaining_reqs_count == 0
     }
 
     pub const fn config_change_time_us(self) -> Option<u64> {
         self.config_change_time_us
+    }
+
+    pub const fn activate_fails(self) -> u64 {
+        self.activate_fails
+    }
+
+    pub const fn cfg_fails(self) -> u64 {
+        self.cfg_fails
+    }
+
+    pub const fn no_avail_buffer(self) -> u64 {
+        self.no_avail_buffer
     }
 
     pub const fn event_fails(self) -> u64 {
@@ -1421,6 +1448,25 @@ impl BlockDeviceMetrics {
 
     pub const fn write_agg(self) -> VirtioBlockLatencyAggregate {
         self.write_agg
+    }
+
+    pub const fn remaining_reqs_count(self) -> u64 {
+        self.remaining_reqs_count
+    }
+
+    pub const fn with_activate_fails(mut self, activate_fails: u64) -> Self {
+        self.activate_fails = activate_fails;
+        self
+    }
+
+    pub const fn with_cfg_fails(mut self, cfg_fails: u64) -> Self {
+        self.cfg_fails = cfg_fails;
+        self
+    }
+
+    pub const fn with_no_avail_buffer(mut self, no_avail_buffer: u64) -> Self {
+        self.no_avail_buffer = no_avail_buffer;
+        self
     }
 
     pub const fn with_event_fails(mut self, event_fails: u64) -> Self {
@@ -1514,12 +1560,20 @@ impl BlockDeviceMetrics {
         self
     }
 
+    pub const fn with_remaining_reqs_count(mut self, remaining_reqs_count: u64) -> Self {
+        self.remaining_reqs_count = remaining_reqs_count;
+        self
+    }
+
     const fn merged_with(self, other: Self) -> Self {
         Self {
             config_change_time_us: match other.config_change_time_us {
                 Some(value) => Some(value),
                 None => self.config_change_time_us,
             },
+            activate_fails: self.activate_fails.saturating_add(other.activate_fails),
+            cfg_fails: self.cfg_fails.saturating_add(other.cfg_fails),
+            no_avail_buffer: self.no_avail_buffer.saturating_add(other.no_avail_buffer),
             event_fails: self.event_fails.saturating_add(other.event_fails),
             execute_fails: self.execute_fails.saturating_add(other.execute_fails),
             invalid_reqs_count: self
@@ -1546,13 +1600,36 @@ impl BlockDeviceMetrics {
             write_count: self.write_count.saturating_add(other.write_count),
             read_agg: self.read_agg.merged_with(other.read_agg),
             write_agg: self.write_agg.merged_with(other.write_agg),
+            remaining_reqs_count: self
+                .remaining_reqs_count
+                .saturating_add(other.remaining_reqs_count),
         }
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default)]
 pub struct BlockDeviceMetricsByDrive {
-    metrics: BTreeMap<String, BlockDeviceMetrics>,
+    metrics: BTreeMap<String, BlockDeviceMetricsByDriveEntry>,
+}
+
+impl PartialEq for BlockDeviceMetricsByDrive {
+    fn eq(&self, other: &Self) -> bool {
+        self.metrics.len() == other.metrics.len()
+            && self.metrics.iter().all(|(drive_id, entry)| {
+                other
+                    .metrics
+                    .get(drive_id)
+                    .is_some_and(|other| entry.metrics == other.metrics)
+            })
+    }
+}
+
+impl Eq for BlockDeviceMetricsByDrive {}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct BlockDeviceMetricsByDriveEntry {
+    generation: u64,
+    metrics: BlockDeviceMetrics,
 }
 
 impl BlockDeviceMetricsByDrive {
@@ -1576,22 +1653,41 @@ impl BlockDeviceMetricsByDrive {
         drive_id: impl Into<String>,
         metrics: BlockDeviceMetrics,
     ) {
+        self.insert_drive_metrics_at_generation(drive_id, 0, metrics);
+    }
+
+    fn insert_drive_metrics_at_generation(
+        &mut self,
+        drive_id: impl Into<String>,
+        generation: u64,
+        metrics: BlockDeviceMetrics,
+    ) {
         self.metrics
             .entry(drive_id.into())
-            .and_modify(|existing| *existing = existing.merged_with(metrics))
-            .or_insert(metrics);
+            .and_modify(|existing| {
+                if existing.generation == generation {
+                    existing.metrics = existing.metrics.merged_with(metrics);
+                } else {
+                    *existing = BlockDeviceMetricsByDriveEntry {
+                        generation,
+                        metrics,
+                    };
+                }
+            })
+            .or_insert(BlockDeviceMetricsByDriveEntry {
+                generation,
+                metrics,
+            });
     }
 
     pub fn is_empty(&self) -> bool {
-        self.metrics
-            .values()
-            .all(|metrics| BlockDeviceMetrics::is_empty(*metrics))
+        self.metrics.values().all(|entry| entry.metrics.is_empty())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&str, BlockDeviceMetrics)> {
         self.metrics
             .iter()
-            .map(|(drive_id, metrics)| (drive_id.as_str(), *metrics))
+            .map(|(drive_id, entry)| (drive_id.as_str(), entry.metrics))
     }
 
     fn delta_since(&self, previous: Option<&Self>) -> Self {
@@ -1601,17 +1697,24 @@ impl BlockDeviceMetricsByDrive {
             .map(|(drive_id, current)| {
                 let previous = previous
                     .and_then(|metrics| metrics.metrics.get(drive_id))
-                    .copied()
+                    .filter(|previous| previous.generation == current.generation)
+                    .map(|previous| previous.metrics)
                     .unwrap_or_default();
-                (drive_id.clone(), current.delta_since(previous))
+                (
+                    drive_id.clone(),
+                    BlockDeviceMetricsByDriveEntry {
+                        generation: current.generation,
+                        metrics: current.metrics.delta_since(previous),
+                    },
+                )
             })
             .collect();
         Self { metrics }
     }
 
     fn merged_with(mut self, other: Self) -> Self {
-        for (drive_id, metrics) in other.metrics {
-            self.insert_drive_metrics(drive_id, metrics);
+        for (drive_id, entry) in other.metrics {
+            self.insert_drive_metrics_at_generation(drive_id, entry.generation, entry.metrics);
         }
         self
     }
@@ -1619,262 +1722,130 @@ impl BlockDeviceMetricsByDrive {
 
 #[derive(Debug, Clone, Default)]
 pub struct SharedBlockDeviceMetrics {
-    inner: Arc<SharedBlockDeviceMetricsInner>,
+    inner: Arc<Mutex<BlockDeviceMetrics>>,
 }
 
 impl SharedBlockDeviceMetrics {
+    pub fn record_observation(&self, observation: BlockDeviceMetrics) {
+        if observation.is_empty() {
+            return;
+        }
+        let mut metrics = lock_block_device_metrics(&self.inner);
+        *metrics = metrics.merged_with(observation);
+    }
+
+    pub fn shares_state_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
     pub fn record_notification_dispatch(&self, dispatch: &VirtioBlockDeviceNotificationDispatch) {
-        self.record_queue_events(usize_to_u64_saturating(
-            dispatch.drained_notifications().len(),
-        ));
+        self.record_queue_events(u64::from(!dispatch.drained_notifications().is_empty()));
         if let Some(queue_dispatch) = dispatch.queue_dispatch() {
             self.record_queue_dispatch(queue_dispatch);
         }
     }
 
     pub fn record_queue_dispatch(&self, dispatch: &VirtioBlockQueueDispatch) {
-        self.record_reads(
-            usize_to_u64_saturating(dispatch.read_count()),
-            dispatch.read_bytes(),
-        );
-        self.record_writes(
-            usize_to_u64_saturating(dispatch.write_count()),
-            dispatch.write_bytes(),
-        );
+        let mut observation = BlockDeviceMetrics::default()
+            .with_read_count(usize_to_u64_saturating(dispatch.read_count()))
+            .with_read_bytes(dispatch.read_bytes())
+            .with_write_count(usize_to_u64_saturating(dispatch.write_count()))
+            .with_write_bytes(dispatch.write_bytes())
+            .with_flush_count(usize_to_u64_saturating(dispatch.flush_count()))
+            .with_rate_limiter_throttled_events(usize_to_u64_saturating(
+                dispatch.rate_limiter_throttled_requests(),
+            ))
+            .with_io_engine_throttled_events(usize_to_u64_saturating(
+                dispatch.io_engine_throttled_events(),
+            ))
+            .with_no_avail_buffer(dispatch.no_avail_buffer())
+            .with_remaining_reqs_count(dispatch.remaining_reqs_count())
+            .with_execute_fails(usize_to_u64_saturating(dispatch.parse_failures()))
+            .with_invalid_reqs_count(usize_to_u64_saturating(
+                dispatch
+                    .io_errors()
+                    .saturating_add(dispatch.unsupported_requests()),
+            ));
         if let Some(read_agg) = dispatch.read_latency_aggregate() {
-            self.record_read_latency_aggregate(read_agg);
+            observation = observation.with_read_agg(read_agg);
         }
         if let Some(write_agg) = dispatch.write_latency_aggregate() {
-            self.record_write_latency_aggregate(write_agg);
+            observation = observation.with_write_agg(write_agg);
         }
-        self.record_flushes(usize_to_u64_saturating(dispatch.flush_count()));
-        self.record_rate_limiter_throttled_events(usize_to_u64_saturating(
-            dispatch.rate_limiter_throttled_requests(),
-        ));
-        self.record_io_engine_throttled_events(usize_to_u64_saturating(
-            dispatch.io_engine_throttled_events(),
-        ));
-        self.record_execute_failures(usize_to_u64_saturating(
-            dispatch
-                .parse_failures()
-                .saturating_add(dispatch.status_write_failures()),
-        ));
-        self.record_invalid_requests(usize_to_u64_saturating(
-            dispatch
-                .io_errors()
-                .saturating_add(dispatch.unsupported_requests()),
-        ));
+        self.record_observation(observation);
+    }
+
+    pub fn record_activation_failure(&self) {
+        self.record_observation(BlockDeviceMetrics::default().with_activate_fails(1));
+    }
+
+    pub fn record_config_failure(&self) {
+        self.record_observation(BlockDeviceMetrics::default().with_cfg_fails(1));
+    }
+
+    pub fn record_rate_limiter_event(&self) {
+        self.record_observation(BlockDeviceMetrics::default().with_rate_limiter_event_count(1));
     }
 
     pub fn record_queue_events(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.queue_event_count, count);
-        }
+        self.record_observation(BlockDeviceMetrics::default().with_queue_event_count(count));
     }
 
     pub fn record_event_failure(&self) {
-        record_atomic_metric(&self.inner.event_fails, 1);
+        self.record_observation(BlockDeviceMetrics::default().with_event_fails(1));
     }
 
     pub fn record_update(&self) {
-        record_atomic_metric(&self.inner.update_count, 1);
+        self.record_observation(BlockDeviceMetrics::default().with_update_count(1));
     }
 
     pub fn record_update_failure(&self) {
-        record_atomic_metric(&self.inner.update_fails, 1);
+        self.record_observation(BlockDeviceMetrics::default().with_update_fails(1));
     }
 
     pub fn record_config_change_time_us(&self, duration_us: u64) {
-        self.inner
-            .config_change_time_us
-            .store(duration_us, Ordering::Relaxed);
-        self.inner
-            .config_change_time_recorded
-            .store(true, Ordering::Release);
+        self.record_observation(
+            BlockDeviceMetrics::default().with_config_change_time_us(duration_us),
+        );
     }
 
     pub fn snapshot(&self) -> BlockDeviceMetrics {
-        BlockDeviceMetrics {
-            config_change_time_us: self
-                .inner
-                .config_change_time_recorded
-                .load(Ordering::Acquire)
-                .then(|| self.inner.config_change_time_us.load(Ordering::Relaxed)),
-            event_fails: self.inner.event_fails.load(Ordering::Relaxed),
-            execute_fails: self.inner.execute_fails.load(Ordering::Relaxed),
-            invalid_reqs_count: self.inner.invalid_reqs_count.load(Ordering::Relaxed),
-            flush_count: self.inner.flush_count.load(Ordering::Relaxed),
-            queue_event_count: self.inner.queue_event_count.load(Ordering::Relaxed),
-            rate_limiter_event_count: self.inner.rate_limiter_event_count.load(Ordering::Relaxed),
-            rate_limiter_throttled_events: self
-                .inner
-                .rate_limiter_throttled_events
-                .load(Ordering::Relaxed),
-            io_engine_throttled_events: self
-                .inner
-                .io_engine_throttled_events
-                .load(Ordering::Relaxed),
-            update_count: self.inner.update_count.load(Ordering::Relaxed),
-            update_fails: self.inner.update_fails.load(Ordering::Relaxed),
-            read_bytes: self.inner.read_bytes.load(Ordering::Relaxed),
-            write_bytes: self.inner.write_bytes.load(Ordering::Relaxed),
-            read_count: self.inner.read_count.load(Ordering::Relaxed),
-            write_count: self.inner.write_count.load(Ordering::Relaxed),
-            read_agg: self.read_latency_aggregate_snapshot(),
-            write_agg: self.write_latency_aggregate_snapshot(),
-        }
-    }
-
-    fn record_reads(&self, count: u64, bytes: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.read_count, count);
-        }
-        if bytes != 0 {
-            record_atomic_metric(&self.inner.read_bytes, bytes);
-        }
-    }
-
-    fn record_writes(&self, count: u64, bytes: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.write_count, count);
-        }
-        if bytes != 0 {
-            record_atomic_metric(&self.inner.write_bytes, bytes);
-        }
-    }
-
-    fn record_read_latency_aggregate(&self, latency_aggregate: VirtioBlockLatencyAggregate) {
-        record_latency_aggregate(
-            latency_aggregate,
-            &self.inner.read_agg_min_us,
-            &self.inner.read_agg_max_us,
-            &self.inner.read_agg_sum_us,
-            &self.inner.read_agg_sample_count,
-        );
-    }
-
-    fn record_write_latency_aggregate(&self, latency_aggregate: VirtioBlockLatencyAggregate) {
-        record_latency_aggregate(
-            latency_aggregate,
-            &self.inner.write_agg_min_us,
-            &self.inner.write_agg_max_us,
-            &self.inner.write_agg_sum_us,
-            &self.inner.write_agg_sample_count,
-        );
-    }
-
-    fn read_latency_aggregate_snapshot(&self) -> VirtioBlockLatencyAggregate {
-        latency_aggregate_snapshot(
-            &self.inner.read_agg_min_us,
-            &self.inner.read_agg_max_us,
-            &self.inner.read_agg_sum_us,
-            &self.inner.read_agg_sample_count,
-        )
-    }
-
-    fn write_latency_aggregate_snapshot(&self) -> VirtioBlockLatencyAggregate {
-        latency_aggregate_snapshot(
-            &self.inner.write_agg_min_us,
-            &self.inner.write_agg_max_us,
-            &self.inner.write_agg_sum_us,
-            &self.inner.write_agg_sample_count,
-        )
-    }
-
-    fn record_flushes(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.flush_count, count);
-        }
-    }
-
-    fn record_rate_limiter_throttled_events(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.rate_limiter_throttled_events, count);
-        }
-    }
-
-    fn record_io_engine_throttled_events(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.io_engine_throttled_events, count);
-        }
-    }
-
-    fn record_execute_failures(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.execute_fails, count);
-        }
-    }
-
-    fn record_invalid_requests(&self, count: u64) {
-        if count != 0 {
-            record_atomic_metric(&self.inner.invalid_reqs_count, count);
-        }
+        *lock_block_device_metrics(&self.inner)
     }
 }
 
-#[derive(Debug)]
-struct SharedBlockDeviceMetricsInner {
-    config_change_time_recorded: AtomicBool,
-    config_change_time_us: AtomicU64,
-    event_fails: AtomicU64,
-    execute_fails: AtomicU64,
-    invalid_reqs_count: AtomicU64,
-    flush_count: AtomicU64,
-    queue_event_count: AtomicU64,
-    rate_limiter_event_count: AtomicU64,
-    rate_limiter_throttled_events: AtomicU64,
-    io_engine_throttled_events: AtomicU64,
-    update_count: AtomicU64,
-    update_fails: AtomicU64,
-    read_bytes: AtomicU64,
-    write_bytes: AtomicU64,
-    read_count: AtomicU64,
-    write_count: AtomicU64,
-    read_agg_min_us: AtomicU64,
-    read_agg_max_us: AtomicU64,
-    read_agg_sum_us: AtomicU64,
-    read_agg_sample_count: AtomicU64,
-    write_agg_min_us: AtomicU64,
-    write_agg_max_us: AtomicU64,
-    write_agg_sum_us: AtomicU64,
-    write_agg_sample_count: AtomicU64,
-}
-
-impl Default for SharedBlockDeviceMetricsInner {
-    fn default() -> Self {
-        Self {
-            config_change_time_recorded: AtomicBool::new(false),
-            config_change_time_us: AtomicU64::new(0),
-            event_fails: AtomicU64::new(0),
-            execute_fails: AtomicU64::new(0),
-            invalid_reqs_count: AtomicU64::new(0),
-            flush_count: AtomicU64::new(0),
-            queue_event_count: AtomicU64::new(0),
-            rate_limiter_event_count: AtomicU64::new(0),
-            rate_limiter_throttled_events: AtomicU64::new(0),
-            io_engine_throttled_events: AtomicU64::new(0),
-            update_count: AtomicU64::new(0),
-            update_fails: AtomicU64::new(0),
-            read_bytes: AtomicU64::new(0),
-            write_bytes: AtomicU64::new(0),
-            read_count: AtomicU64::new(0),
-            write_count: AtomicU64::new(0),
-            read_agg_min_us: AtomicU64::new(u64::MAX),
-            read_agg_max_us: AtomicU64::new(0),
-            read_agg_sum_us: AtomicU64::new(0),
-            read_agg_sample_count: AtomicU64::new(0),
-            write_agg_min_us: AtomicU64::new(u64::MAX),
-            write_agg_max_us: AtomicU64::new(0),
-            write_agg_sum_us: AtomicU64::new(0),
-            write_agg_sample_count: AtomicU64::new(0),
-        }
+fn lock_block_device_metrics(
+    metrics: &Mutex<BlockDeviceMetrics>,
+) -> MutexGuard<'_, BlockDeviceMetrics> {
+    match metrics.lock() {
+        Ok(metrics) => metrics,
+        Err(poisoned) => poisoned.into_inner(),
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct SharedBlockDeviceMetricsRegistry {
-    aggregate: SharedBlockDeviceMetrics,
     per_drive: Arc<Mutex<BlockDeviceMetricsRegistryState>>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BlockDeviceMetricsCapture {
+    aggregate: BlockDeviceMetrics,
+    per_drive: BlockDeviceMetricsByDrive,
+}
+
+impl BlockDeviceMetricsCapture {
+    pub const fn aggregate(&self) -> BlockDeviceMetrics {
+        self.aggregate
+    }
+
+    pub const fn per_drive(&self) -> &BlockDeviceMetricsByDrive {
+        &self.per_drive
+    }
+
+    pub fn into_parts(self) -> (BlockDeviceMetrics, BlockDeviceMetricsByDrive) {
+        (self.aggregate, self.per_drive)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -1937,6 +1908,10 @@ impl fmt::Debug for PreparedBlockDeviceMetrics {
 }
 
 impl PreparedBlockDeviceMetrics {
+    pub fn metrics(&self) -> SharedBlockDeviceMetrics {
+        self.metrics.clone()
+    }
+
     pub fn publish(mut self) -> BlockDeviceMetricsLease {
         let mut state = lock_block_metrics_registry(&self.registry.per_drive);
         let reservation_count = state.reservations.len();
@@ -2033,7 +2008,6 @@ impl std::error::Error for BlockDeviceMetricsRegistryError {}
 impl Default for SharedBlockDeviceMetricsRegistry {
     fn default() -> Self {
         Self {
-            aggregate: SharedBlockDeviceMetrics::default(),
             per_drive: Arc::new(Mutex::new(BlockDeviceMetricsRegistryState::default())),
         }
     }
@@ -2060,7 +2034,6 @@ impl SharedBlockDeviceMetricsRegistry {
         let next_generation = u64::try_from(entries.len()).unwrap_or(u64::MAX);
 
         Self {
-            aggregate: SharedBlockDeviceMetrics::default(),
             per_drive: Arc::new(Mutex::new(BlockDeviceMetricsRegistryState {
                 capacity: entries.len(),
                 entries,
@@ -2104,7 +2077,6 @@ impl SharedBlockDeviceMetricsRegistry {
         let next_generation = u64::try_from(entries.len())
             .map_err(|_| BlockDeviceMetricsRegistryError::GenerationExhausted)?;
         Ok(Self {
-            aggregate: SharedBlockDeviceMetrics::default(),
             per_drive: Arc::new(Mutex::new(BlockDeviceMetricsRegistryState {
                 entries,
                 reservations,
@@ -2153,7 +2125,6 @@ impl SharedBlockDeviceMetricsRegistry {
         let next_generation = u64::try_from(entries.len())
             .map_err(|_| BlockDeviceMetricsRegistryError::GenerationExhausted)?;
         Ok(Self {
-            aggregate: SharedBlockDeviceMetrics::default(),
             per_drive: Arc::new(Mutex::new(BlockDeviceMetricsRegistryState {
                 entries,
                 reservations,
@@ -2269,10 +2240,6 @@ impl SharedBlockDeviceMetricsRegistry {
         })
     }
 
-    pub fn aggregate(&self) -> SharedBlockDeviceMetrics {
-        self.aggregate.clone()
-    }
-
     pub fn per_drive(&self, drive_id: &str) -> Option<SharedBlockDeviceMetrics> {
         lock_block_metrics_registry(&self.per_drive)
             .entries
@@ -2285,7 +2252,6 @@ impl SharedBlockDeviceMetricsRegistry {
         drive_id: &str,
         dispatch: &VirtioBlockDeviceNotificationDispatch,
     ) {
-        self.aggregate.record_notification_dispatch(dispatch);
         if let Some(metrics) = self.per_drive(drive_id) {
             metrics.record_notification_dispatch(dispatch);
         }
@@ -2296,64 +2262,87 @@ impl SharedBlockDeviceMetricsRegistry {
         drive_id: &str,
         dispatch: &VirtioBlockQueueDispatch,
     ) {
-        self.aggregate.record_queue_dispatch(dispatch);
         if let Some(metrics) = self.per_drive(drive_id) {
             metrics.record_queue_dispatch(dispatch);
         }
     }
 
     pub fn record_queue_events_for_drive(&self, drive_id: &str, count: u64) {
-        self.aggregate.record_queue_events(count);
         if let Some(metrics) = self.per_drive(drive_id) {
             metrics.record_queue_events(count);
         }
     }
 
+    /// Records an unattributed transport failure against every live drive.
+    ///
+    /// Callers that retain exact dispatch identity should use
+    /// [`Self::record_event_failure_for_drive`] instead.
     pub fn record_event_failure(&self) {
-        self.aggregate.record_event_failure();
+        let metrics = lock_block_metrics_registry(&self.per_drive)
+            .entries
+            .iter()
+            .map(|entry| entry.metrics.clone())
+            .collect::<Vec<_>>();
+        for metrics in metrics {
+            metrics.record_event_failure();
+        }
     }
 
     pub fn record_event_failure_for_drive(&self, drive_id: &str) {
-        self.aggregate.record_event_failure();
         if let Some(metrics) = self.per_drive(drive_id) {
             metrics.record_event_failure();
         }
     }
 
     pub fn record_update_for_drive(&self, drive_id: &str) {
-        self.aggregate.record_update();
         if let Some(metrics) = self.per_drive(drive_id) {
             metrics.record_update();
         }
     }
 
     pub fn record_update_failure_for_drive(&self, drive_id: &str) {
-        self.aggregate.record_update_failure();
         if let Some(metrics) = self.per_drive(drive_id) {
             metrics.record_update_failure();
         }
     }
 
     pub fn record_config_change_time_for_drive(&self, drive_id: &str, duration_us: u64) {
-        self.aggregate.record_config_change_time_us(duration_us);
         if let Some(metrics) = self.per_drive(drive_id) {
             metrics.record_config_change_time_us(duration_us);
         }
     }
 
+    pub fn record_observation_for_drive(&self, drive_id: &str, observation: BlockDeviceMetrics) {
+        if let Some(metrics) = self.per_drive(drive_id) {
+            metrics.record_observation(observation);
+        }
+    }
+
+    pub fn capture(&self) -> BlockDeviceMetricsCapture {
+        let state = lock_block_metrics_registry(&self.per_drive);
+        let mut aggregate = BlockDeviceMetrics::default();
+        let mut per_drive = BlockDeviceMetricsByDrive::new();
+        for entry in &state.entries {
+            let metrics = entry.metrics.snapshot();
+            aggregate = aggregate.merged_with(metrics);
+            per_drive.insert_drive_metrics_at_generation(
+                entry.drive_id.clone(),
+                entry.generation,
+                metrics,
+            );
+        }
+        BlockDeviceMetricsCapture {
+            aggregate,
+            per_drive,
+        }
+    }
+
     pub fn aggregate_snapshot(&self) -> BlockDeviceMetrics {
-        self.aggregate.snapshot()
+        self.capture().aggregate
     }
 
     pub fn per_drive_snapshot(&self) -> BlockDeviceMetricsByDrive {
-        let mut snapshot = BlockDeviceMetricsByDrive::new();
-        for entry in &lock_block_metrics_registry(&self.per_drive).entries {
-            let metrics = entry.metrics.snapshot();
-            if !metrics.is_empty() {
-                snapshot.insert_drive_metrics(entry.drive_id.clone(), metrics);
-            }
-        }
-        snapshot
+        self.capture().per_drive
     }
 }
 
@@ -6522,42 +6511,6 @@ fn snapshot_network_latency(
     }
 }
 
-fn record_latency_aggregate(
-    latency_aggregate: VirtioBlockLatencyAggregate,
-    min_us: &AtomicU64,
-    max_us: &AtomicU64,
-    sum_us: &AtomicU64,
-    sample_count: &AtomicU64,
-) {
-    if latency_aggregate.is_empty() {
-        return;
-    }
-
-    record_atomic_min_metric(min_us, latency_aggregate.min_us());
-    record_atomic_max_metric(max_us, latency_aggregate.max_us());
-    record_atomic_metric(sum_us, latency_aggregate.sum_us());
-    record_atomic_metric_release(sample_count, latency_aggregate.sample_count());
-}
-
-fn latency_aggregate_snapshot(
-    min_us: &AtomicU64,
-    max_us: &AtomicU64,
-    sum_us: &AtomicU64,
-    sample_count: &AtomicU64,
-) -> VirtioBlockLatencyAggregate {
-    let sample_count = sample_count.load(Ordering::Acquire);
-    if sample_count == 0 {
-        return VirtioBlockLatencyAggregate::default();
-    }
-
-    VirtioBlockLatencyAggregate::new(
-        min_us.load(Ordering::Relaxed),
-        max_us.load(Ordering::Relaxed),
-        sum_us.load(Ordering::Relaxed),
-        sample_count,
-    )
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MetricsDiagnostics {
     block_device_metrics: Option<BlockDeviceMetrics>,
@@ -7384,6 +7337,9 @@ mod tests {
 
     fn block_metrics_with_all_fields() -> BlockDeviceMetrics {
         BlockDeviceMetrics::default()
+            .with_activate_fails(15)
+            .with_cfg_fails(16)
+            .with_no_avail_buffer(17)
             .with_event_fails(1)
             .with_execute_fails(2)
             .with_invalid_reqs_count(3)
@@ -7400,6 +7356,7 @@ mod tests {
             .with_write_count(9)
             .with_read_agg(VirtioBlockLatencyAggregate::new(12, 30, 42, 2))
             .with_write_agg(VirtioBlockLatencyAggregate::new(13, 31, 44, 3))
+            .with_remaining_reqs_count(18)
     }
 
     fn pmem_metrics_with_all_fields() -> PmemDeviceMetrics {
@@ -8757,12 +8714,56 @@ mod tests {
         );
 
         let value = only_metrics_value(&output);
-        assert_eq!(value["block"]["event_fails"], 1);
-        assert_eq!(value["block"]["read_agg"]["min_us"], 0);
-        assert_eq!(value["block"]["read_agg"]["max_us"], 0);
-        assert_eq!(value["block"]["read_agg"]["sum_us"], 42);
-        assert_eq!(value["block_rootfs"]["read_agg"]["min_us"], 12);
-        assert_eq!(value["block_rootfs"]["read_agg"]["max_us"], 30);
+        assert_eq!(
+            value["block"],
+            serde_json::json!({
+                "activate_fails": 15,
+                "cfg_fails": 16,
+                "no_avail_buffer": 17,
+                "event_fails": 1,
+                "execute_fails": 2,
+                "invalid_reqs_count": 3,
+                "flush_count": 4,
+                "queue_event_count": 5,
+                "rate_limiter_event_count": 12,
+                "update_count": 10,
+                "update_fails": 11,
+                "read_bytes": 6,
+                "write_bytes": 7,
+                "read_count": 8,
+                "write_count": 9,
+                "read_agg": {"min_us": 0, "max_us": 0, "sum_us": 42},
+                "write_agg": {"min_us": 0, "max_us": 0, "sum_us": 44},
+                "rate_limiter_throttled_events": 13,
+                "io_engine_throttled_events": 14,
+                "remaining_reqs_count": 18,
+            })
+        );
+        assert_eq!(
+            value["block_rootfs"],
+            serde_json::json!({
+                "activate_fails": 15,
+                "cfg_fails": 16,
+                "no_avail_buffer": 17,
+                "event_fails": 1,
+                "execute_fails": 2,
+                "invalid_reqs_count": 3,
+                "flush_count": 4,
+                "queue_event_count": 5,
+                "rate_limiter_event_count": 12,
+                "update_count": 10,
+                "update_fails": 11,
+                "read_bytes": 6,
+                "write_bytes": 7,
+                "read_count": 8,
+                "write_count": 9,
+                "read_agg": {"min_us": 12, "max_us": 30, "sum_us": 42},
+                "write_agg": {"min_us": 13, "max_us": 31, "sum_us": 44},
+                "rate_limiter_throttled_events": 13,
+                "io_engine_throttled_events": 14,
+                "remaining_reqs_count": 18,
+            })
+        );
     }
 
     #[test]
@@ -8882,8 +8883,8 @@ mod tests {
         );
         assert_eq!(
             registry.aggregate_snapshot().config_change_time_us(),
-            Some(37),
-            "aggregate latest-value store should retain the VM-wide last success"
+            None,
+            "the aggregate is derived from the currently published generation"
         );
         drop(replacement_generation);
     }
@@ -8906,6 +8907,34 @@ mod tests {
     }
 
     #[test]
+    fn block_compound_observation_is_never_torn_by_a_racing_snapshot() {
+        let metrics = SharedBlockDeviceMetrics::default();
+        let observation = BlockDeviceMetrics::default()
+            .with_queue_event_count(1)
+            .with_read_bytes(512)
+            .with_read_count(1)
+            .with_read_agg(VirtioBlockLatencyAggregate::new(7, 7, 7, 1))
+            .with_remaining_reqs_count(2);
+        let start = Arc::new(Barrier::new(2));
+        let writer_metrics = metrics.clone();
+        let writer_start = Arc::clone(&start);
+        let writer = thread::spawn(move || {
+            writer_start.wait();
+            writer_metrics.record_observation(observation);
+        });
+
+        start.wait();
+        let racing_cut = metrics.snapshot();
+        writer.join().expect("block metrics writer should finish");
+
+        assert!(
+            racing_cut == BlockDeviceMetrics::default() || racing_cut == observation,
+            "one coherent observation must be entirely before or after a snapshot cut"
+        );
+        assert_eq!(metrics.snapshot(), observation);
+    }
+
+    #[test]
     fn shared_block_device_metrics_registry_snapshot_is_per_instance() {
         let first = SharedBlockDeviceMetricsRegistry::from_drive_ids(["rootfs", "data"]);
         let second = SharedBlockDeviceMetricsRegistry::from_drive_ids(["rootfs"]);
@@ -8915,12 +8944,12 @@ mod tests {
         first.record_update_for_drive("rootfs");
         first.record_update_failure_for_drive("data");
         first
-            .aggregate()
-            .record_read_latency_aggregate(VirtioBlockLatencyAggregate::new(0, 10, 10, 2));
-        first
             .per_drive("rootfs")
             .expect("rootfs metrics should exist")
-            .record_read_latency_aggregate(VirtioBlockLatencyAggregate::new(0, 10, 10, 2));
+            .record_observation(
+                BlockDeviceMetrics::default()
+                    .with_read_agg(VirtioBlockLatencyAggregate::new(0, 10, 10, 2)),
+            );
 
         assert_eq!(
             first.aggregate_snapshot(),
@@ -8946,6 +8975,65 @@ mod tests {
         );
         assert_eq!(second.aggregate_snapshot(), BlockDeviceMetrics::default());
         assert!(second.per_drive_snapshot().is_empty());
+    }
+
+    #[test]
+    fn block_metrics_capture_is_coherent_and_same_id_delta_is_generation_aware() {
+        let registry =
+            SharedBlockDeviceMetricsRegistry::from_drive_ids_with_capacity(["rootfs", "data"], 2)
+                .expect("bounded block metrics registry should allocate");
+        registry.record_observation_for_drive(
+            "rootfs",
+            BlockDeviceMetrics::default()
+                .with_queue_event_count(5)
+                .with_read_bytes(512),
+        );
+        registry.record_observation_for_drive(
+            "data",
+            BlockDeviceMetrics::default()
+                .with_queue_event_count(2)
+                .with_write_bytes(256),
+        );
+
+        let original = registry.capture();
+        let merged_per_drive = original
+            .per_drive()
+            .iter()
+            .fold(BlockDeviceMetrics::default(), |aggregate, (_, metrics)| {
+                aggregate.merged_with(metrics)
+            });
+        assert_eq!(original.aggregate(), merged_per_drive);
+
+        let old_data = registry
+            .claim_drive_lease("data")
+            .expect("old data generation should be claimable");
+        drop(old_data);
+        let replacement = registry
+            .prepare_drive("data")
+            .expect("same ID should receive a fresh generation");
+        replacement
+            .metrics()
+            .record_observation(BlockDeviceMetrics::default().with_queue_event_count(1));
+        let replacement = replacement.publish();
+
+        let current = registry.capture();
+        let delta = current.per_drive().delta_since(Some(original.per_drive()));
+        assert_eq!(
+            delta,
+            BlockDeviceMetricsByDrive::new()
+                .with_drive_metrics("rootfs", BlockDeviceMetrics::default())
+                .with_drive_metrics(
+                    "data",
+                    BlockDeviceMetrics::default().with_queue_event_count(1),
+                )
+        );
+        assert_eq!(
+            current.aggregate(),
+            BlockDeviceMetrics::default()
+                .with_queue_event_count(6)
+                .with_read_bytes(512)
+        );
+        drop(replacement);
     }
 
     #[test]
@@ -9044,9 +9132,7 @@ mod tests {
     fn block_metric_increment_saturates() {
         let metrics = SharedBlockDeviceMetrics::default();
         metrics
-            .inner
-            .queue_event_count
-            .store(u64::MAX - 1, Ordering::Relaxed);
+            .record_observation(BlockDeviceMetrics::default().with_queue_event_count(u64::MAX - 1));
 
         metrics.record_queue_events(3);
 
@@ -9057,11 +9143,8 @@ mod tests {
     fn block_latency_metric_preserves_saturated_minimum() {
         let metrics = SharedBlockDeviceMetrics::default();
 
-        metrics.record_read_latency_aggregate(VirtioBlockLatencyAggregate::new(
-            u64::MAX,
-            u64::MAX,
-            u64::MAX,
-            1,
+        metrics.record_observation(BlockDeviceMetrics::default().with_read_agg(
+            VirtioBlockLatencyAggregate::new(u64::MAX, u64::MAX, u64::MAX, 1),
         ));
 
         assert_eq!(
@@ -9082,6 +9165,9 @@ mod tests {
     fn block_diagnostics_merge_saturates() {
         let base = MetricsDiagnostics::new().with_block_device_metrics(
             BlockDeviceMetrics::default()
+                .with_activate_fails(u64::MAX - 15)
+                .with_cfg_fails(u64::MAX - 16)
+                .with_no_avail_buffer(u64::MAX - 17)
                 .with_event_fails(u64::MAX - 1)
                 .with_execute_fails(u64::MAX - 2)
                 .with_invalid_reqs_count(u64::MAX - 3)
@@ -9097,7 +9183,8 @@ mod tests {
                 .with_read_count(u64::MAX - 8)
                 .with_write_count(u64::MAX - 9)
                 .with_read_agg(VirtioBlockLatencyAggregate::new(20, 24, u64::MAX - 1, 2))
-                .with_write_agg(VirtioBlockLatencyAggregate::new(14, 20, u64::MAX - 2, 1)),
+                .with_write_agg(VirtioBlockLatencyAggregate::new(14, 20, u64::MAX - 2, 1))
+                .with_remaining_reqs_count(u64::MAX - 18),
         );
         let additional =
             MetricsDiagnostics::new().with_block_device_metrics(block_metrics_with_all_fields());
@@ -9106,6 +9193,9 @@ mod tests {
             base.merged_with(additional).block_device_metrics(),
             Some(
                 BlockDeviceMetrics::default()
+                    .with_activate_fails(u64::MAX)
+                    .with_cfg_fails(u64::MAX)
+                    .with_no_avail_buffer(u64::MAX)
                     .with_event_fails(u64::MAX)
                     .with_execute_fails(u64::MAX)
                     .with_invalid_reqs_count(u64::MAX)
@@ -9122,6 +9212,7 @@ mod tests {
                     .with_write_count(u64::MAX)
                     .with_read_agg(VirtioBlockLatencyAggregate::new(12, 30, u64::MAX, 4))
                     .with_write_agg(VirtioBlockLatencyAggregate::new(13, 31, u64::MAX, 4))
+                    .with_remaining_reqs_count(u64::MAX)
             )
         );
     }
@@ -9146,6 +9237,9 @@ mod tests {
             .with_drive_metrics(
                 "rootfs",
                 BlockDeviceMetrics::default()
+                    .with_activate_fails(15)
+                    .with_cfg_fails(16)
+                    .with_no_avail_buffer(17)
                     .with_event_fails(u64::MAX)
                     .with_execute_fails(2)
                     .with_invalid_reqs_count(3)
@@ -9161,7 +9255,8 @@ mod tests {
                     .with_read_count(u64::MAX)
                     .with_write_count(9)
                     .with_read_agg(VirtioBlockLatencyAggregate::new(12, 30, u64::MAX, 3))
-                    .with_write_agg(VirtioBlockLatencyAggregate::new(13, 31, 44, 3)),
+                    .with_write_agg(VirtioBlockLatencyAggregate::new(13, 31, 44, 3))
+                    .with_remaining_reqs_count(18),
             )
             .with_drive_metrics("data", BlockDeviceMetrics::default().with_write_count(3));
         let merged = base.merged_with(additional);

--- a/crates/runtime/src/metrics/firecracker.rs
+++ b/crates/runtime/src/metrics/firecracker.rs
@@ -712,7 +712,7 @@ pub(super) fn build_metrics_line(
             .block_device_metrics_by_drive
             .as_ref()
             .and_then(|metrics| metrics.metrics.get(drive_id))
-            .copied()
+            .map(|entry| entry.metrics)
             .unwrap_or_default();
         let values = map_block_metrics(metrics);
         add_block_metrics(&mut block, &values);
@@ -753,7 +753,7 @@ pub(super) fn build_metrics_line(
             .block_device_metrics_by_drive
             .as_ref()
             .and_then(|metrics| metrics.metrics.get(drive_id))
-            .copied()
+            .map(|entry| entry.metrics)
             .unwrap_or_default();
         vhost_user_block_devices.push(DynamicMetrics {
             root: try_dynamic_root("vhost_user_block_", drive_id)?,
@@ -1030,6 +1030,9 @@ fn try_dynamic_root(prefix: &str, id: &str) -> Result<String, MetricsLineBuildEr
 
 fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {
     BlockMetrics {
+        activate_fails: metrics.activate_fails,
+        cfg_fails: metrics.cfg_fails,
+        no_avail_buffer: metrics.no_avail_buffer,
         event_fails: metrics.event_fails,
         execute_fails: metrics.execute_fails,
         invalid_reqs_count: metrics.invalid_reqs_count,
@@ -1054,7 +1057,7 @@ fn map_block_metrics(metrics: super::BlockDeviceMetrics) -> BlockMetrics {
         },
         rate_limiter_throttled_events: metrics.rate_limiter_throttled_events,
         io_engine_throttled_events: metrics.io_engine_throttled_events,
-        ..BlockMetrics::default()
+        remaining_reqs_count: metrics.remaining_reqs_count,
     }
 }
 

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -17,6 +17,7 @@ use crate::block::{
 use crate::interrupt::{DeviceInterruptKind, DeviceInterruptStatus, GuestInterruptLine};
 use crate::memory::{GuestAddress, GuestMemory, GuestMemoryRange};
 use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::metrics::SharedBlockDeviceMetrics;
 use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::{
     PCI_BAR64_SIZE, PCI_BAR64_START, PCI_BUS_ZERO, PCI_FIRST_ENDPOINT_DEVICE, PCI_FUNCTION_ZERO,
@@ -1333,8 +1334,8 @@ pub struct PreparedSnapshotV2RootBlock {
 
 impl PreparedSnapshotV2RootBlock {
     /// Returns the canonical block configuration space.
-    pub const fn config_space(&self) -> VirtioBlockConfigSpace {
-        self.config_space
+    pub fn config_space(&self) -> VirtioBlockConfigSpace {
+        self.config_space.clone()
     }
 
     /// Returns the prepared pathless block device.
@@ -1545,6 +1546,15 @@ pub struct PreparedSnapshotV2PciRoot {
 }
 
 impl PreparedSnapshotV2PciRoot {
+    /// Attaches a fresh destination-local ordinary block metrics owner.
+    pub fn attach_metrics(&mut self, metrics: SharedBlockDeviceMetrics) -> bool {
+        if !self.device.attach_metrics(metrics.clone()) {
+            return false;
+        }
+        self.config_space.attach_metrics(metrics);
+        true
+    }
+
     /// Returns the stable drive identifier.
     pub fn drive_id(&self) -> &str {
         &self.drive_id

--- a/crates/runtime/src/snapshot_device_v2/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2/tests.rs
@@ -1506,6 +1506,7 @@ fn capture_ready_mmio(path: &Path) -> CaptureReadyBlockDeviceState {
     let prepared = PreparedBlockDevice::from_config_with_backing(&config, None)
         .expect("test block device should prepare");
     let (_, _, config_space, device) = prepared.into_parts();
+    let available_features = config_space.available_features();
     let mut handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
         VIRTIO_BLOCK_DEVICE_ID,
         config_space.available_features(),
@@ -1514,7 +1515,7 @@ fn capture_ready_mmio(path: &Path) -> CaptureReadyBlockDeviceState {
         device,
     )
     .expect("test MMIO block handler should build");
-    activate_mmio_block(&mut handler, config_space.available_features());
+    activate_mmio_block(&mut handler, available_features);
     let device = handler
         .capture_block_device_state_at(&config, Instant::now())
         .expect("test MMIO block state should capture");
@@ -1698,6 +1699,7 @@ impl PciRuntimeFixture {
         let prepared = PreparedBlockDevice::from_config_with_backing(&config, None)
             .expect("test block device should prepare");
         let (_, _, config_space, device) = prepared.into_parts();
+        let available_features = config_space.available_features();
         let capacity = GuestMemoryRange::new(
             GuestAddress::new(PCI_BAR64_START),
             VIRTIO_PCI_CAPABILITY_BAR_SIZE * 2,
@@ -1729,7 +1731,7 @@ impl PciRuntimeFixture {
             registry,
         )
         .expect("test PCI block endpoint should build");
-        activate_pci_block(&endpoint, &bar, config_space.available_features());
+        activate_pci_block(&endpoint, &bar, available_features);
         Self {
             config,
             endpoint,
@@ -1899,7 +1901,7 @@ fn runtime_conversion_rejects_configuration_limiter_retry_and_mmio_policy_mismat
             config,
             state.transport().clone(),
             state.retry(),
-            *state.device(),
+            state.device().clone(),
         );
         assert_eq!(
             SnapshotV2DeviceGraph::from_capture_ready_root(
@@ -1914,7 +1916,7 @@ fn runtime_conversion_rejects_configuration_limiter_retry_and_mmio_policy_mismat
         state.config().clone(),
         state.transport().clone(),
         StorageRetryState::Immediate,
-        *state.device(),
+        state.device().clone(),
     );
     assert_eq!(
         SnapshotV2DeviceGraph::from_capture_ready_root(
@@ -1945,7 +1947,7 @@ fn runtime_conversion_rejects_configuration_limiter_retry_and_mmio_policy_mismat
             false_policy,
         )),
         state.retry(),
-        *state.device(),
+        state.device().clone(),
     );
     assert_eq!(
         SnapshotV2DeviceGraph::from_capture_ready_root(
@@ -2144,7 +2146,7 @@ fn runtime_conversion_rejects_noncanonical_pci_origin_identity_and_bar() {
             state.config().clone(),
             StorageTransportState::Pci(transport),
             state.retry(),
-            *state.device(),
+            state.device().clone(),
         );
         assert_eq!(
             SnapshotV2DeviceGraph::from_capture_ready_root(

--- a/crates/runtime/src/snapshot_device_v2_5/capture.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/capture.rs
@@ -244,7 +244,7 @@ fn capture_multi_block_state(
     state: &CaptureReadyBlockDeviceState,
     config: &SnapshotV2MultiBlockConfig,
 ) -> Result<SnapshotV2MultiBlockState, SnapshotV2MultiBlockDeviceGraphCaptureError> {
-    let device = *state.device();
+    let device = state.device().clone();
     let backing = device.backing();
     let expected_config_space =
         VirtioBlockConfigSpace::new(backing.len(), config.is_read_only, config.cache_type);

--- a/crates/runtime/src/snapshot_device_v2_5/restore.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/restore.rs
@@ -18,6 +18,7 @@ use crate::block::{
 use crate::interrupt::GuestInterruptLine;
 use crate::memory::{GuestMemory, GuestMemoryRange};
 use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::metrics::SharedBlockDeviceMetrics;
 use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::PciSbdf;
 use crate::snapshot_device_v2::{
@@ -231,7 +232,7 @@ impl SnapshotV2MultiBlockRestorePlan {
         }
 
         for (record, backing) in self.records.iter().zip(&backings) {
-            PreparedBlockDevice::validate_snapshot_backing(backing, record.config_space)
+            PreparedBlockDevice::validate_snapshot_backing(backing, record.config_space.clone())
                 .map_err(SnapshotV2MultiBlockBundleError::Backing)?;
         }
 
@@ -410,7 +411,7 @@ impl PreparedSnapshotV2MultiBlockRecord {
         self.device.is_root_device()
     }
 
-    pub const fn config_space(&self) -> VirtioBlockConfigSpace {
+    pub fn config_space(&self) -> VirtioBlockConfigSpace {
         self.device.config_space()
     }
 
@@ -618,6 +619,15 @@ pub struct PreparedSnapshotV2MultiBlockPciRecord {
 }
 
 impl PreparedSnapshotV2MultiBlockPciRecord {
+    /// Attaches a fresh destination-local ordinary block metrics owner.
+    pub fn attach_metrics(&mut self, metrics: SharedBlockDeviceMetrics) -> bool {
+        if !self.device.attach_metrics(metrics.clone()) {
+            return false;
+        }
+        self.config_space.attach_metrics(metrics);
+        true
+    }
+
     pub const fn key(&self) -> SnapshotV2DeviceKey {
         self.key
     }
@@ -2618,7 +2628,7 @@ mod tests {
                     is_root: record.is_root,
                     io_engine: record.io_engine,
                     cache_type: record.cache_type,
-                    config_space: record.config_space,
+                    config_space: record.config_space.clone(),
                     device_id: record.device_id,
                     queue_ranges: record.queue_ranges,
                     active_queue: record.active_queue.clone(),

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -1751,7 +1751,7 @@ impl Arm64BootBlockNotificationDispatch {
 
 #[derive(Debug)]
 pub enum Arm64BootBlockNotificationOutcome {
-    Dispatched(VirtioBlockDeviceNotificationDispatch),
+    Dispatched(Box<VirtioBlockDeviceNotificationDispatch>),
     DispatchFailed(VirtioBlockDeviceNotificationError),
     HandlerLookupFailed(MmioHandlerLookupError),
 }
@@ -1777,9 +1777,9 @@ impl Arm64BootBlockNotificationOutcome {
         }
     }
 
-    pub const fn dispatched(&self) -> Option<&VirtioBlockDeviceNotificationDispatch> {
+    pub fn dispatched(&self) -> Option<&VirtioBlockDeviceNotificationDispatch> {
         match self {
-            Self::Dispatched(dispatch) => Some(dispatch),
+            Self::Dispatched(dispatch) => Some(dispatch.as_ref()),
             Self::DispatchFailed(_) | Self::HandlerLookupFailed(_) => None,
         }
     }
@@ -3671,7 +3671,9 @@ impl Arm64BootRuntimeResources {
             let region_id = device.registration.region_id();
             let outcome = match mmio_dispatcher.handler_mut::<VirtioBlockMmioHandler>(region_id) {
                 Ok(handler) => match handler.dispatch_block_queue_notifications(memory) {
-                    Ok(dispatch) => Arm64BootBlockNotificationOutcome::Dispatched(dispatch),
+                    Ok(dispatch) => {
+                        Arm64BootBlockNotificationOutcome::Dispatched(Box::new(dispatch))
+                    }
                     Err(source) => Arm64BootBlockNotificationOutcome::DispatchFailed(source),
                 },
                 Err(source) => Arm64BootBlockNotificationOutcome::HandlerLookupFailed(source),

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -695,20 +695,30 @@ fields, newer balloon API/device fields, extra UART fields, and the ordinary
 block configuration-change value remain internal or are discarded at the
 public boundary. Adding an extension requires a separately versioned schema.
 
-The checked device-producer audit now terminally certifies all 81 #1838–#1840
-fields: 80 entropy, pmem, RTC, UART, balloon, memory-hotplug, and vsock fields
-are implemented, while `uart.flush_count` is source-neutral zero because pinned
-Firecracker has no producer for it. Each device owner publishes an immutable
-compound counter snapshot. Entropy counts popped requests before parse or
-throttling; pmem binds configuration and activation failures to both the exact
-current generation and aggregate; RTC records missed counters only for
-invalid/read-only register accesses; UART limiter drops count an attempted
-write while FIFO clears and host-input/state failures stay internal. Balloon
-and memory-hotplug retain coherent operation tuples. Vsock binds configuration,
-device, MMIO/PCI, HVF readiness, and restored sessions to one fresh owner;
-records queue, packet, byte, connection, and I/O failure semantics at their
-source boundaries; and uses a stale-safe bounded deadline queue. Later
-#1841–#1846 records remain nonterminal and repository-final certification
+The checked device-producer audit now terminally certifies all 129 #1838–#1841
+fields: 128 entropy, pmem, RTC, UART, balloon, memory-hotplug, vsock, and
+ordinary-block fields are implemented, while `uart.flush_count` is
+source-neutral zero because pinned Firecracker has no producer for it. Each
+device owner publishes an immutable compound counter snapshot. Entropy counts
+popped requests before parse or throttling; pmem binds configuration and
+activation failures to both the exact current generation and aggregate; RTC
+records missed counters only for invalid/read-only register accesses; UART
+limiter drops count an attempted write while FIFO clears and host-input/state
+failures stay internal. Balloon and memory-hotplug retain coherent operation
+tuples. Vsock binds configuration, device, MMIO/PCI, HVF readiness, and
+restored sessions to one fresh owner; records queue, packet, byte, connection,
+and I/O failure semantics at their source boundaries; and uses a stale-safe
+bounded deadline queue.
+
+Every ordinary block drive likewise owns one fresh coherent generation shared
+by config and MMIO/PCI source paths. Queue admission, retained limiter retry,
+descriptor depth, empty-pass, partial I/O, successful flush, attempted I/O
+latency, runtime update, and exact interrupt-delivery facts are recorded once
+where they become final. One registry capture derives static `block` from the
+same configured values used for `block_{drive_id}`; same-ID replacement starts
+a fresh interval, restore does not inherit counters, static latency extrema
+remain zero, and vhost-user state cannot contaminate the ordinary family.
+Later #1842–#1846 records remain nonterminal and repository-final certification
 remains gated on their delivery.
 
 One flush first freezes missed-log, rate-limited-log, and SIGPIPE totals through

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1553,14 +1553,14 @@ cargo test -p bangbang-firecracker-capability-audit --test metrics_schema --lock
 
 The adjacent human-owned `metrics-device-producer-audit.json` maps all 231
 device-owned fields to closed operation boundaries and the nine concrete #1789
-children. After #1840 it contains 80 implemented
-entropy/pmem/RTC/UART/balloon/memory-hotplug/vsock fields, one source-neutral
-`uart.flush_count`, 135 planned fields, and 15
+children. After #1841 it contains 128 implemented
+entropy/pmem/RTC/UART/balloon/memory-hotplug/vsock/ordinary-block fields, one
+source-neutral `uart.flush_count`, 87 planned fields, and 15
 provisional-platform-zero fields. Only the latter two groups are nonterminal
 and evidence-free. The same focused test checks canonical bytes, exact
 membership and partition, completed-child regression, future-child premature
 promotion, the UART-flush disposition, suffix routing, provisional state,
-anchored-evidence rules, and final-mode rejection of the remaining 150 records.
+anchored-evidence rules, and final-mode rejection of the remaining 102 records.
 
 Focused #1838 producer coverage lives with the owning runtime modules. It
 checks entropy popped-descriptor accounting and owner attachment, exact pmem
@@ -1592,6 +1592,31 @@ owners. They require delivered RX/TX packets and bytes plus admitted TX queue
 work; a restored queue may consume guest-posted RX buffers without a fresh RX
 notification, so the focused source-admission tests—not an unconditional
 positive signed counter—pin `rx_queue_event_count`.
+
+Focused #1841 coverage pins all 24 ordinary block leaves under both static
+`block` and configured `block_{drive_id}`. Runtime tests cover invalid config
+access, failed activation, one event per nonempty notification call, one event
+per retained limiter retry, remaining queue depth after every pop, empty pass,
+limiter and async-pressure stops, parse/unsupported/I/O/status failures,
+full/partial reads and writes, flush-before-status behavior, attempted I/O
+latency, saturation, and a compound record racing a snapshot. Registry tests
+derive aggregate and per-drive values from one capture, retain empty live
+generations, and treat same-ID reuse as a fresh interval. HVF tests bind the
+same owner through normal boot, native-v1/native-v2 MMIO and PCI restore, and
+runtime publication; they also prove exact-drive interrupt-failure attribution
+without duplicate outer dispatch accounting.
+
+The signed direct and production snapshot workloads validate the exact 24-leaf
+shape for `primary`, `data`, and read-only `audit` drives under both MMIO and
+PCI. Every emitted static counter must equal the saturating sum of those three
+configured roots; static latency sums match dynamic sums while static min/max
+remain zero. Successful workloads require zero activation, configuration,
+event, parse, invalid-request, and update failures, positive queue/read
+activity, expected writable-drive writes and limiter throttling, no audit
+write, fresh destination counters, resumed destination I/O, repeated
+restore/recapture, App Sandbox containment, redaction, and cleanup. Focused
+collector tests separately prove immediate zero intervals and whole-line replay
+after failed or ambiguously accepted publication.
 
 The ordinary `compare` command rederives the source projection together with
 the general and logger manifests. To create a metrics source-only candidate:
@@ -1654,7 +1679,7 @@ logger and device-audit validation in delivery mode. It requires the two
 implemented process profiles and all 69 field records to remain terminal at
 exactly 64 implemented, one source-neutral, and four platform-zero. Ten planned
 and four platform-zero device profiles remain #1789-owned; within the 231-field
-device audit, #1838–#1840 contribute 81 terminal records and the other 150
+device audit, #1838–#1841 contribute 129 terminal records and the other 102
 remain nonterminal. The two aggregates remain #1790-owned.
 The composed test mutates both a field record and an aggregate process profile;
 the lower-level suite separately exercises every membership, ordering,

--- a/tools/firecracker-capability-audit/src/metrics_device_validate.rs
+++ b/tools/firecracker-capability-audit/src/metrics_device_validate.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 const EXPECTED_DEVICE_FIELDS: usize = 231;
-const COMPLETED_DELIVERY_ISSUES: &[&str] = &["#1838", "#1839", "#1840"];
+const COMPLETED_DELIVERY_ISSUES: &[&str] = &["#1838", "#1839", "#1840", "#1841"];
 
 /// Validate exact device-producer authority against the resolved metrics schema.
 pub fn validate_metrics_device_producers(

--- a/tools/firecracker-capability-audit/tests/metrics_schema.rs
+++ b/tools/firecracker-capability-audit/tests/metrics_schema.rs
@@ -236,7 +236,7 @@ fn checked_device_producer_audit_is_canonical_and_exact() {
             .iter()
             .filter(|record| record.disposition == MetricsDeviceProducerDisposition::Planned)
             .count(),
-        135
+        87
     );
     assert_eq!(
         audit
@@ -254,7 +254,7 @@ fn checked_device_producer_audit_is_canonical_and_exact() {
             .iter()
             .filter(|record| record.disposition == MetricsDeviceProducerDisposition::Implemented)
             .count(),
-        80
+        128
     );
     assert_eq!(
         audit
@@ -266,11 +266,12 @@ fn checked_device_producer_audit_is_canonical_and_exact() {
             .count(),
         1
     );
-    for record in audit
-        .records
-        .iter()
-        .filter(|record| matches!(record.delivery_issue.as_str(), "#1838" | "#1839" | "#1840"))
-    {
+    for record in audit.records.iter().filter(|record| {
+        matches!(
+            record.delivery_issue.as_str(),
+            "#1838" | "#1839" | "#1840" | "#1841"
+        )
+    }) {
         let expected = if record.field_id == "static:uart.flush_count" {
             MetricsDeviceProducerDisposition::SourceNeutral
         } else {
@@ -286,7 +287,10 @@ fn checked_device_producer_audit_is_canonical_and_exact() {
             .records
             .iter()
             .filter(|record| {
-                !matches!(record.delivery_issue.as_str(), "#1838" | "#1839" | "#1840")
+                !matches!(
+                    record.delivery_issue.as_str(),
+                    "#1838" | "#1839" | "#1840" | "#1841"
+                )
             })
             .all(|record| {
                 record.implementation.is_empty()
@@ -303,11 +307,12 @@ fn checked_device_producer_audit_is_canonical_and_exact() {
             .lines()
             .filter(|line| line.contains("final metrics device producer validation rejects"))
             .count(),
-        150
+        102
     );
 }
 
 // exact #1838 disposition mutation tests, extended through #1840
+// exact #1838 disposition mutation tests, extended through #1841
 #[test]
 fn device_producer_audit_rejects_completed_child_regression_and_future_promotion() {
     let mut implemented_regression = checked_device_audit();
@@ -315,10 +320,10 @@ fn device_producer_audit_rejects_completed_child_regression_and_future_promotion
         .records
         .iter_mut()
         .find(|record| {
-            record.delivery_issue == "#1840"
+            record.delivery_issue == "#1841"
                 && record.disposition == MetricsDeviceProducerDisposition::Implemented
         })
-        .expect("implemented #1840 record must exist")
+        .expect("implemented #1841 record must exist")
         .disposition = MetricsDeviceProducerDisposition::Planned;
     assert!(device_validation_error(&implemented_regression).contains("wrong current disposition"));
 
@@ -335,7 +340,7 @@ fn device_producer_audit_rejects_completed_child_regression_and_future_promotion
     let record = future_promotion
         .records
         .iter_mut()
-        .find(|record| record.delivery_issue == "#1841")
+        .find(|record| record.delivery_issue == "#1842")
         .expect("future child record must exist");
     record.disposition = MetricsDeviceProducerDisposition::Implemented;
     record.implementation.push(anchored_local_reference());
@@ -454,7 +459,11 @@ fn device_producer_audit_rejects_disposition_and_nonterminal_evidence_drift() {
     assert!(device_validation_error(&premature).contains("wrong current disposition"));
 
     let mut evidence = checked_device_audit();
-    evidence.records[0]
+    evidence
+        .records
+        .iter_mut()
+        .find(|record| record.disposition == MetricsDeviceProducerDisposition::Planned)
+        .expect("planned device record must exist")
         .implementation
         .push(anchored_local_reference());
     assert!(device_validation_error(&evidence).contains("must not claim terminal evidence"));


### PR DESCRIPTION
## Summary

- add coherent per-drive ordinary block metric owners and generation-aware interval capture
- record all 24 Firecracker block leaves at config, activation, queue, request, throttle, update, and interrupt source boundaries
- derive static `block` values from the same configured ordinary-drive cut, with exact MMIO/PCI boot, hotplug, and restore binding
- promote exactly the 48 #1841 producer-audit records and document focused and signed evidence

## Scope exclusions

- vhost-user block producers remain assigned to #1842
- network, MMDS, vCPU/interrupt, and platform-zero metric families are unchanged
- no HTTP API, guest virtio behavior, or snapshot wire-format changes

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo test -p bangbang-firecracker-capability-audit --test metrics_schema --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple Silicon signed-target Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` plus a clean `--test executable_hvf_e2e` rerun: all signed groups passed; the first non-PTY full run had one transient pre-pause guest exit in an existing cross-process snapshot test, which passed both exact and full 80-test reruns
- `git diff --check`

Closes #1841

Parent: #1789
