### PR TITLE
feat: add portable CPU template helper foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ name = "bangbang"
 version = "0.1.0"
 dependencies = [
  "bangbang-api",
+ "bangbang-cpu-template-helper",
  "bangbang-hvf",
  "bangbang-pager",
  "bangbang-runtime",
@@ -119,6 +120,17 @@ name = "bangbang-api"
 version = "0.1.0"
 dependencies = [
  "httparse",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bangbang-cpu-template-helper"
+version = "0.1.0"
+dependencies = [
+ "bangbang-api",
+ "bangbang-runtime",
+ "rustix",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/session",
     "crates/vhost-user",
     "crates/bangbang",
+    "tools/cpu-template-helper",
     "tools/firecracker-capability-audit",
     "tools/seccompiler",
     "tools/snapshot-tools",

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ crates/session    Private launcher/worker lifecycle and grant protocols
 crates/vhost-user Portable vhost-user frontend protocol foundations
 tools/firecracker-capability-audit
                   Checked Firecracker source/capability inventory validator
+tools/cpu-template-helper
+                  Library-only portable CPU-template helper foundation
 tools/seccompiler Firecracker-compatible offline seccompiler artifact tool
 tools/snapshot-tools
                   Firecracker-shaped native memory rebase, inspection, and reviewed editing

--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -77,6 +77,7 @@ reviewed delta.
 | [Machine memory](machine-memory-contract.md) | Machine-memory configuration, backing, dirty tracking, and exact platform boundaries |
 | [Machine lifecycle](machine-lifecycle-audit.md) | VM lifecycle, vCPU ownership, pause/resume, power sessions, and snapshot-ready coordination |
 | [CPU templates](cpu-template-contract.md) | Reviewed arm64 profile, selection, application, snapshot boundary, and KVM/static exclusions |
+| [CPU-template helper foundation](cpu-template-helper-contract.md) | Portable helper format, config projection, provider contract, bounded input, and absent-only publication |
 | [Device hotplug](device-hotplug-contract.md) | Runtime block, pmem, and network transactions and their aggregate ownership |
 | [Storage](storage-contract.md) | Block/pmem live and snapshot composition |
 | [Balloon](balloon-contract.md) | Balloon API, queue/accounting behavior, and native-v2 state |

--- a/compat/firecracker/v1.16.0/cpu-template-contract.md
+++ b/compat/firecracker/v1.16.0/cpu-template-contract.md
@@ -213,8 +213,11 @@ leaves the ordinary no-template snapshot profile unchanged.
 
 The terminal [Wave 6 snapshot contract](snapshot-wave6-contract.md) records
 the broader multi-vCPU/device profiles and this deliberate no-custom-template
-snapshot gate. Wave 7 owns cross-host portability and the five public
-`cpu-template-helper` commands and arguments.
+snapshot gate. The
+[CPU-template helper foundation contract](cpu-template-helper-contract.md)
+owns Wave 7's portable format, config projection, provider, input, publication,
+and exit-class boundary. Its public command and signed effective-provider gate
+remain separately owned by #1862.
 
 ## Security and signed evidence
 
@@ -248,4 +251,6 @@ The strict platform-exclusion evidence and alternatives for the seven narrow
 KVM/static inventory leaves, plus the implementation and validation evidence
 for the six completed ARM records, are recorded in `capabilities.json`.
 Mechanical write/readback establishes routing, not a portable or coherent CPU
-feature model; helper capture and comparison remain Wave 7 work.
+feature model. The portable helper foundation cannot create effective platform
+evidence without the real all-vCPU provider and signed process integration
+owned by #1862.

--- a/compat/firecracker/v1.16.0/cpu-template-helper-contract.md
+++ b/compat/firecracker/v1.16.0/cpu-template-helper-contract.md
@@ -1,0 +1,149 @@
+# CPU-template Helper Foundation Contract
+
+This contract owns the portable format, selection, provider, input, and
+publication boundary for Firecracker v1.16.0 CPU-template dump and verify
+work. The runtime register allowlist, application order, readback, boot
+precedence, and platform exclusions remain owned by the
+[CPU-template contract](cpu-template-contract.md).
+
+## Delivery status
+
+Issue [#1861](https://github.com/seven332/bangbang/issues/1861) supplies a
+library-only `bangbang-cpu-template-helper` foundation. It deliberately has no
+binary target, command-line parser, Hypervisor.framework dependency, or
+production effective-profile provider. Tests may supply a fake provider, but
+production code cannot report a successful dump or verification without a
+caller-provided implementation of the provider contract.
+
+Issue [#1862](https://github.com/seven332/bangbang/issues/1862) owns the public
+executable, real signed HVF provider, command behavior, and end-to-end
+promotion gate. Until that slice is merged, these seven checked identities
+remain exactly `audit-required`:
+
+| Capability identity | Current disposition |
+| --- | --- |
+| `tool-argument:cpu-template-helper/template/dump/config` | `audit-required` |
+| `tool-argument:cpu-template-helper/template/dump/output` | `audit-required` |
+| `tool-argument:cpu-template-helper/template/dump/template` | `audit-required` |
+| `tool-argument:cpu-template-helper/template/verify/config` | `audit-required` |
+| `tool-argument:cpu-template-helper/template/verify/template` | `audit-required` |
+| `tool-operation:cpu-template-helper/template/dump` | `audit-required` |
+| `tool-operation:cpu-template-helper/template/verify` | `audit-required` |
+
+## Configuration and selection
+
+The API crate owns one duplicate-safe complete config-document parser used by
+both VMM startup and the helper foundation. A complete document must retain
+the existing top-level object, known-section, required `boot-source`, strict
+section parsing, and production ordering rules. Parsing does not open paths
+named by boot, drive, logger, metrics, snapshot, or device sections.
+
+Helper preparation projects only machine and CPU requests through the real
+backend-neutral `VmmController`. Every section must still parse, and an invalid
+earlier machine or CPU request fails even when a later explicit template would
+replace its selection. Within a valid document, the config CPU selection
+follows machine static-template selection. An explicit template document is
+applied last and therefore has final precedence.
+
+Transport mapping is intentionally narrow and tested against the production
+API-server mapping. The helper does not duplicate controller validation or
+invent a separate machine/CPU state machine.
+
+## Descriptor and provider authority
+
+The runtime crate owns the exact sorted 80-entry arm64 descriptor census used
+by both accepted custom-template decoding and future effective capture. Each
+descriptor binds a Firecracker/KVM-shaped compatibility identity to one typed
+U32, U64, or U128 runtime target, its admitted filter, boot disposition, and
+availability class. The serialized identity is a compatibility token; it does
+not imply a KVM handle or KVM execution mechanism on macOS.
+
+An effective provider returns one topology-common profile in descriptor order.
+Every entry carries its identity explicitly as well as an exact-width
+`Available` value or `Unavailable` status. Construction rejects count, order,
+identity, width, and baseline-availability drift, including swaps between
+same-width registers. All baseline entries must be available. Only the
+descriptor-marked macOS 15 ACTLR and macOS 15.2 ZFR0/SMFR0 entries may be
+unavailable.
+
+Dump captures one profile and includes every available `Retained` entry. It
+omits X0, PC, and PSTATE because normal boot setup supersedes those applied
+values. Each emitted modifier uses the descriptor's complete admitted filter:
+full width for ordinary entries and only ACTLR.EnTSO bit 1 for ACTLR. Optional
+unavailable entries are omitted.
+
+Verify requires a selected nonempty custom template, captures once at the
+application checkpoint, and compares each requested entry as
+`(effective & filter) == value`. A missing descriptor, unavailable requested
+entry, or mismatch fails without exposing the identity, mask, expected value,
+or effective value. Extra profile entries do not affect the result. The future
+HVF provider must obtain a real common result for every configured vCPU; this
+library does not synthesize that platform evidence.
+
+## Template document
+
+Input accepts value-equivalent spellings admitted by the strict `/cpu-config`
+parser, including insignificant JSON whitespace and object-field order. It
+rejects duplicate keys or targets, aliases, identity/width mismatches, values
+outside filters or widths, unsupported KVM capability or vCPU-feature
+categories, forbidden registers, and every other input that cannot become one
+closed runtime custom template.
+
+Canonical output is UTF-8 JSON with these fixed properties:
+
+- fields appear as `kvm_capabilities`, `reg_modifiers`, and `vcpu_features`;
+- the first and last arrays are empty;
+- modifiers are sorted by ascending compatibility identity;
+- addresses are `0x` plus 16 lowercase hexadecimal digits;
+- bitmaps are `0b` plus exactly 32, 64, or 128 `0`, `1`, or `x` characters;
+- serde's two-space pretty layout is used; and
+- exactly one newline terminates the document.
+
+Both accepted inputs and encoded outputs are capped at 1 MiB. Canonical output
+must re-enter the same strict API and runtime closure without loss.
+
+## Input and publication boundary
+
+Path input is opened read-only with close-on-exec, no-follow, and nonblocking
+flags. Descriptor metadata must identify a regular file. Size is checked both
+before and during the bounded read, and the complete bytes must be UTF-8.
+Failures expose only a fixed category; paths and contents are not retained in
+`Debug` or `Display`.
+
+Output publication is absent-only. The parent is opened as a no-follow
+directory, and an existing regular file, symlink, directory, or concurrent
+winner is a collision whose bytes are preserved. A private same-directory
+stage is exclusively created with mode `0600`, written completely, flushed,
+file-synchronized, and checked against its captured device/inode identity.
+The only commit point is an exclusive `NOREPLACE` rename.
+
+Before commit, cleanup removes only a stage whose current identity still
+matches the captured identity, then synchronizes the directory. An identity
+change or cleanup/sync failure returns `PrecommitCleanupUncertain` and never
+removes the unknown object. After rename, the final path is not rolled back.
+A final-identity failure returns `CommittedStateUncertain`; a directory-sync
+failure returns `CommittedDurabilityUncertain`. Both postcommit classes mean a
+complete rename may already be visible and must not be reported as a safe
+precommit failure.
+
+No-clobber and synchronization protect publication integrity and failure
+classification; they do not authenticate template contents or make a hostile
+ancestor path trustworthy. Operators remain responsible for the authority and
+permissions of the selected directory.
+
+## Diagnostics, exit classes, and evidence
+
+All library errors and custom `Debug` implementations are bounded and omit
+paths, config values, register identities, filters, target values, effective
+values, and provider internals. The reserved public exit classes are 0 for
+success, 1 for an operational failure, and 2 for invocation failure. #1862
+owns the exact mapping from public commands and arguments to those classes.
+
+Portable tests cover parser sharing, production projection parity, descriptor
+census and decoder closure, canonical round trips, selection precedence,
+identity-bound profiles, optional availability, filtered verification,
+bounded no-follow input, collision preservation, short writes, synchronization
+faults, identity replacement, cleanup uncertainty, and postcommit uncertainty.
+The audit guard also proves that the package remains library-only and that the
+seven public capability identities remain nonterminal. Real provider and
+process evidence must run through the signed integration wrapper in #1862.

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -1,0 +1,501 @@
+//! Duplicate-safe Firecracker configuration-document parsing.
+
+use std::fmt;
+
+use crate::http::{ApiRequest, CpuConfigRequest, RequestError, parse_request_with_limit};
+use crate::json::parse_value_from_str;
+
+/// One supported top-level Firecracker configuration-file section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSection {
+    Balloon,
+    BootSource,
+    CpuConfig,
+    Drives,
+    Entropy,
+    Logger,
+    MachineConfig,
+    MemoryHotplug,
+    Metrics,
+    MmdsConfig,
+    NetworkInterfaces,
+    Pmem,
+    Serial,
+    Vsock,
+}
+
+impl ConfigSection {
+    /// Return the stable Firecracker configuration-file spelling.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Balloon => "balloon",
+            Self::BootSource => "boot-source",
+            Self::CpuConfig => "cpu-config",
+            Self::Drives => "drives",
+            Self::Entropy => "entropy",
+            Self::Logger => "logger",
+            Self::MachineConfig => "machine-config",
+            Self::MemoryHotplug => "memory-hotplug",
+            Self::Metrics => "metrics",
+            Self::MmdsConfig => "mmds-config",
+            Self::NetworkInterfaces => "network-interfaces",
+            Self::Pmem => "pmem",
+            Self::Serial => "serial",
+            Self::Vsock => "vsock",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        Some(match value {
+            "balloon" => Self::Balloon,
+            "boot-source" => Self::BootSource,
+            "cpu-config" => Self::CpuConfig,
+            "drives" => Self::Drives,
+            "entropy" => Self::Entropy,
+            "logger" => Self::Logger,
+            "machine-config" => Self::MachineConfig,
+            "memory-hotplug" => Self::MemoryHotplug,
+            "metrics" => Self::Metrics,
+            "mmds-config" => Self::MmdsConfig,
+            "network-interfaces" => Self::NetworkInterfaces,
+            "pmem" => Self::Pmem,
+            "serial" => Self::Serial,
+            "vsock" => Self::Vsock,
+            _ => return None,
+        })
+    }
+}
+
+impl fmt::Display for ConfigSection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One strictly parsed API request and its source configuration section.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ConfigRequest {
+    section: ConfigSection,
+    request: ApiRequest,
+}
+
+impl fmt::Debug for ConfigRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ConfigRequest")
+            .field("section", &self.section)
+            .field("request", &"<redacted>")
+            .finish()
+    }
+}
+
+impl ConfigRequest {
+    /// Return the source configuration section.
+    pub const fn section(&self) -> ConfigSection {
+        self.section
+    }
+
+    /// Return the parsed API request.
+    pub const fn request(&self) -> &ApiRequest {
+        &self.request
+    }
+
+    /// Consume the wrapper into its source section and API request.
+    pub fn into_parts(self) -> (ConfigSection, ApiRequest) {
+        (self.section, self.request)
+    }
+}
+
+/// Failure while parsing a complete Firecracker configuration document.
+#[derive(Clone, PartialEq, Eq)]
+pub enum ConfigDocumentError {
+    Malformed,
+    MissingSection(ConfigSection),
+    UnknownSection(String),
+    MalformedSection(ConfigSection),
+    Request {
+        section: ConfigSection,
+        source: RequestError,
+    },
+}
+
+impl ConfigDocumentError {
+    /// Return an unknown section spelling for the production compatibility
+    /// adapter without exposing it through generic diagnostics.
+    pub fn unknown_section(&self) -> Option<&str> {
+        match self {
+            Self::UnknownSection(section) => Some(section),
+            Self::Malformed
+            | Self::MissingSection(_)
+            | Self::MalformedSection(_)
+            | Self::Request { .. } => None,
+        }
+    }
+}
+
+impl fmt::Debug for ConfigDocumentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed => formatter.write_str("Malformed"),
+            Self::MissingSection(section) => formatter
+                .debug_tuple("MissingSection")
+                .field(section)
+                .finish(),
+            Self::UnknownSection(_) => formatter
+                .debug_tuple("UnknownSection")
+                .field(&"<redacted>")
+                .finish(),
+            Self::MalformedSection(section) => formatter
+                .debug_tuple("MalformedSection")
+                .field(section)
+                .finish(),
+            Self::Request { section, source } => formatter
+                .debug_struct("Request")
+                .field("section", section)
+                .field("source", source)
+                .finish(),
+        }
+    }
+}
+
+impl fmt::Display for ConfigDocumentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed => formatter.write_str("malformed configuration document"),
+            Self::MissingSection(section) => {
+                write!(
+                    formatter,
+                    "missing required configuration section: {section}"
+                )
+            }
+            Self::UnknownSection(_) => formatter.write_str("unknown configuration section"),
+            Self::MalformedSection(section) => {
+                write!(formatter, "malformed configuration section: {section}")
+            }
+            Self::Request { section, source } => write!(
+                formatter,
+                "invalid configuration section {section}: {}",
+                source.fault_message()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConfigDocumentError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Request { source, .. } => Some(source),
+            Self::Malformed
+            | Self::MissingSection(_)
+            | Self::UnknownSection(_)
+            | Self::MalformedSection(_) => None,
+        }
+    }
+}
+
+/// Value-free failure while parsing arbitrary duplicate-safe JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JsonDocumentError;
+
+impl fmt::Display for JsonDocumentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("malformed JSON document")
+    }
+}
+
+impl std::error::Error for JsonDocumentError {}
+
+/// Parse JSON while rejecting duplicate keys at every object depth.
+pub fn parse_json_document_without_duplicate_keys(
+    contents: &str,
+) -> Result<serde_json::Value, JsonDocumentError> {
+    parse_value_from_str(contents).map_err(|_| JsonDocumentError)
+}
+
+/// Value-free failure while parsing a standalone custom CPU template.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CpuConfigDocumentError {
+    Malformed,
+    Request(RequestError),
+}
+
+impl fmt::Display for CpuConfigDocumentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed => formatter.write_str("malformed CPU configuration document"),
+            Self::Request(source) => write!(
+                formatter,
+                "invalid CPU configuration document: {}",
+                source.fault_message()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CpuConfigDocumentError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Request(source) => Some(source),
+            Self::Malformed => None,
+        }
+    }
+}
+
+/// Parse a complete Firecracker configuration document into strict API
+/// requests in production startup order.
+pub fn parse_config_document(contents: &str) -> Result<Vec<ConfigRequest>, ConfigDocumentError> {
+    let value = parse_value_from_str(contents).map_err(|_| ConfigDocumentError::Malformed)?;
+    let object = value.as_object().ok_or(ConfigDocumentError::Malformed)?;
+
+    validate_sections(object)?;
+
+    let mut requests = Vec::new();
+    if let Some(machine_config) = object.get(ConfigSection::MachineConfig.as_str()) {
+        requests.push(section_request(
+            ConfigSection::MachineConfig,
+            "PUT",
+            "/machine-config".to_string(),
+            machine_config,
+        )?);
+    }
+
+    let boot_source = object.get(ConfigSection::BootSource.as_str()).ok_or(
+        ConfigDocumentError::MissingSection(ConfigSection::BootSource),
+    )?;
+    requests.push(section_request(
+        ConfigSection::BootSource,
+        "PUT",
+        "/boot-source".to_string(),
+        boot_source,
+    )?);
+
+    if let Some(drives) = object.get(ConfigSection::Drives.as_str()) {
+        for drive in section_array(ConfigSection::Drives, drives)? {
+            let drive_id = section_string_field(ConfigSection::Drives, drive, "drive_id")?;
+            requests.push(section_request(
+                ConfigSection::Drives,
+                "PUT",
+                format!("/drives/{drive_id}"),
+                drive,
+            )?);
+        }
+    }
+
+    if let Some(pmem_devices) = object.get(ConfigSection::Pmem.as_str()) {
+        for pmem in section_array(ConfigSection::Pmem, pmem_devices)? {
+            let pmem_id = section_string_field(ConfigSection::Pmem, pmem, "id")?;
+            requests.push(section_request(
+                ConfigSection::Pmem,
+                "PUT",
+                format!("/pmem/{pmem_id}"),
+                pmem,
+            )?);
+        }
+    }
+
+    if let Some(network_interfaces) = object.get(ConfigSection::NetworkInterfaces.as_str()) {
+        for network_interface in
+            section_array(ConfigSection::NetworkInterfaces, network_interfaces)?
+        {
+            let iface_id = section_string_field(
+                ConfigSection::NetworkInterfaces,
+                network_interface,
+                "iface_id",
+            )?;
+            requests.push(section_request(
+                ConfigSection::NetworkInterfaces,
+                "PUT",
+                format!("/network-interfaces/{iface_id}"),
+                network_interface,
+            )?);
+        }
+    }
+
+    push_optional_request(
+        object,
+        &mut requests,
+        ConfigSection::MmdsConfig,
+        "/mmds/config",
+    )?;
+    push_optional_request(object, &mut requests, ConfigSection::Vsock, "/vsock")?;
+    push_optional_request(object, &mut requests, ConfigSection::Entropy, "/entropy")?;
+    push_optional_request(
+        object,
+        &mut requests,
+        ConfigSection::MemoryHotplug,
+        "/hotplug/memory",
+    )?;
+    push_optional_request(object, &mut requests, ConfigSection::Balloon, "/balloon")?;
+    push_optional_request(
+        object,
+        &mut requests,
+        ConfigSection::CpuConfig,
+        "/cpu-config",
+    )?;
+    push_optional_request(object, &mut requests, ConfigSection::Metrics, "/metrics")?;
+    push_optional_request(object, &mut requests, ConfigSection::Logger, "/logger")?;
+    push_optional_request(object, &mut requests, ConfigSection::Serial, "/serial")?;
+
+    Ok(requests)
+}
+
+/// Parse one standalone duplicate-safe custom CPU-template document through
+/// the strict `/cpu-config` request shape.
+pub fn parse_cpu_config_document(
+    contents: &str,
+) -> Result<CpuConfigRequest, CpuConfigDocumentError> {
+    let value = parse_value_from_str(contents).map_err(|_| CpuConfigDocumentError::Malformed)?;
+    let request = section_request(
+        ConfigSection::CpuConfig,
+        "PUT",
+        "/cpu-config".to_string(),
+        &value,
+    )
+    .map_err(|error| match error {
+        ConfigDocumentError::Request { source, .. } => CpuConfigDocumentError::Request(source),
+        ConfigDocumentError::Malformed
+        | ConfigDocumentError::MissingSection(_)
+        | ConfigDocumentError::UnknownSection(_)
+        | ConfigDocumentError::MalformedSection(_) => CpuConfigDocumentError::Malformed,
+    })?;
+
+    match request.request {
+        ApiRequest::PutCpuConfig(config) => Ok(*config),
+        _ => Err(CpuConfigDocumentError::Malformed),
+    }
+}
+
+fn validate_sections(
+    object: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), ConfigDocumentError> {
+    for section in object.keys() {
+        if ConfigSection::from_str(section).is_none() {
+            return Err(ConfigDocumentError::UnknownSection(section.clone()));
+        }
+    }
+    Ok(())
+}
+
+fn section_array(
+    section: ConfigSection,
+    value: &serde_json::Value,
+) -> Result<&[serde_json::Value], ConfigDocumentError> {
+    value
+        .as_array()
+        .map(Vec::as_slice)
+        .ok_or(ConfigDocumentError::MalformedSection(section))
+}
+
+fn section_string_field<'value>(
+    section: ConfigSection,
+    value: &'value serde_json::Value,
+    field: &str,
+) -> Result<&'value str, ConfigDocumentError> {
+    value
+        .as_object()
+        .and_then(|object| object.get(field))
+        .and_then(serde_json::Value::as_str)
+        .ok_or(ConfigDocumentError::MalformedSection(section))
+}
+
+fn push_optional_request(
+    object: &serde_json::Map<String, serde_json::Value>,
+    requests: &mut Vec<ConfigRequest>,
+    section: ConfigSection,
+    path: &str,
+) -> Result<(), ConfigDocumentError> {
+    if let Some(body) = object.get(section.as_str()) {
+        requests.push(section_request(section, "PUT", path.to_string(), body)?);
+    }
+    Ok(())
+}
+
+fn section_request(
+    section: ConfigSection,
+    method: &str,
+    path: String,
+    body: &serde_json::Value,
+) -> Result<ConfigRequest, ConfigDocumentError> {
+    let body =
+        serde_json::to_vec(body).map_err(|_| ConfigDocumentError::MalformedSection(section))?;
+    let header = format!(
+        "{method} {path} HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    );
+    let mut request = header.into_bytes();
+    request.extend_from_slice(&body);
+
+    parse_request_with_limit(&request, usize::MAX)
+        .map(|request| ConfigRequest { section, request })
+        .map_err(|source| ConfigDocumentError::Request { section, source })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BOOT_SOURCE: &str = r#"{"boot-source":{"kernel_image_path":"kernel"}}"#;
+
+    #[test]
+    fn parses_minimal_document() {
+        let requests = parse_config_document(BOOT_SOURCE).expect("minimal config should parse");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].section(), ConfigSection::BootSource);
+        assert!(matches!(
+            requests[0].request(),
+            ApiRequest::PutBootSource(_)
+        ));
+        assert!(!format!("{:?}", requests[0]).contains("kernel"));
+    }
+
+    #[test]
+    fn rejects_duplicate_keys_at_every_depth() {
+        for contents in [
+            r#"{"boot-source":{"kernel_image_path":"a"},"boot-source":{"kernel_image_path":"b"}}"#,
+            r#"{"boot-source":{"kernel_image_path":"a","kernel_image_path":"b"}}"#,
+            r#"{"boot-source":{"kernel_image_path":"a"},"drives":[{"drive_id":"d","drive_id":"e","path_on_host":"p","is_root_device":true,"is_read_only":true}]}"#,
+        ] {
+            assert_eq!(
+                parse_config_document(contents),
+                Err(ConfigDocumentError::Malformed)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_and_unknown_sections_in_existing_order() {
+        assert_eq!(
+            parse_config_document("{}"),
+            Err(ConfigDocumentError::MissingSection(
+                ConfigSection::BootSource
+            ))
+        );
+        let error = parse_config_document(r#"{"unknown":{},"boot-source":{}}"#)
+            .expect_err("unknown section should fail before the required section is parsed");
+        assert_eq!(error.unknown_section(), Some("unknown"));
+        assert_eq!(format!("{error:?}"), "UnknownSection(\"<redacted>\")");
+        assert_eq!(error.to_string(), "unknown configuration section");
+    }
+
+    #[test]
+    fn standalone_cpu_document_is_duplicate_safe_and_strict() {
+        let parsed = parse_cpu_config_document(
+            r#"{"reg_modifiers":[{"addr":"0x6030000000100000","bitmap":"0b1"}]}"#,
+        )
+        .expect("strict CPU document should parse");
+        assert_eq!(parsed.reg_modifiers().len(), 1);
+
+        assert_eq!(
+            parse_cpu_config_document(
+                r#"{"reg_modifiers":[],"reg_modifiers":[],"kvm_capabilities":[],"vcpu_features":[]}"#,
+            ),
+            Err(CpuConfigDocumentError::Malformed)
+        );
+        assert!(matches!(
+            parse_cpu_config_document(r#"{"unknown":[]}"#),
+            Err(CpuConfigDocumentError::Request(
+                RequestError::MalformedRequest
+            ))
+        ));
+    }
+}

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -2,9 +2,9 @@ use std::collections::HashSet;
 use std::fmt;
 use std::net::Ipv4Addr;
 
-use serde::de::{self, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 
+use crate::json::JsonValueWithoutDuplicateObjectKeys;
 use crate::route::Endpoint;
 use crate::{HTTP_MAX_PAYLOAD_SIZE, HTTP_MAX_REQUEST_HEAD_SIZE};
 
@@ -942,116 +942,6 @@ struct SerialConfigRequestBody {
 struct EntropyDeviceConfigRequestBody {
     #[serde(default)]
     rate_limiter: Option<JsonValueWithoutDuplicateObjectKeys>,
-}
-
-#[derive(Debug)]
-struct JsonValueWithoutDuplicateObjectKeys(serde_json::Value);
-
-impl JsonValueWithoutDuplicateObjectKeys {
-    const fn as_value(&self) -> &serde_json::Value {
-        &self.0
-    }
-}
-
-impl<'de> Deserialize<'de> for JsonValueWithoutDuplicateObjectKeys {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer
-            .deserialize_any(JsonValueWithoutDuplicateObjectKeysVisitor)
-            .map(Self)
-    }
-}
-
-#[derive(Debug)]
-struct JsonValueWithoutDuplicateObjectKeysVisitor;
-
-impl<'de> Visitor<'de> for JsonValueWithoutDuplicateObjectKeysVisitor {
-    type Value = serde_json::Value;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("a JSON value without duplicate object keys")
-    }
-
-    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Bool(value))
-    }
-
-    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Number(value.into()))
-    }
-
-    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Number(value.into()))
-    }
-
-    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        serde_json::Number::from_f64(value)
-            .map(serde_json::Value::Number)
-            .ok_or_else(|| E::custom("invalid JSON number"))
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(serde_json::Value::String(value.to_string()))
-    }
-
-    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::String(value))
-    }
-
-    fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Null)
-    }
-
-    fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Null)
-    }
-
-    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Deserialize::deserialize(deserializer)
-            .map(|JsonValueWithoutDuplicateObjectKeys(value)| value)
-    }
-
-    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
-    where
-        A: SeqAccess<'de>,
-    {
-        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0));
-
-        while let Some(JsonValueWithoutDuplicateObjectKeys(value)) = sequence.next_element()? {
-            values.push(value);
-        }
-
-        Ok(serde_json::Value::Array(values))
-    }
-
-    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut object = serde_json::Map::new();
-
-        while let Some(key) = map.next_key::<String>()? {
-            if object.contains_key(&key) {
-                return Err(de::Error::custom("duplicate object key"));
-            }
-
-            let JsonValueWithoutDuplicateObjectKeys(value) = map.next_value()?;
-            object.insert(key, value);
-        }
-
-        Ok(serde_json::Value::Object(object))
-    }
 }
 
 const fn default_memory_hotplug_block_size_mib() -> u64 {

--- a/crates/api/src/json.rs
+++ b/crates/api/src/json.rs
@@ -1,0 +1,123 @@
+use std::fmt;
+
+use serde::de::{self, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+
+#[derive(Debug)]
+pub(crate) struct JsonValueWithoutDuplicateObjectKeys(serde_json::Value);
+
+impl JsonValueWithoutDuplicateObjectKeys {
+    pub(crate) const fn as_value(&self) -> &serde_json::Value {
+        &self.0
+    }
+
+    pub(crate) fn into_value(self) -> serde_json::Value {
+        self.0
+    }
+}
+
+pub(crate) fn parse_value_from_str(contents: &str) -> Result<serde_json::Value, serde_json::Error> {
+    serde_json::from_str::<JsonValueWithoutDuplicateObjectKeys>(contents)
+        .map(JsonValueWithoutDuplicateObjectKeys::into_value)
+}
+
+impl<'de> Deserialize<'de> for JsonValueWithoutDuplicateObjectKeys {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer
+            .deserialize_any(JsonValueWithoutDuplicateObjectKeysVisitor)
+            .map(Self)
+    }
+}
+
+#[derive(Debug)]
+struct JsonValueWithoutDuplicateObjectKeysVisitor;
+
+impl<'de> Visitor<'de> for JsonValueWithoutDuplicateObjectKeysVisitor {
+    type Value = serde_json::Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        serde_json::Number::from_f64(value)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| E::custom("invalid JSON number"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(serde_json::Value::String(value.to_string()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::String(value))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Null)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(serde_json::Value::Null)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer)
+            .map(|value: JsonValueWithoutDuplicateObjectKeys| value.into_value())
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0));
+
+        while let Some(value) = sequence.next_element::<JsonValueWithoutDuplicateObjectKeys>()? {
+            values.push(value.into_value());
+        }
+
+        Ok(serde_json::Value::Array(values))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut object = serde_json::Map::new();
+
+        while let Some(key) = map.next_key::<String>()? {
+            if object.contains_key(&key) {
+                return Err(de::Error::custom("duplicate object key"));
+            }
+
+            let value = map.next_value::<JsonValueWithoutDuplicateObjectKeys>()?;
+            object.insert(key, value.into_value());
+        }
+
+        Ok(serde_json::Value::Object(object))
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,6 +1,8 @@
 //! Firecracker-compatible API surface.
 
+pub mod config;
 pub mod http;
+mod json;
 pub mod route;
 
 /// Firecracker's default maximum accepted HTTP request body size.

--- a/crates/bangbang/Cargo.toml
+++ b/crates/bangbang/Cargo.toml
@@ -24,6 +24,7 @@ signal-hook = "0.3"
 signal-hook-registry = "1"
 
 [dev-dependencies]
+bangbang-cpu-template-helper = { path = "../../tools/cpu-template-helper" }
 bangbang-session = { path = "../session", features = ["test-support"] }
 crc64 = "2.0.0"
 plist = "1"

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -13477,6 +13477,57 @@ mod tests {
     }
 
     #[test]
+    fn helper_cpu_inspection_projection_matches_production_actions() {
+        let cpu = bangbang_api::config::parse_cpu_config_document(
+            r#"{
+                "kvm_capabilities": ["1", "!2"],
+                "reg_modifiers": [
+                    {"addr":"0x60200000001000d5","bitmap":"0b1"},
+                    {"addr":"0x6030000000100000","bitmap":"0b1x"},
+                    {"addr":"0x6040000000100054","bitmap":"0b0x1"}
+                ],
+                "vcpu_features": [{"index":0,"bitmap":"0b1x"}]
+            }"#,
+        )
+        .expect("CPU request fixture should parse");
+        let cpu_request = ApiRequest::PutCpuConfig(Box::new(cpu));
+        assert_eq!(
+            config_vmm_action_from_api_request(cpu_request.clone()),
+            bangbang_cpu_template_helper::projection::inspection_action_from_api_request(
+                &cpu_request
+            )
+        );
+
+        let requests = bangbang_api::config::parse_config_document(
+            r#"{
+                "machine-config": {
+                    "vcpu_count": 4,
+                    "mem_size_mib": 512,
+                    "smt": true,
+                    "cpu_template": "V1N1",
+                    "track_dirty_pages": true,
+                    "huge_pages": "2M"
+                },
+                "boot-source": {"kernel_image_path":"private-kernel"}
+            }"#,
+        )
+        .expect("machine request fixture should parse");
+        let machine_request = requests
+            .into_iter()
+            .find_map(|request| match request.into_parts().1 {
+                request @ ApiRequest::PutMachineConfig(_) => Some(request),
+                _ => None,
+            })
+            .expect("machine request should be present");
+        assert_eq!(
+            config_vmm_action_from_api_request(machine_request.clone()),
+            bangbang_cpu_template_helper::projection::inspection_action_from_api_request(
+                &machine_request
+            )
+        );
+    }
+
+    #[test]
     fn fails_when_socket_path_is_broken_symlink_without_deleting_it() {
         let path = unique_socket_path("symlink");
         let target = unique_socket_path("missing-target");

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -42,7 +42,10 @@ mod vsock_restore;
 use anchored_socket::bind as bind_anchored_socket;
 use api_server::{ApiServer, ApiServerError, config_vmm_action_from_api_request};
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
-use bangbang_api::http::{RequestError, parse_request_with_limit};
+use bangbang_api::config::{
+    ConfigDocumentError, parse_config_document, parse_json_document_without_duplicate_keys,
+};
+use bangbang_api::http::RequestError;
 use bangbang_hvf::HvfBackend;
 #[cfg(target_os = "macos")]
 use contained_session::PagerGrantAuthority;
@@ -50,7 +53,6 @@ use contained_session::{ContainedSession, GrantAuthority};
 use periodic_metrics::{
     PeriodicBalloonStatisticsScheduler, PeriodicMetricsScheduler, min_poll_timeout_ms,
 };
-use serde::de::{self, MapAccess, SeqAccess, Visitor};
 use signal_hook::consts::signal::SIGTERM;
 use signal_hook::consts::signal::{SIGBUS, SIGHUP, SIGILL, SIGINT, SIGPIPE, SIGSEGV, SIGSYS};
 use signal_hook::consts::signal::{SIGXCPU, SIGXFSZ};
@@ -820,326 +822,33 @@ fn config_file_actions_with_authority(
 }
 
 fn config_file_actions_from_str(contents: &str) -> Result<Vec<VmmAction>, ConfigFileError> {
-    let value = parse_json_value_without_duplicate_object_keys(contents)
-        .map_err(|_| ConfigFileError::Malformed)?;
-    let object = value.as_object().ok_or(ConfigFileError::Malformed)?;
-
-    validate_config_file_sections(object)?;
-
-    let mut requests = Vec::new();
-    if let Some(machine_config) = object.get("machine-config") {
-        requests.push(config_section_request(
-            "machine-config",
-            "PUT",
-            "/machine-config".to_string(),
-            machine_config,
-        )?);
-    }
-
-    let boot_source = object
-        .get("boot-source")
-        .ok_or(ConfigFileError::MissingSection("boot-source"))?;
-    requests.push(config_section_request(
-        "boot-source",
-        "PUT",
-        "/boot-source".to_string(),
-        boot_source,
-    )?);
-
-    if let Some(drives) = object.get("drives") {
-        for drive in config_section_array("drives", drives)? {
-            let drive_id = config_section_string_field("drives", drive, "drive_id")?;
-            requests.push(config_section_request(
-                "drives",
-                "PUT",
-                format!("/drives/{drive_id}"),
-                drive,
-            )?);
-        }
-    }
-
-    if let Some(pmem_devices) = object.get("pmem") {
-        for pmem in config_section_array("pmem", pmem_devices)? {
-            let pmem_id = config_section_string_field("pmem", pmem, "id")?;
-            requests.push(config_section_request(
-                "pmem",
-                "PUT",
-                format!("/pmem/{pmem_id}"),
-                pmem,
-            )?);
-        }
-    }
-
-    if let Some(network_interfaces) = object.get("network-interfaces") {
-        for network_interface in config_section_array("network-interfaces", network_interfaces)? {
-            let iface_id =
-                config_section_string_field("network-interfaces", network_interface, "iface_id")?;
-            requests.push(config_section_request(
-                "network-interfaces",
-                "PUT",
-                format!("/network-interfaces/{iface_id}"),
-                network_interface,
-            )?);
-        }
-    }
-
-    if let Some(mmds_config) = object.get("mmds-config") {
-        requests.push(config_section_request(
-            "mmds-config",
-            "PUT",
-            "/mmds/config".to_string(),
-            mmds_config,
-        )?);
-    }
-
-    if let Some(vsock) = object.get("vsock") {
-        requests.push(config_section_request(
-            "vsock",
-            "PUT",
-            "/vsock".to_string(),
-            vsock,
-        )?);
-    }
-
-    if let Some(entropy) = object.get("entropy") {
-        requests.push(config_section_request(
-            "entropy",
-            "PUT",
-            "/entropy".to_string(),
-            entropy,
-        )?);
-    }
-
-    if let Some(memory_hotplug) = object.get("memory-hotplug") {
-        requests.push(config_section_request(
-            "memory-hotplug",
-            "PUT",
-            "/hotplug/memory".to_string(),
-            memory_hotplug,
-        )?);
-    }
-
-    if let Some(balloon) = object.get("balloon") {
-        requests.push(config_section_request(
-            "balloon",
-            "PUT",
-            "/balloon".to_string(),
-            balloon,
-        )?);
-    }
-
-    if let Some(cpu_config) = object.get("cpu-config") {
-        requests.push(config_section_request(
-            "cpu-config",
-            "PUT",
-            "/cpu-config".to_string(),
-            cpu_config,
-        )?);
-    }
-
-    if let Some(metrics) = object.get("metrics") {
-        requests.push(config_section_request(
-            "metrics",
-            "PUT",
-            "/metrics".to_string(),
-            metrics,
-        )?);
-    }
-
-    if let Some(logger) = object.get("logger") {
-        requests.push(config_section_request(
-            "logger",
-            "PUT",
-            "/logger".to_string(),
-            logger,
-        )?);
-    }
-
-    if let Some(serial) = object.get("serial") {
-        requests.push(config_section_request(
-            "serial",
-            "PUT",
-            "/serial".to_string(),
-            serial,
-        )?);
-    }
-
-    requests
+    parse_config_document(contents)
+        .map_err(config_file_error_from_document)?
         .into_iter()
-        .map(|(section, request)| {
-            config_vmm_action_from_api_request(request)
-                .ok_or(ConfigFileError::UnsupportedRequest { section })
+        .map(|config_request| {
+            let (section, request) = config_request.into_parts();
+            config_vmm_action_from_api_request(request).ok_or(ConfigFileError::UnsupportedRequest {
+                section: section.as_str(),
+            })
         })
         .collect()
 }
 
-fn parse_json_value_without_duplicate_object_keys(
-    contents: &str,
-) -> Result<serde_json::Value, serde_json::Error> {
-    let JsonValueWithoutDuplicateObjectKeys(value) =
-        serde_json::from_str::<JsonValueWithoutDuplicateObjectKeys>(contents)?;
-    Ok(value)
-}
-
-#[derive(Debug)]
-struct JsonValueWithoutDuplicateObjectKeys(serde_json::Value);
-
-impl<'de> serde::Deserialize<'de> for JsonValueWithoutDuplicateObjectKeys {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer
-            .deserialize_any(JsonValueWithoutDuplicateObjectKeysVisitor)
-            .map(Self)
-    }
-}
-
-#[derive(Debug)]
-struct JsonValueWithoutDuplicateObjectKeysVisitor;
-
-impl<'de> Visitor<'de> for JsonValueWithoutDuplicateObjectKeysVisitor {
-    type Value = serde_json::Value;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("a JSON value without duplicate object keys")
-    }
-
-    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Bool(value))
-    }
-
-    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Number(value.into()))
-    }
-
-    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Number(value.into()))
-    }
-
-    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        serde_json::Number::from_f64(value)
-            .map(serde_json::Value::Number)
-            .ok_or_else(|| E::custom("invalid JSON number"))
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(serde_json::Value::String(value.to_string()))
-    }
-
-    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::String(value))
-    }
-
-    fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Null)
-    }
-
-    fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(serde_json::Value::Null)
-    }
-
-    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        serde::Deserialize::deserialize(deserializer)
-            .map(|JsonValueWithoutDuplicateObjectKeys(value)| value)
-    }
-
-    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
-    where
-        A: SeqAccess<'de>,
-    {
-        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0));
-
-        while let Some(JsonValueWithoutDuplicateObjectKeys(value)) = sequence.next_element()? {
-            values.push(value);
+fn config_file_error_from_document(error: ConfigDocumentError) -> ConfigFileError {
+    match error {
+        ConfigDocumentError::Malformed => ConfigFileError::Malformed,
+        ConfigDocumentError::MissingSection(section) => {
+            ConfigFileError::MissingSection(section.as_str())
         }
-
-        Ok(serde_json::Value::Array(values))
+        ConfigDocumentError::UnknownSection(section) => ConfigFileError::UnknownSection(section),
+        ConfigDocumentError::MalformedSection(section) => ConfigFileError::MalformedSection {
+            section: section.as_str(),
+        },
+        ConfigDocumentError::Request { section, source } => ConfigFileError::Request {
+            section: section.as_str(),
+            source,
+        },
     }
-
-    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut object = serde_json::Map::new();
-
-        while let Some(key) = map.next_key::<String>()? {
-            if object.contains_key(&key) {
-                return Err(de::Error::custom("duplicate object key"));
-            }
-
-            let JsonValueWithoutDuplicateObjectKeys(value) = map.next_value()?;
-            object.insert(key, value);
-        }
-
-        Ok(serde_json::Value::Object(object))
-    }
-}
-
-fn validate_config_file_sections(
-    object: &serde_json::Map<String, serde_json::Value>,
-) -> Result<(), ConfigFileError> {
-    for section in object.keys() {
-        match section.as_str() {
-            "balloon" | "boot-source" | "cpu-config" | "drives" | "logger" | "machine-config"
-            | "memory-hotplug" | "metrics" | "mmds-config" | "network-interfaces" | "pmem"
-            | "serial" | "vsock" | "entropy" => {}
-            _ => return Err(ConfigFileError::UnknownSection(section.clone())),
-        }
-    }
-
-    Ok(())
-}
-
-fn config_section_array<'value>(
-    section: &'static str,
-    value: &'value serde_json::Value,
-) -> Result<&'value [serde_json::Value], ConfigFileError> {
-    value
-        .as_array()
-        .map(Vec::as_slice)
-        .ok_or(ConfigFileError::MalformedSection { section })
-}
-
-fn config_section_string_field<'value>(
-    section: &'static str,
-    value: &'value serde_json::Value,
-    field: &'static str,
-) -> Result<&'value str, ConfigFileError> {
-    value
-        .as_object()
-        .and_then(|object| object.get(field))
-        .and_then(serde_json::Value::as_str)
-        .ok_or(ConfigFileError::MalformedSection { section })
-}
-
-fn config_section_request(
-    section: &'static str,
-    method: &str,
-    path: String,
-    body: &serde_json::Value,
-) -> Result<(&'static str, bangbang_api::http::ApiRequest), ConfigFileError> {
-    let body =
-        serde_json::to_vec(body).map_err(|_| ConfigFileError::MalformedSection { section })?;
-    let header = format!(
-        "{method} {path} HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n",
-        body.len()
-    );
-    let mut request = header.into_bytes();
-    request.extend_from_slice(&body);
-
-    parse_request_with_limit(&request, usize::MAX)
-        .map(|request| (section, request))
-        .map_err(|source| ConfigFileError::Request { section, source })
 }
 
 fn apply_startup_metrics_config<S>(
@@ -1226,7 +935,7 @@ fn metadata_content_input_with_authority(
         StartupFileReadError::TooLarge => MetadataFileError::TooLarge,
         StartupFileReadError::Grant => MetadataFileError::Grant,
     })?;
-    let value = parse_json_value_without_duplicate_object_keys(&contents)
+    let value = parse_json_document_without_duplicate_keys(&contents)
         .map_err(|_| MetadataFileError::Malformed)?;
 
     Ok(MmdsContentInput::new(value))

--- a/crates/runtime/src/cpu.rs
+++ b/crates/runtime/src/cpu.rs
@@ -344,41 +344,53 @@ impl CpuConfigArmRegisterModifier {
     }
 
     fn into_executable(self) -> Result<ArmRegisterModifier, CpuConfigError> {
-        match self.width {
-            CpuConfigArmRegisterWidth::U32 => {
-                let register = match core_class_index(self.id) {
-                    Some(212) => ArmRegister32::Fpsr,
-                    Some(213) => ArmRegister32::Fpcr,
-                    Some(index) if expected_core_width(index).is_some() => {
-                        return Err(CpuConfigError::InvalidRegisterWidth);
-                    }
-                    Some(_) => return Err(CpuConfigError::InvalidRegisterIdentity),
-                    None => return Err(classify_unaccepted_register(self.id)),
-                };
-                Ok(ArmRegisterModifier::U32 {
+        if let Some(descriptor) = arm64_cpu_template_register_descriptor(self.id) {
+            if descriptor.width() != self.width {
+                return Err(CpuConfigError::InvalidRegisterWidth);
+            }
+            if self.filter & !descriptor.allowed_filter() != 0 {
+                debug_assert_eq!(
+                    descriptor.register(),
+                    ArmCpuTemplateRegister::U64(ArmRegister64::Actlr)
+                );
+                return Err(CpuConfigError::ActlrFilterUnsupported);
+            }
+
+            return match descriptor.register() {
+                ArmCpuTemplateRegister::U32(register) => Ok(ArmRegisterModifier::U32 {
                     register,
                     filter: u32::try_from(self.filter)
                         .map_err(|_| CpuConfigError::ValueOutsideRegisterWidth)?,
                     value: u32::try_from(self.value)
                         .map_err(|_| CpuConfigError::ValueOutsideRegisterWidth)?,
-                })
-            }
-            CpuConfigArmRegisterWidth::U64 => {
-                let register = classify_u64_register(self.id)?;
-                let filter = u64::try_from(self.filter)
-                    .map_err(|_| CpuConfigError::ValueOutsideRegisterWidth)?;
-                if accepted_system_register(self.id)
-                    .is_some_and(|entry| filter & !entry.allowed_filter != 0)
-                {
-                    return Err(CpuConfigError::ActlrFilterUnsupported);
-                }
-                Ok(ArmRegisterModifier::U64 {
+                }),
+                ArmCpuTemplateRegister::U64(register) => Ok(ArmRegisterModifier::U64 {
                     register,
-                    filter,
+                    filter: u64::try_from(self.filter)
+                        .map_err(|_| CpuConfigError::ValueOutsideRegisterWidth)?,
                     value: u64::try_from(self.value)
                         .map_err(|_| CpuConfigError::ValueOutsideRegisterWidth)?,
-                })
-            }
+                }),
+                ArmCpuTemplateRegister::U128(register) => Ok(ArmRegisterModifier::U128 {
+                    register,
+                    filter: self.filter,
+                    value: self.value,
+                }),
+            };
+        }
+
+        match self.width {
+            CpuConfigArmRegisterWidth::U32 => match core_class_index(self.id) {
+                Some(index) if expected_core_width(index).is_some() => {
+                    Err(CpuConfigError::InvalidRegisterWidth)
+                }
+                Some(_) => Err(CpuConfigError::InvalidRegisterIdentity),
+                None => Err(classify_unaccepted_register(self.id)),
+            },
+            CpuConfigArmRegisterWidth::U64 => match classify_u64_register(self.id) {
+                Ok(_) => Err(CpuConfigError::InvalidRegisterIdentity),
+                Err(error) => Err(error),
+            },
             CpuConfigArmRegisterWidth::U128 => {
                 let Some(index) = core_class_index(self.id) else {
                     return Err(classify_unaccepted_register(self.id));
@@ -390,11 +402,7 @@ impl CpuConfigArmRegisterModifier {
                         Err(CpuConfigError::InvalidRegisterIdentity)
                     };
                 }
-                Ok(ArmRegisterModifier::U128 {
-                    register: ArmRegister128::Q(ArmQRegister(((index - 84) / 4) as u8)),
-                    filter: self.filter,
-                    value: self.value,
-                })
+                Err(CpuConfigError::InvalidRegisterIdentity)
             }
         }
     }
@@ -633,6 +641,292 @@ pub enum ArmRegisterAvailability {
     MacOs15_2,
 }
 
+/// One typed register in the closed arm64 CPU-template profile.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ArmCpuTemplateRegister {
+    U32(ArmRegister32),
+    U64(ArmRegister64),
+    U128(ArmRegister128),
+}
+
+impl ArmCpuTemplateRegister {
+    /// Return the exact architectural width.
+    pub const fn width(self) -> CpuConfigArmRegisterWidth {
+        match self {
+            Self::U32(_) => CpuConfigArmRegisterWidth::U32,
+            Self::U64(_) => CpuConfigArmRegisterWidth::U64,
+            Self::U128(_) => CpuConfigArmRegisterWidth::U128,
+        }
+    }
+
+    /// Return whether initial boot setup retains or supersedes this target.
+    pub const fn boot_disposition(self) -> ArmRegisterBootDisposition {
+        match self {
+            Self::U64(register) => register.boot_disposition(),
+            Self::U32(_) | Self::U128(_) => ArmRegisterBootDisposition::Retained,
+        }
+    }
+
+    /// Return the public Hypervisor.framework availability tier.
+    pub const fn availability(self) -> ArmRegisterAvailability {
+        match self {
+            Self::U64(register) => register.availability(),
+            Self::U32(_) | Self::U128(_) => ArmRegisterAvailability::Baseline,
+        }
+    }
+}
+
+impl fmt::Debug for ArmCpuTemplateRegister {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(CPU_CONFIG_VALUE_REDACTED)
+    }
+}
+
+/// One read-only descriptor in the exact arm64 CPU-template register census.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ArmCpuTemplateRegisterDescriptor {
+    identity: u64,
+    register: ArmCpuTemplateRegister,
+    allowed_filter: u128,
+}
+
+impl ArmCpuTemplateRegisterDescriptor {
+    const fn new(identity: u64, register: ArmCpuTemplateRegister, allowed_filter: u128) -> Self {
+        Self {
+            identity,
+            register,
+            allowed_filter,
+        }
+    }
+
+    const fn full_width(identity: u64, register: ArmCpuTemplateRegister) -> Self {
+        let allowed_filter = match register.width() {
+            CpuConfigArmRegisterWidth::U32 => u32::MAX as u128,
+            CpuConfigArmRegisterWidth::U64 => u64::MAX as u128,
+            CpuConfigArmRegisterWidth::U128 => u128::MAX,
+        };
+        Self::new(identity, register, allowed_filter)
+    }
+
+    /// Return the Firecracker/KVM-shaped compatibility identity.
+    pub const fn identity(self) -> u64 {
+        self.identity
+    }
+
+    /// Return the typed backend-neutral target.
+    pub const fn register(self) -> ArmCpuTemplateRegister {
+        self.register
+    }
+
+    /// Return the exact architectural width.
+    pub const fn width(self) -> CpuConfigArmRegisterWidth {
+        self.register.width()
+    }
+
+    /// Return the complete mask admitted for this target.
+    pub const fn allowed_filter(self) -> u128 {
+        self.allowed_filter
+    }
+
+    /// Return whether initial boot setup retains or supersedes this target.
+    pub const fn boot_disposition(self) -> ArmRegisterBootDisposition {
+        self.register.boot_disposition()
+    }
+
+    /// Return the minimum public Hypervisor.framework availability tier.
+    pub const fn availability(self) -> ArmRegisterAvailability {
+        self.register.availability()
+    }
+}
+
+impl fmt::Debug for ArmCpuTemplateRegisterDescriptor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ArmCpuTemplateRegisterDescriptor")
+            .field("width", &self.width())
+            .field("boot_disposition", &self.boot_disposition())
+            .field("availability", &self.availability())
+            .field("identity", &CPU_CONFIG_VALUE_REDACTED)
+            .field("register", &CPU_CONFIG_VALUE_REDACTED)
+            .field("allowed_filter", &CPU_CONFIG_VALUE_REDACTED)
+            .finish()
+    }
+}
+
+/// Exact number of accepted arm64 CPU-template targets.
+pub const ARM64_CPU_TEMPLATE_REGISTER_COUNT: usize = 80;
+
+const ARM64_SYSTEM_REGISTERS: [(u64, ArmRegister64, u128); 12] = [
+    (
+        KVM_REG_ARM64_ID_AA64PFR0_EL1,
+        ArmRegister64::Id(ArmIdRegister::Pfr0),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64PFR1_EL1,
+        ArmRegister64::Id(ArmIdRegister::Pfr1),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64ZFR0_EL1,
+        ArmRegister64::Id(ArmIdRegister::Zfr0),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64SMFR0_EL1,
+        ArmRegister64::Id(ArmIdRegister::Smfr0),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64DFR0_EL1,
+        ArmRegister64::Id(ArmIdRegister::Dfr0),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64DFR1_EL1,
+        ArmRegister64::Id(ArmIdRegister::Dfr1),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64ISAR0_EL1,
+        ArmRegister64::Id(ArmIdRegister::Isar0),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64ISAR1_EL1,
+        ArmRegister64::Id(ArmIdRegister::Isar1),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64MMFR0_EL1,
+        ArmRegister64::Id(ArmIdRegister::Mmfr0),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64MMFR1_EL1,
+        ArmRegister64::Id(ArmIdRegister::Mmfr1),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ID_AA64MMFR2_EL1,
+        ArmRegister64::Id(ArmIdRegister::Mmfr2),
+        u64::MAX as u128,
+    ),
+    (
+        KVM_REG_ARM64_ACTLR_EL1,
+        ArmRegister64::Actlr,
+        ARM64_ACTLR_ENTSO_MASK as u128,
+    ),
+];
+
+/// Iterator over the exact arm64 CPU-template register census.
+#[derive(Debug, Clone)]
+pub struct ArmCpuTemplateRegisterDescriptors {
+    position: usize,
+}
+
+impl Iterator for ArmCpuTemplateRegisterDescriptors {
+    type Item = ArmCpuTemplateRegisterDescriptor;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let descriptor = descriptor_at(self.position)?;
+        self.position += 1;
+        Some(descriptor)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = ARM64_CPU_TEMPLATE_REGISTER_COUNT.saturating_sub(self.position);
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for ArmCpuTemplateRegisterDescriptors {
+    fn len(&self) -> usize {
+        ARM64_CPU_TEMPLATE_REGISTER_COUNT.saturating_sub(self.position)
+    }
+}
+
+impl std::iter::FusedIterator for ArmCpuTemplateRegisterDescriptors {}
+
+/// Iterate over every accepted arm64 CPU-template register in ascending
+/// compatibility-identity order.
+pub const fn arm64_cpu_template_register_descriptors() -> ArmCpuTemplateRegisterDescriptors {
+    ArmCpuTemplateRegisterDescriptors { position: 0 }
+}
+
+/// Resolve one compatibility identity through the exact descriptor authority.
+pub fn arm64_cpu_template_register_descriptor(
+    identity: u64,
+) -> Option<ArmCpuTemplateRegisterDescriptor> {
+    arm64_cpu_template_register_descriptors().find(|descriptor| descriptor.identity == identity)
+}
+
+fn descriptor_at(position: usize) -> Option<ArmCpuTemplateRegisterDescriptor> {
+    let descriptor = match position {
+        0 => ArmCpuTemplateRegisterDescriptor::full_width(
+            KVM_REG_ARM64_CORE_FPSR,
+            ArmCpuTemplateRegister::U32(ArmRegister32::Fpsr),
+        ),
+        1 => ArmCpuTemplateRegisterDescriptor::full_width(
+            KVM_REG_ARM64_CORE_FPCR,
+            ArmCpuTemplateRegister::U32(ArmRegister32::Fpcr),
+        ),
+        2 => ArmCpuTemplateRegisterDescriptor::full_width(
+            kvm_reg_arm64_core_x(0)?,
+            ArmCpuTemplateRegister::U64(ArmRegister64::X(ArmGeneralRegister(0))),
+        ),
+        3..=29 => {
+            let index = u8::try_from(position + 1).ok()?;
+            ArmCpuTemplateRegisterDescriptor::full_width(
+                kvm_reg_arm64_core_x(index)?,
+                ArmCpuTemplateRegister::U64(ArmRegister64::X(ArmGeneralRegister(index))),
+            )
+        }
+        30 => ArmCpuTemplateRegisterDescriptor::full_width(
+            KVM_REG_ARM64_CORE_SP_EL0,
+            ArmCpuTemplateRegister::U64(ArmRegister64::SpEl0),
+        ),
+        31 => ArmCpuTemplateRegisterDescriptor::full_width(
+            KVM_REG_ARM64_CORE_PC,
+            ArmCpuTemplateRegister::U64(ArmRegister64::Pc),
+        ),
+        32 => ArmCpuTemplateRegisterDescriptor::full_width(
+            KVM_REG_ARM64_CORE_PSTATE,
+            ArmCpuTemplateRegister::U64(ArmRegister64::Pstate),
+        ),
+        33 => ArmCpuTemplateRegisterDescriptor::full_width(
+            KVM_REG_ARM64_CORE_SP_EL1,
+            ArmCpuTemplateRegister::U64(ArmRegister64::SpEl1),
+        ),
+        34 => ArmCpuTemplateRegisterDescriptor::full_width(
+            KVM_REG_ARM64_CORE_ELR_EL1,
+            ArmCpuTemplateRegister::U64(ArmRegister64::ElrEl1),
+        ),
+        35 => ArmCpuTemplateRegisterDescriptor::full_width(
+            KVM_REG_ARM64_CORE_SPSR_EL1,
+            ArmCpuTemplateRegister::U64(ArmRegister64::SpsrEl1),
+        ),
+        36..=47 => {
+            let (identity, register, allowed_filter) =
+                ARM64_SYSTEM_REGISTERS.get(position - 36).copied()?;
+            ArmCpuTemplateRegisterDescriptor::new(
+                identity,
+                ArmCpuTemplateRegister::U64(register),
+                allowed_filter,
+            )
+        }
+        48..=79 => {
+            let index = u8::try_from(position - 48).ok()?;
+            ArmCpuTemplateRegisterDescriptor::full_width(
+                kvm_reg_arm64_core_q(index)?,
+                ArmCpuTemplateRegister::U128(ArmRegister128::Q(ArmQRegister(index))),
+            )
+        }
+        _ => return None,
+    };
+    Some(descriptor)
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ArmRegisterModifier {
     U32 {
@@ -653,11 +947,38 @@ pub enum ArmRegisterModifier {
 }
 
 impl ArmRegisterModifier {
+    /// Return the typed target.
+    pub const fn register(self) -> ArmCpuTemplateRegister {
+        match self {
+            Self::U32 { register, .. } => ArmCpuTemplateRegister::U32(register),
+            Self::U64 { register, .. } => ArmCpuTemplateRegister::U64(register),
+            Self::U128 { register, .. } => ArmCpuTemplateRegister::U128(register),
+        }
+    }
+
     pub const fn width(self) -> CpuConfigArmRegisterWidth {
         match self {
             Self::U32 { .. } => CpuConfigArmRegisterWidth::U32,
             Self::U64 { .. } => CpuConfigArmRegisterWidth::U64,
             Self::U128 { .. } => CpuConfigArmRegisterWidth::U128,
+        }
+    }
+
+    /// Return the modifier filter in a zero-extended transport slot.
+    pub const fn filter(self) -> u128 {
+        match self {
+            Self::U32 { filter, .. } => filter as u128,
+            Self::U64 { filter, .. } => filter as u128,
+            Self::U128 { filter, .. } => filter,
+        }
+    }
+
+    /// Return the modifier value in a zero-extended transport slot.
+    pub const fn value(self) -> u128 {
+        match self {
+            Self::U32 { value, .. } => value as u128,
+            Self::U64 { value, .. } => value as u128,
+            Self::U128 { value, .. } => value,
         }
     }
 
@@ -824,105 +1145,14 @@ impl fmt::Display for CpuConfigError {
 
 impl std::error::Error for CpuConfigError {}
 
-#[derive(Clone, Copy)]
-struct Arm64SystemRegisterProfile {
-    identity: u64,
-    register: ArmRegister64,
-    width: CpuConfigArmRegisterWidth,
-    boot_disposition: ArmRegisterBootDisposition,
-    availability: ArmRegisterAvailability,
-    allowed_filter: u64,
-}
-
-impl Arm64SystemRegisterProfile {
-    const fn accepted(identity: u64, register: ArmRegister64, allowed_filter: u64) -> Self {
-        Self {
-            identity,
-            register,
-            width: CpuConfigArmRegisterWidth::U64,
-            boot_disposition: register.boot_disposition(),
-            availability: register.availability(),
-            allowed_filter,
-        }
-    }
-}
-
-const ARM64_SYSTEM_REGISTER_PROFILE: [Arm64SystemRegisterProfile; 12] = [
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64PFR0_EL1,
-        ArmRegister64::Id(ArmIdRegister::Pfr0),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64PFR1_EL1,
-        ArmRegister64::Id(ArmIdRegister::Pfr1),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64DFR0_EL1,
-        ArmRegister64::Id(ArmIdRegister::Dfr0),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64DFR1_EL1,
-        ArmRegister64::Id(ArmIdRegister::Dfr1),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64ISAR0_EL1,
-        ArmRegister64::Id(ArmIdRegister::Isar0),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64ISAR1_EL1,
-        ArmRegister64::Id(ArmIdRegister::Isar1),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64MMFR0_EL1,
-        ArmRegister64::Id(ArmIdRegister::Mmfr0),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64MMFR1_EL1,
-        ArmRegister64::Id(ArmIdRegister::Mmfr1),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64MMFR2_EL1,
-        ArmRegister64::Id(ArmIdRegister::Mmfr2),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64ZFR0_EL1,
-        ArmRegister64::Id(ArmIdRegister::Zfr0),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ID_AA64SMFR0_EL1,
-        ArmRegister64::Id(ArmIdRegister::Smfr0),
-        u64::MAX,
-    ),
-    Arm64SystemRegisterProfile::accepted(
-        KVM_REG_ARM64_ACTLR_EL1,
-        ArmRegister64::Actlr,
-        ARM64_ACTLR_ENTSO_MASK,
-    ),
-];
-
-fn accepted_system_register(id: u64) -> Option<Arm64SystemRegisterProfile> {
-    ARM64_SYSTEM_REGISTER_PROFILE
-        .iter()
-        .copied()
-        .find(|entry| entry.identity == id)
-}
-
 fn classify_u64_register(id: u64) -> Result<ArmRegister64, CpuConfigError> {
-    if let Some(entry) = accepted_system_register(id) {
-        debug_assert_eq!(entry.width, CpuConfigArmRegisterWidth::U64);
-        debug_assert_eq!(entry.boot_disposition, entry.register.boot_disposition());
-        debug_assert_eq!(entry.availability, entry.register.availability());
-        return Ok(entry.register);
+    if let Some(descriptor) = arm64_cpu_template_register_descriptor(id) {
+        return match descriptor.register() {
+            ArmCpuTemplateRegister::U64(register) => Ok(register),
+            ArmCpuTemplateRegister::U32(_) | ArmCpuTemplateRegister::U128(_) => {
+                Err(CpuConfigError::InvalidRegisterWidth)
+            }
+        };
     }
     if matches!(
         id,
@@ -1005,9 +1235,9 @@ fn classify_unaccepted_register(id: u64) -> CpuConfigError {
 }
 
 fn classify_unaccepted_system_register(register: u16) -> CpuConfigError {
-    if ARM64_SYSTEM_REGISTER_PROFILE
+    if ARM64_SYSTEM_REGISTERS
         .iter()
-        .any(|entry| entry.identity as u16 == register)
+        .any(|(identity, _, _)| *identity as u16 == register)
     {
         return CpuConfigError::InvalidRegisterWidth;
     }
@@ -1188,13 +1418,13 @@ mod tests {
     fn prepares_the_complete_system_register_profile_in_order() {
         let input = CpuConfigInput::new(
             Vec::new(),
-            ARM64_SYSTEM_REGISTER_PROFILE
+            ARM64_SYSTEM_REGISTERS
                 .iter()
-                .map(|entry| {
+                .map(|(identity, _, allowed_filter)| {
                     modifier(
-                        entry.identity,
+                        *identity,
                         CpuConfigArmRegisterWidth::U64,
-                        entry.allowed_filter.into(),
+                        *allowed_filter,
                         0,
                     )
                 })
@@ -1211,16 +1441,22 @@ mod tests {
             .modifiers()
             .iter()
             .copied()
-            .zip(ARM64_SYSTEM_REGISTER_PROFILE)
+            .zip(ARM64_SYSTEM_REGISTERS)
         {
+            let (identity, expected_register, allowed_filter) = entry;
             let (register, filter, value) = u64_modifier_parts(modifier);
-            assert_eq!(register, entry.register);
-            assert_eq!(filter, entry.allowed_filter);
+            assert_eq!(register, expected_register);
+            assert_eq!(filter as u128, allowed_filter);
             assert_eq!(value, 0);
-            assert_eq!(entry.width, CpuConfigArmRegisterWidth::U64);
-            assert_eq!(entry.boot_disposition, ArmRegisterBootDisposition::Retained);
-            assert_eq!(register.boot_disposition(), entry.boot_disposition);
-            assert_eq!(register.availability(), entry.availability);
+            let descriptor = arm64_cpu_template_register_descriptor(identity)
+                .expect("system identity should have one descriptor");
+            assert_eq!(descriptor.width(), CpuConfigArmRegisterWidth::U64);
+            assert_eq!(
+                descriptor.boot_disposition(),
+                ArmRegisterBootDisposition::Retained
+            );
+            assert_eq!(descriptor.register(), ArmCpuTemplateRegister::U64(register));
+            assert_eq!(descriptor.allowed_filter(), allowed_filter);
         }
 
         assert_eq!(
@@ -1252,10 +1488,89 @@ mod tests {
             );
         }
 
-        for (index, left) in ARM64_SYSTEM_REGISTER_PROFILE.iter().enumerate() {
-            for right in &ARM64_SYSTEM_REGISTER_PROFILE[index + 1..] {
-                assert_ne!(left.identity, right.identity);
-                assert_ne!(left.register, right.register);
+        for (index, left) in ARM64_SYSTEM_REGISTERS.iter().enumerate() {
+            for right in &ARM64_SYSTEM_REGISTERS[index + 1..] {
+                assert_ne!(left.0, right.0);
+                assert_ne!(left.1, right.1);
+            }
+        }
+    }
+
+    #[test]
+    fn descriptor_inventory_is_exact_unique_and_ordered() {
+        let descriptors = arm64_cpu_template_register_descriptors().collect::<Vec<_>>();
+        assert_eq!(descriptors.len(), ARM64_CPU_TEMPLATE_REGISTER_COUNT);
+
+        for pair in descriptors.windows(2) {
+            assert!(pair[0].identity() < pair[1].identity());
+            assert_ne!(pair[0].register(), pair[1].register());
+        }
+
+        let width_count = |width| {
+            descriptors
+                .iter()
+                .filter(|descriptor| descriptor.width() == width)
+                .count()
+        };
+        assert_eq!(width_count(CpuConfigArmRegisterWidth::U32), 2);
+        assert_eq!(width_count(CpuConfigArmRegisterWidth::U64), 46);
+        assert_eq!(width_count(CpuConfigArmRegisterWidth::U128), 32);
+
+        let disposition_count = |disposition| {
+            descriptors
+                .iter()
+                .filter(|descriptor| descriptor.boot_disposition() == disposition)
+                .count()
+        };
+        assert_eq!(disposition_count(ArmRegisterBootDisposition::Retained), 77);
+        assert_eq!(
+            disposition_count(ArmRegisterBootDisposition::AppliedThenBootOverridden),
+            3
+        );
+
+        let availability_count = |availability| {
+            descriptors
+                .iter()
+                .filter(|descriptor| descriptor.availability() == availability)
+                .count()
+        };
+        assert_eq!(availability_count(ArmRegisterAvailability::Baseline), 77);
+        assert_eq!(availability_count(ArmRegisterAvailability::MacOs15_0), 1);
+        assert_eq!(availability_count(ArmRegisterAvailability::MacOs15_2), 2);
+
+        for descriptor in descriptors {
+            assert_eq!(
+                arm64_cpu_template_register_descriptor(descriptor.identity()),
+                Some(descriptor)
+            );
+            let expected_full_filter = match descriptor.width() {
+                CpuConfigArmRegisterWidth::U32 => u32::MAX as u128,
+                CpuConfigArmRegisterWidth::U64 => u64::MAX as u128,
+                CpuConfigArmRegisterWidth::U128 => u128::MAX,
+            };
+            if descriptor.register() == ArmCpuTemplateRegister::U64(ArmRegister64::Actlr) {
+                assert_eq!(descriptor.allowed_filter(), ARM64_ACTLR_ENTSO_MASK as u128);
+            } else {
+                assert_eq!(descriptor.allowed_filter(), expected_full_filter);
+            }
+        }
+    }
+
+    #[test]
+    fn descriptor_decoder_rejects_every_mismatched_declared_width() {
+        for descriptor in arm64_cpu_template_register_descriptors() {
+            for width in [
+                CpuConfigArmRegisterWidth::U32,
+                CpuConfigArmRegisterWidth::U64,
+                CpuConfigArmRegisterWidth::U128,
+            ] {
+                if width == descriptor.width() {
+                    continue;
+                }
+                assert_eq!(
+                    executable_modifier(descriptor.identity(), width, 0, 0),
+                    Err(CpuConfigError::InvalidRegisterWidth)
+                );
             }
         }
     }
@@ -1705,34 +2020,9 @@ mod tests {
             );
         }
 
-        let mut accepted = vec![
-            (KVM_REG_ARM64_CORE_FPCR, CpuConfigArmRegisterWidth::U32),
-            (KVM_REG_ARM64_CORE_FPSR, CpuConfigArmRegisterWidth::U32),
-            (KVM_REG_ARM64_CORE_SP_EL0, CpuConfigArmRegisterWidth::U64),
-            (KVM_REG_ARM64_CORE_PC, CpuConfigArmRegisterWidth::U64),
-            (KVM_REG_ARM64_CORE_PSTATE, CpuConfigArmRegisterWidth::U64),
-            (KVM_REG_ARM64_CORE_SP_EL1, CpuConfigArmRegisterWidth::U64),
-            (KVM_REG_ARM64_CORE_ELR_EL1, CpuConfigArmRegisterWidth::U64),
-            (KVM_REG_ARM64_CORE_SPSR_EL1, CpuConfigArmRegisterWidth::U64),
-        ];
-        accepted.extend([0_u8].into_iter().chain(4..=30).map(|index| {
-            (
-                kvm_reg_arm64_core_x(index).expect("reviewed X index should map"),
-                CpuConfigArmRegisterWidth::U64,
-            )
-        }));
-        accepted.extend((0..=31).map(|index| {
-            (
-                kvm_reg_arm64_core_q(index).expect("reviewed Q index should map"),
-                CpuConfigArmRegisterWidth::U128,
-            )
-        }));
-        accepted.extend(
-            ARM64_SYSTEM_REGISTER_PROFILE
-                .iter()
-                .map(|entry| (entry.identity, CpuConfigArmRegisterWidth::U64)),
-        );
-        for (id, correct_width) in accepted {
+        for descriptor in arm64_cpu_template_register_descriptors() {
+            let id = descriptor.identity();
+            let correct_width = descriptor.width();
             for wrong_width in [
                 CpuConfigArmRegisterWidth::U32,
                 CpuConfigArmRegisterWidth::U64,

--- a/docs/security.md
+++ b/docs/security.md
@@ -1848,6 +1848,23 @@ is resource-specific:
   executor/backend construction because live writes cannot establish its
   documented Neoverse V1 source model on Apple Silicon. The complete boundary
   is checked in `compat/firecracker/v1.16.0/cpu-template-contract.md`.
+  The library-only CPU-template helper foundation adds no ambient resource or
+  hypervisor authority. It parses complete config documents but projects only
+  machine and CPU actions, never opening paths from unrelated sections. Config
+  and template files are capped at 1 MiB and opened close-on-exec, no-follow,
+  and nonblocking; only descriptor-confirmed regular UTF-8 files are read.
+  Diagnostics omit paths, register identities, masks, values, and provider
+  internals.
+  Helper output is absent-only: an owner-only same-directory stage is written,
+  synchronized, identity-checked, and committed by exclusive `NOREPLACE`
+  rename. Precommit cleanup removes only the captured stage identity. A changed
+  identity or failed cleanup is explicitly uncertain and leaves the unknown
+  object untouched. After rename, final-state or directory-durability failure
+  is postcommit uncertainty and is never presented as rollback. This is
+  no-clobber integrity, not content authentication or authority over hostile
+  ancestor directories. The complete helper-specific boundary is checked in
+  `compat/firecracker/v1.16.0/cpu-template-helper-contract.md`; real all-vCPU
+  HVF capture and signed public-process evidence remain #1862 work.
   Breakpoint value registers can expose guest virtual addresses, Context IDs,
   or VMIDs. Watchpoint value registers expose guest data virtual addresses, and
   their controls can encode access type, byte selection, linking, and enabled

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1172,6 +1172,26 @@ fixed success/failure markers, never report values. Run both through
 `scripts/run-integration-tests.sh` without `--allow-unsupported`; the direct
 rootfs builder requires the installed stable `aarch64-unknown-linux-musl`
 target and embeds the deterministic static helper.
+
+The library-only CPU-template helper foundation has a separate portable gate:
+
+```sh
+cargo test -p bangbang-api --locked
+cargo test -p bangbang-runtime --all-features --locked --lib cpu
+cargo test -p bangbang-cpu-template-helper --locked
+cargo test -p bangbang --all-features --locked helper_cpu_inspection_projection_matches_production_actions
+cargo test -p bangbang-firecracker-capability-audit --test checked_inventory cpu_template_helper_foundation_policy_is_stable --locked
+```
+
+These tests prove shared duplicate-safe config parsing, exact production action
+projection, the runtime-owned descriptor census and accepted decoder, canonical
+format round trips, identity-bound provider profiles, optional availability,
+filter comparison, bounded regular-file input, value/path redaction, and the
+exclusive publication fault matrix. They do not prove a public command or real
+effective capture. #1862 must add the executable and production provider, run
+its direct and App Sandbox process matrix through
+`scripts/run-integration-tests.sh` without `--allow-unsupported`, and only then
+promote the seven dump/verify capability rows.
 SVE/SME identification signed tests require macOS 15.2 and must capture ZFR0
 and SMFR0 twice from one idle real vCPU. They may assert same-vCPU stability but
 must not hard-code one feature model, enable SVE/SME, enter streaming mode,

--- a/tools/cpu-template-helper/Cargo.toml
+++ b/tools/cpu-template-helper/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bangbang-cpu-template-helper"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+bangbang-api = { path = "../../crates/api" }
+bangbang-runtime = { path = "../../crates/runtime" }
+rustix = { version = "=1.1.4", features = ["fs"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.140"
+
+[lints]
+workspace = true

--- a/tools/cpu-template-helper/src/document.rs
+++ b/tools/cpu-template-helper/src/document.rs
@@ -1,0 +1,400 @@
+//! Strict custom-template decoding and canonical encoding.
+
+use std::fmt;
+
+use bangbang_api::config::parse_cpu_config_document;
+use bangbang_runtime::cpu::{
+    ArmRegisterModifier, CpuConfigArmRegisterModifier, CpuConfigArmRegisterWidth, CpuConfigError,
+    CpuConfigInput, CustomCpuTemplate, arm64_cpu_template_register_descriptors,
+};
+use serde::Serialize;
+
+use crate::CPU_TEMPLATE_DOCUMENT_MAX_BYTES;
+use crate::projection::cpu_config_input_from_request;
+
+const VALUE_REDACTED: &str = "<redacted>";
+
+/// Failure while decoding a persisted custom CPU template.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuTemplateDocumentError {
+    TooLarge,
+    Malformed,
+    NonCanonical,
+    Unsupported,
+}
+
+impl fmt::Display for CpuTemplateDocumentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::TooLarge => "CPU-template document exceeds the size limit",
+            Self::Malformed => "CPU-template document is malformed",
+            Self::NonCanonical => "CPU-template document is not semantically canonical",
+            Self::Unsupported => "CPU-template document requests unsupported state",
+        })
+    }
+}
+
+impl std::error::Error for CpuTemplateDocumentError {}
+
+/// Failure while encoding a canonical custom CPU template.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuTemplateEncodeError {
+    Serialization,
+    TooLarge,
+}
+
+impl fmt::Display for CpuTemplateEncodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Serialization => "CPU-template document could not be encoded",
+            Self::TooLarge => "encoded CPU-template document exceeds the size limit",
+        })
+    }
+}
+
+impl std::error::Error for CpuTemplateEncodeError {}
+
+/// One normalized arm64 register modifier.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CpuTemplateModifier {
+    identity: u64,
+    width: CpuConfigArmRegisterWidth,
+    filter: u128,
+    value: u128,
+}
+
+impl CpuTemplateModifier {
+    pub(crate) const fn new(
+        identity: u64,
+        width: CpuConfigArmRegisterWidth,
+        filter: u128,
+        value: u128,
+    ) -> Self {
+        Self {
+            identity,
+            width,
+            filter,
+            value,
+        }
+    }
+
+    /// Return the compatibility identity.
+    pub const fn identity(self) -> u64 {
+        self.identity
+    }
+
+    /// Return the exact register width.
+    pub const fn width(self) -> CpuConfigArmRegisterWidth {
+        self.width
+    }
+
+    /// Return the modifier filter to trusted comparison code.
+    pub const fn filter(self) -> u128 {
+        self.filter
+    }
+
+    /// Return the modifier value to trusted comparison code.
+    pub const fn value(self) -> u128 {
+        self.value
+    }
+}
+
+impl fmt::Debug for CpuTemplateModifier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CpuTemplateModifier")
+            .field("width", &self.width)
+            .field("identity", &VALUE_REDACTED)
+            .field("filter", &VALUE_REDACTED)
+            .field("value", &VALUE_REDACTED)
+            .finish()
+    }
+}
+
+/// One normalized Firecracker-shaped arm64 custom CPU template.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CpuTemplateDocument {
+    modifiers: Vec<CpuTemplateModifier>,
+}
+
+impl CpuTemplateDocument {
+    /// Return modifiers in ascending compatibility-identity order.
+    pub fn modifiers(&self) -> &[CpuTemplateModifier] {
+        &self.modifiers
+    }
+
+    /// Convert the normalized document back into runtime input.
+    pub fn to_runtime_input(&self) -> CpuConfigInput {
+        CpuConfigInput::new(
+            Vec::new(),
+            self.modifiers
+                .iter()
+                .copied()
+                .map(|modifier| {
+                    CpuConfigArmRegisterModifier::new(
+                        modifier.identity,
+                        modifier.width,
+                        modifier.filter,
+                        modifier.value,
+                    )
+                })
+                .collect(),
+            Vec::new(),
+        )
+    }
+
+    /// Encode fixed-field, fixed-width, sorted pretty JSON with one newline.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, CpuTemplateEncodeError> {
+        let wire = WireDocument {
+            kvm_capabilities: Vec::new(),
+            reg_modifiers: self
+                .modifiers
+                .iter()
+                .copied()
+                .map(|modifier| WireModifier {
+                    addr: format!("0x{:016x}", modifier.identity),
+                    bitmap: canonical_bitmap(modifier),
+                })
+                .collect(),
+            vcpu_features: Vec::new(),
+        };
+        let mut bytes =
+            serde_json::to_vec_pretty(&wire).map_err(|_| CpuTemplateEncodeError::Serialization)?;
+        bytes.push(b'\n');
+        if bytes.len() > CPU_TEMPLATE_DOCUMENT_MAX_BYTES {
+            return Err(CpuTemplateEncodeError::TooLarge);
+        }
+        Ok(bytes)
+    }
+
+    pub(crate) fn from_modifiers(mut modifiers: Vec<CpuTemplateModifier>) -> Self {
+        modifiers.sort_by_key(|modifier| modifier.identity);
+        Self { modifiers }
+    }
+}
+
+impl fmt::Debug for CpuTemplateDocument {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CpuTemplateDocument")
+            .field("modifier_count", &self.modifiers.len())
+            .field("values", &VALUE_REDACTED)
+            .finish()
+    }
+}
+
+/// Decode, close over the runtime target inventory, and normalize one custom
+/// CPU-template document.
+pub fn decode_cpu_template_document(
+    contents: &str,
+) -> Result<CpuTemplateDocument, CpuTemplateDocumentError> {
+    if contents.len() > CPU_TEMPLATE_DOCUMENT_MAX_BYTES {
+        return Err(CpuTemplateDocumentError::TooLarge);
+    }
+    let request =
+        parse_cpu_config_document(contents).map_err(|_| CpuTemplateDocumentError::Malformed)?;
+    let input = cpu_config_input_from_request(&request);
+    input
+        .clone()
+        .into_custom_template()
+        .map_err(classify_runtime_error)?;
+
+    let mut modifiers = input
+        .reg_modifiers()
+        .iter()
+        .copied()
+        .map(|modifier| {
+            CpuTemplateModifier::new(
+                modifier.id(),
+                modifier.width(),
+                modifier.filter(),
+                modifier.value(),
+            )
+        })
+        .collect::<Vec<_>>();
+    modifiers.sort_by_key(|modifier| modifier.identity);
+    Ok(CpuTemplateDocument { modifiers })
+}
+
+pub(crate) fn document_from_custom_template(
+    template: &CustomCpuTemplate,
+) -> Option<CpuTemplateDocument> {
+    let modifiers = template
+        .modifiers()
+        .iter()
+        .copied()
+        .map(modifier_from_runtime)
+        .collect::<Option<Vec<_>>>()?;
+    Some(CpuTemplateDocument::from_modifiers(modifiers))
+}
+
+fn modifier_from_runtime(modifier: ArmRegisterModifier) -> Option<CpuTemplateModifier> {
+    let descriptor = arm64_cpu_template_register_descriptors()
+        .find(|descriptor| descriptor.register() == modifier.register())?;
+    Some(CpuTemplateModifier::new(
+        descriptor.identity(),
+        descriptor.width(),
+        modifier.filter(),
+        modifier.value(),
+    ))
+}
+
+fn classify_runtime_error(error: CpuConfigError) -> CpuTemplateDocumentError {
+    match error {
+        CpuConfigError::TooManyEntries { .. }
+        | CpuConfigError::DuplicateIdentity { .. }
+        | CpuConfigError::FeatureIndexOutOfRange
+        | CpuConfigError::InvalidRegisterArchitecture
+        | CpuConfigError::InvalidRegisterWidth
+        | CpuConfigError::ValueOutsideFilter { .. }
+        | CpuConfigError::ValueOutsideRegisterWidth
+        | CpuConfigError::InvalidRegisterIdentity
+        | CpuConfigError::RegisterAliasUnsupported
+        | CpuConfigError::ActlrFilterUnsupported => CpuTemplateDocumentError::NonCanonical,
+        CpuConfigError::KvmCapabilitiesUnsupported
+        | CpuConfigError::VcpuFeaturesUnsupported
+        | CpuConfigError::MixedUnsupported
+        | CpuConfigError::BootReservedRegister
+        | CpuConfigError::Aarch32BankedRegisterUnavailable
+        | CpuConfigError::KvmDemuxRegisterUnsupported
+        | CpuConfigError::KvmFirmwareRegisterUnsupported
+        | CpuConfigError::KvmFirmwareFeatureRegisterUnsupported
+        | CpuConfigError::KvmSveRegisterUnsupported
+        | CpuConfigError::UnknownKvmRegisterClass
+        | CpuConfigError::TopologyRegisterUnsupported
+        | CpuConfigError::LifecycleRegisterUnsupported
+        | CpuConfigError::SecuritySensitiveRegisterUnsupported
+        | CpuConfigError::TimeDependentRegisterUnsupported
+        | CpuConfigError::SeparatelyOwnedRegisterUnsupported
+        | CpuConfigError::MutableSmeRegisterUnsupported
+        | CpuConfigError::DisabledEl2RegisterUnsupported
+        | CpuConfigError::UnnamedSystemRegisterUnsupported => CpuTemplateDocumentError::Unsupported,
+    }
+}
+
+fn canonical_bitmap(modifier: CpuTemplateModifier) -> String {
+    let bit_count = modifier.width.bits();
+    let mut bitmap = String::with_capacity(bit_count as usize + 2);
+    bitmap.push_str("0b");
+    for bit in (0..bit_count).rev() {
+        let mask = 1_u128 << bit;
+        bitmap.push(if modifier.filter & mask == 0 {
+            'x'
+        } else if modifier.value & mask == 0 {
+            '0'
+        } else {
+            '1'
+        });
+    }
+    bitmap
+}
+
+#[derive(Serialize)]
+struct WireDocument {
+    kvm_capabilities: Vec<()>,
+    reg_modifiers: Vec<WireModifier>,
+    vcpu_features: Vec<()>,
+}
+
+#[derive(Serialize)]
+struct WireModifier {
+    addr: String,
+    bitmap: String,
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+    use bangbang_runtime::cpu::{
+        KVM_REG_ARM64_CORE_FPCR, KVM_REG_ARM64_CORE_SP_EL0, kvm_reg_arm64_core_q,
+    };
+
+    use super::*;
+
+    #[test]
+    fn normalizes_three_widths_and_round_trips_canonical_bytes() {
+        let q0 = kvm_reg_arm64_core_q(0).expect("Q0 should have an identity");
+        let contents = format!(
+            "{{\"reg_modifiers\":[\
+             {{\"bitmap\":\"0b1x\",\"addr\":\"0x{q0:x}\"}},\
+             {{\"addr\":\"0x{KVM_REG_ARM64_CORE_FPCR:x}\",\"bitmap\":\"0b1\"}},\
+             {{\"addr\":\"0x{KVM_REG_ARM64_CORE_SP_EL0:x}\",\"bitmap\":\"0b0x1\"}}]}}"
+        );
+        let document = decode_cpu_template_document(&contents).expect("template should normalize");
+        let bytes = document.canonical_bytes().expect("template should encode");
+        let text = std::str::from_utf8(&bytes).expect("canonical JSON should be UTF-8");
+
+        assert!(text.ends_with("\n"));
+        assert!(text.contains("\"kvm_capabilities\": []"));
+        assert!(text.contains("\"vcpu_features\": []"));
+        assert!(text.contains(&format!("0x{KVM_REG_ARM64_CORE_FPCR:016x}")));
+        assert!(text.contains(&format!("0x{KVM_REG_ARM64_CORE_SP_EL0:016x}")));
+        assert!(text.contains(&format!("0x{q0:016x}")));
+        assert_eq!(text.matches("0b").count(), 3);
+
+        let reparsed = decode_cpu_template_document(text).expect("canonical JSON should reparse");
+        assert_eq!(reparsed, document);
+    }
+
+    #[test]
+    fn canonical_output_has_one_exact_wire_form() {
+        let contents = format!(
+            "{{\"reg_modifiers\":[{{\"bitmap\":\"0b1\",\"addr\":\"0x{KVM_REG_ARM64_CORE_FPCR:x}\"}}]}}"
+        );
+        let document = decode_cpu_template_document(&contents).expect("template should normalize");
+        let bitmap = format!("0b{}1", "x".repeat(31));
+        let expected = format!(
+            "{{\n  \"kvm_capabilities\": [],\n  \"reg_modifiers\": [\n    {{\n      \"addr\": \"0x{KVM_REG_ARM64_CORE_FPCR:016x}\",\n      \"bitmap\": \"{bitmap}\"\n    }}\n  ],\n  \"vcpu_features\": []\n}}\n"
+        );
+        assert_eq!(
+            document.canonical_bytes().as_deref(),
+            Ok(expected.as_bytes())
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_malformed_and_unsupported_documents_without_values() {
+        let oversized = " ".repeat(CPU_TEMPLATE_DOCUMENT_MAX_BYTES + 1);
+        assert_eq!(
+            decode_cpu_template_document(&oversized),
+            Err(CpuTemplateDocumentError::TooLarge)
+        );
+        assert_eq!(
+            decode_cpu_template_document("{"),
+            Err(CpuTemplateDocumentError::Malformed)
+        );
+        assert_eq!(
+            decode_cpu_template_document(r#"{"kvm_capabilities":["1"]}"#),
+            Err(CpuTemplateDocumentError::Unsupported)
+        );
+        assert_eq!(
+            format!("{:?}", decode_cpu_template_document("{").unwrap_err()),
+            "Malformed"
+        );
+
+        let duplicate_target = format!(
+            "{{\"reg_modifiers\":[{{\"addr\":\"0x{KVM_REG_ARM64_CORE_FPCR:x}\",\"bitmap\":\"0b1\"}},{{\"addr\":\"0x{KVM_REG_ARM64_CORE_FPCR:x}\",\"bitmap\":\"0b0\"}}]}}"
+        );
+        assert_eq!(
+            decode_cpu_template_document(&duplicate_target),
+            Err(CpuTemplateDocumentError::Malformed)
+        );
+        assert_eq!(
+            decode_cpu_template_document(r#"{"unknown":[]}"#),
+            Err(CpuTemplateDocumentError::Malformed)
+        );
+        assert_eq!(
+            decode_cpu_template_document(
+                r#"{"reg_modifiers":[{"addr":"0x60300000001000d5","bitmap":"0b1"}]}"#,
+            ),
+            Err(CpuTemplateDocumentError::NonCanonical)
+        );
+        assert_eq!(
+            decode_cpu_template_document(
+                r#"{"reg_modifiers":[{"addr":"0x603000000013c200","bitmap":"0b1"}]}"#,
+            ),
+            Err(CpuTemplateDocumentError::NonCanonical)
+        );
+    }
+}

--- a/tools/cpu-template-helper/src/input.rs
+++ b/tools/cpu-template-helper/src/input.rs
@@ -1,0 +1,178 @@
+//! Bounded path-redacted CPU-template helper input.
+
+use std::fmt;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use rustix::fs::{FileType, Mode, OFlags, fstat, open};
+
+use crate::CPU_TEMPLATE_DOCUMENT_MAX_BYTES;
+
+/// Failure while reading one helper input document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputError {
+    Open,
+    Inspect,
+    NotRegular,
+    TooLarge,
+    Read,
+    InvalidUtf8,
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Open => "helper input could not be opened safely",
+            Self::Inspect => "helper input could not be inspected safely",
+            Self::NotRegular => "helper input must be a regular file",
+            Self::TooLarge => "helper input exceeds the size limit",
+            Self::Read => "helper input could not be read",
+            Self::InvalidUtf8 => "helper input is not UTF-8",
+        })
+    }
+}
+
+impl std::error::Error for InputError {}
+
+/// Read at most one MiB from a no-follow regular file and validate UTF-8.
+pub fn read_regular_utf8(path: &Path) -> Result<String, InputError> {
+    read_regular_utf8_with_post_inspection(path, || {})
+}
+
+fn read_regular_utf8_with_post_inspection(
+    path: &Path,
+    post_inspection: impl FnOnce(),
+) -> Result<String, InputError> {
+    let descriptor = open(
+        path,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
+        Mode::empty(),
+    )
+    .map_err(|_| InputError::Open)?;
+    let metadata = fstat(&descriptor).map_err(|_| InputError::Inspect)?;
+    if FileType::from_raw_mode(metadata.st_mode) != FileType::RegularFile {
+        return Err(InputError::NotRegular);
+    }
+    let size = usize::try_from(metadata.st_size).map_err(|_| InputError::Inspect)?;
+    if size > CPU_TEMPLATE_DOCUMENT_MAX_BYTES {
+        return Err(InputError::TooLarge);
+    }
+    post_inspection();
+
+    let file = File::from(descriptor);
+    let mut contents = Vec::with_capacity(size);
+    file.take(CPU_TEMPLATE_DOCUMENT_MAX_BYTES as u64 + 1)
+        .read_to_end(&mut contents)
+        .map_err(|_| InputError::Read)?;
+    if contents.len() > CPU_TEMPLATE_DOCUMENT_MAX_BYTES {
+        return Err(InputError::TooLarge);
+    }
+    String::from_utf8(contents).map_err(|_| InputError::InvalidUtf8)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use std::fs;
+    use std::io::Write;
+    use std::os::unix::fs::symlink;
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    static TEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug)]
+    struct TestDirectory(std::path::PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should follow epoch")
+                .as_nanos();
+            let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bangbang-cpu-template-input-{}-{nonce}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("test directory should be created");
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn reads_boundaries_and_rejects_oversize_or_invalid_utf8() {
+        let directory = TestDirectory::new();
+        let empty = directory.0.join("empty");
+        fs::write(&empty, []).expect("empty fixture should be written");
+        assert_eq!(read_regular_utf8(&empty).as_deref(), Ok(""));
+
+        let exact = directory.0.join("exact");
+        fs::write(&exact, vec![b'a'; CPU_TEMPLATE_DOCUMENT_MAX_BYTES])
+            .expect("fixture should be written");
+        assert_eq!(
+            read_regular_utf8(&exact)
+                .expect("exact limit should read")
+                .len(),
+            CPU_TEMPLATE_DOCUMENT_MAX_BYTES
+        );
+
+        let oversized = directory.0.join("oversized");
+        fs::write(&oversized, vec![b'a'; CPU_TEMPLATE_DOCUMENT_MAX_BYTES + 1])
+            .expect("fixture should be written");
+        assert_eq!(read_regular_utf8(&oversized), Err(InputError::TooLarge));
+
+        let invalid = directory.0.join("invalid");
+        fs::write(&invalid, [0xff]).expect("fixture should be written");
+        assert_eq!(read_regular_utf8(&invalid), Err(InputError::InvalidUtf8));
+
+        let growing = directory.0.join("growing");
+        fs::write(&growing, vec![b'a'; CPU_TEMPLATE_DOCUMENT_MAX_BYTES])
+            .expect("growing fixture should be written");
+        assert_eq!(
+            read_regular_utf8_with_post_inspection(&growing, || {
+                let mut file = fs::OpenOptions::new()
+                    .append(true)
+                    .open(&growing)
+                    .expect("growing fixture should reopen");
+                file.write_all(b"x").expect("growing fixture should extend");
+            }),
+            Err(InputError::TooLarge)
+        );
+    }
+
+    #[test]
+    fn rejects_symlink_and_non_regular_paths_without_echoing_paths() {
+        let directory = TestDirectory::new();
+        let target = directory.0.join("target");
+        fs::write(&target, b"{}").expect("fixture should be written");
+        let link = directory.0.join("private-link-name");
+        symlink(&target, &link).expect("symlink fixture should be created");
+        let error = read_regular_utf8(&link).expect_err("symlink should fail closed");
+        assert_eq!(error, InputError::Open);
+        assert!(!error.to_string().contains("private-link-name"));
+
+        assert_eq!(read_regular_utf8(&directory.0), Err(InputError::NotRegular));
+
+        let fifo = directory.0.join("private-fifo-name");
+        let status = Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("mkfifo should be available on supported hosts");
+        assert!(status.success(), "FIFO fixture should be created");
+        let error = read_regular_utf8(&fifo).expect_err("FIFO should fail without blocking");
+        assert_eq!(error, InputError::NotRegular);
+        assert!(!error.to_string().contains("private-fifo-name"));
+    }
+}

--- a/tools/cpu-template-helper/src/lib.rs
+++ b/tools/cpu-template-helper/src/lib.rs
@@ -1,0 +1,29 @@
+//! Portable contract foundation for Firecracker-shaped CPU-template tools.
+
+pub mod document;
+pub mod input;
+pub mod profile;
+pub mod projection;
+pub mod publication;
+
+/// Maximum accepted config, template, or emitted template document size.
+pub const CPU_TEMPLATE_DOCUMENT_MAX_BYTES: usize = 1024 * 1024;
+
+/// Stable process-exit class reserved for the future public helper binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelperExitClass {
+    Success,
+    OperationalFailure,
+    InvocationFailure,
+}
+
+impl HelperExitClass {
+    /// Return the stable process exit code.
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::Success => 0,
+            Self::OperationalFailure => 1,
+            Self::InvocationFailure => 2,
+        }
+    }
+}

--- a/tools/cpu-template-helper/src/profile.rs
+++ b/tools/cpu-template-helper/src/profile.rs
@@ -1,0 +1,528 @@
+//! Effective-profile contract and portable dump/verify orchestration.
+
+use std::fmt;
+
+use bangbang_runtime::cpu::{
+    ARM64_CPU_TEMPLATE_REGISTER_COUNT, ArmRegisterAvailability, ArmRegisterBootDisposition,
+    CpuConfigArmRegisterWidth, arm64_cpu_template_register_descriptor,
+    arm64_cpu_template_register_descriptors,
+};
+
+use crate::HelperExitClass;
+use crate::document::{
+    CpuTemplateDocument, CpuTemplateEncodeError, CpuTemplateModifier, document_from_custom_template,
+};
+use crate::projection::PreparedCpuTemplateInspection;
+
+const VALUE_REDACTED: &str = "<redacted>";
+
+/// One exact-width effective register value.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ArmCpuTemplateValue {
+    U32(u32),
+    U64(u64),
+    U128(u128),
+}
+
+impl ArmCpuTemplateValue {
+    /// Return the exact architectural width.
+    pub const fn width(self) -> CpuConfigArmRegisterWidth {
+        match self {
+            Self::U32(_) => CpuConfigArmRegisterWidth::U32,
+            Self::U64(_) => CpuConfigArmRegisterWidth::U64,
+            Self::U128(_) => CpuConfigArmRegisterWidth::U128,
+        }
+    }
+
+    /// Return the value in a zero-extended transport slot.
+    pub const fn zero_extended(self) -> u128 {
+        match self {
+            Self::U32(value) => value as u128,
+            Self::U64(value) => value as u128,
+            Self::U128(value) => value,
+        }
+    }
+}
+
+impl fmt::Debug for ArmCpuTemplateValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(VALUE_REDACTED)
+    }
+}
+
+/// Availability result for one descriptor slot.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum EffectiveRegisterStatus {
+    Available(ArmCpuTemplateValue),
+    Unavailable,
+}
+
+impl fmt::Debug for EffectiveRegisterStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Available(_) => formatter
+                .debug_tuple("Available")
+                .field(&VALUE_REDACTED)
+                .finish(),
+            Self::Unavailable => formatter.write_str("Unavailable"),
+        }
+    }
+}
+
+/// One identity-bound entry returned by an effective provider.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct EffectiveCpuTemplateProfileEntry {
+    identity: u64,
+    status: EffectiveRegisterStatus,
+}
+
+impl EffectiveCpuTemplateProfileEntry {
+    /// Construct one available identity-bound entry.
+    pub const fn available(identity: u64, value: ArmCpuTemplateValue) -> Self {
+        Self {
+            identity,
+            status: EffectiveRegisterStatus::Available(value),
+        }
+    }
+
+    /// Construct one explicitly unavailable identity-bound entry.
+    pub const fn unavailable(identity: u64) -> Self {
+        Self {
+            identity,
+            status: EffectiveRegisterStatus::Unavailable,
+        }
+    }
+
+    /// Return the compatibility identity.
+    pub const fn identity(self) -> u64 {
+        self.identity
+    }
+
+    /// Return the effective availability/value status.
+    pub const fn status(self) -> EffectiveRegisterStatus {
+        self.status
+    }
+}
+
+impl fmt::Debug for EffectiveCpuTemplateProfileEntry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EffectiveCpuTemplateProfileEntry")
+            .field("identity", &VALUE_REDACTED)
+            .field("status", &self.status)
+            .finish()
+    }
+}
+
+/// Invalid structure returned by an effective profile provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectiveCpuTemplateProfileError {
+    EntryCount,
+    IdentityOrOrder,
+    Width,
+    RequiredUnavailable,
+}
+
+impl fmt::Display for EffectiveCpuTemplateProfileError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::EntryCount => "effective CPU profile has an invalid entry count",
+            Self::IdentityOrOrder => "effective CPU profile has an invalid identity order",
+            Self::Width => "effective CPU profile has an invalid value width",
+            Self::RequiredUnavailable => "effective CPU profile omits a baseline-required register",
+        })
+    }
+}
+
+impl std::error::Error for EffectiveCpuTemplateProfileError {}
+
+/// A topology-common application-checkpoint result covering the exact runtime
+/// descriptor census.
+#[derive(Clone, PartialEq, Eq)]
+pub struct EffectiveCpuTemplateProfile {
+    entries: Vec<EffectiveCpuTemplateProfileEntry>,
+}
+
+impl EffectiveCpuTemplateProfile {
+    /// Validate identity, order, width, and availability against the runtime
+    /// descriptor authority.
+    pub fn try_new(
+        entries: Vec<EffectiveCpuTemplateProfileEntry>,
+    ) -> Result<Self, EffectiveCpuTemplateProfileError> {
+        if entries.len() != ARM64_CPU_TEMPLATE_REGISTER_COUNT {
+            return Err(EffectiveCpuTemplateProfileError::EntryCount);
+        }
+        for (entry, descriptor) in entries
+            .iter()
+            .copied()
+            .zip(arm64_cpu_template_register_descriptors())
+        {
+            if entry.identity != descriptor.identity() {
+                return Err(EffectiveCpuTemplateProfileError::IdentityOrOrder);
+            }
+            match entry.status {
+                EffectiveRegisterStatus::Available(value)
+                    if value.width() != descriptor.width() =>
+                {
+                    return Err(EffectiveCpuTemplateProfileError::Width);
+                }
+                EffectiveRegisterStatus::Unavailable
+                    if descriptor.availability() == ArmRegisterAvailability::Baseline =>
+                {
+                    return Err(EffectiveCpuTemplateProfileError::RequiredUnavailable);
+                }
+                EffectiveRegisterStatus::Available(_) | EffectiveRegisterStatus::Unavailable => {}
+            }
+        }
+        Ok(Self { entries })
+    }
+
+    /// Return entries in exact descriptor order.
+    pub fn entries(&self) -> &[EffectiveCpuTemplateProfileEntry] {
+        &self.entries
+    }
+
+    fn entry(&self, identity: u64) -> Option<EffectiveCpuTemplateProfileEntry> {
+        self.entries
+            .iter()
+            .copied()
+            .find(|entry| entry.identity == identity)
+    }
+}
+
+impl fmt::Debug for EffectiveCpuTemplateProfile {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EffectiveCpuTemplateProfile")
+            .field("entry_count", &self.entries.len())
+            .field("values", &VALUE_REDACTED)
+            .finish()
+    }
+}
+
+/// Stable value-free failure stage returned by a production effective
+/// provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectiveProfileProviderError {
+    Unsupported,
+    Prepare,
+    Apply,
+    Capture,
+    Teardown,
+}
+
+impl fmt::Display for EffectiveProfileProviderError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Unsupported => "effective CPU inspection is unsupported",
+            Self::Prepare => "effective CPU inspection preparation failed",
+            Self::Apply => "effective CPU-template application failed",
+            Self::Capture => "effective CPU profile capture failed",
+            Self::Teardown => "effective CPU inspection teardown failed",
+        })
+    }
+}
+
+impl std::error::Error for EffectiveProfileProviderError {}
+
+/// Platform adapter for one real topology-common application-checkpoint
+/// inspection.
+pub trait EffectiveCpuTemplateProvider {
+    fn inspect(
+        &mut self,
+        request: &PreparedCpuTemplateInspection,
+    ) -> Result<EffectiveCpuTemplateProfile, EffectiveProfileProviderError>;
+}
+
+/// Portable dump or verification failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuTemplateOperationError {
+    Provider(EffectiveProfileProviderError),
+    NoTemplate,
+    RequestedRegisterUnavailable,
+    VerificationMismatch,
+    Encoding(CpuTemplateEncodeError),
+}
+
+impl CpuTemplateOperationError {
+    /// All orchestration failures are operational exit class 1.
+    pub const fn exit_class(self) -> HelperExitClass {
+        HelperExitClass::OperationalFailure
+    }
+}
+
+impl fmt::Display for CpuTemplateOperationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Provider(_) => "effective CPU inspection failed",
+            Self::NoTemplate => "no custom CPU template was selected",
+            Self::RequestedRegisterUnavailable => {
+                "a requested CPU-template register is unavailable"
+            }
+            Self::VerificationMismatch => "effective CPU-template verification failed",
+            Self::Encoding(_) => "effective CPU profile could not be encoded",
+        })
+    }
+}
+
+impl std::error::Error for CpuTemplateOperationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Provider(source) => Some(source),
+            Self::Encoding(source) => Some(source),
+            Self::NoTemplate | Self::RequestedRegisterUnavailable | Self::VerificationMismatch => {
+                None
+            }
+        }
+    }
+}
+
+/// Capture and canonically encode every available retained profile entry.
+pub fn dump_with_provider(
+    provider: &mut impl EffectiveCpuTemplateProvider,
+    request: &PreparedCpuTemplateInspection,
+) -> Result<Vec<u8>, CpuTemplateOperationError> {
+    let profile = provider
+        .inspect(request)
+        .map_err(CpuTemplateOperationError::Provider)?;
+    let modifiers = profile
+        .entries
+        .iter()
+        .copied()
+        .zip(arm64_cpu_template_register_descriptors())
+        .filter_map(|(entry, descriptor)| {
+            if descriptor.boot_disposition() != ArmRegisterBootDisposition::Retained {
+                return None;
+            }
+            let EffectiveRegisterStatus::Available(value) = entry.status else {
+                return None;
+            };
+            let filter = descriptor.allowed_filter();
+            Some(CpuTemplateModifier::new(
+                descriptor.identity(),
+                descriptor.width(),
+                filter,
+                value.zero_extended() & filter,
+            ))
+        })
+        .collect();
+    CpuTemplateDocument::from_modifiers(modifiers)
+        .canonical_bytes()
+        .map_err(CpuTemplateOperationError::Encoding)
+}
+
+/// Capture once and compare the selected custom template under its filters.
+pub fn verify_with_provider(
+    provider: &mut impl EffectiveCpuTemplateProvider,
+    request: &PreparedCpuTemplateInspection,
+) -> Result<(), CpuTemplateOperationError> {
+    let template = request
+        .custom_template()
+        .ok_or(CpuTemplateOperationError::NoTemplate)?;
+    let expected = document_from_custom_template(template)
+        .ok_or(CpuTemplateOperationError::VerificationMismatch)?;
+    let profile = provider
+        .inspect(request)
+        .map_err(CpuTemplateOperationError::Provider)?;
+
+    for modifier in expected.modifiers().iter().copied() {
+        let descriptor = arm64_cpu_template_register_descriptor(modifier.identity())
+            .ok_or(CpuTemplateOperationError::VerificationMismatch)?;
+        debug_assert_eq!(descriptor.width(), modifier.width());
+        let entry = profile
+            .entry(modifier.identity())
+            .ok_or(CpuTemplateOperationError::VerificationMismatch)?;
+        let EffectiveRegisterStatus::Available(effective) = entry.status else {
+            return Err(CpuTemplateOperationError::RequestedRegisterUnavailable);
+        };
+        if effective.zero_extended() & modifier.filter() != modifier.value() {
+            return Err(CpuTemplateOperationError::VerificationMismatch);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+    use bangbang_runtime::cpu::{
+        KVM_REG_ARM64_ACTLR_EL1, KVM_REG_ARM64_CORE_PC, KVM_REG_ARM64_CORE_SP_EL0,
+        KVM_REG_ARM64_ID_AA64SMFR0_EL1, KVM_REG_ARM64_ID_AA64ZFR0_EL1,
+    };
+
+    use super::*;
+    use crate::document::decode_cpu_template_document;
+    use crate::projection::prepare_inspection_request;
+
+    #[derive(Debug)]
+    struct FakeProvider {
+        profile: EffectiveCpuTemplateProfile,
+        calls: usize,
+    }
+
+    impl EffectiveCpuTemplateProvider for FakeProvider {
+        fn inspect(
+            &mut self,
+            _request: &PreparedCpuTemplateInspection,
+        ) -> Result<EffectiveCpuTemplateProfile, EffectiveProfileProviderError> {
+            self.calls += 1;
+            Ok(self.profile.clone())
+        }
+    }
+
+    fn zero_value(width: CpuConfigArmRegisterWidth) -> ArmCpuTemplateValue {
+        match width {
+            CpuConfigArmRegisterWidth::U32 => ArmCpuTemplateValue::U32(0),
+            CpuConfigArmRegisterWidth::U64 => ArmCpuTemplateValue::U64(0),
+            CpuConfigArmRegisterWidth::U128 => ArmCpuTemplateValue::U128(0),
+        }
+    }
+
+    fn profile_with(overrides: &[(u64, EffectiveRegisterStatus)]) -> EffectiveCpuTemplateProfile {
+        let entries = arm64_cpu_template_register_descriptors()
+            .map(|descriptor| {
+                let status = overrides
+                    .iter()
+                    .find(|(identity, _)| *identity == descriptor.identity())
+                    .map_or_else(
+                        || EffectiveRegisterStatus::Available(zero_value(descriptor.width())),
+                        |(_, status)| *status,
+                    );
+                EffectiveCpuTemplateProfileEntry {
+                    identity: descriptor.identity(),
+                    status,
+                }
+            })
+            .collect();
+        EffectiveCpuTemplateProfile::try_new(entries).expect("profile fixture should validate")
+    }
+
+    #[test]
+    fn profile_rejects_same_width_identity_swaps_and_required_omissions() {
+        let profile = profile_with(&[]);
+        let mut swapped = profile.entries.clone();
+        swapped.swap(3, 4);
+        assert_eq!(
+            EffectiveCpuTemplateProfile::try_new(swapped),
+            Err(EffectiveCpuTemplateProfileError::IdentityOrOrder)
+        );
+
+        let unavailable = profile_with(&[])
+            .entries
+            .into_iter()
+            .map(|entry| {
+                if entry.identity == KVM_REG_ARM64_CORE_SP_EL0 {
+                    EffectiveCpuTemplateProfileEntry::unavailable(entry.identity)
+                } else {
+                    entry
+                }
+            })
+            .collect();
+        assert_eq!(
+            EffectiveCpuTemplateProfile::try_new(unavailable),
+            Err(EffectiveCpuTemplateProfileError::RequiredUnavailable)
+        );
+    }
+
+    #[test]
+    fn dump_uses_one_profile_and_excludes_boot_overridden_targets() {
+        let request =
+            prepare_inspection_request(None, None).expect("default request should prepare");
+        let mut provider = FakeProvider {
+            profile: profile_with(&[]),
+            calls: 0,
+        };
+        let bytes = dump_with_provider(&mut provider, &request).expect("dump should encode");
+        let document = decode_cpu_template_document(
+            std::str::from_utf8(&bytes).expect("dump should be UTF-8"),
+        )
+        .expect("dump should reparse");
+
+        assert_eq!(provider.calls, 1);
+        assert_eq!(document.modifiers().len(), 77);
+        assert!(
+            document
+                .modifiers()
+                .iter()
+                .all(|modifier| modifier.identity() != KVM_REG_ARM64_CORE_PC)
+        );
+    }
+
+    #[test]
+    fn optional_unavailable_registers_are_omitted_but_explicit_requests_fail() {
+        let unavailable = [
+            KVM_REG_ARM64_ACTLR_EL1,
+            KVM_REG_ARM64_ID_AA64ZFR0_EL1,
+            KVM_REG_ARM64_ID_AA64SMFR0_EL1,
+        ]
+        .map(|identity| (identity, EffectiveRegisterStatus::Unavailable));
+        let profile = profile_with(&unavailable);
+        let default_request =
+            prepare_inspection_request(None, None).expect("default request should prepare");
+        let mut dump_provider = FakeProvider {
+            profile: profile.clone(),
+            calls: 0,
+        };
+        let bytes = dump_with_provider(&mut dump_provider, &default_request)
+            .expect("dump should omit unavailable optional registers");
+        let document = decode_cpu_template_document(
+            std::str::from_utf8(&bytes).expect("dump should be UTF-8"),
+        )
+        .expect("dump should reparse");
+        assert_eq!(document.modifiers().len(), 74);
+
+        let contents = format!(
+            "{{\"reg_modifiers\":[{{\"addr\":\"0x{KVM_REG_ARM64_ACTLR_EL1:016x}\",\"bitmap\":\"0b1x\"}}]}}"
+        );
+        let explicit_request = prepare_inspection_request(None, Some(&contents))
+            .expect("ACTLR EnTSO request should prepare");
+        let mut verify_provider = FakeProvider { profile, calls: 0 };
+        assert_eq!(
+            verify_with_provider(&mut verify_provider, &explicit_request),
+            Err(CpuTemplateOperationError::RequestedRegisterUnavailable)
+        );
+    }
+
+    #[test]
+    fn verify_uses_filters_and_checks_boot_overridden_application_values() {
+        let contents = format!(
+            "{{\"reg_modifiers\":[{{\"addr\":\"0x{KVM_REG_ARM64_CORE_PC:016x}\",\"bitmap\":\"0b1x\"}}]}}"
+        );
+        let request = prepare_inspection_request(None, Some(&contents))
+            .expect("explicit template should prepare");
+        let mut matching = FakeProvider {
+            profile: profile_with(&[(
+                KVM_REG_ARM64_CORE_PC,
+                EffectiveRegisterStatus::Available(ArmCpuTemplateValue::U64(0b11)),
+            )]),
+            calls: 0,
+        };
+        verify_with_provider(&mut matching, &request).expect("masked value should match");
+        assert_eq!(matching.calls, 1);
+
+        let mut mismatching = FakeProvider {
+            profile: profile_with(&[]),
+            calls: 0,
+        };
+        assert_eq!(
+            verify_with_provider(&mut mismatching, &request),
+            Err(CpuTemplateOperationError::VerificationMismatch)
+        );
+    }
+
+    #[test]
+    fn verify_without_custom_template_does_not_call_provider() {
+        let request =
+            prepare_inspection_request(None, None).expect("default request should prepare");
+        let mut provider = FakeProvider {
+            profile: profile_with(&[]),
+            calls: 0,
+        };
+        assert_eq!(
+            verify_with_provider(&mut provider, &request),
+            Err(CpuTemplateOperationError::NoTemplate)
+        );
+        assert_eq!(provider.calls, 0);
+    }
+}

--- a/tools/cpu-template-helper/src/projection.rs
+++ b/tools/cpu-template-helper/src/projection.rs
@@ -1,0 +1,300 @@
+//! CPU-inspection projection over strict API requests.
+
+use std::fmt;
+
+use bangbang_api::config::parse_config_document;
+use bangbang_api::http::{
+    ApiRequest, CpuConfigArmRegisterWidth as ApiArmRegisterWidth,
+    CpuConfigKvmCapability as ApiKvmCapability, CpuConfigRequest, MachineConfigCpuTemplate,
+    MachineConfigHugePages, MachineConfigRequest,
+};
+use bangbang_runtime::cpu::{
+    CpuConfigArmRegisterModifier, CpuConfigArmRegisterWidth, CpuConfigInput,
+    CpuConfigKvmCapability, CpuConfigVcpuFeature, CustomCpuTemplate,
+};
+use bangbang_runtime::machine::{
+    MachineConfig, MachineConfigCpuTemplate as RuntimeCpuTemplate,
+    MachineConfigHugePages as RuntimeHugePages, MachineConfigInput,
+};
+use bangbang_runtime::{VmmAction, VmmController};
+
+use crate::document::{CpuTemplateDocumentError, decode_cpu_template_document};
+
+const HELPER_INSTANCE_ID: &str = "cpu-template-helper";
+const HELPER_APP_NAME: &str = "cpu-template-helper";
+
+/// Failure while preparing one backend-neutral CPU inspection request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InspectionPreparationError {
+    ConfigDocument,
+    TemplateDocument(CpuTemplateDocumentError),
+    Configuration,
+}
+
+impl fmt::Display for InspectionPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::ConfigDocument => "invalid helper configuration document",
+            Self::TemplateDocument(_) => "invalid helper CPU-template document",
+            Self::Configuration => "CPU inspection configuration could not be applied",
+        })
+    }
+}
+
+impl std::error::Error for InspectionPreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TemplateDocument(source) => Some(source),
+            Self::ConfigDocument | Self::Configuration => None,
+        }
+    }
+}
+
+/// Fully validated machine and CPU-template selection for an effective
+/// provider.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PreparedCpuTemplateInspection {
+    machine_config: MachineConfig,
+    custom_template: Option<CustomCpuTemplate>,
+}
+
+impl PreparedCpuTemplateInspection {
+    /// Return the validated machine configuration.
+    pub const fn machine_config(&self) -> MachineConfig {
+        self.machine_config
+    }
+
+    /// Return the final custom template after config and explicit precedence.
+    pub const fn custom_template(&self) -> Option<&CustomCpuTemplate> {
+        self.custom_template.as_ref()
+    }
+}
+
+impl fmt::Debug for PreparedCpuTemplateInspection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedCpuTemplateInspection")
+            .field("vcpu_count", &self.machine_config.vcpu_count())
+            .field("static_template", &self.machine_config.cpu_template())
+            .field(
+                "custom_modifier_count",
+                &self
+                    .custom_template
+                    .as_ref()
+                    .map_or(0, |template| template.modifiers().len()),
+            )
+            .finish()
+    }
+}
+
+/// Parse and apply the CPU-relevant projection of an optional complete config
+/// document, then apply an optional explicit custom template last.
+pub fn prepare_inspection_request(
+    config_document: Option<&str>,
+    explicit_template_document: Option<&str>,
+) -> Result<PreparedCpuTemplateInspection, InspectionPreparationError> {
+    let mut controller = VmmController::new(
+        HELPER_INSTANCE_ID,
+        env!("CARGO_PKG_VERSION"),
+        HELPER_APP_NAME,
+    );
+
+    if let Some(contents) = config_document {
+        let requests = parse_config_document(contents)
+            .map_err(|_| InspectionPreparationError::ConfigDocument)?;
+        for request in requests {
+            if let Some(action) = inspection_action_from_api_request(request.request()) {
+                controller
+                    .handle_action(action)
+                    .map_err(|_| InspectionPreparationError::Configuration)?;
+            }
+        }
+    }
+
+    if let Some(contents) = explicit_template_document {
+        let document = decode_cpu_template_document(contents)
+            .map_err(InspectionPreparationError::TemplateDocument)?;
+        controller
+            .handle_action(VmmAction::PutCpuConfig(document.to_runtime_input()))
+            .map_err(|_| InspectionPreparationError::Configuration)?;
+    }
+
+    Ok(PreparedCpuTemplateInspection {
+        machine_config: controller.machine_config(),
+        custom_template: controller.custom_cpu_template().cloned(),
+    })
+}
+
+/// Project a strict API request when it affects CPU inspection state.
+pub fn inspection_action_from_api_request(request: &ApiRequest) -> Option<VmmAction> {
+    match request {
+        ApiRequest::PutMachineConfig(config) => Some(VmmAction::PutMachineConfig(
+            machine_config_input_from_request(config),
+        )),
+        ApiRequest::PutCpuConfig(config) => Some(VmmAction::PutCpuConfig(
+            cpu_config_input_from_request(config),
+        )),
+        _ => None,
+    }
+}
+
+/// Convert the strict transport CPU request into the backend-neutral input.
+pub fn cpu_config_input_from_request(config: &CpuConfigRequest) -> CpuConfigInput {
+    let kvm_capabilities = config
+        .kvm_capabilities()
+        .iter()
+        .copied()
+        .map(|capability| match capability {
+            ApiKvmCapability::Add(value) => CpuConfigKvmCapability::Add(value),
+            ApiKvmCapability::Remove(value) => CpuConfigKvmCapability::Remove(value),
+        })
+        .collect();
+    let reg_modifiers = config
+        .reg_modifiers()
+        .iter()
+        .copied()
+        .map(|modifier| {
+            CpuConfigArmRegisterModifier::new(
+                modifier.id(),
+                match modifier.width() {
+                    ApiArmRegisterWidth::U32 => CpuConfigArmRegisterWidth::U32,
+                    ApiArmRegisterWidth::U64 => CpuConfigArmRegisterWidth::U64,
+                    ApiArmRegisterWidth::U128 => CpuConfigArmRegisterWidth::U128,
+                },
+                modifier.filter(),
+                modifier.value(),
+            )
+        })
+        .collect();
+    let vcpu_features = config
+        .vcpu_features()
+        .iter()
+        .copied()
+        .map(|feature| {
+            CpuConfigVcpuFeature::new(feature.index(), feature.filter(), feature.value())
+        })
+        .collect();
+
+    CpuConfigInput::new(kvm_capabilities, reg_modifiers, vcpu_features)
+}
+
+/// Convert the strict transport machine request into the backend-neutral
+/// input used by the production controller.
+pub fn machine_config_input_from_request(config: &MachineConfigRequest) -> MachineConfigInput {
+    let mut input = MachineConfigInput::new(config.vcpu_count(), config.mem_size_mib())
+        .with_smt(config.smt())
+        .with_track_dirty_pages(config.track_dirty_pages())
+        .with_huge_pages(match config.huge_pages() {
+            MachineConfigHugePages::None => RuntimeHugePages::None,
+            MachineConfigHugePages::TwoM => RuntimeHugePages::TwoM,
+        });
+
+    if let Some(cpu_template) = config.cpu_template() {
+        input = input.with_cpu_template(machine_cpu_template_from_request(cpu_template));
+    }
+
+    input
+}
+
+const fn machine_cpu_template_from_request(
+    cpu_template: MachineConfigCpuTemplate,
+) -> RuntimeCpuTemplate {
+    match cpu_template {
+        MachineConfigCpuTemplate::C3 => RuntimeCpuTemplate::C3,
+        MachineConfigCpuTemplate::T2 => RuntimeCpuTemplate::T2,
+        MachineConfigCpuTemplate::T2S => RuntimeCpuTemplate::T2S,
+        MachineConfigCpuTemplate::T2CL => RuntimeCpuTemplate::T2CL,
+        MachineConfigCpuTemplate::T2A => RuntimeCpuTemplate::T2A,
+        MachineConfigCpuTemplate::V1N1 => RuntimeCpuTemplate::V1N1,
+        MachineConfigCpuTemplate::None => RuntimeCpuTemplate::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use bangbang_runtime::cpu::{
+        ArmCpuTemplateRegister, ArmRegister64, KVM_REG_ARM64_CORE_PC, KVM_REG_ARM64_CORE_SP_EL0,
+    };
+
+    use super::*;
+
+    #[test]
+    fn explicit_template_replaces_config_selection_after_valid_projection() {
+        let config = format!(
+            r#"{{
+                "machine-config": {{
+                    "vcpu_count": 2,
+                    "mem_size_mib": 256,
+                    "cpu_template": "V1N1"
+                }},
+                "boot-source": {{"kernel_image_path":"/missing/private-kernel"}},
+                "drives": [{{
+                    "drive_id":"root",
+                    "path_on_host":"/missing/private-root",
+                    "is_root_device":true,
+                    "is_read_only":true
+                }}],
+                "cpu-config": {{"reg_modifiers":[{{
+                    "addr":"0x{KVM_REG_ARM64_CORE_SP_EL0:016x}",
+                    "bitmap":"0b1"
+                }}]}}
+            }}"#
+        );
+        let explicit = format!(
+            r#"{{"reg_modifiers":[{{
+                "addr":"0x{KVM_REG_ARM64_CORE_PC:016x}",
+                "bitmap":"0b1"
+            }}]}}"#
+        );
+        let prepared = prepare_inspection_request(Some(&config), Some(&explicit))
+            .expect("CPU-only projection must not open unrelated resource paths");
+
+        assert_eq!(prepared.machine_config().vcpu_count(), 2);
+        assert_eq!(prepared.machine_config().cpu_template(), None);
+        let modifiers = prepared
+            .custom_template()
+            .expect("explicit custom template should win")
+            .modifiers();
+        assert_eq!(modifiers.len(), 1);
+        assert_eq!(
+            modifiers[0].register(),
+            ArmCpuTemplateRegister::U64(ArmRegister64::Pc)
+        );
+    }
+
+    #[test]
+    fn invalid_earlier_machine_config_fails_before_explicit_override() {
+        let config = r#"{
+            "machine-config":{"vcpu_count":0,"mem_size_mib":128},
+            "boot-source":{"kernel_image_path":"kernel"}
+        }"#;
+        let explicit = format!(
+            r#"{{"reg_modifiers":[{{
+                "addr":"0x{KVM_REG_ARM64_CORE_PC:016x}",
+                "bitmap":"0b1"
+            }}]}}"#
+        );
+        assert_eq!(
+            prepare_inspection_request(Some(config), Some(&explicit)),
+            Err(InspectionPreparationError::Configuration)
+        );
+    }
+
+    #[test]
+    fn errors_and_debug_output_are_value_and_path_redacted() {
+        let error = prepare_inspection_request(
+            Some(r#"{"private-unknown-section":{},"boot-source":{}}"#),
+            None,
+        )
+        .expect_err("unknown config section should fail");
+        assert_eq!(error, InspectionPreparationError::ConfigDocument);
+        assert!(!error.to_string().contains("private-unknown-section"));
+
+        let prepared = prepare_inspection_request(None, None).expect("default should prepare");
+        let debug = format!("{prepared:?}");
+        assert!(!debug.contains("kernel"));
+        assert!(!debug.contains("0x"));
+    }
+}

--- a/tools/cpu-template-helper/src/publication.rs
+++ b/tools/cpu-template-helper/src/publication.rs
@@ -1,0 +1,625 @@
+//! Failure-aware exclusive publication for one helper artifact.
+
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rustix::fs::{
+    AtFlags, Mode, OFlags, RenameFlags, fstat, fsync, open, openat, renameat_with, statat, unlinkat,
+};
+use rustix::io::Errno;
+
+use crate::CPU_TEMPLATE_DOCUMENT_MAX_BYTES;
+
+static PRIVATE_NAME_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Failure while exclusively publishing one complete helper artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicationError {
+    InvalidOutputPath,
+    ArtifactTooLarge,
+    OutputDirectoryOpen,
+    OutputInspection,
+    Collision,
+    Staging,
+    AtomicCommitUnsupported,
+    Commit,
+    PrecommitCleanupUncertain,
+    CommittedStateUncertain,
+    CommittedDurabilityUncertain,
+}
+
+impl fmt::Display for PublicationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidOutputPath => "output path is invalid",
+            Self::ArtifactTooLarge => "output artifact exceeds the size limit",
+            Self::OutputDirectoryOpen => "output directory could not be opened safely",
+            Self::OutputInspection => "output target could not be inspected safely",
+            Self::Collision => "output target already exists",
+            Self::Staging => "complete output artifact could not be staged",
+            Self::AtomicCommitUnsupported => {
+                "output filesystem lacks exclusive atomic rename support"
+            }
+            Self::Commit => "output artifact could not be committed",
+            Self::PrecommitCleanupUncertain => {
+                "output was not committed, but private staging cleanup is uncertain"
+            }
+            Self::CommittedStateUncertain => {
+                "output commit occurred, but the published identity is uncertain"
+            }
+            Self::CommittedDurabilityUncertain => {
+                "output was committed, but directory durability is uncertain"
+            }
+        })
+    }
+}
+
+impl std::error::Error for PublicationError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Identity {
+    device: u64,
+    inode: u64,
+}
+
+#[derive(Debug, Default)]
+struct Faults {
+    stage_collisions: usize,
+    fail_write_after: Option<usize>,
+    fail_flush: bool,
+    fail_file_sync: bool,
+    replace_stage_before_commit: bool,
+    concurrent_winner: bool,
+    fail_commit: bool,
+    force_atomic_unsupported: bool,
+    replace_final_after_commit: bool,
+    fail_directory_sync: bool,
+    fail_cleanup: bool,
+    fail_cleanup_sync: bool,
+}
+
+/// Publish one owner-only artifact only when the final path is absent.
+pub fn publish_new_artifact(path: &Path, bytes: &[u8]) -> Result<(), PublicationError> {
+    publish_with_faults(path, bytes, &Faults::default())
+}
+
+fn publish_with_faults(path: &Path, bytes: &[u8], faults: &Faults) -> Result<(), PublicationError> {
+    if bytes.len() > CPU_TEMPLATE_DOCUMENT_MAX_BYTES {
+        return Err(PublicationError::ArtifactTooLarge);
+    }
+    let final_name = path
+        .file_name()
+        .filter(|name| !name.is_empty())
+        .ok_or(PublicationError::InvalidOutputPath)?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let directory = open(
+        parent,
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map_err(|_| PublicationError::OutputDirectoryOpen)?;
+
+    match stat_identity(&directory, final_name) {
+        Ok(None) => {}
+        Ok(Some(_)) => return Err(PublicationError::Collision),
+        Err(()) => return Err(PublicationError::OutputInspection),
+    }
+
+    let (stage_name, stage_identity) = create_stage(&directory, final_name, faults)?;
+    if stage_bytes(&directory, &stage_name, stage_identity, bytes, faults).is_err() {
+        return fail_before_commit(
+            &directory,
+            &stage_name,
+            stage_identity,
+            PublicationError::Staging,
+            faults,
+        );
+    }
+
+    if faults.replace_stage_before_commit && replace_path_for_test(&directory, &stage_name).is_err()
+    {
+        return fail_before_commit(
+            &directory,
+            &stage_name,
+            stage_identity,
+            PublicationError::OutputInspection,
+            faults,
+        );
+    }
+    if identity_at(&directory, &stage_name, stage_identity).is_err() {
+        return Err(PublicationError::PrecommitCleanupUncertain);
+    }
+
+    if faults.concurrent_winner && create_concurrent_winner(&directory, final_name).is_err() {
+        return fail_before_commit(
+            &directory,
+            &stage_name,
+            stage_identity,
+            PublicationError::OutputInspection,
+            faults,
+        );
+    }
+    if faults.fail_commit {
+        return fail_before_commit(
+            &directory,
+            &stage_name,
+            stage_identity,
+            PublicationError::Commit,
+            faults,
+        );
+    }
+    if faults.force_atomic_unsupported {
+        return fail_before_commit(
+            &directory,
+            &stage_name,
+            stage_identity,
+            PublicationError::AtomicCommitUnsupported,
+            faults,
+        );
+    }
+
+    if let Err(error) = renameat_with(
+        &directory,
+        &stage_name,
+        &directory,
+        final_name,
+        RenameFlags::NOREPLACE,
+    ) {
+        let publication_error = if error == Errno::EXIST {
+            PublicationError::Collision
+        } else if matches!(error, Errno::NOSYS | Errno::NOTSUP | Errno::INVAL) {
+            PublicationError::AtomicCommitUnsupported
+        } else {
+            PublicationError::Commit
+        };
+        return fail_before_commit(
+            &directory,
+            &stage_name,
+            stage_identity,
+            publication_error,
+            faults,
+        );
+    }
+
+    if faults.replace_final_after_commit && replace_path_for_test(&directory, final_name).is_err() {
+        return Err(PublicationError::CommittedStateUncertain);
+    }
+    if identity_at(&directory, final_name, stage_identity).is_err() {
+        return Err(PublicationError::CommittedStateUncertain);
+    }
+    if faults.fail_directory_sync || fsync(&directory).is_err() {
+        return Err(PublicationError::CommittedDurabilityUncertain);
+    }
+    Ok(())
+}
+
+fn create_stage<Fd: std::os::fd::AsFd>(
+    directory: &Fd,
+    final_name: &OsStr,
+    faults: &Faults,
+) -> Result<(OsString, Identity), PublicationError> {
+    for attempt in 0..128 {
+        let serial = PRIVATE_NAME_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let name: OsString = format!(
+            ".bangbang-cpu-template-helper.stage.{}.{}",
+            std::process::id(),
+            serial
+        )
+        .into();
+        if name == final_name {
+            continue;
+        }
+        if attempt < faults.stage_collisions {
+            create_stage_collision_for_test(directory, &name)?;
+        }
+        let descriptor = match openat(
+            directory,
+            &name,
+            OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+            Mode::RUSR | Mode::WUSR,
+        ) {
+            Ok(descriptor) => descriptor,
+            Err(error) if error == Errno::EXIST => continue,
+            Err(_) => return Err(PublicationError::Staging),
+        };
+        let metadata =
+            fstat(&descriptor).map_err(|_| PublicationError::PrecommitCleanupUncertain)?;
+        return Ok((name, identity(&metadata)));
+    }
+    Err(PublicationError::Staging)
+}
+
+fn create_stage_collision_for_test<Fd: std::os::fd::AsFd>(
+    directory: &Fd,
+    stage_name: &OsStr,
+) -> Result<(), PublicationError> {
+    let descriptor = openat(
+        directory,
+        stage_name,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::RUSR | Mode::WUSR,
+    )
+    .map_err(|_| PublicationError::Staging)?;
+    let mut file = File::from(descriptor);
+    file.write_all(b"occupied-stage")
+        .map_err(|_| PublicationError::Staging)
+}
+
+fn stage_bytes<Fd: std::os::fd::AsFd>(
+    directory: &Fd,
+    stage_name: &OsStr,
+    stage_identity: Identity,
+    bytes: &[u8],
+    faults: &Faults,
+) -> Result<(), ()> {
+    let descriptor = openat(
+        directory,
+        stage_name,
+        OFlags::WRONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map_err(|_| ())?;
+    if identity(&fstat(&descriptor).map_err(|_| ())?) != stage_identity {
+        return Err(());
+    }
+    let mut file = File::from(descriptor);
+    if let Some(limit) = faults.fail_write_after {
+        let prefix = bytes.get(..limit.min(bytes.len())).ok_or(())?;
+        file.write_all(prefix).map_err(|_| ())?;
+        return Err(());
+    }
+    file.write_all(bytes).map_err(|_| ())?;
+    if faults.fail_flush || file.flush().is_err() {
+        return Err(());
+    }
+    if faults.fail_file_sync || file.sync_all().is_err() {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn fail_before_commit<Fd: std::os::fd::AsFd>(
+    directory: &Fd,
+    stage_name: &OsStr,
+    stage_identity: Identity,
+    error: PublicationError,
+    faults: &Faults,
+) -> Result<(), PublicationError> {
+    if cleanup_stage(directory, stage_name, stage_identity, faults).is_ok() {
+        Err(error)
+    } else {
+        Err(PublicationError::PrecommitCleanupUncertain)
+    }
+}
+
+fn cleanup_stage<Fd: std::os::fd::AsFd>(
+    directory: &Fd,
+    stage_name: &OsStr,
+    stage_identity: Identity,
+    faults: &Faults,
+) -> Result<(), ()> {
+    if faults.fail_cleanup {
+        return Err(());
+    }
+    match stat_identity(directory, stage_name)? {
+        Some(identity) if identity == stage_identity => {
+            unlinkat(directory, stage_name, AtFlags::empty()).map_err(|_| ())?;
+        }
+        None => {}
+        Some(_) => return Err(()),
+    }
+    if faults.fail_cleanup_sync || fsync(directory).is_err() {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn create_concurrent_winner<Fd: std::os::fd::AsFd>(
+    directory: &Fd,
+    final_name: &OsStr,
+) -> Result<(), ()> {
+    let descriptor = openat(
+        directory,
+        final_name,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::RUSR | Mode::WUSR,
+    )
+    .map_err(|_| ())?;
+    let mut file = File::from(descriptor);
+    file.write_all(b"concurrent-winner").map_err(|_| ())?;
+    file.sync_all().map_err(|_| ())
+}
+
+fn replace_path_for_test<Fd: std::os::fd::AsFd>(
+    directory: &Fd,
+    stage_name: &OsStr,
+) -> Result<(), ()> {
+    unlinkat(directory, stage_name, AtFlags::empty()).map_err(|_| ())?;
+    let descriptor = openat(
+        directory,
+        stage_name,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::RUSR | Mode::WUSR,
+    )
+    .map_err(|_| ())?;
+    let mut file = File::from(descriptor);
+    file.write_all(b"identity-replacement").map_err(|_| ())?;
+    file.sync_all().map_err(|_| ())
+}
+
+fn identity_at<Fd: std::os::fd::AsFd>(
+    directory: &Fd,
+    name: &OsStr,
+    expected: Identity,
+) -> Result<(), ()> {
+    match stat_identity(directory, name)? {
+        Some(actual) if actual == expected => Ok(()),
+        Some(_) | None => Err(()),
+    }
+}
+
+fn stat_identity<Fd: std::os::fd::AsFd>(
+    directory: &Fd,
+    name: &OsStr,
+) -> Result<Option<Identity>, ()> {
+    match statat(directory, name, AtFlags::SYMLINK_NOFOLLOW) {
+        Ok(metadata) => Ok(Some(identity(&metadata))),
+        Err(error) if error == Errno::NOENT => Ok(None),
+        Err(_) => Err(()),
+    }
+}
+
+fn identity(metadata: &rustix::fs::Stat) -> Identity {
+    Identity {
+        #[cfg(target_os = "linux")]
+        device: metadata.st_dev,
+        #[cfg(target_os = "macos")]
+        device: metadata.st_dev as u64,
+        inode: metadata.st_ino,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    static TEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug)]
+    struct TestDirectory(std::path::PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should follow epoch")
+                .as_nanos();
+            let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bangbang-cpu-template-publication-{}-{nonce}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("test directory should be created");
+            Self(path)
+        }
+
+        fn stage_count(&self) -> usize {
+            fs::read_dir(&self.0)
+                .expect("test directory should be readable")
+                .filter_map(Result::ok)
+                .filter(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with(".bangbang-cpu-template-helper.stage.")
+                })
+                .count()
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn publishes_complete_absent_artifact_and_rejects_existing_types() {
+        let directory = TestDirectory::new();
+        let output = directory.0.join("cpu.json");
+        publish_new_artifact(&output, b"complete").expect("absent output should publish");
+        assert_eq!(fs::read(&output).unwrap(), b"complete");
+        assert_eq!(directory.stage_count(), 0);
+        assert_eq!(
+            publish_new_artifact(&output, b"replacement"),
+            Err(PublicationError::Collision)
+        );
+        assert_eq!(fs::read(&output).unwrap(), b"complete");
+
+        let target = directory.0.join("target");
+        fs::write(&target, b"target-bytes").unwrap();
+        let link = directory.0.join("link");
+        symlink(&target, &link).unwrap();
+        assert_eq!(
+            publish_new_artifact(&link, b"replacement"),
+            Err(PublicationError::Collision)
+        );
+        assert_eq!(fs::read(&target).unwrap(), b"target-bytes");
+
+        let child_directory = directory.0.join("child");
+        fs::create_dir(&child_directory).unwrap();
+        assert_eq!(
+            publish_new_artifact(&child_directory, b"replacement"),
+            Err(PublicationError::Collision)
+        );
+    }
+
+    #[test]
+    fn concurrent_winner_is_preserved_and_stage_is_cleaned() {
+        let directory = TestDirectory::new();
+        let output = directory.0.join("cpu.json");
+        let error = publish_with_faults(
+            &output,
+            b"ours",
+            &Faults {
+                concurrent_winner: true,
+                ..Faults::default()
+            },
+        )
+        .expect_err("concurrent winner should win");
+        assert_eq!(error, PublicationError::Collision);
+        assert_eq!(fs::read(&output).unwrap(), b"concurrent-winner");
+        assert_eq!(directory.stage_count(), 0);
+    }
+
+    #[test]
+    fn occupied_private_stage_names_are_skipped_without_removing_them() {
+        let directory = TestDirectory::new();
+        let output = directory.0.join("cpu.json");
+        publish_with_faults(
+            &output,
+            b"complete",
+            &Faults {
+                stage_collisions: 2,
+                ..Faults::default()
+            },
+        )
+        .expect("fresh stage should be selected after occupied names");
+        assert_eq!(fs::read(&output).unwrap(), b"complete");
+        assert_eq!(directory.stage_count(), 2);
+        for entry in fs::read_dir(&directory.0).unwrap().filter_map(Result::ok) {
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".bangbang-cpu-template-helper.stage.")
+            {
+                assert_eq!(fs::read(entry.path()).unwrap(), b"occupied-stage");
+            }
+        }
+    }
+
+    #[test]
+    fn every_injected_precommit_io_failure_leaves_no_final() {
+        for faults in [
+            Faults {
+                fail_write_after: Some(2),
+                ..Faults::default()
+            },
+            Faults {
+                fail_flush: true,
+                ..Faults::default()
+            },
+            Faults {
+                fail_file_sync: true,
+                ..Faults::default()
+            },
+            Faults {
+                fail_commit: true,
+                ..Faults::default()
+            },
+            Faults {
+                force_atomic_unsupported: true,
+                ..Faults::default()
+            },
+        ] {
+            let directory = TestDirectory::new();
+            let output = directory.0.join("cpu.json");
+            let error = publish_with_faults(&output, b"complete", &faults)
+                .expect_err("injected operation should fail");
+            assert!(matches!(
+                error,
+                PublicationError::Staging
+                    | PublicationError::Commit
+                    | PublicationError::AtomicCommitUnsupported
+            ));
+            assert!(!output.exists());
+            assert_eq!(directory.stage_count(), 0);
+        }
+    }
+
+    #[test]
+    fn postcommit_directory_sync_reports_uncertain_with_complete_final() {
+        let directory = TestDirectory::new();
+        let output = directory.0.join("cpu.json");
+        assert_eq!(
+            publish_with_faults(
+                &output,
+                b"complete",
+                &Faults {
+                    fail_directory_sync: true,
+                    ..Faults::default()
+                }
+            ),
+            Err(PublicationError::CommittedDurabilityUncertain)
+        );
+        assert_eq!(fs::read(&output).unwrap(), b"complete");
+        assert_eq!(directory.stage_count(), 0);
+
+        let replaced_directory = TestDirectory::new();
+        let replaced_output = replaced_directory.0.join("cpu.json");
+        assert_eq!(
+            publish_with_faults(
+                &replaced_output,
+                b"complete",
+                &Faults {
+                    replace_final_after_commit: true,
+                    ..Faults::default()
+                }
+            ),
+            Err(PublicationError::CommittedStateUncertain)
+        );
+        assert_eq!(fs::read(&replaced_output).unwrap(), b"identity-replacement");
+        assert_eq!(replaced_directory.stage_count(), 0);
+    }
+
+    #[test]
+    fn identity_change_and_cleanup_failures_are_explicitly_uncertain() {
+        for faults in [
+            Faults {
+                replace_stage_before_commit: true,
+                ..Faults::default()
+            },
+            Faults {
+                fail_write_after: Some(1),
+                fail_cleanup: true,
+                ..Faults::default()
+            },
+            Faults {
+                fail_write_after: Some(1),
+                fail_cleanup_sync: true,
+                ..Faults::default()
+            },
+        ] {
+            let directory = TestDirectory::new();
+            let output = directory.0.join("cpu.json");
+            assert_eq!(
+                publish_with_faults(&output, b"complete", &faults),
+                Err(PublicationError::PrecommitCleanupUncertain)
+            );
+            assert!(!output.exists());
+        }
+    }
+
+    #[test]
+    fn rejects_oversized_artifact_before_path_access() {
+        let private_path = Path::new("/definitely/private/unreachable/output");
+        assert_eq!(
+            publish_new_artifact(private_path, &vec![0; CPU_TEMPLATE_DOCUMENT_MAX_BYTES + 1]),
+            Err(PublicationError::ArtifactTooLarge)
+        );
+    }
+}

--- a/tools/firecracker-capability-audit/tests/checked_inventory.rs
+++ b/tools/firecracker-capability-audit/tests/checked_inventory.rs
@@ -2104,6 +2104,71 @@ fn wave_7_ownership_and_core_api_policy_is_stable() {
 }
 
 #[test]
+fn cpu_template_helper_foundation_policy_is_stable() {
+    const HELPER_CAPABILITIES: [&str; 7] = [
+        "tool-argument:cpu-template-helper/template/dump/config",
+        "tool-argument:cpu-template-helper/template/dump/output",
+        "tool-argument:cpu-template-helper/template/dump/template",
+        "tool-argument:cpu-template-helper/template/verify/config",
+        "tool-argument:cpu-template-helper/template/verify/template",
+        "tool-operation:cpu-template-helper/template/dump",
+        "tool-operation:cpu-template-helper/template/verify",
+    ];
+
+    let repository_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|tools| tools.parent())
+        .expect("tool package must be nested under the repository tools directory")
+        .to_path_buf();
+    let inventory = read_capability_inventory(&repository_root.join(CAPABILITY_INVENTORY_PATH))
+        .expect("checked capability inventory must parse");
+    let by_id = inventory
+        .capabilities
+        .iter()
+        .map(|capability| (capability.id.as_str(), capability))
+        .collect::<BTreeMap<_, _>>();
+    let contract_path = "compat/firecracker/v1.16.0/cpu-template-helper-contract.md";
+    let contract = std::fs::read_to_string(repository_root.join(contract_path))
+        .expect("CPU-template helper contract must be readable");
+
+    assert_eq!(
+        HELPER_CAPABILITIES
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+            .len(),
+        7,
+        "CPU-template helper capability set must remain exact"
+    );
+    for id in HELPER_CAPABILITIES {
+        let capability = by_id
+            .get(id)
+            .unwrap_or_else(|| panic!("CPU-template helper capability must exist: {id}"));
+        assert_eq!(
+            capability.disposition,
+            Disposition::AuditRequired,
+            "library-only foundation must not promote public helper behavior: {id}"
+        );
+        assert_eq!(
+            contract
+                .matches(&format!("| `{id}` | `audit-required` |"))
+                .count(),
+            1,
+            "helper contract must contain one exact nonterminal row: {id}"
+        );
+    }
+    assert!(contract.contains("#1862"));
+
+    let package_root = repository_root.join("tools/cpu-template-helper");
+    let package_manifest = std::fs::read_to_string(package_root.join("Cargo.toml"))
+        .expect("CPU-template helper package manifest must be readable");
+    assert!(package_root.join("src/lib.rs").is_file());
+    assert!(!package_root.join("src/main.rs").exists());
+    assert!(!package_root.join("src/bin").exists());
+    assert!(!package_manifest.contains("[[bin]]"));
+    assert!(!package_manifest.contains("bangbang-hvf"));
+}
+
+#[test]
 fn snapshot_paging_terminal_policy_is_stable() {
     const CAPABILITY_ID: &str = "corpus:snapshot-page-faults";
 


### PR DESCRIPTION
## Summary

- share the duplicate-safe full Firecracker config-document parser between production startup and reusable callers
- make the runtime's exact 80-entry arm64 CPU-template descriptor census the accepted decoder authority
- add a library-only CPU-template helper foundation with canonical JSON, controller-backed selection, identity-bound provider profiles, filter verification, bounded input, and absent-only publication
- document the helper boundary and guard that all seven #1792 public capabilities remain `audit-required` until #1862 supplies the real signed HVF CLI

## Scope exclusions

- no `cpu-template-helper` binary or CLI registration
- no production or fake-success HVF provider
- no signed helper process target and no capability promotion
- no strip, fingerprint, or corpus-certification work

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p bangbang-api --locked`
- `cargo test -p bangbang-runtime --all-features --locked --lib cpu`
- `cargo test -p bangbang-cpu-template-helper --locked`
- `cargo test -p bangbang --all-features --locked helper_cpu_inspection_projection_matches_production_actions`
- `cargo test -p bangbang-firecracker-capability-audit --test checked_inventory --locked`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple-target integration Clippy commands required by `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1861

Parent: #1792
