### PR TITLE
feat: add deterministic guest specification workload

### DIFF
--- a/compat/firecracker/v1.16.0/guest-workflow-audit.json
+++ b/compat/firecracker/v1.16.0/guest-workflow-audit.json
@@ -111,6 +111,7 @@
         "compat/firecracker/v1.16.0/guest-workflow-audit.json",
         "scripts/fetch-firecracker-rootfs.sh",
         "scripts/guest/arm64-id-register-report.rs",
+        "scripts/guest/specification-benchmark.rs",
         "scripts/guest_artifact_policy.py"
       ],
       "sidecar": {

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -70,6 +70,17 @@ mod macos_arm64 {
     const DIRECT_ROOTFS_BLOCK_MARKER: &[u8] = b"BANGBANG_DIRECT_ROOTFS_BLOCK_OK";
     const DIRECT_ROOTFS_BOOT_OK_MARKER: &[u8] = b"BANGBANG_DIRECT_ROOTFS_BOOT_OK";
     const BOOT_TIMER_LOG_MARKER: &[u8] = b"Guest-boot-time =";
+    const SPECIFICATION_WORKLOAD_HEADER: &str = "BANGBANG_SPEC_WORKLOAD_V1";
+    const SPECIFICATION_WORKLOAD_READY: &str = "BANGBANG_SPEC_INIT_READY release_byte=82";
+    const SPECIFICATION_WORKLOAD_SUCCESS: &str = "BANGBANG_SPEC_WORKLOAD_OK";
+    const SPECIFICATION_WORKLOAD_FAILURE: &str = "BANGBANG_SPEC_WORKLOAD_FAIL";
+    const SPECIFICATION_WORKLOAD_RELEASE: &[u8] = b"R";
+    const SPECIFICATION_COMPUTE_OPERATIONS: u64 = 5_000_000;
+    const SPECIFICATION_COMPUTE_CHECKSUM: u64 = 8_398_723_902_783_368_615;
+    const SPECIFICATION_STORAGE_BYTES: usize = 16 * 1024 * 1024;
+    const SPECIFICATION_STORAGE_BLOCK_BYTES: usize = 4096;
+    const SPECIFICATION_STORAGE_FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const SPECIFICATION_STORAGE_FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
     const DIRECT_ROOTFS_BALLOON_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.balloon-check=1";
     const DIRECT_ROOTFS_BALLOON_MARKER: &[u8] = b"BANGBANG_BALLOON_REPORTING_GUEST_CHECK_OK";
     const DIRECT_ROOTFS_MEMORY_HOTPLUG_READY_MARKER: &[u8] = b"BANGBANG_MEMORY_HOTPLUG_GUEST_READY";
@@ -416,6 +427,7 @@ mod macos_arm64 {
     const SNAPSHOT_PMEM_LIMITER_REFILL_MS: u64 = 5000;
     const ROOTFS_BOOT_TIMER_BOOT_ARGS: &str =
         "console=ttyS0 reboot=k panic=1 nomodule swiotlb=noforce init=/usr/local/bin/init";
+    const SPECIFICATION_WORKLOAD_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 root=/dev/vda ro rootwait init=/bangbang-specification-benchmark";
     const DIRECT_ROOTFS_ENTROPY_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.entropy-read=1";
     const DIRECT_ROOTFS_MMDS_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.mmds-fetch=1";
     const DIRECT_ROOTFS_MMDS_MTU_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.mmds-fetch=1 bangbang.mmds-mtu=1280";
@@ -432,6 +444,7 @@ mod macos_arm64 {
     const DIRECT_ROOTFS_HOST_VSOCK_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.vsock-host-connect=1";
     const DIRECT_ROOTFS_HOST_VSOCK_MULTISTREAM_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.vsock-host-multistream=1";
     const GUEST_EXECUTION_TIMEOUT: Duration = Duration::from_secs(30);
+    const SPECIFICATION_WORKLOAD_TIMEOUT: Duration = Duration::from_secs(60);
     const GUEST_STOP_TIMEOUT: Duration = Duration::from_secs(60);
     const PCI_ALL_VIRTIO_GUEST_TIMEOUT: Duration = Duration::from_secs(90);
     const SNAPSHOT_GUEST_IMAGE_HEADER_SIZE: usize = 64;
@@ -3515,6 +3528,125 @@ mod macos_arm64 {
             bangbang.terminate(),
             &socket_path,
             "bangbang direct rootfs boot timer",
+        );
+    }
+
+    #[test]
+    fn signed_executable_runs_released_guest_specification_workload() {
+        let test_dir = TestDir::new();
+        let socket_path = test_dir.path().join("api.socket");
+        let logger_path = test_dir.path().join("logger.out");
+        let kernel_path = env_path(BANGBANG_GUEST_KERNEL_PATH_ENV);
+        let rootfs_path = env_path(BANGBANG_GUEST_EXT4_ROOTFS_PATH_ENV);
+        let expected_storage_checksum = specification_storage_checksum(&rootfs_path);
+        let instance_id = test_dir.instance_id();
+
+        let mut bangbang =
+            BangbangProcess::start_with_extra_args(&socket_path, &instance_id, &["--boot-timer"]);
+
+        assert_no_content_response(
+            &http_put_json(
+                &socket_path,
+                "/machine-config",
+                r#"{"vcpu_count":1,"mem_size_mib":256}"#,
+            ),
+            "PUT /machine-config specification workload",
+        );
+
+        let boot_body = format!(
+            r#"{{"kernel_image_path":{},"boot_args":{}}}"#,
+            json_string(path_text(&kernel_path)),
+            json_string(SPECIFICATION_WORKLOAD_BOOT_ARGS),
+        );
+        assert_no_content_response(
+            &http_put_json(&socket_path, "/boot-source", &boot_body),
+            "PUT /boot-source specification workload",
+        );
+
+        let rootfs_body = format!(
+            r#"{{"drive_id":"rootfs","path_on_host":{},"is_root_device":true,"is_read_only":true}}"#,
+            json_string(path_text(&rootfs_path)),
+        );
+        assert_no_content_response(
+            &http_put_json(&socket_path, "/drives/rootfs", &rootfs_body),
+            "PUT /drives/rootfs specification workload",
+        );
+
+        let logger_body = format!(r#"{{"log_path":{}}}"#, json_string(path_text(&logger_path)),);
+        assert_no_content_response(
+            &http_put_json(&socket_path, "/logger", &logger_body),
+            "PUT /logger specification workload",
+        );
+
+        assert_no_content_response(
+            &http_put_json(
+                &socket_path,
+                "/actions",
+                r#"{"action_type":"InstanceStart"}"#,
+            ),
+            "PUT /actions InstanceStart specification workload",
+        );
+
+        if let Err(error) =
+            bangbang.wait_for_stdout_marker(SPECIFICATION_WORKLOAD_READY, GUEST_EXECUTION_TIMEOUT)
+        {
+            let output = bangbang.force_stop_and_collect();
+            panic!(
+                "specification workload did not become ready: {error}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                output.status, output.stdout, output.stderr
+            );
+        }
+        if let Err(error) = wait_for_file_contains_marker(
+            &logger_path,
+            BOOT_TIMER_LOG_MARKER,
+            GUEST_EXECUTION_TIMEOUT,
+        ) {
+            let logger_prefix = file_prefix_lossy(&logger_path, 1024);
+            let output = bangbang.force_stop_and_collect();
+            panic!(
+                "specification workload did not signal the production boot timer: {error}; logger: {logger_prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                output.status, output.stdout, output.stderr
+            );
+        }
+
+        let running = http_get(&socket_path, "/");
+        assert_ok_response(&running, "GET / while specification workload is ready");
+        assert_response_contains(
+            &running,
+            r#""state":"Running""#,
+            "GET / while specification workload is ready",
+        );
+        std::thread::sleep(Duration::from_millis(200));
+        let waiting_transcript = bangbang.stdout_snapshot();
+        assert_specification_waiting_transcript(&waiting_transcript);
+
+        bangbang.write_stdin(SPECIFICATION_WORKLOAD_RELEASE);
+        if let Err(error) = bangbang.wait_for_stdout_marker(
+            SPECIFICATION_WORKLOAD_SUCCESS,
+            SPECIFICATION_WORKLOAD_TIMEOUT,
+        ) {
+            let output = bangbang.force_stop_and_collect();
+            panic!(
+                "released specification workload did not complete: {error}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                output.status, output.stdout, output.stderr
+            );
+        }
+
+        let output = bangbang.wait_for_exit_with_timeout(
+            SPECIFICATION_WORKLOAD_TIMEOUT,
+            "guest specification workload poweroff",
+        );
+        assert_specification_transcript(&output.stdout, expected_storage_checksum);
+        let logger_output = fs::read_to_string(&logger_path)
+            .expect("specification workload logger should be readable");
+        assert!(
+            logger_output.contains("Guest-boot-time ="),
+            "specification workload must exercise the production boot timer; logger:\n{logger_output}"
+        );
+        assert_clean_shutdown(
+            output,
+            &socket_path,
+            "bangbang guest specification workload",
         );
     }
 
@@ -18496,6 +18628,133 @@ mod macos_arm64 {
             .create_new(true)
             .open(path)
             .expect("empty test output file should create");
+    }
+
+    fn specification_storage_checksum(path: &Path) -> u64 {
+        let mut file = fs::File::open(path).unwrap_or_else(|error| {
+            panic!(
+                "specification root drive {} should be readable: {error}",
+                path.display()
+            )
+        });
+        let mut block = [0_u8; SPECIFICATION_STORAGE_BLOCK_BYTES];
+        let mut checksum = SPECIFICATION_STORAGE_FNV_OFFSET;
+        for _ in 0..(SPECIFICATION_STORAGE_BYTES / SPECIFICATION_STORAGE_BLOCK_BYTES) {
+            file.read_exact(&mut block).unwrap_or_else(|error| {
+                panic!(
+                    "specification root drive {} must contain the fixed read range: {error}",
+                    path.display()
+                )
+            });
+            for byte in block {
+                checksum ^= u64::from(byte);
+                checksum = checksum.wrapping_mul(SPECIFICATION_STORAGE_FNV_PRIME);
+            }
+        }
+        checksum
+    }
+
+    fn specification_marker_lines(transcript: &str) -> Vec<&str> {
+        transcript
+            .lines()
+            .filter_map(|raw_line| {
+                let line = raw_line.trim_end_matches('\r');
+                if !line.contains("BANGBANG_SPEC_") {
+                    return None;
+                }
+                assert!(
+                    line.starts_with("BANGBANG_SPEC_"),
+                    "specification workload record must be line-aligned: {line:?}"
+                );
+                Some(line)
+            })
+            .collect()
+    }
+
+    fn assert_specification_waiting_transcript(transcript: &str) {
+        let markers = specification_marker_lines(transcript);
+        assert_eq!(
+            markers,
+            [SPECIFICATION_WORKLOAD_HEADER, SPECIFICATION_WORKLOAD_READY,],
+            "the unreleased workload must expose only its version and ready records"
+        );
+        assert!(
+            !transcript.contains(SPECIFICATION_WORKLOAD_FAILURE),
+            "the waiting workload must not expose a failure record"
+        );
+    }
+
+    fn specification_record_values(
+        record: &str,
+        prefix: &str,
+        expected_fields: &[&str],
+    ) -> Vec<u64> {
+        let payload = record
+            .strip_prefix(prefix)
+            .unwrap_or_else(|| panic!("specification record has the wrong prefix: {record:?}"));
+        let tokens = payload.split_ascii_whitespace().collect::<Vec<_>>();
+        assert_eq!(
+            tokens.len(),
+            expected_fields.len(),
+            "specification record has the wrong field count: {record:?}"
+        );
+        tokens
+            .iter()
+            .zip(expected_fields)
+            .map(|(token, expected_field)| {
+                let (field, value) = token.split_once('=').unwrap_or_else(|| {
+                    panic!("specification field must contain exactly one '=': {token:?}")
+                });
+                assert_eq!(
+                    field, *expected_field,
+                    "specification field order or identity drifted in {record:?}"
+                );
+                assert!(
+                    !value.is_empty()
+                        && value.bytes().all(|byte| byte.is_ascii_digit())
+                        && (value == "0" || !value.starts_with('0')),
+                    "specification field must use canonical u64 decimal: {token:?}"
+                );
+                value.parse::<u64>().unwrap_or_else(|error| {
+                    panic!("specification field must fit u64: {token:?}: {error}")
+                })
+            })
+            .collect()
+    }
+
+    fn assert_specification_transcript(transcript: &str, expected_storage_checksum: u64) {
+        assert!(
+            !transcript.contains(SPECIFICATION_WORKLOAD_FAILURE),
+            "completed specification workload must not expose a failure record; transcript:\n{transcript}"
+        );
+        let markers = specification_marker_lines(transcript);
+        assert_eq!(
+            markers.len(),
+            5,
+            "completed specification transcript must contain exactly five records: {markers:?}"
+        );
+        assert_eq!(markers[0], SPECIFICATION_WORKLOAD_HEADER);
+        assert_eq!(markers[1], SPECIFICATION_WORKLOAD_READY);
+
+        let compute = specification_record_values(
+            markers[2],
+            "BANGBANG_SPEC_COMPUTE ",
+            &["duration_ns", "operations", "checksum"],
+        );
+        let _compute_duration_ns = compute[0];
+        assert_eq!(compute[1], SPECIFICATION_COMPUTE_OPERATIONS);
+        assert_eq!(compute[2], SPECIFICATION_COMPUTE_CHECKSUM);
+
+        let storage = specification_record_values(
+            markers[3],
+            "BANGBANG_SPEC_STORAGE ",
+            &["duration_ns", "bytes", "block_bytes", "checksum"],
+        );
+        let _storage_duration_ns = storage[0];
+        assert_eq!(storage[1], SPECIFICATION_STORAGE_BYTES as u64);
+        assert_eq!(storage[2], SPECIFICATION_STORAGE_BLOCK_BYTES as u64);
+        assert_eq!(storage[3], expected_storage_checksum);
+        assert_eq!(markers[4], SPECIFICATION_WORKLOAD_SUCCESS);
     }
 
     fn assert_metrics_output(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2571,6 +2571,23 @@ second writable drive. A boot-timer scenario starts the signed executable with
 `--boot-timer`, boots the Firecracker rootfs-provided `/usr/local/bin/init`
 wrapper, and waits for `Guest-boot-time` in the configured logger output after
 that wrapper writes the Firecracker magic byte to the boot-timer MMIO address.
+The companion `signed_executable_runs_released_guest_specification_workload`
+scenario boots the checked `/bangbang-specification-benchmark` PID 1 with one
+vCPU, 256 MiB, and that same production boot timer. The guest establishes
+devtmpfs (accepting the pinned kernel's existing mount), opens its read-only
+root block device, emits its versioned ready record, and blocks on one exact
+serial byte. The host proves that no timed record exists before release, then
+validates guest-monotonic compute and sequential 16 MiB
+root-drive durations, fixed counts, the fixed compute checksum, a checksum of
+the actual pinned root image bytes, guest-requested poweroff, and API-socket
+cleanup. Durations are evidence values, not numeric pass/fail thresholds. Run
+the signed oracle alone with:
+
+```sh
+scripts/run-integration-tests.sh --test executable_hvf_e2e -- \
+  macos_arm64::signed_executable_runs_released_guest_specification_workload --exact
+```
+
 This verifies the public process/API/config-file/HVF path, including public
 serial output redirection and implemented observability reachability. The executable HVF
 e2e target also includes direct-rootfs MMDS v1 and v2 token-flow scenarios that
@@ -3186,7 +3203,13 @@ deterministic direct-rootfs boot. For those scenarios,
 `.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v109.ext4`
 after confirming the host can execute HVF. The generated image is an ext4 copy
 of the pinned Firecracker rootfs with a test-specific
-`/bangbang-direct-rootfs-init` script added before image creation. The test
+`/bangbang-direct-rootfs-init` script plus static
+`/bangbang-arm64-id-register-report` and
+`/bangbang-specification-benchmark` helpers added before image creation. Both
+Rust helpers use the same closed `aarch64-unknown-linux-musl`, `rust-lld`,
+path-remapping, static-link, relocation, and stripping flags. Their checked
+sources are direct-rootfs recipe-digest inputs, so changing or omitting either
+source invalidates the sidecar-verified cache. The test
 boots without the tiny initrd, attaches that ext4 image as a read-only root
 drive, and passes `init=/bangbang-direct-rootfs-init`. The `guest_boot` target
 expects deterministic serial markers plus Ubuntu os-release content from

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -24,7 +24,7 @@ Environment:
   BANGBANG_GUEST_ARTIFACTS_DIR  Override the guest artifact cache root.
   BANGBANG_MKFS_EXT4            Override the mkfs.ext4 executable path.
   BANGBANG_RUSTC                Override the rustc executable used to build the
-                                static arm64 ID-register report helper.
+                                checked static arm64 guest helpers.
 EOF
 }
 
@@ -122,9 +122,109 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 direct_boot_variant="direct-boot-v109"
 extract_dir=""
 
-install_arm64_id_register_report_helper() {
-  local helper_source="${repo_root}/scripts/guest/arm64-id-register-report.rs"
-  local helper_path="${extract_dir}/bangbang-arm64-id-register-report"
+validate_static_arm64_guest_helper() {
+  local helper_path="$1"
+  local helper_description="$2"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required to validate the checked static arm64 guest helpers" >&2
+    exit 1
+  fi
+  if ! python3 - "$helper_path" <<'PY'
+import os
+import stat
+import struct
+import sys
+
+path = sys.argv[1]
+
+
+def reject(message):
+    raise SystemExit(message)
+
+
+try:
+    metadata = os.lstat(path)
+    with open(path, "rb") as binary:
+        data = binary.read()
+except OSError as error:
+    reject(f"guest helper could not be inspected: {error}")
+
+if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+    reject("guest helper is not a regular non-symlink file")
+if stat.S_IMODE(metadata.st_mode) != 0o755:
+    reject("guest helper does not have mode 0755")
+if len(data) < 64:
+    reject("guest helper is shorter than an ELF64 header")
+
+header = struct.unpack_from("<16sHHIQQQIHHHHHH", data)
+(
+    identity,
+    elf_type,
+    machine,
+    version,
+    entry,
+    program_offset,
+    section_offset,
+    _flags,
+    header_size,
+    program_entry_size,
+    program_count,
+    section_entry_size,
+    section_count,
+    _section_names,
+) = header
+if identity[:7] != b"\x7fELF\x02\x01\x01":
+    reject("guest helper is not a little-endian ELF64 executable")
+if elf_type != 2 or machine != 183 or version != 1 or header_size != 64 or entry == 0:
+    reject("guest helper is not an aarch64 ET_EXEC image")
+if program_entry_size < 56 or program_count == 0:
+    reject("guest helper has no valid program-header table")
+program_end = program_offset + program_entry_size * program_count
+if program_offset < header_size or program_end > len(data):
+    reject("guest helper program-header table is out of bounds")
+
+has_load = False
+entry_is_executable = False
+for index in range(program_count):
+    offset = program_offset + index * program_entry_size
+    segment_type, segment_flags, file_offset, virtual_address, _, file_size, memory_size, _ = (
+        struct.unpack_from("<IIQQQQQQ", data, offset)
+    )
+    if segment_type in (2, 3):
+        reject("guest helper contains a dynamic or interpreter segment")
+    if segment_type != 1:
+        continue
+    has_load = True
+    if file_size > memory_size or file_offset + file_size > len(data):
+        reject("guest helper load segment is out of bounds")
+    if segment_flags & 1 and virtual_address <= entry < virtual_address + memory_size:
+        entry_is_executable = True
+if not has_load or not entry_is_executable:
+    reject("guest helper has no executable load segment covering its entry point")
+
+if section_count:
+    if section_entry_size < 64:
+        reject("guest helper has an invalid section-header table")
+    section_end = section_offset + section_entry_size * section_count
+    if section_offset == 0 or section_end > len(data):
+        reject("guest helper section-header table is out of bounds")
+    for index in range(section_count):
+        offset = section_offset + index * section_entry_size
+        section_type = struct.unpack_from("<I", data, offset + 4)[0]
+        if section_type in (2, 11):
+            reject("guest helper retains a symbol table")
+PY
+  then
+    echo "$helper_description output is not a stripped static aarch64 ELF: $helper_path" >&2
+    exit 1
+  fi
+}
+
+build_static_arm64_guest_helper() {
+  local helper_source="$1"
+  local helper_path="$2"
+  local helper_description="$3"
   local rustc_path="${BANGBANG_RUSTC:-rustc}"
   local host_target
   local rust_lld
@@ -132,11 +232,11 @@ install_arm64_id_register_report_helper() {
   local target_libdir
 
   if [[ ! -f "$helper_source" ]]; then
-    echo "arm64 ID-register report helper source is missing: $helper_source" >&2
+    echo "$helper_description source is missing: $helper_source" >&2
     exit 1
   fi
   if ! command -v "$rustc_path" >/dev/null 2>&1; then
-    echo "rustc is required to build the arm64 ID-register report helper" >&2
+    echo "rustc is required to build the checked static arm64 guest helpers" >&2
     exit 1
   fi
 
@@ -154,7 +254,7 @@ install_arm64_id_register_report_helper() {
     exit 1
   fi
 
-  echo "building static arm64 ID-register report helper" >&2
+  echo "building static $helper_description" >&2
   "$rustc_path" \
     "$helper_source" \
     --edition 2024 \
@@ -171,6 +271,18 @@ install_arm64_id_register_report_helper() {
     -C relocation-model=static \
     -o "$helper_path"
   chmod 0755 "$helper_path"
+  validate_static_arm64_guest_helper "$helper_path" "$helper_description"
+}
+
+install_static_arm64_guest_helpers() {
+  build_static_arm64_guest_helper \
+    "${repo_root}/scripts/guest/arm64-id-register-report.rs" \
+    "${extract_dir}/bangbang-arm64-id-register-report" \
+    "arm64 ID-register report helper"
+  build_static_arm64_guest_helper \
+    "${repo_root}/scripts/guest/specification-benchmark.rs" \
+    "${extract_dir}/bangbang-specification-benchmark" \
+    "arm64 specification benchmark workload"
 }
 
 install_direct_boot_init() {
@@ -5165,7 +5277,7 @@ if [[ -n "$internal_populate_dir" ]]; then
     exit 1
   fi
   extract_dir="$internal_populate_dir"
-  install_arm64_id_register_report_helper
+  install_static_arm64_guest_helpers
   install_direct_boot_init
   extract_dir=""
   exit 0

--- a/scripts/guest/specification-benchmark.rs
+++ b/scripts/guest/specification-benchmark.rs
@@ -1,0 +1,636 @@
+#![no_main]
+#![no_std]
+
+use core::arch::asm;
+use core::hint::black_box;
+use core::panic::PanicInfo;
+use core::ptr;
+
+const STDOUT: usize = 1;
+const AT_FDCWD: usize = (-100_isize) as usize;
+const O_RDONLY: usize = 0;
+const O_RDWR: usize = 2;
+const O_SYNC: usize = 0x10_1000;
+const PROT_WRITE: usize = 2;
+const MAP_SHARED: usize = 1;
+const MS_ASYNC: usize = 1;
+const CLOCK_MONOTONIC: usize = 1;
+const TCSETS: usize = 0x5402;
+
+const SYS_IOCTL: usize = 29;
+const SYS_MOUNT: usize = 40;
+const SYS_OPENAT: usize = 56;
+const SYS_CLOSE: usize = 57;
+const SYS_READ: usize = 63;
+const SYS_WRITE: usize = 64;
+const SYS_EXIT: usize = 93;
+const SYS_CLOCK_GETTIME: usize = 113;
+const SYS_REBOOT: usize = 142;
+const SYS_MUNMAP: usize = 215;
+const SYS_MMAP: usize = 222;
+const SYS_MSYNC: usize = 227;
+
+const EINTR: isize = 4;
+const EBUSY: isize = 16;
+const LINUX_REBOOT_MAGIC1: usize = 0xfee1_dead;
+const LINUX_REBOOT_MAGIC2: usize = 0x2812_1969;
+const LINUX_REBOOT_CMD_POWER_OFF: usize = 0x4321_fedc;
+
+const GUEST_PAGE_SIZE: usize = 4096;
+const BOOT_TIMER_ADDRESS: usize = 0x4000_0000;
+const BOOT_TIMER_MAGIC: u8 = 123;
+const RELEASE_TOKEN: u8 = b'R';
+const COMPUTE_OPERATIONS: u64 = 5_000_000;
+const COMPUTE_CHECKSUM: u64 = 8_398_723_902_783_368_615;
+const STORAGE_BYTES: u64 = 16 * 1024 * 1024;
+const STORAGE_BLOCK_BYTES: usize = 4096;
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+const SERIAL_WRITE_CHUNK_BYTES: usize = 16;
+
+const HEADER: &[u8] = b"BANGBANG_SPEC_WORKLOAD_V1\n";
+const READY: &[u8] = b"BANGBANG_SPEC_INIT_READY release_byte=82\n";
+const SUCCESS: &[u8] = b"BANGBANG_SPEC_WORKLOAD_OK\n";
+const FAILURE_PREFIX: &[u8] = b"BANGBANG_SPEC_WORKLOAD_FAIL phase=";
+
+const DEVTMPFS: &[u8] = b"devtmpfs\0";
+const DEV: &[u8] = b"/dev\0";
+const SERIAL: &[u8] = b"/dev/ttyS0\0";
+const MEMORY: &[u8] = b"/dev/mem\0";
+const ROOT_BLOCK: &[u8] = b"/dev/vda\0";
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Timespec {
+    seconds: i64,
+    nanoseconds: i64,
+}
+
+#[repr(C)]
+struct Termios {
+    input_flags: u32,
+    output_flags: u32,
+    control_flags: u32,
+    local_flags: u32,
+    line: u8,
+    control_characters: [u8; 19],
+}
+
+const _: [(); 36] = [(); core::mem::size_of::<Termios>()];
+
+#[derive(Clone, Copy)]
+struct Failure {
+    output_fd: usize,
+    phase: &'static [u8],
+}
+
+struct Line {
+    bytes: [u8; 192],
+    length: usize,
+}
+
+impl Line {
+    const fn new() -> Self {
+        Self {
+            bytes: [0; 192],
+            length: 0,
+        }
+    }
+
+    fn append(&mut self, value: &[u8]) -> bool {
+        let Some(end) = self.length.checked_add(value.len()) else {
+            return false;
+        };
+        let Some(destination) = self.bytes.get_mut(self.length..end) else {
+            return false;
+        };
+        destination.copy_from_slice(value);
+        self.length = end;
+        true
+    }
+
+    fn append_u64(&mut self, value: u64) -> bool {
+        let mut digits = [0_u8; 20];
+        let mut cursor = digits.len();
+        let mut remaining = value;
+        loop {
+            cursor -= 1;
+            digits[cursor] = b'0' + (remaining % 10) as u8;
+            remaining /= 10;
+            if remaining == 0 {
+                break;
+            }
+        }
+        self.append(&digits[cursor..])
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.length]
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo<'_>) -> ! {
+    let _ = write_all(STDOUT, b"BANGBANG_SPEC_WORKLOAD_FAIL phase=panic\n");
+    power_off(STDOUT, 101)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() -> ! {
+    match run() {
+        Ok(output_fd) => {
+            if !write_all(output_fd, SUCCESS) {
+                fail(Failure {
+                    output_fd,
+                    phase: b"success-write",
+                });
+            }
+            power_off(output_fd, 0)
+        }
+        Err(failure) => fail(failure),
+    }
+}
+
+fn run() -> Result<usize, Failure> {
+    let mut output_fd = STDOUT;
+
+    // SAFETY: all strings are static NUL-terminated buffers and the mount data
+    // pointer is unused for devtmpfs.
+    let mounted = unsafe {
+        syscall6(
+            SYS_MOUNT,
+            DEVTMPFS.as_ptr() as usize,
+            DEV.as_ptr() as usize,
+            DEVTMPFS.as_ptr() as usize,
+            0,
+            0,
+            0,
+        )
+    };
+    // The pinned kernel may have already mounted devtmpfs through
+    // CONFIG_DEVTMPFS_MOUNT; EBUSY therefore proves the same ready state.
+    if mounted != 0 && mounted != -EBUSY {
+        return Err(Failure {
+            output_fd,
+            phase: b"mount-devtmpfs",
+        });
+    }
+
+    let serial_fd = open(SERIAL, O_RDWR).ok_or(Failure {
+        output_fd,
+        phase: b"open-serial",
+    })?;
+    output_fd = serial_fd;
+    configure_serial(output_fd)?;
+
+    signal_boot_complete(output_fd)?;
+
+    let root_block_fd = open(ROOT_BLOCK, O_RDONLY).ok_or(Failure {
+        output_fd,
+        phase: b"open-root-block",
+    })?;
+
+    if !write_all(output_fd, HEADER) || !write_all(output_fd, READY) {
+        return Err(Failure {
+            output_fd,
+            phase: b"ready-write",
+        });
+    }
+
+    wait_for_release(output_fd)?;
+
+    let compute_started = monotonic_now(output_fd, b"compute-clock-start")?;
+    let compute_checksum = compute_workload();
+    let compute_finished = monotonic_now(output_fd, b"compute-clock-end")?;
+    let compute_duration = elapsed_ns(compute_started, compute_finished).ok_or(Failure {
+        output_fd,
+        phase: b"compute-clock-range",
+    })?;
+    if compute_checksum != COMPUTE_CHECKSUM {
+        return Err(Failure {
+            output_fd,
+            phase: b"compute-checksum",
+        });
+    }
+    emit_compute(output_fd, compute_duration, compute_checksum)?;
+
+    let storage_started = monotonic_now(output_fd, b"storage-clock-start")?;
+    let storage_checksum = read_storage(root_block_fd, output_fd)?;
+    let storage_finished = monotonic_now(output_fd, b"storage-clock-end")?;
+    let storage_duration = elapsed_ns(storage_started, storage_finished).ok_or(Failure {
+        output_fd,
+        phase: b"storage-clock-range",
+    })?;
+    emit_storage(output_fd, storage_duration, storage_checksum)?;
+
+    require_zero(close(root_block_fd), output_fd, b"close-root-block")?;
+    Ok(output_fd)
+}
+
+fn configure_serial(output_fd: usize) -> Result<(), Failure> {
+    let mut control_characters = [0_u8; 19];
+    control_characters[6] = 1;
+    let raw = Termios {
+        input_flags: 0,
+        output_flags: 0,
+        control_flags: 0x08bf,
+        local_flags: 0,
+        line: 0,
+        control_characters,
+    };
+    // SAFETY: `raw` is the Linux arm64 termios layout used by TCSETS and stays
+    // readable for the duration of the ioctl.
+    let result = unsafe {
+        syscall6(
+            SYS_IOCTL,
+            output_fd,
+            TCSETS,
+            ptr::from_ref(&raw) as usize,
+            0,
+            0,
+            0,
+        )
+    };
+    require_zero(result, output_fd, b"configure-serial")
+}
+
+fn signal_boot_complete(output_fd: usize) -> Result<(), Failure> {
+    let memory_fd = open(MEMORY, O_RDWR | O_SYNC).ok_or(Failure {
+        output_fd,
+        phase: b"open-boot-timer",
+    })?;
+    // SAFETY: the boot timer occupies one checked guest page at the fixed
+    // production MMIO address and `memory_fd` is an open /dev/mem descriptor.
+    let mapped = unsafe {
+        syscall6(
+            SYS_MMAP,
+            0,
+            GUEST_PAGE_SIZE,
+            PROT_WRITE,
+            MAP_SHARED,
+            memory_fd,
+            BOOT_TIMER_ADDRESS,
+        )
+    };
+    if is_error(mapped) {
+        return Err(Failure {
+            output_fd,
+            phase: b"map-boot-timer",
+        });
+    }
+    let mapped_address = mapped as usize;
+    // SAFETY: the successful mapping above covers at least one writable byte.
+    unsafe {
+        ptr::write_volatile(mapped_address as *mut u8, BOOT_TIMER_MAGIC);
+    }
+    // SAFETY: the mapped address and length are the exact successful mapping.
+    let synced = unsafe {
+        syscall6(
+            SYS_MSYNC,
+            mapped_address,
+            GUEST_PAGE_SIZE,
+            MS_ASYNC,
+            0,
+            0,
+            0,
+        )
+    };
+    require_zero(synced, output_fd, b"sync-boot-timer")?;
+    // SAFETY: the mapped address and length are the exact successful mapping.
+    let unmapped = unsafe { syscall6(SYS_MUNMAP, mapped_address, GUEST_PAGE_SIZE, 0, 0, 0, 0) };
+    require_zero(unmapped, output_fd, b"unmap-boot-timer")?;
+    require_zero(close(memory_fd), output_fd, b"close-boot-timer")
+}
+
+fn wait_for_release(output_fd: usize) -> Result<(), Failure> {
+    let mut tokens = [0_u8; 2];
+    loop {
+        // SAFETY: `tokens` is writable for the requested two bytes and the
+        // serial descriptor remains open for the workload lifetime.
+        let result = unsafe {
+            syscall6(
+                SYS_READ,
+                output_fd,
+                tokens.as_mut_ptr() as usize,
+                tokens.len(),
+                0,
+                0,
+                0,
+            )
+        };
+        if result == -EINTR {
+            continue;
+        }
+        if result == 0 {
+            return Err(Failure {
+                output_fd,
+                phase: b"release-eof",
+            });
+        }
+        if result > 1 {
+            return Err(Failure {
+                output_fd,
+                phase: b"release-extra",
+            });
+        }
+        if result != 1 {
+            return Err(Failure {
+                output_fd,
+                phase: b"release-read",
+            });
+        }
+        if tokens[0] != RELEASE_TOKEN {
+            return Err(Failure {
+                output_fd,
+                phase: b"release-byte",
+            });
+        }
+        return Ok(());
+    }
+}
+
+fn compute_workload() -> u64 {
+    let mut checksum = 0x6a09_e667_f3bc_c909_u64;
+    for operation in 0..COMPUTE_OPERATIONS {
+        checksum ^= operation.wrapping_mul(0x9e37_79b1_85eb_ca87);
+        checksum = checksum.rotate_left(17);
+        checksum = checksum.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        checksum ^= checksum >> 29;
+        checksum = black_box(checksum);
+    }
+    checksum
+}
+
+fn read_storage(root_block_fd: usize, output_fd: usize) -> Result<u64, Failure> {
+    let mut buffer = [0_u8; STORAGE_BLOCK_BYTES];
+    let mut remaining = STORAGE_BYTES;
+    let mut checksum = FNV_OFFSET_BASIS;
+    while remaining != 0 {
+        // SAFETY: `buffer` is writable for exactly the requested block and the
+        // checked root block descriptor remains open.
+        let result = unsafe {
+            syscall6(
+                SYS_READ,
+                root_block_fd,
+                buffer.as_mut_ptr() as usize,
+                STORAGE_BLOCK_BYTES,
+                0,
+                0,
+                0,
+            )
+        };
+        if result == -EINTR {
+            continue;
+        }
+        if result != STORAGE_BLOCK_BYTES as isize {
+            return Err(Failure {
+                output_fd,
+                phase: b"storage-short-read",
+            });
+        }
+        for byte in buffer {
+            checksum ^= u64::from(byte);
+            checksum = checksum.wrapping_mul(FNV_PRIME);
+        }
+        remaining -= STORAGE_BLOCK_BYTES as u64;
+    }
+    Ok(checksum)
+}
+
+fn monotonic_now(output_fd: usize, phase: &'static [u8]) -> Result<Timespec, Failure> {
+    let mut time = Timespec {
+        seconds: 0,
+        nanoseconds: 0,
+    };
+    // SAFETY: `time` is writable for one Linux aarch64 timespec.
+    let result = unsafe {
+        syscall6(
+            SYS_CLOCK_GETTIME,
+            CLOCK_MONOTONIC,
+            ptr::from_mut(&mut time) as usize,
+            0,
+            0,
+            0,
+            0,
+        )
+    };
+    require_zero(result, output_fd, phase)?;
+    if time.seconds < 0 || !(0..1_000_000_000).contains(&time.nanoseconds) {
+        return Err(Failure { output_fd, phase });
+    }
+    Ok(time)
+}
+
+fn elapsed_ns(start: Timespec, end: Timespec) -> Option<u64> {
+    if end.seconds < start.seconds {
+        return None;
+    }
+    let mut seconds = end.seconds - start.seconds;
+    let nanoseconds = if end.nanoseconds < start.nanoseconds {
+        seconds = seconds.checked_sub(1)?;
+        end.nanoseconds + 1_000_000_000 - start.nanoseconds
+    } else {
+        end.nanoseconds - start.nanoseconds
+    };
+    let seconds = u64::try_from(seconds).ok()?;
+    let nanoseconds = u64::try_from(nanoseconds).ok()?;
+    seconds.checked_mul(1_000_000_000)?.checked_add(nanoseconds)
+}
+
+fn emit_compute(output_fd: usize, duration_ns: u64, checksum: u64) -> Result<(), Failure> {
+    let mut line = Line::new();
+    if !line.append(b"BANGBANG_SPEC_COMPUTE duration_ns=")
+        || !line.append_u64(duration_ns)
+        || !line.append(b" operations=")
+        || !line.append_u64(COMPUTE_OPERATIONS)
+        || !line.append(b" checksum=")
+        || !line.append_u64(checksum)
+        || !line.append(b"\n")
+        || !write_all(output_fd, line.as_bytes())
+    {
+        return Err(Failure {
+            output_fd,
+            phase: b"compute-write",
+        });
+    }
+    Ok(())
+}
+
+fn emit_storage(output_fd: usize, duration_ns: u64, checksum: u64) -> Result<(), Failure> {
+    let mut line = Line::new();
+    if !line.append(b"BANGBANG_SPEC_STORAGE duration_ns=")
+        || !line.append_u64(duration_ns)
+        || !line.append(b" bytes=")
+        || !line.append_u64(STORAGE_BYTES)
+        || !line.append(b" block_bytes=")
+        || !line.append_u64(STORAGE_BLOCK_BYTES as u64)
+        || !line.append(b" checksum=")
+        || !line.append_u64(checksum)
+        || !line.append(b"\n")
+        || !write_all(output_fd, line.as_bytes())
+    {
+        return Err(Failure {
+            output_fd,
+            phase: b"storage-write",
+        });
+    }
+    Ok(())
+}
+
+fn open(path: &'static [u8], flags: usize) -> Option<usize> {
+    // SAFETY: `path` is one of the static NUL-terminated device paths above.
+    let result = unsafe { syscall6(SYS_OPENAT, AT_FDCWD, path.as_ptr() as usize, flags, 0, 0, 0) };
+    (!is_error(result)).then_some(result as usize)
+}
+
+fn close(fd: usize) -> isize {
+    // SAFETY: the syscall accepts any descriptor value and returns an error for
+    // an invalid one.
+    unsafe { syscall6(SYS_CLOSE, fd, 0, 0, 0, 0, 0) }
+}
+
+fn require_zero(result: isize, output_fd: usize, phase: &'static [u8]) -> Result<(), Failure> {
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(Failure { output_fd, phase })
+    }
+}
+
+fn is_error(result: isize) -> bool {
+    (-4095..0).contains(&result)
+}
+
+fn write_all(fd: usize, bytes: &[u8]) -> bool {
+    let mut written = 0;
+    while written < bytes.len() {
+        let request = (bytes.len() - written).min(SERIAL_WRITE_CHUNK_BYTES);
+        // SAFETY: `written` and `request` select a readable range within
+        // `bytes`, and the syscall accepts any descriptor value.
+        let result = unsafe {
+            syscall6(
+                SYS_WRITE,
+                fd,
+                bytes.as_ptr().add(written) as usize,
+                request,
+                0,
+                0,
+                0,
+            )
+        };
+        if result == -EINTR {
+            continue;
+        }
+        if result <= 0 || result as usize > request {
+            return false;
+        }
+        written += result as usize;
+    }
+    true
+}
+
+fn fail(failure: Failure) -> ! {
+    let mut line = Line::new();
+    if line.append(FAILURE_PREFIX) && line.append(failure.phase) && line.append(b"\n") {
+        let _ = write_all(failure.output_fd, line.as_bytes());
+    }
+    power_off(failure.output_fd, 1)
+}
+
+fn power_off(output_fd: usize, status: usize) -> ! {
+    // SAFETY: these are the Linux reboot magic constants and the power-off
+    // command; a PID-1 workload has the required guest privilege.
+    unsafe {
+        let _ = syscall6(
+            SYS_REBOOT,
+            LINUX_REBOOT_MAGIC1,
+            LINUX_REBOOT_MAGIC2,
+            LINUX_REBOOT_CMD_POWER_OFF,
+            0,
+            0,
+            0,
+        );
+    }
+    if status == 0 {
+        let _ = write_all(
+            output_fd,
+            b"BANGBANG_SPEC_WORKLOAD_FAIL phase=poweroff\n",
+        );
+        exit(1)
+    }
+    exit(status)
+}
+
+fn exit(status: usize) -> ! {
+    // SAFETY: the Linux aarch64 exit syscall takes only the status and never
+    // returns.
+    unsafe {
+        asm!(
+            "svc 0",
+            in("x8") SYS_EXIT,
+            in("x0") status,
+            options(noreturn, nostack),
+        );
+    }
+}
+
+unsafe fn syscall6(
+    number: usize,
+    argument0: usize,
+    argument1: usize,
+    argument2: usize,
+    argument3: usize,
+    argument4: usize,
+    argument5: usize,
+) -> isize {
+    let result: usize;
+    // SAFETY: callers document every pointer and descriptor supplied to the
+    // Linux aarch64 syscall ABI. Linux returns its scalar result in x0.
+    unsafe {
+        asm!(
+            "svc 0",
+            in("x8") number,
+            inlateout("x0") argument0 => result,
+            in("x1") argument1,
+            in("x2") argument2,
+            in("x3") argument3,
+            in("x4") argument4,
+            in("x5") argument5,
+            options(nostack),
+        );
+    }
+    result as isize
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+unsafe extern "C" fn memcpy(destination: *mut u8, source: *const u8, length: usize) -> *mut u8 {
+    for index in 0..length {
+        // SAFETY: the compiler calls this symbol with non-overlapping readable
+        // and writable ranges of at least `length` bytes.
+        unsafe {
+            destination
+                .add(index)
+                .write_volatile(source.add(index).read_volatile());
+        }
+    }
+    destination
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+unsafe extern "C" fn memset(destination: *mut u8, value: i32, length: usize) -> *mut u8 {
+    for index in 0..length {
+        // SAFETY: the compiler calls this symbol with a writable range of at
+        // least `length` bytes.
+        unsafe {
+            destination.add(index).write_volatile(value as u8);
+        }
+    }
+    destination
+}
+
+// The static no-std link still references the personality symbol through a
+// core cold path. `panic=abort` guarantees that unwinding never calls it.
+#[unsafe(no_mangle)]
+extern "C" fn rust_eh_personality() {}

--- a/scripts/specification_workload.py
+++ b/scripts/specification_workload.py
@@ -1,0 +1,139 @@
+"""Strict parser for the checked guest specification-workload transcript."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+RELEASE_BYTE = b"R"
+COMPUTE_OPERATIONS = 5_000_000
+COMPUTE_CHECKSUM = 8_398_723_902_783_368_615
+STORAGE_BYTES = 16 * 1024 * 1024
+STORAGE_BLOCK_BYTES = 4096
+
+_MARKER_PREFIX = b"BANGBANG_SPEC_"
+_HEADER = b"BANGBANG_SPEC_WORKLOAD_V1"
+_READY = b"BANGBANG_SPEC_INIT_READY release_byte=82"
+_SUCCESS = b"BANGBANG_SPEC_WORKLOAD_OK"
+_FAILURE = re.compile(rb"BANGBANG_SPEC_WORKLOAD_FAIL phase=([a-z][a-z0-9-]{0,47})")
+_COMPUTE = re.compile(
+    rb"BANGBANG_SPEC_COMPUTE duration_ns=([0-9]+) operations=([0-9]+) checksum=([0-9]+)"
+)
+_STORAGE = re.compile(
+    rb"BANGBANG_SPEC_STORAGE duration_ns=([0-9]+) bytes=([0-9]+) "
+    rb"block_bytes=([0-9]+) checksum=([0-9]+)"
+)
+_U64_MAX = (1 << 64) - 1
+
+
+class SpecificationWorkloadError(ValueError):
+    """The guest transcript is not the complete checked v1 protocol."""
+
+
+@dataclass(frozen=True)
+class SpecificationWorkloadResult:
+    compute_duration_ns: int
+    compute_operations: int
+    compute_checksum: int
+    storage_duration_ns: int
+    storage_bytes: int
+    storage_block_bytes: int
+    storage_checksum: int
+
+
+def _u64(token: bytes, field: str) -> int:
+    if token != b"0" and token.startswith(b"0"):
+        raise SpecificationWorkloadError(f"{field} is not canonical decimal")
+    value = int(token)
+    if value > _U64_MAX:
+        raise SpecificationWorkloadError(f"{field} exceeds u64")
+    return value
+
+
+def _marker_lines(transcript: bytes | str) -> list[bytes]:
+    if isinstance(transcript, str):
+        try:
+            data = transcript.encode("ascii")
+        except UnicodeEncodeError as error:
+            raise SpecificationWorkloadError("transcript is not ASCII") from error
+    elif isinstance(transcript, bytes):
+        data = transcript
+    else:
+        raise TypeError("transcript must be bytes or str")
+
+    markers: list[bytes] = []
+    for line in data.splitlines():
+        if _MARKER_PREFIX not in line:
+            continue
+        if not line.startswith(_MARKER_PREFIX):
+            raise SpecificationWorkloadError("workload record is not line-aligned")
+        markers.append(line)
+    return markers
+
+
+def parse_transcript(
+    transcript: bytes | str,
+    *,
+    expected_storage_checksum: int | None = None,
+) -> SpecificationWorkloadResult:
+    """Parse one complete v1 run, rejecting all grammar and constant drift."""
+
+    markers = _marker_lines(transcript)
+    for marker in markers:
+        failure = _FAILURE.fullmatch(marker)
+        if failure is not None:
+            phase = failure.group(1).decode("ascii")
+            raise SpecificationWorkloadError(f"guest workload failed in phase {phase}")
+        if marker.startswith(b"BANGBANG_SPEC_WORKLOAD_FAIL"):
+            raise SpecificationWorkloadError("malformed guest failure record")
+
+    if len(markers) != 5:
+        raise SpecificationWorkloadError(
+            f"expected exactly 5 workload records, observed {len(markers)}"
+        )
+    if markers[0] != _HEADER:
+        raise SpecificationWorkloadError("missing or misplaced v1 header")
+    if markers[1] != _READY:
+        raise SpecificationWorkloadError("missing, misplaced, or drifted ready record")
+
+    compute_match = _COMPUTE.fullmatch(markers[2])
+    if compute_match is None:
+        raise SpecificationWorkloadError("malformed or misplaced compute record")
+    compute_duration_ns = _u64(compute_match.group(1), "compute duration")
+    compute_operations = _u64(compute_match.group(2), "compute operations")
+    compute_checksum = _u64(compute_match.group(3), "compute checksum")
+    if compute_operations != COMPUTE_OPERATIONS:
+        raise SpecificationWorkloadError("compute operation count drifted")
+    if compute_checksum != COMPUTE_CHECKSUM:
+        raise SpecificationWorkloadError("compute checksum drifted")
+
+    storage_match = _STORAGE.fullmatch(markers[3])
+    if storage_match is None:
+        raise SpecificationWorkloadError("malformed or misplaced storage record")
+    storage_duration_ns = _u64(storage_match.group(1), "storage duration")
+    storage_bytes = _u64(storage_match.group(2), "storage bytes")
+    storage_block_bytes = _u64(storage_match.group(3), "storage block bytes")
+    storage_checksum = _u64(storage_match.group(4), "storage checksum")
+    if storage_bytes != STORAGE_BYTES:
+        raise SpecificationWorkloadError("storage byte count drifted")
+    if storage_block_bytes != STORAGE_BLOCK_BYTES:
+        raise SpecificationWorkloadError("storage block size drifted")
+    if expected_storage_checksum is not None:
+        if not 0 <= expected_storage_checksum <= _U64_MAX:
+            raise ValueError("expected storage checksum must fit u64")
+        if storage_checksum != expected_storage_checksum:
+            raise SpecificationWorkloadError("storage checksum did not match the root drive")
+
+    if markers[4] != _SUCCESS:
+        raise SpecificationWorkloadError("missing or misplaced success record")
+
+    return SpecificationWorkloadResult(
+        compute_duration_ns=compute_duration_ns,
+        compute_operations=compute_operations,
+        compute_checksum=compute_checksum,
+        storage_duration_ns=storage_duration_ns,
+        storage_bytes=storage_bytes,
+        storage_block_bytes=storage_block_bytes,
+        storage_checksum=storage_checksum,
+    )

--- a/scripts/tests/test_specification_workload.py
+++ b/scripts/tests/test_specification_workload.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, os.fspath(REPOSITORY_ROOT / "scripts"))
+
+import specification_workload as workload  # noqa: E402
+
+
+STORAGE_CHECKSUM = 12_345_678_901
+VALID_TRANSCRIPT = (
+    b"Linux boot noise\r\n"
+    b"BANGBANG_SPEC_WORKLOAD_V1\r\n"
+    b"BANGBANG_SPEC_INIT_READY release_byte=82\r\n"
+    b"BANGBANG_SPEC_COMPUTE duration_ns=0 operations=5000000 "
+    b"checksum=8398723902783368615\r\n"
+    b"BANGBANG_SPEC_STORAGE duration_ns=987654 bytes=16777216 "
+    b"block_bytes=4096 checksum=12345678901\r\n"
+    b"BANGBANG_SPEC_WORKLOAD_OK\r\n"
+    b"shutdown noise\r\n"
+)
+
+
+class SpecificationWorkloadParserTests(unittest.TestCase):
+    def test_complete_transcript_parses_without_performance_thresholds(self) -> None:
+        result = workload.parse_transcript(
+            VALID_TRANSCRIPT,
+            expected_storage_checksum=STORAGE_CHECKSUM,
+        )
+
+        self.assertEqual(result.compute_duration_ns, 0)
+        self.assertEqual(result.compute_operations, workload.COMPUTE_OPERATIONS)
+        self.assertEqual(result.compute_checksum, workload.COMPUTE_CHECKSUM)
+        self.assertEqual(result.storage_duration_ns, 987_654)
+        self.assertEqual(result.storage_bytes, workload.STORAGE_BYTES)
+        self.assertEqual(result.storage_block_bytes, workload.STORAGE_BLOCK_BYTES)
+        self.assertEqual(result.storage_checksum, STORAGE_CHECKSUM)
+        self.assertEqual(workload.RELEASE_BYTE, b"R")
+
+    def test_missing_duplicate_reordered_and_unknown_records_fail(self) -> None:
+        records = [
+            line
+            for line in VALID_TRANSCRIPT.splitlines()
+            if line.startswith(b"BANGBANG_SPEC_")
+        ]
+        cases = {
+            "missing": records[:-1],
+            "duplicate": [*records, records[-1]],
+            "reordered": [records[0], records[1], records[3], records[2], records[4]],
+            "unknown": [*records[:-1], b"BANGBANG_SPEC_FUTURE", records[-1]],
+        }
+        for name, lines in cases.items():
+            with self.subTest(name=name), self.assertRaises(
+                workload.SpecificationWorkloadError
+            ):
+                workload.parse_transcript(b"\n".join(lines))
+
+    def test_malformed_and_constant_drifted_records_fail(self) -> None:
+        replacements = {
+            "leading zero": (b"duration_ns=0", b"duration_ns=00"),
+            "u64 overflow": (
+                b"duration_ns=0",
+                b"duration_ns=18446744073709551616",
+            ),
+            "release": (b"release_byte=82", b"release_byte=10"),
+            "operations": (b"operations=5000000", b"operations=4999999"),
+            "compute checksum": (
+                b"checksum=8398723902783368615",
+                b"checksum=8398723902783368614",
+            ),
+            "storage bytes": (b"bytes=16777216", b"bytes=16777215"),
+            "block bytes": (b"block_bytes=4096", b"block_bytes=512"),
+            "storage checksum": (b"checksum=12345678901", b"checksum=12345678900"),
+        }
+        for name, (before, after) in replacements.items():
+            with self.subTest(name=name), self.assertRaises(
+                workload.SpecificationWorkloadError
+            ):
+                workload.parse_transcript(
+                    VALID_TRANSCRIPT.replace(before, after, 1),
+                    expected_storage_checksum=STORAGE_CHECKSUM,
+                )
+
+    def test_guest_failure_and_non_line_aligned_record_fail(self) -> None:
+        with self.assertRaisesRegex(
+            workload.SpecificationWorkloadError,
+            "failed in phase release-eof",
+        ):
+            workload.parse_transcript(
+                b"BANGBANG_SPEC_WORKLOAD_V1\n"
+                b"BANGBANG_SPEC_WORKLOAD_FAIL phase=release-eof\n"
+            )
+        with self.assertRaisesRegex(
+            workload.SpecificationWorkloadError,
+            "not line-aligned",
+        ):
+            workload.parse_transcript(b"noise BANGBANG_SPEC_WORKLOAD_V1\n")
+        with self.assertRaisesRegex(
+            workload.SpecificationWorkloadError,
+            "failed in phase poweroff",
+        ):
+            workload.parse_transcript(
+                VALID_TRANSCRIPT
+                + b"BANGBANG_SPEC_WORKLOAD_FAIL phase=poweroff\n"
+            )
+
+
+class SpecificationWorkloadBuildBoundaryTests(unittest.TestCase):
+    def test_direct_rootfs_installs_both_helpers_with_identical_closed_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            temp = Path(raw_temp)
+            populate = temp / "rootfs"
+            populate.mkdir()
+            sysroot = temp / "sysroot"
+            target_libdir = sysroot / "lib/rustlib/aarch64-unknown-linux-musl/lib"
+            target_libdir.mkdir(parents=True)
+            (target_libdir / "libcore-test.rlib").write_bytes(b"core")
+            host_bin = sysroot / "lib/rustlib/fake-host/bin"
+            host_bin.mkdir(parents=True)
+            rust_lld = host_bin / "rust-lld"
+            rust_lld.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            rust_lld.chmod(0o755)
+
+            log_path = temp / "rustc.jsonl"
+            fake_rustc = temp / "rustc"
+            fake_rustc.write_text(
+                """#!/usr/bin/env python3
+import json
+import os
+import struct
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+sysroot = Path(os.environ["FAKE_RUST_SYSROOT"])
+mode = os.environ.get("FAKE_RUST_MODE", "static")
+if args[:2] == ["--print", "target-libdir"]:
+    target = "missing-target" if mode == "missing-target" else "aarch64-unknown-linux-musl"
+    print(sysroot / f"lib/rustlib/{target}/lib")
+elif args == ["--print", "sysroot"]:
+    print(sysroot)
+elif args == ["-vV"]:
+    host = "missing-host" if mode == "missing-linker" else "fake-host"
+    print(f"host: {host}")
+else:
+    with Path(os.environ["FAKE_RUST_LOG"]).open("a", encoding="utf-8") as log:
+        log.write(json.dumps(args) + "\\n")
+    output = Path(args[args.index("-o") + 1])
+    if mode == "malformed":
+        output.write_bytes(b"not an ELF")
+    else:
+        identity = b"\\x7fELF\\x02\\x01\\x01" + bytes(9)
+        image_size = 64 + 56
+        header = struct.pack(
+            "<16sHHIQQQIHHHHHH",
+            identity,
+            2,
+            183,
+            1,
+            0x400000,
+            64,
+            0,
+            0,
+            64,
+            56,
+            1,
+            0,
+            0,
+            0,
+        )
+        segment_type = 3 if mode == "dynamic" else 1
+        program = struct.pack(
+            "<IIQQQQQQ",
+            segment_type,
+            5,
+            0,
+            0x400000,
+            0x400000,
+            image_size,
+            image_size,
+            4096,
+        )
+        output.write_bytes(header + program)
+""",
+                encoding="utf-8",
+            )
+            fake_rustc.chmod(0o755)
+
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "BANGBANG_GUEST_POLICY_INTERNAL": "1",
+                    "BANGBANG_RUSTC": os.fspath(fake_rustc),
+                    "FAKE_RUST_LOG": os.fspath(log_path),
+                    "FAKE_RUST_SYSROOT": os.fspath(sysroot),
+                }
+            )
+            result = subprocess.run(
+                (
+                    os.fspath(REPOSITORY_ROOT / "scripts/fetch-firecracker-rootfs.sh"),
+                    "--internal-populate-direct",
+                    os.fspath(populate),
+                ),
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            report = populate / "bangbang-arm64-id-register-report"
+            benchmark = populate / "bangbang-specification-benchmark"
+            self.assertTrue(report.is_file())
+            self.assertTrue(benchmark.is_file())
+            self.assertEqual(stat.S_IMODE(report.stat().st_mode), 0o755)
+            self.assertEqual(stat.S_IMODE(benchmark.stat().st_mode), 0o755)
+
+            invocations = [
+                json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(len(invocations), 2)
+            self.assertEqual(
+                [Path(arguments[0]).name for arguments in invocations],
+                ["arm64-id-register-report.rs", "specification-benchmark.rs"],
+            )
+            normalized: list[list[str]] = []
+            for arguments in invocations:
+                output_index = arguments.index("-o")
+                normalized.append(
+                    ["<source>", *arguments[1:output_index], "-o", "<output>"]
+                )
+            self.assertEqual(normalized[0], normalized[1])
+            self.assertIn("--target", normalized[0])
+            self.assertIn("aarch64-unknown-linux-musl", normalized[0])
+            self.assertIn("-C", normalized[0])
+            self.assertIn("link-arg=-static", normalized[0])
+            self.assertIn("relocation-model=static", normalized[0])
+
+            for mode, expected_error in (
+                ("missing-target", "Rust target aarch64-unknown-linux-musl is required"),
+                ("missing-linker", "does not provide rust-lld"),
+                ("malformed", "shorter than an ELF64 header"),
+                ("dynamic", "dynamic or interpreter segment"),
+            ):
+                with self.subTest(rejected_boundary=mode):
+                    rejected_root = temp / f"rejected-{mode}"
+                    rejected_root.mkdir()
+                    rejected_environment = dict(environment)
+                    rejected_environment["FAKE_RUST_MODE"] = mode
+                    rejected = subprocess.run(
+                        (
+                            os.fspath(
+                                REPOSITORY_ROOT / "scripts/fetch-firecracker-rootfs.sh"
+                            ),
+                            "--internal-populate-direct",
+                            os.fspath(rejected_root),
+                        ),
+                        env=rejected_environment,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertNotEqual(rejected.returncode, 0)
+                    self.assertIn(expected_error, rejected.stderr)
+
+    def test_recipe_digest_tracks_the_workload_source(self) -> None:
+        manifest = json.loads(
+            (
+                REPOSITORY_ROOT
+                / "compat/firecracker/v1.16.0/guest-workflow-audit.json"
+            ).read_text(encoding="utf-8")
+        )
+        direct = next(
+            recipe
+            for recipe in manifest["ext4_recipes"]
+            if recipe["id"] == "rootfs-ext4-direct-boot-v109"
+        )
+        self.assertEqual(
+            direct["tracked_inputs"],
+            [
+                "compat/firecracker/v1.16.0/guest-workflow-audit.json",
+                "scripts/fetch-firecracker-rootfs.sh",
+                "scripts/guest/arm64-id-register-report.rs",
+                "scripts/guest/specification-benchmark.rs",
+                "scripts/guest_artifact_policy.py",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/firecracker-capability-audit/src/guest_workflow_audit_validate.rs
+++ b/tools/firecracker-capability-audit/src/guest_workflow_audit_validate.rs
@@ -283,6 +283,7 @@ fn validate_ext4_recipes(audit: &GuestWorkflowAudit, errors: &mut Vec<String>) {
                     GUEST_WORKFLOW_AUDIT_PATH,
                     "scripts/fetch-firecracker-rootfs.sh",
                     "scripts/guest/arm64-id-register-report.rs",
+                    "scripts/guest/specification-benchmark.rs",
                     "scripts/guest_artifact_policy.py",
                 ],
             )


### PR DESCRIPTION
## Summary

- add a checked no-std arm64 PID-1 workload with an exact serial release barrier, guest-monotonic compute/storage measurements, checksums, boot-timer signaling, and bounded failure records
- install both static guest helpers through one validated direct-rootfs compiler boundary and bind the new source into the recipe digest
- add a reusable strict transcript parser, portable boundary tests, and a signed public-process HVF oracle

## Scope exclusions

- no performance thresholds or Firecracker parity claims
- no report collector, optional network fixture, or capability-row promotion; those remain in #1877

## Verification

- `cargo fmt --all -- --check`
- `python3 -m unittest discover -s scripts/tests -p test_*.py` (51 passed)
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked` (1540 passed)
- workspace and signed-target Clippy commands from AGENTS.md with `-D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` (full signed suite green before the final localized release/poweroff failure-path tightening)
- `scripts/run-integration-tests.sh --test executable_hvf_e2e -- macos_arm64::signed_executable_runs_released_guest_specification_workload --exact` (rerun after tightening; passed)

Closes #1876