### PR TITLE
test: prove sandboxed chroot boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,41 @@ jobs:
       - name: Check unsupported CPU-template helper target
         run: cargo check -p bangbang-cpu-template-helper --all-targets --all-features --locked --target aarch64-unknown-linux-musl
 
+      - name: Build statically isolated elevated-bootstrap evidence bundle
+        run: |
+          mkdir -p "$RUNNER_TEMP/elevated-bootstrap"
+          scripts/build-elevated-bootstrap-probe.sh \
+            --output "$RUNNER_TEMP/elevated-bootstrap/Bangbang.app"
+
+      - name: Verify elevated proof requires explicit root
+        run: |
+          for invalid_uid in 0 0501 4294967296 '1:2'; do
+            set +e
+            invalid_output="$(scripts/run-elevated-bootstrap-probe.sh \
+              --bundle "$RUNNER_TEMP/elevated-bootstrap/Bangbang.app" \
+              --target-uid "$invalid_uid" \
+              --target-gid 20 2>&1)"
+            invalid_status=$?
+            set -e
+            if [[ "$invalid_status" -ne 2 \
+              || "$invalid_output" != "target uid and gid must be explicit nonzero decimal values" ]]; then
+              echo "elevated proof accepted a malformed target identity" >&2
+              exit 1
+            fi
+          done
+          set +e
+          proof_output="$(scripts/run-elevated-bootstrap-probe.sh \
+            --bundle "$RUNNER_TEMP/elevated-bootstrap/Bangbang.app" \
+            --target-uid 501 \
+            --target-gid 20 2>&1)"
+          proof_status=$?
+          set -e
+          if [[ "$proof_status" -ne 4 \
+            || "$proof_output" != "bangbang elevated bootstrap proof: explicit root required" ]]; then
+            echo "elevated proof did not preserve its explicit-root boundary" >&2
+            exit 1
+          fi
+
       - name: Validate Firecracker capability inventory
         run: cargo run -p bangbang-firecracker-capability-audit --locked -- validate
 

--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -124,6 +124,7 @@ reviewed delta.
 | [Specification benchmark](specification-benchmark-contract.md) | Terminal three-row reference interpretation, strict signed collector/report/comparison, real FIFO loss/replay evidence, optional fixture boundary, and exact performance nonclaims |
 | [Wave 7 aggregate](observability-tools-specification-contract.md#wave-7-aggregate-certification) | Terminal 93-row parent distribution, exact design/device API/release/tool/MMIO ledgers, and explicit #1351/#1373/#1378/Wave 8 handoffs |
 | [Wave 8 platform-feasible certification](wave8-certification-contract.md) | Final seven-domain/21-pair interaction authority, four current platform-mechanism reviews, one exact successor transition, and its retained external outcomes |
+| [Elevated macOS bootstrap evidence](elevated-bootstrap-evidence.md) | Same-host root + HVF signed evidence that exact-root `fchdir` succeeds while mandatory App Sandbox rejects public `chroot`, with an unsandboxed control and exact cleanup |
 
 ## Dispositions
 

--- a/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
+++ b/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
@@ -24,15 +24,16 @@ The evidence bundle keeps the production layout and identity split:
 
 The root wrapper never invokes `sudo`. It requires exact real/effective
 uid/gid zero, accepts explicit numeric target uid/gid values, runs with a
-closed environment and fixed absolute tools, and refuses missing root or HVF
-support rather than skipping. It creates only root-owned mode-0700 children
-beneath the fixed non-writable `/private/var/root` ancestry. The launcher walks
-that ancestry with no-follow directory descriptors, binds the leaf device and
-inode into a random nonce record, and transfers only the retained root
-descriptor as new filesystem authority, at fixed worker fd 8. The existing
-fixed production session and dormant broker endpoints remain closed-role
-socket descriptors; the worker receives no host path and cannot reopen the
-root by name.
+closed environment and fixed absolute tools, replaces inherited standard input
+with `/dev/null`, and refuses missing root or HVF support rather than skipping.
+Caller-provided elevation input therefore cannot be inherited by the launcher
+or worker. The wrapper creates only root-owned mode-0700 children beneath the
+fixed non-writable `/private/var/root` ancestry. The launcher walks that
+ancestry with no-follow directory descriptors, binds the leaf device and inode
+into a random nonce record, and transfers only the retained root descriptor as
+new filesystem authority, at fixed worker fd 8. The existing fixed production
+session and dormant broker endpoints remain closed-role socket descriptors;
+the worker receives no host path and cannot reopen the root by name.
 
 The signed worker verifies initial root identity, the nonce-bound descriptor
 identity, and exact mode before `fchdir`, public `chroot(2)`, `chdir("/")`,

--- a/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
+++ b/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
@@ -1,0 +1,129 @@
+# Elevated macOS Bootstrap Evidence
+
+This contract records the #1373 evidence result for the direct-root operator
+branch beneath #1371. It tests whether Firecracker's chroot-first credential
+transition can coexist with Bangbang's mandatory production worker boundary;
+it does not add a public root mode, accept jailer uid/gid/chroot options, or
+change a capability disposition by itself.
+
+## Exact test boundary
+
+The evidence bundle keeps the production layout and identity split:
+
+- the outer launcher is signed with Hardened Runtime and has neither App
+  Sandbox nor Hypervisor entitlement;
+- the separately signed nested worker has Hardened Runtime and exactly the App
+  Sandbox plus Hypervisor entitlements;
+- the launcher performs the normal static bundle and suspended/live worker
+  identity checks before authorizing the probe; and
+- both launcher and worker probe entries are compiled only with the
+  `elevated-bootstrap-probe` feature. A normal `--no-default-features` build is
+  checked for absence of both activation strings, the ready and status records,
+  and the marker resource, and the normal signed bundle rejects the internal
+  argv.
+
+The root wrapper never invokes `sudo`. It requires exact real/effective
+uid/gid zero, accepts explicit numeric target uid/gid values, runs with a
+closed environment and fixed absolute tools, and refuses missing root or HVF
+support rather than skipping. It creates only root-owned mode-0700 children
+beneath the fixed non-writable `/private/var/root` ancestry. The launcher walks
+that ancestry with no-follow directory descriptors, binds the leaf device and
+inode into a random nonce record, and transfers only the retained root
+descriptor as new filesystem authority, at fixed worker fd 8. The existing
+fixed production session and dormant broker endpoints remain closed-role
+socket descriptors; the worker receives no host path and cannot reopen the
+root by name.
+
+The signed worker verifies initial root identity, the nonce-bound descriptor
+identity, and exact mode before `fchdir`, public `chroot(2)`, `chdir("/")`,
+`setgroups`, `setgid`, or `setuid`. The launcher reports only fixed mode, stage,
+and error categories. Target IDs, paths, nonce, device/inode values, descriptor
+numbers, signing values, account data, and environment values are never
+reported.
+
+## Capable-host result
+
+The final evidence shape was executed on 2026-08-08 on Apple Silicon with
+macOS 26.5.2, macOS SDK 26.5, and `kern.hv_support=1`, under explicit operator
+root authority. The same private directory and public syscall produced these
+results:
+
+| Process boundary | Mode | Result |
+| --- | --- | --- |
+| signed outer launcher, no App Sandbox | root control | `chroot` and `chdir("/")` succeeded |
+| signed nested App Sandbox + Hypervisor worker | explicit ordinary target, repeated three times | exact root fd and `fchdir` succeeded; `chroot` returned permission denied |
+| same worker | uid/gid zero no-drop | exact root fd and `fchdir` succeeded; `chroot` returned permission denied |
+| same worker | high unmapped numeric uid/gid syscall case | exact root fd and `fchdir` succeeded; `chroot` returned permission denied |
+| two concurrent launcher/worker pairs | distinct exact roots and the same explicit target class | both returned the same chroot-stage permission denial |
+
+Focused negative cases also reject a group-writable leaf and a symlink leaf
+before worker activation. Every successful, rejected, and concurrent case
+leaves the exact private roots empty; cleanup rechecks device, inode, owner,
+group, and mode before `rmdir`, and refuses to remove a replacement.
+
+The host had real HVF support and the rejected worker carried the real
+Hypervisor entitlement, but no guest was started: mandatory App Sandbox denied
+the earlier public chroot syscall before credential transition, lifecycle/API,
+typed resource consumption, or HVF construction could begin. Treating later
+steps as passing through a mock or a separate invocation would not change that
+ordered combination result.
+
+After that result was established, the checked harness was deliberately kept
+at the evidence boundary: it contains no dormant credential-changing product
+path. If a future platform permits the sandboxed `chroot`, the worker reports
+`unexpected-continuation` and exits before `setgroups`, `setgid`, `setuid`,
+lifecycle, API, or HVF work. That failure forces a fresh implementation and
+Challenge instead of silently treating an unproved continuation as success.
+Connected-socket credentials therefore never cross a credential change in the
+measured branch; the harness authenticates the initial root peer by exact PID
+and effective IDs plus the random nonce, leaves the normal peer verifier
+unchanged, and makes no dynamic-versus-snapshot credential claim for #1374.
+
+## Supported conclusion and nonclaims
+
+On the measured public macOS/SDK boundary, a mandatory App Sandbox worker
+cannot enter a caller-selected chroot, even when it starts with exact root
+identity and receives an already-opened, validated directory descriptor. The
+successful unsandboxed control distinguishes this result from missing host
+root authority, an invalid root, or an unavailable `chroot(2)` primitive.
+
+Moving `chroot` to an unsandboxed helper cannot change another process's root;
+performing it before loading the worker removes the production bundle and
+dynamic-loader path needed to spawn that worker; removing App Sandbox,
+installing a privileged daemon/setuid helper, or using private Seatbelt APIs
+changes the challenged product/security model. Therefore the exact
+Firecracker chroot-plus-mandatory-containment branch has a reproducible public
+platform blocker and should be dispositioned through #1371's fresh Challenge.
+
+This does not prove that numeric `setgroups`/`setgid`/`setuid` alone are
+unavailable on macOS, does not claim Linux mount/PID/user namespace parity,
+does not certify notarized distribution, and does not generalize beyond the
+recorded OS/SDK behavior. A future public platform change requires rerunning
+the wrapper and a fresh ID-by-ID Challenge.
+
+## Reproduction
+
+Build the statically isolated evidence bundle as an ordinary user:
+
+```sh
+scripts/build-elevated-bootstrap-probe.sh \
+  --output /absolute/absent/path/Bangbang.app
+```
+
+Capture target values before elevation, then explicitly run the root wrapper:
+
+```sh
+target_uid="$(id -u)"
+target_gid="$(id -g)"
+sudo /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
+  /bin/bash "$PWD/scripts/run-elevated-bootstrap-probe.sh" \
+  --bundle /absolute/absent/path/Bangbang.app \
+  --target-uid "$target_uid" \
+  --target-gid "$target_gid"
+```
+
+The required terminal summary is value-free:
+
+```text
+result: app-sandbox-chroot=permission-denied control=success cleanup=exact
+```

--- a/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
+++ b/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
@@ -18,9 +18,9 @@ The evidence bundle keeps the production layout and identity split:
   identity checks before authorizing the probe; and
 - both launcher and worker probe entries are compiled only with the
   `elevated-bootstrap-probe` feature. A normal `--no-default-features` build is
-  checked for absence of both activation strings, the ready and status records,
-  and the marker resource, and the normal signed bundle rejects the internal
-  argv.
+  checked for absence of the launcher-owned worker activation, ready and status
+  records, and the marker resource, and the normal signed bundle rejects the
+  internal launcher argv.
 
 The root wrapper never invokes `sudo`. It requires exact real/effective
 uid/gid zero, accepts explicit numeric target uid/gid values, runs with a

--- a/compat/firecracker/v1.16.0/wave8-certification-contract.md
+++ b/compat/firecracker/v1.16.0/wave8-certification-contract.md
@@ -99,6 +99,14 @@ local HVF without noninteractive root, missing credentials, a skipped test, or
 an unexecuted harness does not satisfy either gate. These are feasible external
 handoffs and are not platform-impossible classifications.
 
+That #1373 execution gate has since run on the controlled Apple Silicon host.
+The [elevated bootstrap evidence](elevated-bootstrap-evidence.md) records a
+successful unsandboxed root control and a repeated chroot-stage permission
+denial in the exact App Sandbox + Hypervisor worker. The six rows remain
+`audit-required` in this Wave 8 snapshot until #1371 performs its fresh
+ID-specific Challenge and an authoritative inventory transition; the evidence
+result itself does not silently rewrite this checked historical boundary.
+
 The direct #1348 delivery-parent policy retains #1351 open and requires the
 other nine preceding parents complete. #1371, #1373, #1374, #1375, and #1378
 remain explicit open external branches. The offline validator checks this

--- a/crates/bangbang/Cargo.toml
+++ b/crates/bangbang/Cargo.toml
@@ -6,6 +6,7 @@ repository.workspace = true
 
 [features]
 default = []
+elevated-bootstrap-probe = ["bangbang-session/elevated-bootstrap-probe"]
 grant-integration-probe = ["dep:bangbang-pager", "bangbang-runtime/test-support"]
 tracing = ["bangbang-runtime/tracing"]
 

--- a/crates/bangbang/src/elevated_bootstrap_probe.rs
+++ b/crates/bangbang/src/elevated_bootstrap_probe.rs
@@ -1,0 +1,209 @@
+use std::env;
+use std::ffi::OsStr;
+use std::io::{self, Read, Write};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::net::UnixStream;
+use std::process::ExitCode;
+
+use bangbang_session::elevated_probe::{
+    BOOTSTRAP_RECORD_BYTES, ProbeBootstrap, ProbeErrorCategory, ProbeResult, ProbeStage,
+    READY_RECORD, RESULT_RECORD_BYTES, ROOT_FD, WORKER_ACTIVATION,
+};
+use bangbang_session::{ObjectIdentity, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD};
+
+#[derive(Clone, Copy)]
+struct ProbeError {
+    stage: ProbeStage,
+    kind: io::ErrorKind,
+}
+
+pub(crate) fn is_requested() -> bool {
+    env::args_os()
+        .nth(1)
+        .is_some_and(|argument| argument == OsStr::new(WORKER_ACTIVATION))
+}
+
+pub(crate) fn run() -> ExitCode {
+    let (mut stream, bootstrap) = match probe_session() {
+        Ok(session) => session,
+        Err(_) => return ExitCode::FAILURE,
+    };
+    let outcome = execute(bootstrap);
+    let result = match outcome {
+        Ok(()) => ProbeResult::success(bootstrap.mode(), bootstrap.nonce()),
+        Err(error) => ProbeResult::failure(
+            bootstrap.mode(),
+            bootstrap.nonce(),
+            error.stage,
+            ProbeErrorCategory::from_io_kind(error.kind),
+        ),
+    };
+    let Ok(result) = result else {
+        return ExitCode::FAILURE;
+    };
+    let encoded = result.encode();
+    debug_assert_eq!(encoded.len(), RESULT_RECORD_BYTES);
+    if stream.write_all(&encoded).is_err() {
+        return ExitCode::FAILURE;
+    }
+    if outcome.is_ok() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+fn probe_session() -> Result<(UnixStream, ProbeBootstrap), ProbeError> {
+    let arguments = env::args_os().skip(1).collect::<Vec<_>>();
+    if arguments.as_slice() != [OsStr::new(WORKER_ACTIVATION)] {
+        return Err(invalid(ProbeStage::InitialIdentity));
+    }
+    let value = env::var_os(SESSION_ENV_KEY).ok_or_else(|| invalid(ProbeStage::InitialIdentity))?;
+    // SAFETY: This runs at process entry before application threads exist and
+    // consumes the private marker before any later child could inherit it.
+    unsafe { env::remove_var(SESSION_ENV_KEY) };
+    if value != OsStr::new(SESSION_ENV_VALUE) {
+        return Err(invalid(ProbeStage::InitialIdentity));
+    }
+    bangbang_session::macos::set_cloexec(SESSION_FD)
+        .map_err(|error| with_kind(ProbeStage::InitialIdentity, error.kind()))?;
+    // SAFETY: The validated production spawn contract transfers fixed fd 3
+    // exactly once to this process.
+    let owned = unsafe { OwnedFd::from_raw_fd(SESSION_FD) };
+    let mut stream = UnixStream::from(owned);
+    // SAFETY: `getppid` has no pointer or ownership contract.
+    let parent = unsafe { libc::getppid() };
+    bangbang_session::macos::verify_peer(stream.as_raw_fd(), parent)
+        .map_err(|_| permission(ProbeStage::InitialIdentity))?;
+    stream
+        .write_all(&READY_RECORD)
+        .map_err(|error| with_kind(ProbeStage::InitialIdentity, error.kind()))?;
+    let mut encoded = [0_u8; BOOTSTRAP_RECORD_BYTES];
+    stream
+        .read_exact(&mut encoded)
+        .map_err(|error| with_kind(ProbeStage::InitialIdentity, error.kind()))?;
+    let bootstrap =
+        ProbeBootstrap::decode(&encoded).map_err(|_| invalid(ProbeStage::InitialIdentity))?;
+    Ok((stream, bootstrap))
+}
+
+fn execute(config: ProbeBootstrap) -> Result<(), ProbeError> {
+    validate_initial_identity()?;
+    bangbang_session::macos::set_cloexec(ROOT_FD)
+        .map_err(|error| with_kind(ProbeStage::TakeRoot, error.kind()))?;
+    // SAFETY: The feature-gated production spawn contract transfers fixed fd 8
+    // exactly once to this process.
+    let root = unsafe { OwnedFd::from_raw_fd(ROOT_FD) };
+    validate_root(root.as_raw_fd(), config.root())?;
+    // SAFETY: `root` is the live, validated private directory descriptor.
+    syscall(ProbeStage::EnterRoot, unsafe {
+        libc::fchdir(root.as_raw_fd())
+    })?;
+    // SAFETY: The current directory is the retained exact root and the fixed
+    // relative path contains no attacker-controlled bytes.
+    syscall(ProbeStage::Chroot, unsafe { libc::chroot(c".".as_ptr()) })?;
+    // SAFETY: The process has entered the private root and the fixed absolute
+    // path is NUL-terminated.
+    syscall(ProbeStage::ChangeDirectory, unsafe {
+        libc::chdir(c"/".as_ptr())
+    })?;
+    drop(root);
+    Err(ProbeError {
+        stage: ProbeStage::UnexpectedContinuation,
+        kind: io::ErrorKind::Other,
+    })
+}
+
+fn validate_initial_identity() -> Result<(), ProbeError> {
+    // SAFETY: Credential getters have no pointer or ownership contract.
+    let identities = unsafe {
+        (
+            libc::getuid(),
+            libc::geteuid(),
+            libc::getgid(),
+            libc::getegid(),
+        )
+    };
+    if identities == (0, 0, 0, 0) {
+        Ok(())
+    } else {
+        Err(permission(ProbeStage::InitialIdentity))
+    }
+}
+
+fn validate_root(descriptor: libc::c_int, expected: ObjectIdentity) -> Result<(), ProbeError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `descriptor` is live and `stat` is writable for one result.
+    if unsafe { libc::fstat(descriptor, stat.as_mut_ptr()) } != 0 {
+        return Err(last(ProbeStage::ValidateRoot));
+    }
+    // SAFETY: Successful `fstat` initialized the complete value.
+    let stat = unsafe { stat.assume_init() };
+    let actual = ObjectIdentity {
+        device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
+        inode: stat.st_ino,
+    };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFDIR
+        || stat.st_mode & 0o7777 != 0o700
+        || stat.st_uid != 0
+        || stat.st_gid != 0
+        || stat.st_nlink < 2
+        || actual != expected
+    {
+        return Err(permission(ProbeStage::ValidateRoot));
+    }
+    Ok(())
+}
+
+fn syscall(stage: ProbeStage, status: libc::c_int) -> Result<(), ProbeError> {
+    if status == 0 {
+        Ok(())
+    } else {
+        Err(last(stage))
+    }
+}
+
+fn last(stage: ProbeStage) -> ProbeError {
+    with_kind(stage, io::Error::last_os_error().kind())
+}
+
+const fn with_kind(stage: ProbeStage, kind: io::ErrorKind) -> ProbeError {
+    ProbeError { stage, kind }
+}
+
+const fn invalid(stage: ProbeStage) -> ProbeError {
+    ProbeError {
+        stage,
+        kind: io::ErrorKind::InvalidInput,
+    }
+}
+
+const fn permission(stage: ProbeStage) -> ProbeError {
+    ProbeError {
+        stage,
+        kind: io::ErrorKind::PermissionDenied,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_mapping_is_value_free() {
+        for (kind, expected) in [
+            (
+                io::ErrorKind::PermissionDenied,
+                ProbeErrorCategory::PermissionDenied,
+            ),
+            (
+                io::ErrorKind::InvalidInput,
+                ProbeErrorCategory::InvalidInput,
+            ),
+            (io::ErrorKind::NotFound, ProbeErrorCategory::Other),
+        ] {
+            assert_eq!(ProbeErrorCategory::from_io_kind(kind), expected);
+        }
+    }
+}

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -18,6 +18,8 @@ mod api_server;
 mod contained_session;
 mod direct_snapshot_pager;
 mod direct_vhost_user;
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+mod elevated_bootstrap_probe;
 #[cfg(all(target_os = "macos", feature = "grant-integration-probe"))]
 mod grant_integration_probe;
 #[doc(hidden)]
@@ -113,6 +115,10 @@ fn write_process_stdout_line(
 }
 
 fn main() -> ExitCode {
+    #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+    if elevated_bootstrap_probe::is_requested() {
+        return elevated_bootstrap_probe::run();
+    }
     #[cfg(target_os = "macos")]
     if anchored_socket::is_binder_invocation() {
         return if anchored_socket::run_binder() {

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+elevated-bootstrap-probe = ["bangbang-session/elevated-bootstrap-probe"]
+
 [dependencies]
 bangbang-session = { path = "../session" }
 libc = "0.2"

--- a/crates/launcher/src/elevated_probe.rs
+++ b/crates/launcher/src/elevated_probe.rs
@@ -1,0 +1,350 @@
+use std::ffi::{CStr, OsStr, OsString};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path, PathBuf};
+
+use bangbang_session::elevated_probe::{
+    LAUNCHER_ACTIVATION, ProbeBootstrap, ProbeMode, WORKER_ACTIVATION,
+};
+use bangbang_session::{ObjectIdentity, SessionId};
+
+use crate::LauncherError;
+
+const ROOT_OPTION: &str = "--root";
+const TARGET_UID_OPTION: &str = "--target-uid";
+const TARGET_GID_OPTION: &str = "--target-gid";
+const MODE_OPTION: &str = "--mode";
+const DELIMITER: &str = "--";
+const MAX_ROOT_PATH_BYTES: usize = 1024;
+const ROOT_CHILD_PREFIX: &str = "bangbang-elevated-probe.";
+const ROOT_CHILD_SUFFIX_BYTES: usize = 8;
+
+pub(crate) struct Config {
+    root: OwnedFd,
+    root_identity: ObjectIdentity,
+    target_uid: u32,
+    target_gid: u32,
+    mode: ProbeMode,
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ElevatedProbeConfig(<redacted>)")
+    }
+}
+
+impl Config {
+    pub(crate) fn parse(
+        args: Vec<OsString>,
+    ) -> Result<(Option<Self>, Vec<OsString>), LauncherError> {
+        if args
+            .first()
+            .is_none_or(|arg| arg != OsStr::new(LAUNCHER_ACTIVATION))
+        {
+            return Ok((None, args));
+        }
+        if args.len() != 10
+            || args.get(1) != Some(&OsString::from(ROOT_OPTION))
+            || args.get(3) != Some(&OsString::from(TARGET_UID_OPTION))
+            || args.get(5) != Some(&OsString::from(TARGET_GID_OPTION))
+            || args.get(7) != Some(&OsString::from(MODE_OPTION))
+            || args.get(9) != Some(&OsString::from(DELIMITER))
+        {
+            return Err(LauncherError::InvalidLaunchPolicy);
+        }
+        let root_path = args
+            .get(2)
+            .filter(|value| {
+                !value.is_empty()
+                    && value.as_bytes().len() <= MAX_ROOT_PATH_BYTES
+                    && !value.as_bytes().contains(&0)
+                    && value.to_str().is_some()
+            })
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .ok_or(LauncherError::InvalidLaunchPolicy)?;
+        let target_uid = parse_u32(args.get(4))?;
+        let target_gid = parse_u32(args.get(6))?;
+        let mode = args
+            .get(8)
+            .and_then(|value| value.to_str())
+            .and_then(|value| ProbeMode::parse(value, target_uid, target_gid))
+            .ok_or(LauncherError::InvalidLaunchPolicy)?;
+        validate_initial_root()?;
+        let (root, root_identity) = open_private_root(&root_path)?;
+        Ok((
+            Some(Self {
+                root,
+                root_identity,
+                target_uid,
+                target_gid,
+                mode,
+            }),
+            Vec::new(),
+        ))
+    }
+
+    pub(crate) fn prepend_worker_activation(
+        &self,
+        worker_args: &mut Vec<OsString>,
+    ) -> Result<(), LauncherError> {
+        if !worker_args.is_empty() {
+            return Err(LauncherError::InvalidLaunchPolicy);
+        }
+        worker_args.push(OsString::from(WORKER_ACTIVATION));
+        Ok(())
+    }
+
+    pub(crate) fn root_fd(&self) -> RawFd {
+        self.root.as_raw_fd()
+    }
+
+    pub(crate) const fn mode(&self) -> ProbeMode {
+        self.mode
+    }
+
+    pub(crate) fn bootstrap(&self) -> Result<ProbeBootstrap, LauncherError> {
+        let nonce = SessionId::generate().map_err(|_| LauncherError::SessionProtocol)?;
+        ProbeBootstrap::new(
+            self.mode,
+            self.target_uid,
+            self.target_gid,
+            self.root_identity,
+            nonce,
+        )
+        .map_err(|_| LauncherError::SessionProtocol)
+    }
+
+    pub(crate) fn run_control(&self) -> Result<(), LauncherError> {
+        if self.mode != ProbeMode::Control {
+            return Err(LauncherError::InvalidLaunchPolicy);
+        }
+        // SAFETY: `root` is the exact retained private directory validated by
+        // descriptor and this root-only control process is single-threaded.
+        if unsafe { libc::fchdir(self.root.as_raw_fd()) } != 0 {
+            return Err(LauncherError::SessionProtocol);
+        }
+        // SAFETY: Cwd is the retained root and the fixed relative string is
+        // NUL-terminated. This signed launcher intentionally exits afterward.
+        if unsafe { libc::chroot(c".".as_ptr()) } != 0 {
+            return Err(LauncherError::SessionProtocol);
+        }
+        // SAFETY: The process is inside the private root and the fixed absolute
+        // path is NUL-terminated.
+        if unsafe { libc::chdir(c"/".as_ptr()) } != 0 {
+            return Err(LauncherError::SessionProtocol);
+        }
+        Ok(())
+    }
+}
+
+fn parse_u32(value: Option<&OsString>) -> Result<u32, LauncherError> {
+    value
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
+        .filter(|value| value.len() == 1 || !value.starts_with('0'))
+        .and_then(|value| value.parse().ok())
+        .ok_or(LauncherError::InvalidLaunchPolicy)
+}
+
+fn validate_initial_root() -> Result<(), LauncherError> {
+    // SAFETY: Credential getters have no pointer or ownership contract.
+    let identities = unsafe {
+        (
+            libc::getuid(),
+            libc::geteuid(),
+            libc::getgid(),
+            libc::getegid(),
+        )
+    };
+    if identities == (0, 0, 0, 0) {
+        Ok(())
+    } else {
+        Err(LauncherError::InvalidLaunchPolicy)
+    }
+}
+
+fn open_private_root(path: &Path) -> Result<(OwnedFd, ObjectIdentity), LauncherError> {
+    let child = private_root_child(path).ok_or(LauncherError::InvalidLaunchPolicy)?;
+    let mut directory = open_directory(c"/")?;
+    validate_ancestor(directory.as_raw_fd())?;
+    for component in [c"private", c"var", c"root"] {
+        directory = openat_directory(directory.as_raw_fd(), component)?;
+        validate_ancestor(directory.as_raw_fd())?;
+    }
+    let child =
+        std::ffi::CString::new(child.as_bytes()).map_err(|_| LauncherError::InvalidLaunchPolicy)?;
+    let root = openat_directory(directory.as_raw_fd(), &child)?;
+    let stat = descriptor_stat(root.as_raw_fd())?;
+    if stat.st_mode & libc::S_IFMT != libc::S_IFDIR
+        || stat.st_mode & 0o7777 != 0o700
+        || stat.st_uid != 0
+        || stat.st_gid != 0
+        || stat.st_nlink < 2
+    {
+        return Err(LauncherError::InvalidLaunchPolicy);
+    }
+    let identity = stat_identity(&stat);
+    if identity.device == 0 || identity.inode == 0 {
+        return Err(LauncherError::InvalidLaunchPolicy);
+    }
+    Ok((root, identity))
+}
+
+fn private_root_child(path: &Path) -> Option<&OsStr> {
+    let mut components = path.components();
+    if components.next() != Some(Component::RootDir)
+        || components.next() != Some(Component::Normal(OsStr::new("private")))
+        || components.next() != Some(Component::Normal(OsStr::new("var")))
+        || components.next() != Some(Component::Normal(OsStr::new("root")))
+    {
+        return None;
+    }
+    let child = match components.next()? {
+        Component::Normal(child) => child,
+        _ => return None,
+    };
+    if components.next().is_some() {
+        return None;
+    }
+    let child = child.to_str()?;
+    let suffix = child.strip_prefix(ROOT_CHILD_PREFIX)?;
+    if suffix.len() != ROOT_CHILD_SUFFIX_BYTES
+        || !suffix.bytes().all(|byte| byte.is_ascii_alphanumeric())
+    {
+        return None;
+    }
+    Some(OsStr::new(child))
+}
+
+fn open_directory(path: &CStr) -> Result<OwnedFd, LauncherError> {
+    // SAFETY: `path` is NUL-terminated and no pointer is retained.
+    let descriptor = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    owned_descriptor(descriptor)
+}
+
+fn openat_directory(parent: RawFd, child: &CStr) -> Result<OwnedFd, LauncherError> {
+    // SAFETY: `parent` is a retained directory, `child` is NUL-terminated, and
+    // no pointer is retained.
+    let descriptor = unsafe {
+        libc::openat(
+            parent,
+            child.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    owned_descriptor(descriptor)
+}
+
+fn owned_descriptor(descriptor: RawFd) -> Result<OwnedFd, LauncherError> {
+    if descriptor < 0 {
+        Err(LauncherError::InvalidLaunchPolicy)
+    } else {
+        // SAFETY: `descriptor` is a fresh successful result whose ownership is
+        // transferred exactly once.
+        Ok(unsafe { OwnedFd::from_raw_fd(descriptor) })
+    }
+}
+
+fn validate_ancestor(descriptor: RawFd) -> Result<(), LauncherError> {
+    let stat = descriptor_stat(descriptor)?;
+    if stat.st_mode & libc::S_IFMT != libc::S_IFDIR
+        || stat.st_mode & 0o022 != 0
+        || stat.st_uid != 0
+        || stat.st_gid != 0
+        || stat.st_nlink < 2
+    {
+        Err(LauncherError::InvalidLaunchPolicy)
+    } else {
+        Ok(())
+    }
+}
+
+fn descriptor_stat(descriptor: RawFd) -> Result<libc::stat, LauncherError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `descriptor` is live and `stat` is writable for one result.
+    if unsafe { libc::fstat(descriptor, stat.as_mut_ptr()) } != 0 {
+        return Err(LauncherError::InvalidLaunchPolicy);
+    }
+    // SAFETY: Successful `fstat` initialized the complete value.
+    Ok(unsafe { stat.assume_init() })
+}
+
+fn stat_identity(stat: &libc::stat) -> ObjectIdentity {
+    ObjectIdentity {
+        device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
+        inode: stat.st_ino,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn private_root_path_is_exact_and_symlink_free_by_shape() {
+        assert_eq!(
+            private_root_child(Path::new(
+                "/private/var/root/bangbang-elevated-probe.A1b2C3d4"
+            )),
+            Some(OsStr::new("bangbang-elevated-probe.A1b2C3d4"))
+        );
+        for path in [
+            "/tmp/bangbang-elevated-probe.A1b2C3d4",
+            "/private/var/root/bangbang-elevated-probe.short",
+            "/private/var/root/bangbang-elevated-probe.A1b2C3d4/child",
+            "/private/var/root/not-the-probe.A1b2C3d4",
+        ] {
+            assert_eq!(private_root_child(Path::new(path)), None);
+        }
+    }
+
+    #[test]
+    fn debug_output_redacts_values() {
+        let root = std::fs::File::open("/").expect("test root descriptor should open");
+        let config = Config {
+            root: root.into(),
+            root_identity: ObjectIdentity {
+                device: 123,
+                inode: 456,
+            },
+            target_uid: 1_234_567_891,
+            target_gid: 1_234_567_893,
+            mode: ProbeMode::Drop,
+        };
+        let output = format!("{config:?}");
+        assert_eq!(output, "ElevatedProbeConfig(<redacted>)");
+        assert!(!output.contains("1234567891"));
+        assert!(!output.contains("456"));
+
+        let mut unexpected = vec![OsString::from("--version")];
+        assert!(config.prepend_worker_activation(&mut unexpected).is_err());
+        assert_eq!(unexpected, [OsString::from("--version")]);
+        let mut empty = Vec::new();
+        config
+            .prepend_worker_activation(&mut empty)
+            .expect("empty worker envelope should activate");
+        assert_eq!(empty, [OsString::from(WORKER_ACTIVATION)]);
+    }
+
+    #[test]
+    fn numeric_parser_is_decimal_and_bounded() {
+        assert_eq!(parse_u32(Some(&OsString::from("0"))), Ok(0));
+        assert_eq!(
+            parse_u32(Some(&OsString::from(u32::MAX.to_string()))),
+            Ok(u32::MAX)
+        );
+        for invalid in ["", "00", "0501", "+1", "-1", "4294967296", "1_000", " 1"] {
+            assert_eq!(
+                parse_u32(Some(&OsString::from(invalid))),
+                Err(LauncherError::InvalidLaunchPolicy)
+            );
+        }
+    }
+}

--- a/crates/launcher/src/lib.rs
+++ b/crates/launcher/src/lib.rs
@@ -4,6 +4,8 @@
 #[doc(hidden)]
 pub const VMNET_AUTHORIZATION_PROBE_ARG: &str = "--private-vmnet-authorization-probe";
 
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+mod elevated_probe;
 mod error;
 #[cfg(target_os = "macos")]
 mod grant_manifest;

--- a/crates/launcher/src/macos/spawn.rs
+++ b/crates/launcher/src/macos/spawn.rs
@@ -147,6 +147,43 @@ pub(crate) fn spawn_suspended(
     executable: &Path,
     args: Vec<OsString>,
 ) -> Result<SuspendedWorker, LauncherError> {
+    spawn_suspended_inner(executable, args, None)
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub(crate) fn spawn_suspended_elevated(
+    executable: &Path,
+    args: Vec<OsString>,
+    root: RawFd,
+) -> Result<SuspendedWorker, LauncherError> {
+    spawn_suspended_inner(executable, args, Some(root))
+}
+
+fn spawn_suspended_inner(
+    executable: &Path,
+    args: Vec<OsString>,
+    elevated_root: Option<RawFd>,
+) -> Result<SuspendedWorker, LauncherError> {
+    #[cfg(not(feature = "elevated-bootstrap-probe"))]
+    let _ = elevated_root;
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    let elevated_root = elevated_root
+        .map(|root| {
+            if root < 0 {
+                return Err(LauncherError::SessionSetup(io::ErrorKind::InvalidInput));
+            }
+            // SAFETY: `root` remains owned by the caller; success returns an
+            // independent close-on-exec descriptor reserved above fixed fds.
+            let duplicate = unsafe { libc::fcntl(root, libc::F_DUPFD_CLOEXEC, MIN_TRANSPORT_FD) };
+            if duplicate < 0 {
+                return Err(LauncherError::SessionSetup(
+                    io::Error::last_os_error().kind(),
+                ));
+            }
+            // SAFETY: `duplicate` is a fresh descriptor owned by this scope.
+            Ok(unsafe { OwnedFd::from_raw_fd(duplicate) })
+        })
+        .transpose()?;
     let (parent, child) =
         UnixStream::pair().map_err(|error| LauncherError::SessionSetup(error.kind()))?;
     let parent = duplicate_stream_at_or_above(parent, MIN_TRANSPORT_FD)?;
@@ -202,6 +239,14 @@ pub(crate) fn spawn_suspended(
     actions.duplicate(block_child.as_raw_fd(), BLOCK_CONTROL_BROKER_FD)?;
     if block_child.as_raw_fd() != BLOCK_CONTROL_BROKER_FD {
         actions.close(block_child.as_raw_fd())?;
+    }
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    if let Some(root) = elevated_root.as_ref() {
+        let fixed = bangbang_session::elevated_probe::ROOT_FD;
+        actions.duplicate(root.as_raw_fd(), fixed)?;
+        if root.as_raw_fd() != fixed {
+            actions.close(root.as_raw_fd())?;
+        }
     }
 
     let mut pid = 0;

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -25,13 +25,16 @@ where
 {
     #[cfg(target_os = "macos")]
     {
+        let args = args.into_iter().collect::<Vec<_>>();
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        let (elevated_probe, args) = crate::elevated_probe::Config::parse(args)?;
         let child_bootstrap = crate::macos::daemon::child_bootstrap()?;
         let timing = child_bootstrap
             .as_ref()
             .map_or_else(crate::launch_policy::LaunchTiming::sample, |bootstrap| {
                 Ok(bootstrap.timing)
             })?;
-        let command = crate::launch_policy::LaunchCommand::parse(args.into_iter().collect())?;
+        let command = crate::launch_policy::LaunchCommand::parse(args)?;
         let request = match command {
             crate::launch_policy::LaunchCommand::Help => {
                 print!("{}", crate::launch_policy::help());
@@ -46,6 +49,21 @@ where
         let executable = std::env::current_exe().map_err(|_| LauncherError::InvalidBundleLayout)?;
         let layout = BundleLayout::from_launcher_executable(&executable)?;
         let worker_profile = crate::macos::code_sign::validate_bundle(&layout)?;
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        if elevated_probe.is_some() && (child_bootstrap.is_some() || request.requests_daemonize()) {
+            return Err(LauncherError::InvalidLaunchPolicy);
+        }
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        if elevated_probe.as_ref().is_some_and(|probe| {
+            probe.mode() == bangbang_session::elevated_probe::ProbeMode::Control
+        }) {
+            let probe = elevated_probe
+                .as_ref()
+                .ok_or(LauncherError::InvalidLaunchPolicy)?;
+            probe.run_control()?;
+            println!("status: elevated bootstrap control complete");
+            return Ok(LauncherExit(0));
+        }
         if let Some(mut bootstrap) = child_bootstrap {
             let result = (|| {
                 if !request.requests_daemonize()
@@ -73,6 +91,13 @@ where
             return Ok(LauncherExit(0));
         }
         let launch = request.prepare(layout.worker_executable(), timing, false, worker_profile)?;
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        let mut launch = launch;
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        if let Some(elevated_probe) = elevated_probe {
+            elevated_probe.prepend_worker_activation(&mut launch.worker_args)?;
+            return launch_elevated_prepared(&layout, launch, elevated_probe);
+        }
         launch_prepared(&layout, launch, None)
     }
 
@@ -80,6 +105,91 @@ where
     {
         let _ = args;
         Err(LauncherError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn launch_elevated_prepared(
+    layout: &BundleLayout,
+    launch: crate::launch_policy::PreparedLaunch,
+    elevated_probe: crate::elevated_probe::Config,
+) -> Result<LauncherExit, LauncherError> {
+    use std::io::{Read, Write};
+    use std::os::fd::AsRawFd;
+    use std::time::Duration;
+
+    use bangbang_session::elevated_probe::{ProbeResult, READY_RECORD, RESULT_RECORD_BYTES};
+
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let bootstrap = elevated_probe.bootstrap()?;
+    let mut spawned = crate::macos::spawn::spawn_suspended_elevated(
+        layout.worker_executable(),
+        launch.worker_args,
+        elevated_probe.root_fd(),
+    )?;
+    if crate::macos::code_sign::validate_worker_process(spawned.worker.pid())?
+        != launch.worker_profile
+    {
+        return Err(LauncherError::InvalidWorkerIdentity);
+    }
+    spawned
+        .session
+        .set_read_timeout(Some(TIMEOUT))
+        .map_err(|error| LauncherError::SessionSetup(error.kind()))?;
+    spawned
+        .session
+        .set_write_timeout(Some(TIMEOUT))
+        .map_err(|error| LauncherError::SessionSetup(error.kind()))?;
+    spawned.worker.resume()?;
+    let mut ready = [0_u8; READY_RECORD.len()];
+    spawned
+        .session
+        .read_exact(&mut ready)
+        .map_err(|_| LauncherError::SessionProtocol)?;
+    if ready != READY_RECORD {
+        return Err(LauncherError::SessionProtocol);
+    }
+    bangbang_session::macos::verify_peer(spawned.session.as_raw_fd(), spawned.worker.pid())
+        .map_err(|_| LauncherError::InvalidWorkerIdentity)?;
+    if crate::macos::code_sign::validate_worker_process(spawned.worker.pid())?
+        != launch.worker_profile
+    {
+        return Err(LauncherError::InvalidWorkerIdentity);
+    }
+    spawned
+        .session
+        .write_all(&bootstrap.encode())
+        .map_err(|_| LauncherError::SessionProtocol)?;
+    let mut encoded_result = [0_u8; RESULT_RECORD_BYTES];
+    spawned
+        .session
+        .read_exact(&mut encoded_result)
+        .map_err(|_| LauncherError::SessionProtocol)?;
+    let result =
+        ProbeResult::decode(&encoded_result).map_err(|_| LauncherError::SessionProtocol)?;
+    if result.mode() != bootstrap.mode() || result.nonce() != bootstrap.nonce() {
+        return Err(LauncherError::SessionProtocol);
+    }
+    let status = spawned.worker.wait()?;
+    let exit = map_exit_status(status)?;
+    match result.outcome() {
+        Ok(()) if exit.code() == 0 => {
+            println!(
+                "status: elevated bootstrap {} complete",
+                result.mode().name()
+            );
+            Ok(exit)
+        }
+        Err((stage, category)) if exit.code() == 1 => {
+            println!(
+                "status: elevated bootstrap blocked stage={} error={}",
+                stage.name(),
+                category.name()
+            );
+            Ok(LauncherExit(3))
+        }
+        Ok(()) | Err(_) => Err(LauncherError::SessionProtocol),
     }
 }
 

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -82,6 +82,11 @@ const GRANT_PROBE_READY: &str = "status: grant integration probe ready";
 const GRANT_DELAY_OPTION: &str = "--bangbang-internal-grant-delay-v1";
 const GRANT_DELAY_READY: &str = "status: grant integration delay ready";
 const GRANT_PROBE_MARKER: &str = "grant-integration-probe.enabled";
+const ELEVATED_PROBE_OPTION: &str = "--bangbang-internal-elevated-bootstrap-probe-v1";
+const ELEVATED_WORKER_OPTION: &[u8] = b"--bangbang-internal-elevated-bootstrap-worker-v1";
+const ELEVATED_READY_RECORD: &[u8] = b"BBEP-READY-V1";
+const ELEVATED_BLOCKED_STATUS: &[u8] = b"status: elevated bootstrap blocked";
+const ELEVATED_PROBE_MARKER: &str = "elevated-bootstrap-probe.enabled";
 const GRANT_PROBE_OUTSIDE: &str = "bangbang-grant-probe-outside";
 const RESTORE_ROOT_ID: &str = "restore-root-1601";
 const RESTORE_VSOCK_ID: &str = "restore-vsock-1601";
@@ -13022,6 +13027,66 @@ fn normal_production_bundle_excludes_grant_probe_behavior() {
     assert!(!String::from_utf8_lossy(&output.stdout).contains(RESTORE_ACTIVE_READY));
     assert_restore_output_redacted(&output, &restore);
     restore.assert_pristine();
+}
+
+#[test]
+fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe() {
+    let bundle = production_bundle();
+    assert!(
+        !worker_bundle(&bundle)
+            .join("Contents/Resources")
+            .join(ELEVATED_PROBE_MARKER)
+            .exists(),
+        "normal production bundle must not carry the elevated probe marker"
+    );
+    let launcher_bytes = fs::read(launcher(&bundle)).expect("normal launcher should read");
+    let worker_bytes = fs::read(worker_executable(&bundle)).expect("normal worker should read");
+    for marker in [
+        ELEVATED_PROBE_OPTION.as_bytes(),
+        ELEVATED_WORKER_OPTION,
+        ELEVATED_BLOCKED_STATUS,
+    ] {
+        assert!(
+            !launcher_bytes
+                .windows(marker.len())
+                .any(|window| window == marker),
+            "normal launcher must statically exclude the elevated probe"
+        );
+    }
+    for marker in [ELEVATED_WORKER_OPTION, ELEVATED_READY_RECORD] {
+        assert!(
+            !worker_bytes
+                .windows(marker.len())
+                .any(|window| window == marker),
+            "normal worker must statically exclude the elevated bootstrap"
+        );
+    }
+
+    let output = run_launcher(
+        &bundle,
+        &[
+            OsStr::new(ELEVATED_PROBE_OPTION),
+            OsStr::new("--root"),
+            OsStr::new("/private/var/root/bangbang-elevated-probe.Disabled"),
+            OsStr::new("--target-uid"),
+            OsStr::new("501"),
+            OsStr::new("--target-gid"),
+            OsStr::new("20"),
+            OsStr::new("--mode"),
+            OsStr::new("drop"),
+            OsStr::new("--"),
+        ],
+    );
+    assert_eq!(output.status.code(), Some(ARGUMENT_PARSING_EXIT_CODE));
+    let diagnostics = [output.stdout, output.stderr].concat();
+    for marker in [ELEVATED_READY_RECORD, ELEVATED_BLOCKED_STATUS] {
+        assert!(
+            !diagnostics
+                .windows(marker.len())
+                .any(|window| window == marker),
+            "normal bundle must not activate elevated probe behavior"
+        );
+    }
 }
 
 #[test]

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -13041,11 +13041,7 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
     );
     let launcher_bytes = fs::read(launcher(&bundle)).expect("normal launcher should read");
     let worker_bytes = fs::read(worker_executable(&bundle)).expect("normal worker should read");
-    for marker in [
-        ELEVATED_PROBE_OPTION.as_bytes(),
-        ELEVATED_WORKER_OPTION,
-        ELEVATED_BLOCKED_STATUS,
-    ] {
+    for marker in [ELEVATED_WORKER_OPTION, ELEVATED_BLOCKED_STATUS] {
         assert!(
             !launcher_bytes
                 .windows(marker.len())
@@ -13053,14 +13049,12 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             "normal launcher must statically exclude the elevated probe"
         );
     }
-    for marker in [ELEVATED_WORKER_OPTION, ELEVATED_READY_RECORD] {
-        assert!(
-            !worker_bytes
-                .windows(marker.len())
-                .any(|window| window == marker),
-            "normal worker must statically exclude the elevated bootstrap"
-        );
-    }
+    assert!(
+        !worker_bytes
+            .windows(ELEVATED_READY_RECORD.len())
+            .any(|window| window == ELEVATED_READY_RECORD),
+        "normal worker must statically exclude the elevated bootstrap"
+    );
 
     let output = run_launcher(
         &bundle,

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
+elevated-bootstrap-probe = []
 test-support = []
 
 [dependencies]

--- a/crates/session/src/elevated_probe.rs
+++ b/crates/session/src/elevated_probe.rs
@@ -1,0 +1,514 @@
+//! Closed wire contract for the test-only elevated bootstrap evidence harness.
+
+use std::fmt;
+
+use crate::{ObjectIdentity, SessionId};
+
+/// Launcher argv activation compiled only into the evidence bundle.
+pub const LAUNCHER_ACTIVATION: &str = "--bangbang-internal-elevated-bootstrap-probe-v1";
+/// Worker argv activation compiled only into the evidence bundle.
+pub const WORKER_ACTIVATION: &str = "--bangbang-internal-elevated-bootstrap-worker-v1";
+/// Fixed inherited descriptor carrying the exact private root.
+pub const ROOT_FD: libc::c_int = 8;
+/// Fixed worker-ready record sent before live code validation completes.
+pub const READY_RECORD: [u8; 16] = *b"BBEP-READY-V1\0\0\0";
+/// Encoded bootstrap record length.
+pub const BOOTSTRAP_RECORD_BYTES: usize = 64;
+/// Encoded terminal result record length.
+pub const RESULT_RECORD_BYTES: usize = 48;
+
+const VERSION: u16 = 1;
+const BOOTSTRAP_MAGIC: [u8; 4] = *b"BBE1";
+const RESULT_MAGIC: [u8; 4] = *b"BBR1";
+
+/// Exact evidence mode selected by the explicit root wrapper.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProbeMode {
+    /// Chroot and permanently drop to an explicit ordinary numeric identity.
+    Drop = 1,
+    /// Chroot while retaining exact uid/gid zero for the upstream no-drop shape.
+    RetainRoot = 2,
+    /// Exercise a high unmapped numeric identity at the syscall boundary.
+    UnmappedSyscall = 3,
+    /// Run the same chroot primitive in the unsandboxed launcher control process.
+    Control = 4,
+}
+
+impl ProbeMode {
+    /// Parses the closed root-wrapper spelling.
+    pub fn parse(value: &str, uid: u32, gid: u32) -> Option<Self> {
+        let mode = match value {
+            "drop" => Self::Drop,
+            "retain-root" => Self::RetainRoot,
+            "unmapped-syscall" => Self::UnmappedSyscall,
+            "control" => Self::Control,
+            _ => return None,
+        };
+        mode.accepts_target(uid, gid).then_some(mode)
+    }
+
+    /// Returns the fixed, value-free status spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Drop => "drop",
+            Self::RetainRoot => "retain-root",
+            Self::UnmappedSyscall => "unmapped-syscall",
+            Self::Control => "control",
+        }
+    }
+
+    /// Returns whether this mode admits the exact target category.
+    #[must_use]
+    pub const fn accepts_target(self, uid: u32, gid: u32) -> bool {
+        match self {
+            Self::Drop | Self::UnmappedSyscall => uid != 0 && gid != 0,
+            Self::RetainRoot | Self::Control => uid == 0 && gid == 0,
+        }
+    }
+
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            1 => Ok(Self::Drop),
+            2 => Ok(Self::RetainRoot),
+            3 => Ok(Self::UnmappedSyscall),
+            4 => Ok(Self::Control),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+/// Stable point reached by the root bootstrap state machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProbeStage {
+    /// Validate exact initial root credentials and the closed bootstrap.
+    InitialIdentity = 1,
+    /// Consume the fixed inherited private-root descriptor.
+    TakeRoot = 2,
+    /// Validate root type, ownership, mode, and identity.
+    ValidateRoot = 3,
+    /// Enter the retained root directory by descriptor.
+    EnterRoot = 4,
+    /// Call the public Darwin chroot primitive.
+    Chroot = 5,
+    /// Reset cwd to slash inside the new root.
+    ChangeDirectory = 6,
+    /// Fail closed if a future platform unexpectedly permits continuation.
+    UnexpectedContinuation = 7,
+}
+
+impl ProbeStage {
+    /// Returns the stable, value-free diagnostic spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::InitialIdentity => "initial-identity",
+            Self::TakeRoot => "take-root",
+            Self::ValidateRoot => "validate-root",
+            Self::EnterRoot => "enter-root",
+            Self::Chroot => "chroot",
+            Self::ChangeDirectory => "change-directory",
+            Self::UnexpectedContinuation => "unexpected-continuation",
+        }
+    }
+
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            1 => Ok(Self::InitialIdentity),
+            2 => Ok(Self::TakeRoot),
+            3 => Ok(Self::ValidateRoot),
+            4 => Ok(Self::EnterRoot),
+            5 => Ok(Self::Chroot),
+            6 => Ok(Self::ChangeDirectory),
+            7 => Ok(Self::UnexpectedContinuation),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+/// Redacted error category sent by the signed worker.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProbeErrorCategory {
+    /// The kernel rejected the operation for lack of authority.
+    PermissionDenied = 1,
+    /// The closed bootstrap or an input was malformed.
+    InvalidInput = 2,
+    /// Another value-free operating-system failure occurred.
+    Other = 3,
+}
+
+impl ProbeErrorCategory {
+    /// Maps a standard I/O category without retaining raw errno or values.
+    #[must_use]
+    pub const fn from_io_kind(kind: std::io::ErrorKind) -> Self {
+        match kind {
+            std::io::ErrorKind::PermissionDenied => Self::PermissionDenied,
+            std::io::ErrorKind::InvalidInput | std::io::ErrorKind::InvalidData => {
+                Self::InvalidInput
+            }
+            _ => Self::Other,
+        }
+    }
+
+    /// Returns the stable diagnostic spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::PermissionDenied => "permission-denied",
+            Self::InvalidInput => "invalid-input",
+            Self::Other => "other",
+        }
+    }
+
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            1 => Ok(Self::PermissionDenied),
+            2 => Ok(Self::InvalidInput),
+            3 => Ok(Self::Other),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+/// One nonce-bound exact-root bootstrap command.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ProbeBootstrap {
+    mode: ProbeMode,
+    target_uid: u32,
+    target_gid: u32,
+    root: ObjectIdentity,
+    nonce: SessionId,
+}
+
+impl ProbeBootstrap {
+    /// Constructs a complete worker command; launcher-only control is rejected.
+    pub fn new(
+        mode: ProbeMode,
+        target_uid: u32,
+        target_gid: u32,
+        root: ObjectIdentity,
+        nonce: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
+        if mode == ProbeMode::Control
+            || !mode.accepts_target(target_uid, target_gid)
+            || root.device == 0
+            || root.inode == 0
+            || nonce.is_pre_session()
+        {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            mode,
+            target_uid,
+            target_gid,
+            root,
+            nonce,
+        })
+    }
+
+    /// Returns the selected worker mode.
+    #[must_use]
+    pub const fn mode(self) -> ProbeMode {
+        self.mode
+    }
+
+    /// Returns the exact target user ID.
+    #[must_use]
+    pub const fn target_uid(self) -> u32 {
+        self.target_uid
+    }
+
+    /// Returns the exact target group ID.
+    #[must_use]
+    pub const fn target_gid(self) -> u32 {
+        self.target_gid
+    }
+
+    /// Returns the independently measured root identity.
+    #[must_use]
+    pub const fn root(self) -> ObjectIdentity {
+        self.root
+    }
+
+    /// Returns the random command identity.
+    #[must_use]
+    pub const fn nonce(self) -> SessionId {
+        self.nonce
+    }
+
+    /// Encodes the fixed v1 record.
+    #[must_use]
+    pub fn encode(self) -> [u8; BOOTSTRAP_RECORD_BYTES] {
+        let mut bytes = [0_u8; BOOTSTRAP_RECORD_BYTES];
+        bytes[0..4].copy_from_slice(&BOOTSTRAP_MAGIC);
+        bytes[4..6].copy_from_slice(&VERSION.to_be_bytes());
+        bytes[6] = self.mode as u8;
+        bytes[8..12].copy_from_slice(&self.target_uid.to_be_bytes());
+        bytes[12..16].copy_from_slice(&self.target_gid.to_be_bytes());
+        bytes[16..24].copy_from_slice(&self.root.device.to_be_bytes());
+        bytes[24..32].copy_from_slice(&self.root.inode.to_be_bytes());
+        bytes[32..64].copy_from_slice(self.nonce.as_bytes());
+        bytes
+    }
+
+    /// Decodes one exact fixed-size record.
+    pub fn decode(bytes: &[u8; BOOTSTRAP_RECORD_BYTES]) -> Result<Self, ProbeProtocolError> {
+        if bytes[0..4] != BOOTSTRAP_MAGIC || bytes[4..6] != VERSION.to_be_bytes() || bytes[7] != 0 {
+            return Err(ProbeProtocolError);
+        }
+        let mode = ProbeMode::from_byte(bytes[6])?;
+        let target_uid = u32::from_be_bytes(array(bytes, 8)?);
+        let target_gid = u32::from_be_bytes(array(bytes, 12)?);
+        let root = ObjectIdentity {
+            device: u64::from_be_bytes(array(bytes, 16)?),
+            inode: u64::from_be_bytes(array(bytes, 24)?),
+        };
+        let nonce = SessionId::from_bytes(array(bytes, 32)?);
+        Self::new(mode, target_uid, target_gid, root, nonce)
+    }
+}
+
+impl fmt::Debug for ProbeBootstrap {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ProbeBootstrap(<redacted>)")
+    }
+}
+
+/// Authenticated terminal result for one bootstrap command.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ProbeResult {
+    mode: ProbeMode,
+    outcome: Result<(), (ProbeStage, ProbeErrorCategory)>,
+    nonce: SessionId,
+}
+
+impl ProbeResult {
+    /// Constructs a successful terminal result.
+    pub fn success(mode: ProbeMode, nonce: SessionId) -> Result<Self, ProbeProtocolError> {
+        if mode == ProbeMode::Control || nonce.is_pre_session() {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            mode,
+            outcome: Ok(()),
+            nonce,
+        })
+    }
+
+    /// Constructs a value-redacted failure result.
+    pub fn failure(
+        mode: ProbeMode,
+        nonce: SessionId,
+        stage: ProbeStage,
+        category: ProbeErrorCategory,
+    ) -> Result<Self, ProbeProtocolError> {
+        if mode == ProbeMode::Control || nonce.is_pre_session() {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            mode,
+            outcome: Err((stage, category)),
+            nonce,
+        })
+    }
+
+    /// Returns the selected mode.
+    #[must_use]
+    pub const fn mode(self) -> ProbeMode {
+        self.mode
+    }
+
+    /// Returns success or the stable failure pair.
+    pub const fn outcome(self) -> Result<(), (ProbeStage, ProbeErrorCategory)> {
+        self.outcome
+    }
+
+    /// Returns the command nonce echoed by the worker.
+    #[must_use]
+    pub const fn nonce(self) -> SessionId {
+        self.nonce
+    }
+
+    /// Encodes the fixed v1 terminal record.
+    #[must_use]
+    pub fn encode(self) -> [u8; RESULT_RECORD_BYTES] {
+        let mut bytes = [0_u8; RESULT_RECORD_BYTES];
+        bytes[0..4].copy_from_slice(&RESULT_MAGIC);
+        bytes[4..6].copy_from_slice(&VERSION.to_be_bytes());
+        bytes[6] = self.mode as u8;
+        match self.outcome {
+            Ok(()) => bytes[7] = 1,
+            Err((stage, category)) => {
+                bytes[8] = stage as u8;
+                bytes[9] = category as u8;
+            }
+        }
+        bytes[16..48].copy_from_slice(self.nonce.as_bytes());
+        bytes
+    }
+
+    /// Decodes one exact fixed-size terminal record.
+    pub fn decode(bytes: &[u8; RESULT_RECORD_BYTES]) -> Result<Self, ProbeProtocolError> {
+        if bytes[0..4] != RESULT_MAGIC
+            || bytes[4..6] != VERSION.to_be_bytes()
+            || bytes[10..16] != [0; 6]
+        {
+            return Err(ProbeProtocolError);
+        }
+        let mode = ProbeMode::from_byte(bytes[6])?;
+        if mode == ProbeMode::Control {
+            return Err(ProbeProtocolError);
+        }
+        let nonce = SessionId::from_bytes(array(bytes, 16)?);
+        if nonce.is_pre_session() {
+            return Err(ProbeProtocolError);
+        }
+        let outcome = match (bytes[7], bytes[8], bytes[9]) {
+            (1, 0, 0) => Ok(()),
+            (0, stage, category) => Err((
+                ProbeStage::from_byte(stage)?,
+                ProbeErrorCategory::from_byte(category)?,
+            )),
+            _ => return Err(ProbeProtocolError),
+        };
+        Ok(Self {
+            mode,
+            outcome,
+            nonce,
+        })
+    }
+}
+
+impl fmt::Debug for ProbeResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ProbeResult(<redacted>)")
+    }
+}
+
+/// Malformed or inconsistent test-only bootstrap protocol data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProbeProtocolError;
+
+impl fmt::Display for ProbeProtocolError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("invalid elevated bootstrap probe record")
+    }
+}
+
+impl std::error::Error for ProbeProtocolError {}
+
+fn array<const N: usize>(bytes: &[u8], start: usize) -> Result<[u8; N], ProbeProtocolError> {
+    bytes
+        .get(start..start.checked_add(N).ok_or(ProbeProtocolError)?)
+        .and_then(|value| value.try_into().ok())
+        .ok_or(ProbeProtocolError)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bootstrap() -> ProbeBootstrap {
+        ProbeBootstrap::new(
+            ProbeMode::Drop,
+            501,
+            20,
+            ObjectIdentity {
+                device: 12,
+                inode: 34,
+            },
+            SessionId::from_bytes([7; 32]),
+        )
+        .expect("valid probe bootstrap")
+    }
+
+    #[test]
+    fn bootstrap_round_trip_is_exact_and_redacted() {
+        let bootstrap = bootstrap();
+        let encoded = bootstrap.encode();
+        assert_eq!(encoded.len(), BOOTSTRAP_RECORD_BYTES);
+        assert_eq!(ProbeBootstrap::decode(&encoded), Ok(bootstrap));
+        assert_eq!(format!("{bootstrap:?}"), "ProbeBootstrap(<redacted>)");
+        assert!(!format!("{bootstrap:?}").contains("501"));
+    }
+
+    #[test]
+    fn bootstrap_rejects_malformed_version_reserved_nonce_and_targets() {
+        let encoded = bootstrap().encode();
+        for index in [0, 4, 7] {
+            let mut malformed = encoded;
+            malformed[index] ^= 0xff;
+            assert_eq!(ProbeBootstrap::decode(&malformed), Err(ProbeProtocolError));
+        }
+        let mut zero_nonce = encoded;
+        zero_nonce[32..64].fill(0);
+        assert_eq!(ProbeBootstrap::decode(&zero_nonce), Err(ProbeProtocolError));
+        assert!(
+            ProbeBootstrap::new(
+                ProbeMode::Control,
+                0,
+                0,
+                ObjectIdentity {
+                    device: 1,
+                    inode: 1,
+                },
+                SessionId::from_bytes([1; 32]),
+            )
+            .is_err()
+        );
+        assert!(
+            ProbeBootstrap::new(
+                ProbeMode::Drop,
+                0,
+                0,
+                ObjectIdentity {
+                    device: 1,
+                    inode: 1,
+                },
+                SessionId::from_bytes([1; 32]),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn terminal_results_round_trip_and_reject_inconsistent_shapes() {
+        let nonce = SessionId::from_bytes([9; 32]);
+        for result in [
+            ProbeResult::success(ProbeMode::Drop, nonce).expect("valid success"),
+            ProbeResult::failure(
+                ProbeMode::Drop,
+                nonce,
+                ProbeStage::Chroot,
+                ProbeErrorCategory::PermissionDenied,
+            )
+            .expect("valid failure"),
+        ] {
+            let encoded = result.encode();
+            assert_eq!(ProbeResult::decode(&encoded), Ok(result));
+            assert_eq!(format!("{result:?}"), "ProbeResult(<redacted>)");
+        }
+        let mut malformed = ProbeResult::success(ProbeMode::Drop, nonce)
+            .expect("valid success")
+            .encode();
+        malformed[8] = ProbeStage::Chroot as u8;
+        assert_eq!(ProbeResult::decode(&malformed), Err(ProbeProtocolError));
+        assert!(ProbeResult::success(ProbeMode::Control, nonce).is_err());
+        assert!(ProbeResult::success(ProbeMode::Drop, SessionId::pre_session()).is_err());
+    }
+
+    #[test]
+    fn mode_parser_requires_exact_target_categories() {
+        assert_eq!(ProbeMode::parse("drop", 501, 20), Some(ProbeMode::Drop));
+        assert_eq!(ProbeMode::parse("drop", 0, 0), None);
+        assert_eq!(
+            ProbeMode::parse("retain-root", 0, 0),
+            Some(ProbeMode::RetainRoot)
+        );
+        assert_eq!(ProbeMode::parse("retain-root", 501, 20), None);
+        assert_eq!(ProbeMode::parse("unknown", 501, 20), None);
+    }
+}

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -1,6 +1,9 @@
 //! Private launcher-worker session protocol and macOS ownership primitives.
 
 mod codec;
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+#[doc(hidden)]
+pub mod elevated_probe;
 mod grant;
 #[cfg(target_os = "macos")]
 pub mod macos;

--- a/docs/security.md
+++ b/docs/security.md
@@ -3427,12 +3427,31 @@ and seccomp/cgroup/network/PID namespace mechanisms are not aliases for public
 HVF registers/granules, XNU allocation, App Sandbox, rlimits, launchd,
 Network Extension, vmnet, or Endpoint Security.
 
-Six #1373 audit outcomes still require root and real HVF on the same host; two
+Six #1373 outcomes remain audit entries pending their parent Challenge; two
 #1378 outcomes still require caller-owned Apple-approved signing/profile
 authority and an isolated vmnet fixture; three #1351 isolation semantics remain
 platform-feasible. Missing authority or credentials is not an impossibility
-proof. The repository does not inspect, fabricate, or claim those external
-inputs, and global `--final` stays blocked by all eleven outcomes.
+proof. Global `--final` stays blocked until evidence is translated into an
+ID-specific disposition and the other external outcomes complete.
+
+The #1373 same-host gate has now been executed rather than inferred from split
+environments. On Apple Silicon macOS 26.5.2 / SDK 26.5 with exact root and
+`kern.hv_support=1`, the unsandboxed signed launcher successfully entered the
+private chroot. The separately signed worker—with mandatory App Sandbox and
+Hypervisor entitlements—accepted the same nonce-bound root descriptor and
+completed `fchdir`, but public `chroot(2)` returned permission denied for the
+ordinary-target, uid/gid-zero, high-unmapped, repeated, and concurrent shapes.
+No credential transition, API, resource, or HVF operation can occur after that
+ordered blocker. This proves the exact chroot-plus-mandatory-containment branch,
+not that public numeric credential syscalls alone are absent. The complete
+boundary, alternatives, cleanup rules, reproduction command, and future-OS
+nonclaim are in the checked
+[elevated bootstrap evidence](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
+
+The six rows remain audit outcomes until #1371 completes its fresh per-ID
+Challenge and an inventory transition lands. The evidence harness is test-only
+and statically absent from normal launcher and worker builds; it is not a root
+service, public jailer mode, daemon, setuid helper, or ambient path authority.
 
 ## Current Non-Goals
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2094,6 +2094,45 @@ external root/HVF and approved-vmnet evidence gates pass. The Rust command is
 offline; live GitHub hierarchy, reviews, CI, branches, merge state, and
 merged-main OID are checked and recorded by the pull-request workflow.
 
+## Explicit Elevated Bootstrap Evidence
+
+The #1373 root proof is deliberately separate from
+`scripts/run-integration-tests.sh`. Normal validation never invokes `sudo`,
+prompts for a password, or treats missing root/HVF support as a passing skip.
+First build the test-only bundle as an ordinary user at an absent absolute
+destination:
+
+```sh
+scripts/build-elevated-bootstrap-probe.sh \
+  --output /absolute/absent/path/Bangbang.app
+```
+
+The build compiles normal launcher and worker artifacts first and verifies that
+the probe status/worker activation/ready bytes are absent. It then builds both
+ends with the same disabled-by-default feature, adds a visible test-only
+resource marker, and uses the normal production packager, signature split,
+entitlements, Hardened Runtime, and inspections.
+
+On a capable Apple Silicon host, calculate the explicit numeric target before
+elevation and invoke the wrapper yourself:
+
+```sh
+target_uid="$(id -u)"
+target_gid="$(id -g)"
+sudo /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
+  /bin/bash "$PWD/scripts/run-elevated-bootstrap-probe.sh" \
+  --bundle /absolute/absent/path/Bangbang.app \
+  --target-uid "$target_uid" \
+  --target-gid "$target_gid"
+```
+
+Do not use `--allow-unsupported` for this proof. Missing exact root, Apple
+Silicon, HVF, bundle identity, or cleanup is failure. The wrapper never reads
+`SUDO_UID`, `SUDO_GID`, `HOME`, `PATH`, account names, or a password; the
+caller owns the elevation mechanism. It reports OS/SDK/architecture and only
+the value-free terminal result. The measured result and its limits are in the
+[elevated bootstrap evidence contract](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
+
 ## Running Tests
 
 Run the standard workspace checks before opening or updating a PR:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2129,9 +2129,11 @@ sudo /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
 Do not use `--allow-unsupported` for this proof. Missing exact root, Apple
 Silicon, HVF, bundle identity, or cleanup is failure. The wrapper never reads
 `SUDO_UID`, `SUDO_GID`, `HOME`, `PATH`, account names, or a password; the
-caller owns the elevation mechanism. It reports OS/SDK/architecture and only
-the value-free terminal result. The measured result and its limits are in the
-[elevated bootstrap evidence contract](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
+caller owns the elevation mechanism. On entry it replaces inherited standard
+input with `/dev/null`, so elevation input cannot flow into the launcher or
+signed worker. It reports OS/SDK/architecture and only the value-free terminal
+result. The measured result and its limits are in the [elevated bootstrap
+evidence contract](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
 
 ## Running Tests
 

--- a/scripts/build-elevated-bootstrap-probe.sh
+++ b/scripts/build-elevated-bootstrap-probe.sh
@@ -73,7 +73,6 @@ cd "$repo_root"
 target_triple="aarch64-apple-darwin"
 launcher_bin="$repo_root/target/$target_triple/release/bangbang-launcher"
 worker_bin="$repo_root/target/$target_triple/release/bangbang"
-launcher_activation="--bangbang-internal-elevated-bootstrap-probe-v1"
 worker_activation="--bangbang-internal-elevated-bootstrap-worker-v1"
 status_activation="status: elevated bootstrap blocked"
 ready_activation="BBEP-READY-V1"
@@ -88,10 +87,8 @@ cargo build \
   --locked \
   --target "$target_triple"
 
-if LC_ALL=C /usr/bin/grep -a -F -q -- "$launcher_activation" "$launcher_bin" \
-  || LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$launcher_bin" \
+if LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$launcher_bin" \
   || LC_ALL=C /usr/bin/grep -a -F -q -- "$status_activation" "$launcher_bin" \
-  || LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$worker_bin" \
   || LC_ALL=C /usr/bin/grep -a -F -q -- "$ready_activation" "$worker_bin"; then
   echo "normal artifact unexpectedly contains elevated probe code" >&2
   exit 1
@@ -108,10 +105,8 @@ cargo build \
   --locked \
   --target "$target_triple"
 
-if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$launcher_activation" "$launcher_bin" \
-  || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$launcher_bin" \
+if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$launcher_bin" \
   || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$status_activation" "$launcher_bin" \
-  || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$worker_bin" \
   || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$ready_activation" "$worker_bin"; then
   echo "evidence artifact is missing the elevated probe boundary" >&2
   exit 1

--- a/scripts/build-elevated-bootstrap-probe.sh
+++ b/scripts/build-elevated-bootstrap-probe.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  /bin/cat <<'EOF'
+Usage: scripts/build-elevated-bootstrap-probe.sh --output /absolute/path/Bangbang.app
+
+Build and ad-hoc sign the feature-gated elevated-bootstrap evidence bundle.
+The destination must be absent. This build step must run as an ordinary user;
+the separate run-elevated-bootstrap-probe.sh wrapper owns explicit root use.
+EOF
+}
+
+output=""
+output_set=false
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --output)
+      if [[ "$output_set" == true ]]; then
+        echo "duplicate option" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      if [[ "$#" -eq 0 || -z "$1" ]]; then
+        echo "--output requires a path" >&2
+        usage >&2
+        exit 2
+      fi
+      output="$1"
+      output_set=true
+      ;;
+    --output=*)
+      if [[ "$output_set" == true ]]; then
+        echo "duplicate option" >&2
+        usage >&2
+        exit 2
+      fi
+      output="${1#--output=}"
+      output_set=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "$output_set" != true || "$output" != /* || "$(basename "$output")" != "Bangbang.app" ]]; then
+  echo "--output must be an absolute absent path named Bangbang.app" >&2
+  usage >&2
+  exit 2
+fi
+if [[ -e "$output" || -L "$output" ]]; then
+  echo "output already exists" >&2
+  exit 1
+fi
+if [[ "$(/usr/bin/id -u)" == "0" ]]; then
+  echo "elevated probe build must run as an ordinary user" >&2
+  exit 4
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+target_triple="aarch64-apple-darwin"
+launcher_bin="$repo_root/target/$target_triple/release/bangbang-launcher"
+worker_bin="$repo_root/target/$target_triple/release/bangbang"
+launcher_activation="--bangbang-internal-elevated-bootstrap-probe-v1"
+worker_activation="--bangbang-internal-elevated-bootstrap-worker-v1"
+status_activation="status: elevated bootstrap blocked"
+ready_activation="BBEP-READY-V1"
+
+cargo build \
+  -p bangbang \
+  -p bangbang-launcher \
+  --bin bangbang \
+  --bin bangbang-launcher \
+  --release \
+  --no-default-features \
+  --locked \
+  --target "$target_triple"
+
+if LC_ALL=C /usr/bin/grep -a -F -q -- "$launcher_activation" "$launcher_bin" \
+  || LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$launcher_bin" \
+  || LC_ALL=C /usr/bin/grep -a -F -q -- "$status_activation" "$launcher_bin" \
+  || LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$worker_bin" \
+  || LC_ALL=C /usr/bin/grep -a -F -q -- "$ready_activation" "$worker_bin"; then
+  echo "normal artifact unexpectedly contains elevated probe code" >&2
+  exit 1
+fi
+
+cargo build \
+  -p bangbang \
+  -p bangbang-launcher \
+  --bin bangbang \
+  --bin bangbang-launcher \
+  --release \
+  --no-default-features \
+  --features elevated-bootstrap-probe \
+  --locked \
+  --target "$target_triple"
+
+if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$launcher_activation" "$launcher_bin" \
+  || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$launcher_bin" \
+  || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$status_activation" "$launcher_bin" \
+  || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$worker_bin" \
+  || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$ready_activation" "$worker_bin"; then
+  echo "evidence artifact is missing the elevated probe boundary" >&2
+  exit 1
+fi
+
+cargo build \
+  -p bangbang-launcher \
+  --bin bangbang-bundle \
+  --release \
+  --locked
+
+resources="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/bangbang-elevated-resources.XXXXXXXX")"
+marker="$resources/elevated-bootstrap-probe.enabled"
+cleanup_resources() {
+  local prior_status=$?
+  trap - EXIT
+  if [[ -f "$marker" && ! -L "$marker" ]]; then
+    /bin/unlink "$marker" || exit 1
+  fi
+  if [[ -d "$resources" && ! -L "$resources" ]]; then
+    /bin/rmdir "$resources" || exit 1
+  fi
+  exit "$prior_status"
+}
+trap cleanup_resources EXIT
+
+/usr/bin/printf 'test-only\n' > "$marker"
+/bin/chmod 0600 "$marker"
+
+"$repo_root/target/release/bangbang-bundle" build \
+  --launcher "$launcher_bin" \
+  --worker "$worker_bin" \
+  --output "$output" \
+  --signing-identity - \
+  --worker-profile networkless \
+  --test-worker-resources "$resources"

--- a/scripts/run-elevated-bootstrap-probe.sh
+++ b/scripts/run-elevated-bootstrap-probe.sh
@@ -175,6 +175,7 @@ workspace=""
 workspace_identity=""
 symlink_root=""
 symlink_target=""
+symlink_identity=""
 symlink_placeholder_identity=""
 replacement_root=""
 replacement_root_identity=""
@@ -229,15 +230,28 @@ cleanup_directory() {
   /bin/rmdir "$path"
 }
 
+cleanup_symlink() {
+  local path="$1"
+  local target="$2"
+  local identity="$3"
+  if [[ ! -L "$path" \
+    || "$(/usr/bin/readlink "$path")" != "$target" \
+    || "$(/usr/bin/stat -f '%d:%i' "$path" 2>/dev/null || true)" != "$identity" \
+    || "$(/usr/bin/stat -f '%u:%g' "$path" 2>/dev/null || true)" != "0:0" ]]; then
+    return 1
+  fi
+  /bin/unlink "$path"
+}
+
 cleanup() {
   local prior_status=$?
   trap - EXIT
   trap '' INT TERM HUP
   local cleanup_status=0
   if [[ -n "$symlink_root" ]]; then
-    if [[ -L "$symlink_root" \
-      && "$(/usr/bin/readlink "$symlink_root")" == "$symlink_target" ]]; then
-      /bin/unlink "$symlink_root" || cleanup_status=1
+    if [[ -n "$symlink_identity" ]]; then
+      cleanup_symlink "$symlink_root" "$symlink_target" "$symlink_identity" \
+        || cleanup_status=1
     elif [[ -n "$symlink_placeholder_identity" ]]; then
       cleanup_directory "$symlink_root" "$symlink_placeholder_identity" \
         || cleanup_status=1
@@ -342,6 +356,7 @@ trap '' INT TERM HUP
 cleanup_directory "$symlink_root" "$symlink_placeholder_identity"
 /bin/ln -s "$probe_root" "$symlink_root"
 symlink_placeholder_identity=""
+symlink_identity="$(/usr/bin/stat -f '%d:%i' "$symlink_root")"
 trap 'exit 130' INT
 trap 'exit 143' TERM
 trap 'exit 129' HUP
@@ -353,9 +368,10 @@ if [[ "$symlink_status" -ne 1 || "$symlink_output" != "bangbang launcher: invali
   echo "bangbang elevated bootstrap proof: symlink case failed" >&2
   exit 1
 fi
-/bin/unlink "$symlink_root"
+cleanup_symlink "$symlink_root" "$symlink_target" "$symlink_identity"
 symlink_root=""
 symlink_target=""
+symlink_identity=""
 
 original_replacement_identity=""
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \

--- a/scripts/run-elevated-bootstrap-probe.sh
+++ b/scripts/run-elevated-bootstrap-probe.sh
@@ -4,6 +4,11 @@ LC_ALL=C
 export LC_ALL
 umask 077
 
+# The caller may supply an elevation credential on standard input. Sudo starts
+# this wrapper only after consuming it, so replace that descriptor before any
+# validation tool, launcher, or signed worker can inherit it.
+exec </dev/null
+
 usage() {
   /bin/cat <<'EOF'
 Usage: scripts/run-elevated-bootstrap-probe.sh --bundle /absolute/path/Bangbang.app
@@ -236,12 +241,25 @@ cleanup() {
       cleanup_status=1
     fi
   fi
-  if [[ -n "$workspace" && -d "$workspace" ]]; then
-    for output in "$workspace"/case-*; do
-      if [[ -f "$output" && ! -L "$output" ]]; then
-        /bin/unlink "$output" || cleanup_status=1
-      fi
-    done
+  if [[ -n "$workspace" && -e "$workspace" ]]; then
+    local workspace_current
+    local workspace_ownership
+    local workspace_shape
+    workspace_current="$(/usr/bin/stat -f '%d:%i' "$workspace" 2>/dev/null || true)"
+    workspace_ownership="$(/usr/bin/stat -f '%u:%g' "$workspace" 2>/dev/null || true)"
+    workspace_shape="$(/usr/bin/stat -f '%HT:%Lp' "$workspace" 2>/dev/null || true)"
+    if [[ -d "$workspace" && ! -L "$workspace" \
+      && "$workspace_current" == "$workspace_identity" \
+      && "$workspace_ownership" == "0:0" \
+      && "$workspace_shape" == "Directory:700" ]]; then
+      for output in "$workspace/case-a" "$workspace/case-b"; do
+        if [[ -f "$output" && ! -L "$output" ]]; then
+          /bin/unlink "$output" || cleanup_status=1
+        fi
+      done
+    else
+      cleanup_status=1
+    fi
   fi
   cleanup_directory "$concurrent_root_a" "$concurrent_root_a_identity" || cleanup_status=1
   cleanup_directory "$concurrent_root_b" "$concurrent_root_b_identity" || cleanup_status=1

--- a/scripts/run-elevated-bootstrap-probe.sh
+++ b/scripts/run-elevated-bootstrap-probe.sh
@@ -1,0 +1,385 @@
+#!/bin/bash
+set -euo pipefail
+LC_ALL=C
+export LC_ALL
+umask 077
+
+usage() {
+  /bin/cat <<'EOF'
+Usage: scripts/run-elevated-bootstrap-probe.sh --bundle /absolute/path/Bangbang.app
+       --target-uid UID --target-gid GID
+
+Run the no-skip elevated bootstrap evidence matrix on a capable Apple Silicon
+host. This wrapper must already have exact real/effective uid/gid zero. It does
+not invoke sudo or infer authority from SUDO_*, HOME, PATH, or account names.
+EOF
+}
+
+bundle=""
+bundle_set=false
+target_uid=""
+target_uid_set=false
+target_gid=""
+target_gid_set=false
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --bundle)
+      if [[ "$bundle_set" == true ]]; then
+        echo "duplicate option" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      if [[ "$#" -eq 0 || -z "$1" ]]; then
+        echo "--bundle requires a path" >&2
+        usage >&2
+        exit 2
+      fi
+      bundle="$1"
+      bundle_set=true
+      ;;
+    --target-uid)
+      if [[ "$target_uid_set" == true ]]; then
+        echo "duplicate option" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      if [[ "$#" -eq 0 ]]; then
+        echo "--target-uid requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      target_uid="$1"
+      target_uid_set=true
+      ;;
+    --target-gid)
+      if [[ "$target_gid_set" == true ]]; then
+        echo "duplicate option" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      if [[ "$#" -eq 0 ]]; then
+        echo "--target-gid requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      target_gid="$1"
+      target_gid_set=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "$bundle_set" != true || "$target_uid_set" != true || "$target_gid_set" != true ]]; then
+  echo "bundle, target uid, and target gid are required" >&2
+  usage >&2
+  exit 2
+fi
+
+is_nonzero_u32_decimal() {
+  local value="$1"
+  case "$value" in
+    "" | 0* | *[!0-9]*)
+      return 1
+      ;;
+  esac
+  if [[ "${#value}" -gt 10 \
+    || ("${#value}" -eq 10 && "$value" > "4294967295") ]]; then
+    return 1
+  fi
+  return 0
+}
+
+if ! is_nonzero_u32_decimal "$target_uid" \
+  || ! is_nonzero_u32_decimal "$target_gid"; then
+    echo "target uid and gid must be explicit nonzero decimal values" >&2
+    exit 2
+fi
+
+if [[ "$(/usr/bin/id -u)" != "0" \
+  || "$(/usr/bin/id -ru)" != "0" \
+  || "$(/usr/bin/id -g)" != "0" \
+  || "$(/usr/bin/id -rg)" != "0" ]]; then
+  echo "bangbang elevated bootstrap proof: explicit root required" >&2
+  exit 4
+fi
+
+if [[ "$bundle" != /* || "$(/usr/bin/basename "$bundle")" != "Bangbang.app" || ! -d "$bundle" || -L "$bundle" ]]; then
+  echo "invalid evidence bundle" >&2
+  exit 2
+fi
+launcher="$bundle/Contents/MacOS/bangbang"
+worker_bundle="$bundle/Contents/Helpers/BangbangWorker.app"
+worker="$worker_bundle/Contents/MacOS/bangbang-worker"
+marker="$worker_bundle/Contents/Resources/elevated-bootstrap-probe.enabled"
+for entry in "$launcher" "$worker" "$marker"; do
+  if [[ ! -f "$entry" || -L "$entry" ]]; then
+    echo "invalid evidence bundle" >&2
+    exit 1
+  fi
+done
+
+if [[ "$(/usr/bin/uname -m)" != "arm64" ]]; then
+  echo "bangbang elevated bootstrap proof: Apple Silicon required" >&2
+  exit 1
+fi
+hv_support="$(/usr/sbin/sysctl -n kern.hv_support 2>/dev/null || true)"
+hv_disable="$(/usr/sbin/sysctl -n kern.hv_disable 2>/dev/null || true)"
+if [[ "$hv_support" != "1" || "$hv_disable" == "1" ]]; then
+  echo "bangbang elevated bootstrap proof: Hypervisor.framework unavailable" >&2
+  exit 1
+fi
+if ! /usr/bin/codesign --verify --deep --strict "$bundle" >/dev/null 2>&1; then
+  echo "bangbang elevated bootstrap proof: bundle validation failed" >&2
+  exit 1
+fi
+if [[ -n "$(/usr/bin/dscacheutil -q user -a uid 2147483647)" \
+  || -n "$(/usr/bin/dscacheutil -q group -a gid 2147483647)" ]]; then
+  echo "bangbang elevated bootstrap proof: unmapped numeric fixture unavailable" >&2
+  exit 1
+fi
+if [[ -z "$(/usr/bin/dscacheutil -q user -a uid "$target_uid")" \
+  || -z "$(/usr/bin/dscacheutil -q group -a gid "$target_gid")" ]]; then
+  echo "bangbang elevated bootstrap proof: explicit target account unavailable" >&2
+  exit 1
+fi
+
+os_version="$(/usr/bin/sw_vers -productVersion)"
+sdk_version="$(/usr/bin/xcrun --sdk macosx --show-sdk-version)"
+echo "platform: macos=$os_version sdk=$sdk_version arch=arm64 hvf=supported root=exact"
+
+probe_root=""
+probe_root_identity=""
+concurrent_root_a=""
+concurrent_root_a_identity=""
+concurrent_root_b=""
+concurrent_root_b_identity=""
+workspace=""
+workspace_identity=""
+symlink_root=""
+symlink_target=""
+replacement_root=""
+replacement_root_identity=""
+replacement_candidate=""
+replacement_candidate_identity=""
+
+create_private_directory() {
+  local pattern="$1"
+  local path_variable="$2"
+  local identity_variable="$3"
+  local path
+  trap '' INT TERM HUP
+  path="$(/usr/bin/mktemp -d "$pattern")"
+  /bin/chmod 0700 "$path"
+  /usr/sbin/chown 0:0 "$path"
+  printf -v "$path_variable" '%s' "$path"
+  printf -v "$identity_variable" '%s' "$(/usr/bin/stat -f '%d:%i' "$path")"
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  trap 'exit 129' HUP
+}
+
+cleanup_directory() {
+  local path="$1"
+  local identity="$2"
+  if [[ -z "$path" ]]; then
+    return 0
+  fi
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    return 0
+  fi
+  if [[ ! -d "$path" || -L "$path" ]]; then
+    return 1
+  fi
+  local current
+  current="$(/usr/bin/stat -f '%d:%i' "$path" 2>/dev/null || true)"
+  if [[ "$current" != "$identity" ]]; then
+    return 1
+  fi
+  local ownership
+  ownership="$(/usr/bin/stat -f '%u:%g' "$path" 2>/dev/null || true)"
+  if [[ "$ownership" != "0:0" ]]; then
+    return 1
+  fi
+  local shape
+  shape="$(/usr/bin/stat -f '%HT:%Lp' "$path" 2>/dev/null || true)"
+  case "$shape" in
+    Directory:700 | Directory:770) ;;
+    *) return 1 ;;
+  esac
+  /bin/chmod 0700 "$path" || return 1
+  /bin/rmdir "$path"
+}
+
+cleanup() {
+  local prior_status=$?
+  trap - EXIT
+  trap '' INT TERM HUP
+  local cleanup_status=0
+  if [[ -n "$symlink_root" ]]; then
+    if [[ -L "$symlink_root" \
+      && "$(/usr/bin/readlink "$symlink_root")" == "$symlink_target" ]]; then
+      /bin/unlink "$symlink_root" || cleanup_status=1
+    else
+      cleanup_status=1
+    fi
+  fi
+  if [[ -n "$workspace" && -d "$workspace" ]]; then
+    for output in "$workspace"/case-*; do
+      if [[ -f "$output" && ! -L "$output" ]]; then
+        /bin/unlink "$output" || cleanup_status=1
+      fi
+    done
+  fi
+  cleanup_directory "$concurrent_root_a" "$concurrent_root_a_identity" || cleanup_status=1
+  cleanup_directory "$concurrent_root_b" "$concurrent_root_b_identity" || cleanup_status=1
+  cleanup_directory "$replacement_candidate" "$replacement_candidate_identity" || cleanup_status=1
+  cleanup_directory "$replacement_root" "$replacement_root_identity" || cleanup_status=1
+  cleanup_directory "$probe_root" "$probe_root_identity" || cleanup_status=1
+  cleanup_directory "$workspace" "$workspace_identity" || cleanup_status=1
+  if [[ "$cleanup_status" -ne 0 ]]; then
+    echo "bangbang elevated bootstrap proof: exact cleanup failed" >&2
+    exit 5
+  fi
+  exit "$prior_status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  probe_root probe_root_identity
+
+invoke() {
+  local root="$1"
+  local uid="$2"
+  local gid="$3"
+  local mode="$4"
+  /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
+    "$launcher" \
+    --bangbang-internal-elevated-bootstrap-probe-v1 \
+    --root "$root" \
+    --target-uid "$uid" \
+    --target-gid "$gid" \
+    --mode "$mode" \
+    --
+}
+
+assert_case() {
+  local root="$1"
+  local uid="$2"
+  local gid="$3"
+  local mode="$4"
+  local expected_status="$5"
+  local expected_output="$6"
+  local output
+  local status
+  set +e
+  output="$(invoke "$root" "$uid" "$gid" "$mode" 2>&1)"
+  status=$?
+  set -e
+  if [[ "$status" -ne "$expected_status" || "$output" != "$expected_output" ]]; then
+    echo "bangbang elevated bootstrap proof: case failed" >&2
+    exit 1
+  fi
+}
+
+assert_case "$probe_root" 0 0 control 0 \
+  "status: elevated bootstrap control complete"
+for _ in 1 2 3; do
+  assert_case "$probe_root" "$target_uid" "$target_gid" drop 3 \
+    "status: elevated bootstrap blocked stage=chroot error=permission-denied"
+done
+assert_case "$probe_root" 0 0 retain-root 3 \
+  "status: elevated bootstrap blocked stage=chroot error=permission-denied"
+assert_case "$probe_root" 2147483647 2147483647 unmapped-syscall 3 \
+  "status: elevated bootstrap blocked stage=chroot error=permission-denied"
+
+/bin/chmod 0770 "$probe_root"
+assert_case "$probe_root" 0 0 control 1 \
+  "bangbang launcher: invalid production launch policy"
+/bin/chmod 0700 "$probe_root"
+
+symlink_root="/private/var/root/bangbang-elevated-probe.Symlink1"
+symlink_target="$probe_root"
+if [[ -e "$symlink_root" || -L "$symlink_root" ]]; then
+  echo "bangbang elevated bootstrap proof: symlink fixture collision" >&2
+  exit 1
+fi
+/bin/ln -s "$probe_root" "$symlink_root"
+set +e
+symlink_output="$(invoke "$symlink_root" 0 0 control 2>&1)"
+symlink_status=$?
+set -e
+if [[ "$symlink_status" -ne 1 || "$symlink_output" != "bangbang launcher: invalid production launch policy" ]]; then
+  echo "bangbang elevated bootstrap proof: symlink case failed" >&2
+  exit 1
+fi
+/bin/unlink "$symlink_root"
+symlink_root=""
+symlink_target=""
+
+original_replacement_identity=""
+create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  replacement_root original_replacement_identity
+replacement_root_identity="$original_replacement_identity"
+create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  replacement_candidate replacement_candidate_identity
+/bin/rmdir "$replacement_root"
+trap '' INT TERM HUP
+/bin/mv "$replacement_candidate" "$replacement_root"
+replacement_root_identity="$replacement_candidate_identity"
+replacement_candidate=""
+replacement_candidate_identity=""
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+if [[ "$replacement_root_identity" == "$original_replacement_identity" ]] \
+  || cleanup_directory "$replacement_root" "$original_replacement_identity" \
+  || [[ ! -d "$replacement_root" ]]; then
+  echo "bangbang elevated bootstrap proof: replacement preservation failed" >&2
+  exit 1
+fi
+
+create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  concurrent_root_a concurrent_root_a_identity
+create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  concurrent_root_b concurrent_root_b_identity
+create_private_directory "/private/var/root/bangbang-elevated-work.XXXXXXXX" \
+  workspace workspace_identity
+
+set +e
+invoke "$concurrent_root_a" "$target_uid" "$target_gid" drop > "$workspace/case-a" 2>&1 &
+pid_a=$!
+invoke "$concurrent_root_b" "$target_uid" "$target_gid" drop > "$workspace/case-b" 2>&1 &
+pid_b=$!
+wait "$pid_a"
+status_a=$?
+wait "$pid_b"
+status_b=$?
+set -e
+output_a="$(<"$workspace/case-a")"
+output_b="$(<"$workspace/case-b")"
+expected_block="status: elevated bootstrap blocked stage=chroot error=permission-denied"
+if [[ "$status_a" -ne 3 || "$status_b" -ne 3 \
+  || "$output_a" != "$expected_block" || "$output_b" != "$expected_block" ]]; then
+  echo "bangbang elevated bootstrap proof: concurrency case failed" >&2
+  exit 1
+fi
+/bin/unlink "$workspace/case-a"
+/bin/unlink "$workspace/case-b"
+
+echo "result: app-sandbox-chroot=permission-denied control=success cleanup=exact"

--- a/scripts/run-elevated-bootstrap-probe.sh
+++ b/scripts/run-elevated-bootstrap-probe.sh
@@ -175,6 +175,7 @@ workspace=""
 workspace_identity=""
 symlink_root=""
 symlink_target=""
+symlink_placeholder_identity=""
 replacement_root=""
 replacement_root_identity=""
 replacement_candidate=""
@@ -237,6 +238,9 @@ cleanup() {
     if [[ -L "$symlink_root" \
       && "$(/usr/bin/readlink "$symlink_root")" == "$symlink_target" ]]; then
       /bin/unlink "$symlink_root" || cleanup_status=1
+    elif [[ -n "$symlink_placeholder_identity" ]]; then
+      cleanup_directory "$symlink_root" "$symlink_placeholder_identity" \
+        || cleanup_status=1
     else
       cleanup_status=1
     fi
@@ -331,13 +335,16 @@ assert_case "$probe_root" 0 0 control 1 \
   "bangbang launcher: invalid production launch policy"
 /bin/chmod 0700 "$probe_root"
 
-symlink_root="/private/var/root/bangbang-elevated-probe.Symlink1"
+create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  symlink_root symlink_placeholder_identity
 symlink_target="$probe_root"
-if [[ -e "$symlink_root" || -L "$symlink_root" ]]; then
-  echo "bangbang elevated bootstrap proof: symlink fixture collision" >&2
-  exit 1
-fi
+trap '' INT TERM HUP
+cleanup_directory "$symlink_root" "$symlink_placeholder_identity"
 /bin/ln -s "$probe_root" "$symlink_root"
+symlink_placeholder_identity=""
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 set +e
 symlink_output="$(invoke "$symlink_root" 0 0 control 2>&1)"
 symlink_status=$?


### PR DESCRIPTION
## Summary

- add a disabled-by-default, closed and redacted launcher/worker bootstrap probe that uses the production bundle layout, signature split, App Sandbox, Hypervisor entitlement, suspended/live code validation, and an exact retained root descriptor
- add an explicit-root, no-skip capable-host wrapper covering the unsandboxed control, repeated ordinary-target shape, uid/gid-zero shape, unmapped numeric shape, writable/symlink negatives, replacement-safe cleanup, and concurrent roots
- prove on Apple Silicon macOS 26.5.2 / SDK 26.5 that the unsandboxed control can chroot while the signed App Sandbox + Hypervisor worker is repeatedly denied at public `chroot(2)` after exact-root validation and `fchdir`
- keep the probe statically and dynamically absent from normal bundles, and record the result and its limits without changing capability dispositions yet

## Scope exclusions

- no public launcher option, privileged service, setuid helper, daemon registration, persistent root state, or ambient sudo behavior
- no credential-changing product path: a future sandboxed chroot success fails closed before `setgroups`, `setgid`, `setuid`, lifecycle, API, or HVF work
- no uid/gid disposition change and no connected-socket credential claim; #1371 must re-challenge the evidence before subsequent delivery

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all repository-documented signed-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `scripts/run-integration-tests.sh` (no `--allow-unsupported`; all signed HVF, guest, App Sandbox, production-bundle, and executable tests passed)
- `scripts/build-elevated-bootstrap-probe.sh --output <absent-Bangbang.app>`
- explicit-root `scripts/run-elevated-bootstrap-probe.sh`: `app-sandbox-chroot=permission-denied control=success cleanup=exact`; external residue check passed

Closes #1373

Parent context: #1371, #1351, #1348
