### PR TITLE
test: prove inherited-root worker bootstrap boundary

### DIFF
--- a/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
+++ b/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
@@ -1,10 +1,10 @@
 # Elevated macOS Bootstrap Evidence
 
-This contract records the #1373 evidence result for the direct-root operator
-branch beneath #1371. It tests whether Firecracker's chroot-first credential
-transition can coexist with Bangbang's mandatory production worker boundary;
-it does not add a public root mode, accept jailer uid/gid/chroot options, or
-change a capability disposition by itself.
+This contract records the #1373 direct-worker result and the #1884
+inherited-root follow-up beneath #1371. Together they test two public orderings
+for combining Firecracker's chroot-first model with Bangbang's mandatory
+production worker boundary. They do not add a public root mode, accept jailer
+uid/gid/chroot options, or change a capability disposition by themselves.
 
 ## Exact test boundary
 
@@ -14,8 +14,8 @@ The evidence bundle keeps the production layout and identity split:
   Sandbox nor Hypervisor entitlement;
 - the separately signed nested worker has Hardened Runtime and exactly the App
   Sandbox plus Hypervisor entitlements;
-- the launcher performs the normal static bundle and suspended/live worker
-  identity checks before authorizing the probe; and
+- the launcher retains normal static bundle validation and performs the
+  suspended/live worker identity checks whenever the child reaches them; and
 - both launcher and worker probe entries are compiled only with the
   `elevated-bootstrap-probe` feature. A normal `--no-default-features` build is
   checked for absence of the launcher-owned worker activation, ready and status
@@ -35,19 +35,32 @@ new filesystem authority, at fixed worker fd 8. The existing fixed production
 session and dormant broker endpoints remain closed-role socket descriptors;
 the worker receives no host path and cannot reopen the root by name.
 
-The signed worker verifies initial root identity, the nonce-bound descriptor
-identity, and exact mode before `fchdir`, public `chroot(2)`, `chdir("/")`,
-`setgroups`, `setgid`, or `setuid`. The launcher reports only fixed mode, stage,
-and error categories. Target IDs, paths, nonce, device/inode values, descriptor
-numbers, signing values, account data, and environment values are never
-reported.
+For the inherited-root branch, the wrapper copies exactly the complete signed
+probe bundle plus the current host's Apple-signed `/usr/lib/dyld` into fixed
+`/Bangbang.app` and `/usr/lib/dyld` locations inside a separate private root.
+It admits exactly 20 manifest entries, normalizes and records each original
+device/inode/owner/group/type/mode tuple, proves the loader bytes match the
+host file, and revalidates the loader and complete nested code signatures. The
+launcher independently validates the host-visible staged layout/profile and
+loader through no-follow descriptors, prepares every spawn object, enters the
+root with public `fchdir`/`chroot`/`chdir`, reattests `/`, and only then calls
+public `posix_spawn` with the fixed in-root worker path.
+
+In direct modes, the signed worker verifies initial root identity, the
+nonce-bound descriptor identity, and exact mode before `fchdir`, public
+`chroot(2)`, or `chdir("/")`. If the inherited worker reaches application
+entry, it must additionally attest that `/` and cwd are the same exact root,
+observe the direct App Sandbox chroot retry denial, and create then destroy one
+real HVF VM. No mode executes `setgroups`, `setgid`, or `setuid`. The launcher
+reports only fixed mode, stage, and error categories. Target IDs, paths,
+nonces, device/inode values, descriptor numbers, signing values, account data,
+and environment values are never reported.
 
 ## Capable-host result
 
 The final evidence shape was executed on 2026-08-08 on Apple Silicon with
 macOS 26.5.2, macOS SDK 26.5, and `kern.hv_support=1`, under explicit operator
-root authority. The same private directory and public syscall produced these
-results:
+root authority. The complete matrix produced these results:
 
 | Process boundary | Mode | Result |
 | --- | --- | --- |
@@ -55,52 +68,71 @@ results:
 | signed nested App Sandbox + Hypervisor worker | explicit ordinary target, repeated three times | exact root fd and `fchdir` succeeded; `chroot` returned permission denied |
 | same worker | uid/gid zero no-drop | exact root fd and `fchdir` succeeded; `chroot` returned permission denied |
 | same worker | high unmapped numeric uid/gid syscall case | exact root fd and `fchdir` succeeded; `chroot` returned permission denied |
-| two concurrent launcher/worker pairs | distinct exact roots and the same explicit target class | both returned the same chroot-stage permission denial |
+| two concurrent direct launcher/worker pairs | distinct exact roots and the same explicit target class | both returned the same chroot-stage permission denial |
+| same signed App Sandbox + Hypervisor worker, unchrooted | HVF control | exact worker validation and real HVF create/destroy succeeded |
+| launcher enters staged root before spawn | inherited-root, repeated three times | static bundle/loader validation and launcher root entry succeeded; `posix_spawn` returned success, but the worker exited before the earliest Ready record (`worker-bootstrap` / `other`) |
+| two concurrent complete inherited roots | distinct staged bundle/loader trees | both returned the same `worker-bootstrap` / `other` blocker |
 
-Focused negative cases also reject a group-writable leaf and a symlink leaf
-before worker activation. Every successful, rejected, and concurrent case
-leaves the exact private roots empty; cleanup rechecks device, inode, owner,
-group, and mode before `rmdir`, and refuses to remove a replacement.
+Focused negative cases reject a group-writable root and a symlink root. The
+staged manifest also rejects a writable, missing, symlinked, or inode-replaced
+loader, a missing nested worker, and an unexpected entry before worker
+activation. Every successful, rejected, repeated, and concurrent case leaves
+no root or workspace residue. Nonempty-root cleanup preflights all 20 ledger
+entries before removing any, then uses only reverse exact `unlink`/`rmdir`;
+root cleanup rechecks device, inode, owner, group, and mode and refuses to
+remove a replacement.
 
-The host had real HVF support and the rejected worker carried the real
-Hypervisor entitlement, but no guest was started: mandatory App Sandbox denied
-the earlier public chroot syscall before credential transition, lifecycle/API,
-typed resource consumption, or HVF construction could begin. Treating later
-steps as passing through a mock or a separate invocation would not change that
-ordered combination result.
+The inherited result is not a missing-HVF or generally invalid-signature
+result: the same exact unchrooted signed worker completed real HVF
+create/destroy in the same wrapper run. The inherited branch nevertheless
+never reached application entry, root attestation, the direct-chroot sandbox
+control, or HVF. No guest, credential transition, lifecycle/API, or typed
+resource consumption was attempted.
 
-After that result was established, the checked harness was deliberately kept
-at the evidence boundary: it contains no dormant credential-changing product
-path. If a future platform permits the sandboxed `chroot`, the worker reports
-`unexpected-continuation` and exits before `setgroups`, `setgid`, `setuid`,
-lifecycle, API, or HVF work. That failure forces a fresh implementation and
-Challenge instead of silently treating an unproved continuation as success.
-Connected-socket credentials therefore never cross a credential change in the
-measured branch; the harness authenticates the initial root peer by exact PID
-and effective IDs plus the random nonce, leaves the normal peer verifier
-unchanged, and makes no dynamic-versus-snapshot credential claim for #1374.
+After those results were established, the checked harness remained at the
+evidence boundary: it contains no credential-changing product path. If a
+future platform permits the direct sandboxed `chroot`, that branch reports
+`unexpected-continuation` before later work. If an inherited worker reaches
+entry, it must pass exact root, sandbox-denial, and HVF checks before success.
+Either changed result forces fresh implementation research and Challenge.
+Connected-socket credentials never cross a credential change in these measured
+branches; the harness leaves the normal peer verifier unchanged and makes no
+dynamic-versus-snapshot credential claim for #1374.
 
 ## Supported conclusion and nonclaims
 
-On the measured public macOS/SDK boundary, a mandatory App Sandbox worker
-cannot enter a caller-selected chroot, even when it starts with exact root
-identity and receives an already-opened, validated directory descriptor. The
-successful unsandboxed control distinguishes this result from missing host
-root authority, an invalid root, or an unavailable `chroot(2)` primitive.
+On the measured public macOS/SDK boundary, a running mandatory App Sandbox
+worker cannot directly enter a caller-selected chroot, even with exact root
+identity and an already-opened validated directory descriptor. The successful
+unsandboxed control distinguishes that result from missing root authority, an
+invalid root, or an unavailable `chroot(2)` primitive.
 
-Moving `chroot` to an unsandboxed helper cannot change another process's root;
-performing it before loading the worker removes the production bundle and
-dynamic-loader path needed to spawn that worker; removing App Sandbox,
-installing a privileged daemon/setuid helper, or using private Seatbelt APIs
-changes the challenged product/security model. Therefore the exact
-Firecracker chroot-plus-mandatory-containment branch has a reproducible public
-platform blocker and should be dispositioned through #1371's fresh Challenge.
+Pre-spawn inheritance is materially different and #1884 measured it rather
+than dismissing it. Staging the complete signed bundle and current host dyld
+was sufficient for `posix_spawn` to return success after launcher chroot, so
+the former assumption that root entry necessarily removes all executable and
+loader lookup was too broad. It was not sufficient for the spawned image to
+reach the first application record. Because no authenticated worker code ran,
+the evidence cannot distinguish a dyld/shared-cache bootstrap dependency from
+another pre-entry platform launch dependency and cannot claim inherited App
+Sandbox or HVF execution.
+
+This is a reproducible blocker for the exact public staged-bundle/current-dyld
+shape, with successful direct-root and unchrooted-HVF controls. It is evidence
+for #1371's fresh Challenge, not an inventory disposition by this PR. Removing
+App Sandbox, installing a privileged daemon/setuid helper, using private
+Seatbelt APIs, or switching to a different VMM process changes the challenged
+product/security model; any credible public in-root dependency alternative
+must instead be evaluated explicitly by the parent.
 
 This does not prove that numeric `setgroups`/`setgid`/`setuid` alone are
-unavailable on macOS, does not claim Linux mount/PID/user namespace parity,
-does not certify notarized distribution, and does not generalize beyond the
-recorded OS/SDK behavior. A future public platform change requires rerunning
-the wrapper and a fresh ID-by-ID Challenge.
+unavailable on macOS, that no larger fixed in-root Darwin dependency set can
+bootstrap, or that inherited-root success would supply full resources,
+lifecycle, API, guest boot, daemon/crash, grant, or credential semantics. It
+does not claim Linux mount/PID/user namespace parity, certify notarized
+distribution, or generalize beyond the recorded OS/SDK behavior. A changed
+root content or future public platform requires rerunning the wrapper and a
+fresh ID-by-ID Challenge.
 
 ## Reproduction
 
@@ -126,5 +158,5 @@ sudo /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
 The required terminal summary is value-free:
 
 ```text
-result: app-sandbox-chroot=permission-denied control=success cleanup=exact
+result: inherited-root-worker=blocked stage=worker-bootstrap error=other controls=success cleanup=exact
 ```

--- a/compat/firecracker/v1.16.0/wave8-certification-contract.md
+++ b/compat/firecracker/v1.16.0/wave8-certification-contract.md
@@ -99,13 +99,17 @@ local HVF without noninteractive root, missing credentials, a skipped test, or
 an unexecuted harness does not satisfy either gate. These are feasible external
 handoffs and are not platform-impossible classifications.
 
-That #1373 execution gate has since run on the controlled Apple Silicon host.
-The [elevated bootstrap evidence](elevated-bootstrap-evidence.md) records a
-successful unsandboxed root control and a repeated chroot-stage permission
-denial in the exact App Sandbox + Hypervisor worker. The six rows remain
-`audit-required` in this Wave 8 snapshot until #1371 performs its fresh
-ID-specific Challenge and an authoritative inventory transition; the evidence
-result itself does not silently rewrite this checked historical boundary.
+That same-host execution gate has since run on the controlled Apple Silicon
+host. The [elevated bootstrap evidence](elevated-bootstrap-evidence.md) records
+#1373's successful unsandboxed root control and repeated direct-worker chroot
+denial, plus #1884's follow-up. In the follow-up, the same unchrooted signed
+worker completed real HVF create/destroy; after the launcher entered an exact
+root containing the complete signed bundle and current dyld, `posix_spawn`
+returned success but the worker exited before the first application record.
+The six rows remain `audit-required` in this Wave 8 snapshot until #1371
+challenges the result and any remaining credible public alternative per ID and
+an authoritative inventory transition lands. Neither evidence PR silently
+rewrites this checked historical boundary.
 
 The direct #1348 delivery-parent policy retains #1351 open and requires the
 other nine preceding parents complete. #1371, #1373, #1374, #1375, and #1378

--- a/crates/bangbang/src/elevated_bootstrap_probe.rs
+++ b/crates/bangbang/src/elevated_bootstrap_probe.rs
@@ -6,13 +6,15 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::process::ExitCode;
 
+use bangbang_hvf::HvfBackend;
+use bangbang_runtime::VmBackend;
 use bangbang_session::elevated_probe::{
     BOOTSTRAP_RECORD_BYTES, ProbeBootstrap, ProbeErrorCategory, ProbeResult, ProbeStage,
     READY_RECORD, RESULT_RECORD_BYTES, ROOT_FD, WORKER_ACTIVATION,
 };
 use bangbang_session::{ObjectIdentity, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ProbeError {
     stage: ProbeStage,
     kind: io::ErrorKind,
@@ -96,6 +98,24 @@ fn execute(config: ProbeBootstrap) -> Result<(), ProbeError> {
     // exactly once to this process.
     let root = unsafe { OwnedFd::from_raw_fd(ROOT_FD) };
     validate_root(root.as_raw_fd(), config.root())?;
+    match config.mode() {
+        bangbang_session::elevated_probe::ProbeMode::HvfControl => {
+            drop(root);
+            return run_hvf_control();
+        }
+        bangbang_session::elevated_probe::ProbeMode::InheritedRoot => {
+            validate_inherited_root(config.root())?;
+            drop(root);
+            validate_sandbox_chroot_control()?;
+            return run_hvf_control();
+        }
+        bangbang_session::elevated_probe::ProbeMode::Drop
+        | bangbang_session::elevated_probe::ProbeMode::RetainRoot
+        | bangbang_session::elevated_probe::ProbeMode::UnmappedSyscall => {}
+        bangbang_session::elevated_probe::ProbeMode::Control => {
+            return Err(invalid(ProbeStage::InitialIdentity));
+        }
+    }
     // SAFETY: `root` is the live, validated private directory descriptor.
     syscall(ProbeStage::EnterRoot, unsafe {
         libc::fchdir(root.as_raw_fd())
@@ -113,6 +133,95 @@ fn execute(config: ProbeBootstrap) -> Result<(), ProbeError> {
         stage: ProbeStage::UnexpectedContinuation,
         kind: io::ErrorKind::Other,
     })
+}
+
+fn validate_inherited_root(expected: ObjectIdentity) -> Result<(), ProbeError> {
+    let slash = open_directory(c"/")?;
+    validate_root(slash.as_raw_fd(), expected).map_err(|error| ProbeError {
+        stage: ProbeStage::InheritedRoot,
+        kind: error.kind,
+    })?;
+    let cwd = open_directory(c".")?;
+    validate_root(cwd.as_raw_fd(), expected).map_err(|error| ProbeError {
+        stage: ProbeStage::InheritedRoot,
+        kind: error.kind,
+    })
+}
+
+fn validate_sandbox_chroot_control() -> Result<(), ProbeError> {
+    validate_sandbox_chroot_control_with(|| {
+        // SAFETY: Cwd is the already inherited exact root and the fixed
+        // relative string is NUL-terminated. Success would retain the same
+        // root but violate the expected App Sandbox denial established by the
+        // signed control.
+        if unsafe { libc::chroot(c".".as_ptr()) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error().kind())
+        }
+    })
+}
+
+fn validate_sandbox_chroot_control_with<F>(chroot: F) -> Result<(), ProbeError>
+where
+    F: FnOnce() -> Result<(), io::ErrorKind>,
+{
+    match chroot() {
+        Ok(()) => Err(ProbeError {
+            stage: ProbeStage::UnexpectedContinuation,
+            kind: io::ErrorKind::Other,
+        }),
+        Err(io::ErrorKind::PermissionDenied) => Ok(()),
+        Err(kind) => Err(with_kind(ProbeStage::SandboxChrootControl, kind)),
+    }
+}
+
+fn run_hvf_control() -> Result<(), ProbeError> {
+    let mut backend = HvfBackend::new();
+    run_hvf_control_with(&mut backend)
+}
+
+trait HvfControl {
+    fn create(&mut self) -> Result<(), ()>;
+    fn destroy(&mut self) -> Result<(), ()>;
+}
+
+impl HvfControl for HvfBackend {
+    fn create(&mut self) -> Result<(), ()> {
+        self.create_vm().map_err(|_| ())
+    }
+
+    fn destroy(&mut self) -> Result<(), ()> {
+        self.destroy_vm().map_err(|_| ())
+    }
+}
+
+fn run_hvf_control_with<B: HvfControl>(backend: &mut B) -> Result<(), ProbeError> {
+    backend.create().map_err(|()| ProbeError {
+        stage: ProbeStage::HvfCreate,
+        kind: io::ErrorKind::Other,
+    })?;
+    backend.destroy().map_err(|()| ProbeError {
+        stage: ProbeStage::HvfDestroy,
+        kind: io::ErrorKind::Other,
+    })
+}
+
+fn open_directory(path: &std::ffi::CStr) -> Result<OwnedFd, ProbeError> {
+    // SAFETY: `path` is NUL-terminated, fixed by the caller, and no pointer is
+    // retained by `open`.
+    let descriptor = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if descriptor < 0 {
+        Err(last(ProbeStage::InheritedRoot))
+    } else {
+        // SAFETY: `descriptor` is a fresh successful result owned by this scope.
+        Ok(unsafe { OwnedFd::from_raw_fd(descriptor) })
+    }
 }
 
 fn validate_initial_identity() -> Result<(), ProbeError> {
@@ -140,6 +249,10 @@ fn validate_root(descriptor: libc::c_int, expected: ObjectIdentity) -> Result<()
     }
     // SAFETY: Successful `fstat` initialized the complete value.
     let stat = unsafe { stat.assume_init() };
+    validate_root_stat(&stat, expected)
+}
+
+fn validate_root_stat(stat: &libc::stat, expected: ObjectIdentity) -> Result<(), ProbeError> {
     let actual = ObjectIdentity {
         device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
         inode: stat.st_ino,
@@ -190,6 +303,24 @@ const fn permission(stage: ProbeStage) -> ProbeError {
 mod tests {
     use super::*;
 
+    struct FakeHvfControl {
+        calls: Vec<&'static str>,
+        create_result: Result<(), ()>,
+        destroy_result: Result<(), ()>,
+    }
+
+    impl HvfControl for FakeHvfControl {
+        fn create(&mut self) -> Result<(), ()> {
+            self.calls.push("create");
+            self.create_result
+        }
+
+        fn destroy(&mut self) -> Result<(), ()> {
+            self.calls.push("destroy");
+            self.destroy_result
+        }
+    }
+
     #[test]
     fn error_mapping_is_value_free() {
         for (kind, expected) in [
@@ -205,5 +336,99 @@ mod tests {
         ] {
             assert_eq!(ProbeErrorCategory::from_io_kind(kind), expected);
         }
+    }
+
+    #[test]
+    fn sandbox_chroot_control_accepts_only_permission_denied() {
+        validate_sandbox_chroot_control_with(|| Err(io::ErrorKind::PermissionDenied))
+            .expect("the signed denial control should pass");
+
+        let continuation = validate_sandbox_chroot_control_with(|| Ok(()))
+            .expect_err("unexpected chroot success should fail closed");
+        assert_eq!(continuation.stage, ProbeStage::UnexpectedContinuation);
+        assert_eq!(continuation.kind, io::ErrorKind::Other);
+
+        let other = validate_sandbox_chroot_control_with(|| Err(io::ErrorKind::NotFound))
+            .expect_err("a different failure class should remain distinct");
+        assert_eq!(other.stage, ProbeStage::SandboxChrootControl);
+        assert_eq!(other.kind, io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn inherited_root_stat_requires_the_exact_closed_identity_shape() {
+        let root = std::fs::File::open("/").expect("test root descriptor should open");
+        let mut stat = MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: `root` is live and `stat` is writable for one result.
+        let status = unsafe { libc::fstat(root.as_raw_fd(), stat.as_mut_ptr()) };
+        assert_eq!(status, 0);
+        // SAFETY: Successful `fstat` initialized the complete value.
+        let mut stat = unsafe { stat.assume_init() };
+        stat.st_mode = libc::S_IFDIR | 0o700;
+        stat.st_uid = 0;
+        stat.st_gid = 0;
+        stat.st_nlink = 2;
+        let expected = ObjectIdentity {
+            device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
+            inode: stat.st_ino,
+        };
+        validate_root_stat(&stat, expected).expect("the exact inherited root should pass");
+
+        let mut wrong_type = stat;
+        wrong_type.st_mode = libc::S_IFREG | 0o700;
+        let mut wrong_mode = stat;
+        wrong_mode.st_mode = libc::S_IFDIR | 0o755;
+        let mut wrong_uid = stat;
+        wrong_uid.st_uid = 1;
+        let mut wrong_gid = stat;
+        wrong_gid.st_gid = 1;
+        let mut wrong_links = stat;
+        wrong_links.st_nlink = 1;
+        for invalid in [wrong_type, wrong_mode, wrong_uid, wrong_gid, wrong_links] {
+            assert_eq!(
+                validate_root_stat(&invalid, expected),
+                Err(permission(ProbeStage::ValidateRoot))
+            );
+        }
+        assert_eq!(
+            validate_root_stat(
+                &stat,
+                ObjectIdentity {
+                    device: expected.device,
+                    inode: expected.inode ^ 1,
+                }
+            ),
+            Err(permission(ProbeStage::ValidateRoot))
+        );
+    }
+
+    #[test]
+    fn hvf_control_destroys_exactly_after_successful_create() {
+        let mut success = FakeHvfControl {
+            calls: Vec::new(),
+            create_result: Ok(()),
+            destroy_result: Ok(()),
+        };
+        run_hvf_control_with(&mut success).expect("create and destroy should succeed");
+        assert_eq!(success.calls, ["create", "destroy"]);
+
+        let mut create_failure = FakeHvfControl {
+            calls: Vec::new(),
+            create_result: Err(()),
+            destroy_result: Ok(()),
+        };
+        let failure = run_hvf_control_with(&mut create_failure)
+            .expect_err("create failure should stop the sequence");
+        assert_eq!(failure.stage, ProbeStage::HvfCreate);
+        assert_eq!(create_failure.calls, ["create"]);
+
+        let mut destroy_failure = FakeHvfControl {
+            calls: Vec::new(),
+            create_result: Ok(()),
+            destroy_result: Err(()),
+        };
+        let failure = run_hvf_control_with(&mut destroy_failure)
+            .expect_err("destroy failure should be reported");
+        assert_eq!(failure.stage, ProbeStage::HvfDestroy);
+        assert_eq!(destroy_failure.calls, ["create", "destroy"]);
     }
 }

--- a/crates/launcher/src/elevated_probe.rs
+++ b/crates/launcher/src/elevated_probe.rs
@@ -5,11 +5,12 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 
 use bangbang_session::elevated_probe::{
-    LAUNCHER_ACTIVATION, ProbeBootstrap, ProbeMode, WORKER_ACTIVATION,
+    LAUNCHER_ACTIVATION, ProbeBootstrap, ProbeErrorCategory, ProbeMode, ProbeStage,
+    WORKER_ACTIVATION,
 };
 use bangbang_session::{ObjectIdentity, SessionId};
 
-use crate::LauncherError;
+use crate::{BundleLayout, LauncherError};
 
 const ROOT_OPTION: &str = "--root";
 const TARGET_UID_OPTION: &str = "--target-uid";
@@ -19,10 +20,22 @@ const DELIMITER: &str = "--";
 const MAX_ROOT_PATH_BYTES: usize = 1024;
 const ROOT_CHILD_PREFIX: &str = "bangbang-elevated-probe.";
 const ROOT_CHILD_SUFFIX_BYTES: usize = 8;
+const STAGED_LAUNCHER_PATH: &str = "Bangbang.app/Contents/MacOS/bangbang";
+const IN_ROOT_WORKER_PATH: &str =
+    "/Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/MacOS/bangbang-worker";
+const MAX_STAGED_DYLD_BYTES: u64 = 16 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ProbeFailure {
+    pub(crate) stage: ProbeStage,
+    pub(crate) category: ProbeErrorCategory,
+}
 
 pub(crate) struct Config {
     root: OwnedFd,
+    root_path: PathBuf,
     root_identity: ObjectIdentity,
+    staged_loader_identity: Option<ObjectIdentity>,
     target_uid: u32,
     target_gid: u32,
     mode: ProbeMode,
@@ -73,10 +86,17 @@ impl Config {
             .ok_or(LauncherError::InvalidLaunchPolicy)?;
         validate_initial_root()?;
         let (root, root_identity) = open_private_root(&root_path)?;
+        let staged_loader_identity = if mode == ProbeMode::InheritedRoot {
+            Some(validate_staged_loader(root.as_raw_fd(), None)?)
+        } else {
+            None
+        };
         Ok((
             Some(Self {
                 root,
+                root_path,
                 root_identity,
+                staged_loader_identity,
                 target_uid,
                 target_gid,
                 mode,
@@ -102,6 +122,28 @@ impl Config {
 
     pub(crate) const fn mode(&self) -> ProbeMode {
         self.mode
+    }
+
+    pub(crate) fn staged_layout(&self) -> Result<BundleLayout, LauncherError> {
+        if self.mode != ProbeMode::InheritedRoot {
+            return Err(LauncherError::InvalidLaunchPolicy);
+        }
+        BundleLayout::from_launcher_executable(&self.root_path.join(STAGED_LAUNCHER_PATH))
+    }
+
+    pub(crate) fn validate_staged_loader(&self) -> Result<(), LauncherError> {
+        let expected = self
+            .staged_loader_identity
+            .ok_or(LauncherError::InvalidLaunchPolicy)?;
+        validate_staged_loader(self.root.as_raw_fd(), Some(expected)).map(|_| ())
+    }
+
+    pub(crate) fn in_root_worker(&self) -> Result<&'static Path, LauncherError> {
+        if self.mode == ProbeMode::InheritedRoot {
+            Ok(Path::new(IN_ROOT_WORKER_PATH))
+        } else {
+            Err(LauncherError::InvalidLaunchPolicy)
+        }
     }
 
     pub(crate) fn bootstrap(&self) -> Result<ProbeBootstrap, LauncherError> {
@@ -137,6 +179,127 @@ impl Config {
         }
         Ok(())
     }
+
+    pub(crate) fn enter_inherited_root(&self) -> Result<(), ProbeFailure> {
+        if self.mode != ProbeMode::InheritedRoot {
+            return Err(ProbeFailure {
+                stage: ProbeStage::EnterRoot,
+                category: ProbeErrorCategory::InvalidInput,
+            });
+        }
+        self.validate_staged_loader().map_err(|_| ProbeFailure {
+            stage: ProbeStage::ValidateStagedLoader,
+            category: ProbeErrorCategory::InvalidInput,
+        })?;
+        ordered_root_transition(
+            || {
+                // SAFETY: `root` is the exact retained private directory
+                // validated by descriptor and this feature-gated launcher has
+                // not started workers.
+                cvt_root_syscall(unsafe { libc::fchdir(self.root.as_raw_fd()) })
+            },
+            || {
+                // SAFETY: Cwd is the retained exact root and the fixed relative
+                // string is NUL-terminated. The process intentionally never
+                // escapes this root.
+                cvt_root_syscall(unsafe { libc::chroot(c".".as_ptr()) })
+            },
+            || {
+                // SAFETY: The process is inside the private root and the fixed
+                // path is NUL-terminated.
+                cvt_root_syscall(unsafe { libc::chdir(c"/".as_ptr()) })
+            },
+            || {
+                let slash = open_directory(c"/").map_err(|_| ProbeErrorCategory::Other)?;
+                let stat =
+                    descriptor_stat(slash.as_raw_fd()).map_err(|_| ProbeErrorCategory::Other)?;
+                if stat.st_mode & libc::S_IFMT != libc::S_IFDIR
+                    || stat.st_mode & 0o7777 != 0o700
+                    || stat.st_uid != 0
+                    || stat.st_gid != 0
+                    || stat_identity(&stat) != self.root_identity
+                {
+                    return Err(ProbeErrorCategory::InvalidInput);
+                }
+                Ok(())
+            },
+        )
+    }
+}
+
+fn cvt_root_syscall(result: libc::c_int) -> Result<(), ProbeErrorCategory> {
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(ProbeErrorCategory::from_io_kind(
+            std::io::Error::last_os_error().kind(),
+        ))
+    }
+}
+
+fn ordered_root_transition<F, C, D, V>(
+    fchdir: F,
+    chroot: C,
+    chdir: D,
+    validate: V,
+) -> Result<(), ProbeFailure>
+where
+    F: FnOnce() -> Result<(), ProbeErrorCategory>,
+    C: FnOnce() -> Result<(), ProbeErrorCategory>,
+    D: FnOnce() -> Result<(), ProbeErrorCategory>,
+    V: FnOnce() -> Result<(), ProbeErrorCategory>,
+{
+    fchdir().map_err(|category| ProbeFailure {
+        stage: ProbeStage::EnterRoot,
+        category,
+    })?;
+    chroot().map_err(|category| ProbeFailure {
+        stage: ProbeStage::Chroot,
+        category,
+    })?;
+    chdir().map_err(|category| ProbeFailure {
+        stage: ProbeStage::ChangeDirectory,
+        category,
+    })?;
+    validate().map_err(|category| ProbeFailure {
+        stage: ProbeStage::InheritedRoot,
+        category,
+    })?;
+    Ok(())
+}
+
+fn validate_staged_loader(
+    root: RawFd,
+    expected: Option<ObjectIdentity>,
+) -> Result<ObjectIdentity, LauncherError> {
+    let usr = openat_directory(root, c"usr")?;
+    let lib = openat_directory(usr.as_raw_fd(), c"lib")?;
+    let loader = openat_plain_file(lib.as_raw_fd(), c"dyld")?;
+    let stat = descriptor_stat(loader.as_raw_fd())?;
+    validate_staged_loader_stat(&stat, expected)
+}
+
+fn validate_staged_loader_stat(
+    stat: &libc::stat,
+    expected: Option<ObjectIdentity>,
+) -> Result<ObjectIdentity, LauncherError> {
+    let identity = stat_identity(stat);
+    if stat.st_mode & libc::S_IFMT != libc::S_IFREG
+        || stat.st_mode & 0o022 != 0
+        || stat.st_mode & 0o111 == 0
+        || stat.st_uid != 0
+        || stat.st_gid != 0
+        || stat.st_size <= 0
+        || u64::try_from(stat.st_size)
+            .ok()
+            .is_none_or(|size| size > MAX_STAGED_DYLD_BYTES)
+        || identity.device == 0
+        || identity.inode == 0
+        || expected.is_some_and(|expected| expected != identity)
+    {
+        return Err(LauncherError::InvalidLaunchPolicy);
+    }
+    Ok(identity)
 }
 
 fn parse_u32(value: Option<&OsString>) -> Result<u32, LauncherError> {
@@ -242,6 +405,19 @@ fn openat_directory(parent: RawFd, child: &CStr) -> Result<OwnedFd, LauncherErro
     owned_descriptor(descriptor)
 }
 
+fn openat_plain_file(parent: RawFd, child: &CStr) -> Result<OwnedFd, LauncherError> {
+    // SAFETY: `parent` is a retained directory, `child` is NUL-terminated, and
+    // no pointer is retained.
+    let descriptor = unsafe {
+        libc::openat(
+            parent,
+            child.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+        )
+    };
+    owned_descriptor(descriptor)
+}
+
 fn owned_descriptor(descriptor: RawFd) -> Result<OwnedFd, LauncherError> {
     if descriptor < 0 {
         Err(LauncherError::InvalidLaunchPolicy)
@@ -285,6 +461,8 @@ fn stat_identity(stat: &libc::stat) -> ObjectIdentity {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
     use super::*;
 
     #[test]
@@ -310,10 +488,12 @@ mod tests {
         let root = std::fs::File::open("/").expect("test root descriptor should open");
         let config = Config {
             root: root.into(),
+            root_path: PathBuf::from("/private/var/root/bangbang-elevated-probe.A1b2C3d4"),
             root_identity: ObjectIdentity {
                 device: 123,
                 inode: 456,
             },
+            staged_loader_identity: None,
             target_uid: 1_234_567_891,
             target_gid: 1_234_567_893,
             mode: ProbeMode::Drop,
@@ -334,6 +514,20 @@ mod tests {
     }
 
     #[test]
+    fn in_root_worker_path_is_fixed_to_the_nested_bundle() {
+        assert_eq!(
+            Path::new(STAGED_LAUNCHER_PATH),
+            Path::new("Bangbang.app/Contents/MacOS/bangbang")
+        );
+        assert_eq!(
+            Path::new(IN_ROOT_WORKER_PATH),
+            Path::new(
+                "/Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/MacOS/bangbang-worker"
+            )
+        );
+    }
+
+    #[test]
     fn numeric_parser_is_decimal_and_bounded() {
         assert_eq!(parse_u32(Some(&OsString::from("0"))), Ok(0));
         assert_eq!(
@@ -346,5 +540,109 @@ mod tests {
                 Err(LauncherError::InvalidLaunchPolicy)
             );
         }
+    }
+
+    #[test]
+    fn inherited_root_transition_is_ordered_and_stops_on_first_failure() {
+        let stages = [
+            ProbeStage::EnterRoot,
+            ProbeStage::Chroot,
+            ProbeStage::ChangeDirectory,
+            ProbeStage::InheritedRoot,
+        ];
+        for (fail_at, expected_stage) in stages.into_iter().enumerate() {
+            let calls = RefCell::new(Vec::new());
+            let operation = |index| {
+                calls.borrow_mut().push(index);
+                if index == fail_at {
+                    Err(ProbeErrorCategory::PermissionDenied)
+                } else {
+                    Ok(())
+                }
+            };
+            let failure = ordered_root_transition(
+                || operation(0),
+                || operation(1),
+                || operation(2),
+                || operation(3),
+            )
+            .expect_err("the selected transition operation should fail");
+            assert_eq!(
+                failure,
+                ProbeFailure {
+                    stage: expected_stage,
+                    category: ProbeErrorCategory::PermissionDenied,
+                }
+            );
+            assert_eq!(*calls.borrow(), (0..=fail_at).collect::<Vec<_>>());
+        }
+
+        let calls = RefCell::new(Vec::new());
+        let operation = |index| {
+            calls.borrow_mut().push(index);
+            Ok(())
+        };
+        ordered_root_transition(
+            || operation(0),
+            || operation(1),
+            || operation(2),
+            || operation(3),
+        )
+        .expect("all transition operations should succeed");
+        assert_eq!(*calls.borrow(), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn staged_loader_metadata_and_identity_are_closed() {
+        let loader = std::fs::File::open("/usr/lib/dyld")
+            .expect("the macOS dynamic loader should be present");
+        let stat = descriptor_stat(loader.as_raw_fd()).expect("loader should stat");
+        let identity = validate_staged_loader_stat(&stat, None)
+            .expect("the system loader should satisfy the closed metadata shape");
+        validate_staged_loader_stat(&stat, Some(identity))
+            .expect("the recorded loader identity should match");
+
+        let mut wrong_type = stat;
+        wrong_type.st_mode = (wrong_type.st_mode & !libc::S_IFMT) | libc::S_IFDIR;
+        let mut writable = stat;
+        writable.st_mode |= 0o022;
+        let mut wrong_uid = stat;
+        wrong_uid.st_uid = 1;
+        let mut wrong_gid = stat;
+        wrong_gid.st_gid = 1;
+        let mut empty = stat;
+        empty.st_size = 0;
+        let mut oversized = stat;
+        oversized.st_size =
+            i64::try_from(MAX_STAGED_DYLD_BYTES + 1).expect("loader bound should fit off_t");
+        let mut zero_device = stat;
+        zero_device.st_dev = 0;
+        let mut zero_inode = stat;
+        zero_inode.st_ino = 0;
+        for invalid in [
+            wrong_type,
+            writable,
+            wrong_uid,
+            wrong_gid,
+            empty,
+            oversized,
+            zero_device,
+            zero_inode,
+        ] {
+            assert_eq!(
+                validate_staged_loader_stat(&invalid, None),
+                Err(LauncherError::InvalidLaunchPolicy)
+            );
+        }
+        assert_eq!(
+            validate_staged_loader_stat(
+                &stat,
+                Some(ObjectIdentity {
+                    device: identity.device,
+                    inode: identity.inode ^ 1,
+                })
+            ),
+            Err(LauncherError::InvalidLaunchPolicy)
+        );
     }
 }

--- a/crates/launcher/src/macos/spawn.rs
+++ b/crates/launcher/src/macos/spawn.rs
@@ -147,23 +147,87 @@ pub(crate) fn spawn_suspended(
     executable: &Path,
     args: Vec<OsString>,
 ) -> Result<SuspendedWorker, LauncherError> {
-    spawn_suspended_inner(executable, args, None)
+    prepare_suspended_inner(executable, args, None)?.spawn()
 }
 
 #[cfg(feature = "elevated-bootstrap-probe")]
-pub(crate) fn spawn_suspended_elevated(
+pub(crate) fn prepare_suspended_elevated(
     executable: &Path,
     args: Vec<OsString>,
     root: RawFd,
-) -> Result<SuspendedWorker, LauncherError> {
-    spawn_suspended_inner(executable, args, Some(root))
+) -> Result<PreparedSuspendedWorker, LauncherError> {
+    prepare_suspended_inner(executable, args, Some(root))
 }
 
-fn spawn_suspended_inner(
+pub(crate) struct PreparedSuspendedWorker {
+    executable: CString,
+    _argv: Vec<CString>,
+    _environment: Vec<CString>,
+    argv_pointers: Vec<*mut c_char>,
+    environment_pointers: Vec<*mut c_char>,
+    attributes: SpawnAttributes,
+    actions: SpawnFileActions,
+    parent: UnixStream,
+    child: UnixStream,
+    grant_parent: UnixDatagram,
+    grant_child: UnixDatagram,
+    broker_parent: UnixDatagram,
+    broker_child: UnixDatagram,
+    vhost_parent: UnixDatagram,
+    vhost_child: UnixDatagram,
+    block_parent: UnixDatagram,
+    block_child: UnixDatagram,
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    _elevated_root: Option<OwnedFd>,
+}
+
+impl PreparedSuspendedWorker {
+    pub(crate) fn spawn(self) -> Result<SuspendedWorker, LauncherError> {
+        let mut pid = 0;
+        // SAFETY: Preparation owns every C string, pointer array, descriptor,
+        // attribute, and action through this synchronous call. Moving a
+        // `CString` does not move its allocation, so the precomputed pointers
+        // remain valid. `pid` is writable for exactly one result.
+        let result = unsafe {
+            libc::posix_spawn(
+                &raw mut pid,
+                self.executable.as_ptr(),
+                self.actions.as_ptr(),
+                self.attributes.as_ptr(),
+                self.argv_pointers.as_ptr(),
+                self.environment_pointers.as_ptr(),
+            )
+        };
+        if result != 0 {
+            return Err(LauncherError::WorkerSpawn(
+                io::Error::from_raw_os_error(result).kind(),
+            ));
+        }
+        drop(self.child);
+        drop(self.grant_child);
+        drop(self.broker_child);
+        drop(self.vhost_child);
+        drop(self.block_child);
+        Ok(SuspendedWorker {
+            worker: OwnedWorker {
+                pid,
+                status: None,
+                released: false,
+            },
+            session: self.parent,
+            grants: self.grant_parent,
+            socket_broker: self.broker_parent,
+            vhost_user_broker: self.vhost_parent,
+            block_control_broker: self.block_parent,
+        })
+    }
+}
+
+fn prepare_suspended_inner(
     executable: &Path,
     args: Vec<OsString>,
     elevated_root: Option<RawFd>,
-) -> Result<SuspendedWorker, LauncherError> {
+) -> Result<PreparedSuspendedWorker, LauncherError> {
     #[cfg(not(feature = "elevated-bootstrap-probe"))]
     let _ = elevated_root;
     #[cfg(feature = "elevated-bootstrap-probe")]
@@ -208,9 +272,9 @@ fn spawn_suspended_inner(
     let executable = cstring(executable.as_os_str())
         .map_err(|_| LauncherError::WorkerSpawn(io::ErrorKind::InvalidInput))?;
     let argv = argv(&executable, args)?;
-    let env = environment()?;
+    let environment = environment()?;
     let argv_pointers = pointer_array(&argv);
-    let env_pointers = pointer_array(&env);
+    let environment_pointers = pointer_array(&environment);
 
     let mut attributes = SpawnAttributes::new()?;
     attributes.configure(false)?;
@@ -249,41 +313,26 @@ fn spawn_suspended_inner(
         }
     }
 
-    let mut pid = 0;
-    // SAFETY: All C strings and null-terminated pointer arrays remain live for
-    // the synchronous spawn. Attribute/action wrappers own initialized Darwin
-    // objects and `pid` is writable for one result.
-    let result = unsafe {
-        libc::posix_spawn(
-            &raw mut pid,
-            executable.as_ptr(),
-            actions.as_ptr(),
-            attributes.as_ptr(),
-            argv_pointers.as_ptr(),
-            env_pointers.as_ptr(),
-        )
-    };
-    if result != 0 {
-        return Err(LauncherError::WorkerSpawn(
-            io::Error::from_raw_os_error(result).kind(),
-        ));
-    }
-    drop(child);
-    drop(grant_child);
-    drop(broker_child);
-    drop(vhost_child);
-    drop(block_child);
-    Ok(SuspendedWorker {
-        worker: OwnedWorker {
-            pid,
-            status: None,
-            released: false,
-        },
-        session: parent,
-        grants: grant_parent,
-        socket_broker: broker_parent,
-        vhost_user_broker: vhost_parent,
-        block_control_broker: block_parent,
+    Ok(PreparedSuspendedWorker {
+        executable,
+        _argv: argv,
+        _environment: environment,
+        argv_pointers,
+        environment_pointers,
+        attributes,
+        actions,
+        parent,
+        child,
+        grant_parent,
+        grant_child,
+        broker_parent,
+        broker_child,
+        vhost_parent,
+        vhost_child,
+        block_parent,
+        block_child,
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        _elevated_root: elevated_root,
     })
 }
 

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -114,65 +114,260 @@ fn launch_elevated_prepared(
     launch: crate::launch_policy::PreparedLaunch,
     elevated_probe: crate::elevated_probe::Config,
 ) -> Result<LauncherExit, LauncherError> {
+    let bootstrap = elevated_probe.bootstrap()?;
+    if elevated_probe.mode() == bangbang_session::elevated_probe::ProbeMode::InheritedRoot {
+        return launch_inherited_prepared(launch, elevated_probe, bootstrap);
+    }
+    let spawned = crate::macos::spawn::prepare_suspended_elevated(
+        layout.worker_executable(),
+        launch.worker_args,
+        elevated_probe.root_fd(),
+    )?
+    .spawn()?;
+    finish_elevated_exchange(spawned, launch.worker_profile, bootstrap, false)
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn launch_inherited_prepared(
+    launch: crate::launch_policy::PreparedLaunch,
+    elevated_probe: crate::elevated_probe::Config,
+    bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
+) -> Result<LauncherExit, LauncherError> {
+    use bangbang_session::elevated_probe::{ProbeErrorCategory, ProbeStage};
+
+    let staged_layout = match elevated_probe.staged_layout() {
+        Ok(layout) => layout,
+        Err(_) => {
+            return Ok(elevated_blocked(
+                ProbeStage::ValidateStagedBundle,
+                ProbeErrorCategory::InvalidInput,
+            ));
+        }
+    };
+    let staged_profile = match crate::macos::code_sign::validate_bundle(&staged_layout) {
+        Ok(profile) => profile,
+        Err(_) => {
+            return Ok(elevated_blocked(
+                ProbeStage::ValidateStagedBundle,
+                ProbeErrorCategory::Other,
+            ));
+        }
+    };
+    if staged_profile != launch.worker_profile {
+        return Ok(elevated_blocked(
+            ProbeStage::ValidateStagedBundle,
+            ProbeErrorCategory::InvalidInput,
+        ));
+    }
+    if elevated_probe.validate_staged_loader().is_err() {
+        return Ok(elevated_blocked(
+            ProbeStage::ValidateStagedLoader,
+            ProbeErrorCategory::InvalidInput,
+        ));
+    }
+    let worker = match elevated_probe.in_root_worker() {
+        Ok(worker) => worker,
+        Err(_) => {
+            return Ok(elevated_blocked(
+                ProbeStage::SpawnWorker,
+                ProbeErrorCategory::InvalidInput,
+            ));
+        }
+    };
+    let prepared = match crate::macos::spawn::prepare_suspended_elevated(
+        worker,
+        launch.worker_args,
+        elevated_probe.root_fd(),
+    ) {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            return Ok(elevated_blocked(
+                ProbeStage::SpawnWorker,
+                probe_error_category(&error),
+            ));
+        }
+    };
+    if let Err(failure) = elevated_probe.enter_inherited_root() {
+        return Ok(elevated_blocked(failure.stage, failure.category));
+    }
+    let spawned = match prepared.spawn() {
+        Ok(spawned) => spawned,
+        Err(error) => {
+            return Ok(elevated_blocked(
+                ProbeStage::SpawnWorker,
+                probe_error_category(&error),
+            ));
+        }
+    };
+    finish_elevated_exchange(spawned, launch.worker_profile, bootstrap, true)
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn finish_elevated_exchange(
+    mut spawned: crate::macos::spawn::SuspendedWorker,
+    expected_profile: crate::macos::code_sign::WorkerProfile,
+    bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
+    inherited_root: bool,
+) -> Result<LauncherExit, LauncherError> {
     use std::io::{Read, Write};
     use std::os::fd::AsRawFd;
     use std::time::Duration;
 
-    use bangbang_session::elevated_probe::{ProbeResult, READY_RECORD, RESULT_RECORD_BYTES};
+    use bangbang_session::elevated_probe::{
+        ProbeErrorCategory, ProbeResult, ProbeStage, READY_RECORD, RESULT_RECORD_BYTES,
+    };
 
     const TIMEOUT: Duration = Duration::from_secs(5);
 
-    let bootstrap = elevated_probe.bootstrap()?;
-    let mut spawned = crate::macos::spawn::spawn_suspended_elevated(
-        layout.worker_executable(),
-        launch.worker_args,
-        elevated_probe.root_fd(),
-    )?;
-    if crate::macos::code_sign::validate_worker_process(spawned.worker.pid())?
-        != launch.worker_profile
-    {
-        return Err(LauncherError::InvalidWorkerIdentity);
+    match crate::macos::code_sign::validate_worker_process(spawned.worker.pid()) {
+        Ok(profile) if profile == expected_profile => {}
+        Ok(_) if inherited_root => {
+            return Ok(elevated_blocked(
+                ProbeStage::SuspendedIdentity,
+                ProbeErrorCategory::InvalidInput,
+            ));
+        }
+        Ok(_) => return Err(LauncherError::InvalidWorkerIdentity),
+        Err(_) if inherited_root => {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::Other,
+            ));
+        }
+        Err(error) => return Err(error),
     }
-    spawned
-        .session
-        .set_read_timeout(Some(TIMEOUT))
-        .map_err(|error| LauncherError::SessionSetup(error.kind()))?;
-    spawned
-        .session
-        .set_write_timeout(Some(TIMEOUT))
-        .map_err(|error| LauncherError::SessionSetup(error.kind()))?;
-    spawned.worker.resume()?;
+    if let Err(error) = spawned.session.set_read_timeout(Some(TIMEOUT)) {
+        if inherited_root {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::from_io_kind(error.kind()),
+            ));
+        }
+        return Err(LauncherError::SessionSetup(error.kind()));
+    }
+    if let Err(error) = spawned.session.set_write_timeout(Some(TIMEOUT)) {
+        if inherited_root {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::from_io_kind(error.kind()),
+            ));
+        }
+        return Err(LauncherError::SessionSetup(error.kind()));
+    }
+    if let Err(error) = spawned.worker.resume() {
+        if inherited_root {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                probe_error_category(&error),
+            ));
+        }
+        return Err(error);
+    }
     let mut ready = [0_u8; READY_RECORD.len()];
-    spawned
-        .session
-        .read_exact(&mut ready)
-        .map_err(|_| LauncherError::SessionProtocol)?;
-    if ready != READY_RECORD {
+    if let Err(error) = spawned.session.read_exact(&mut ready) {
+        if inherited_root {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::from_io_kind(error.kind()),
+            ));
+        }
         return Err(LauncherError::SessionProtocol);
     }
-    bangbang_session::macos::verify_peer(spawned.session.as_raw_fd(), spawned.worker.pid())
-        .map_err(|_| LauncherError::InvalidWorkerIdentity)?;
-    if crate::macos::code_sign::validate_worker_process(spawned.worker.pid())?
-        != launch.worker_profile
+    if ready != READY_RECORD {
+        if inherited_root {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::InvalidInput,
+            ));
+        }
+        return Err(LauncherError::SessionProtocol);
+    }
+    if bangbang_session::macos::verify_peer(spawned.session.as_raw_fd(), spawned.worker.pid())
+        .is_err()
     {
+        if inherited_root {
+            return Ok(elevated_blocked(
+                ProbeStage::LiveIdentity,
+                ProbeErrorCategory::Other,
+            ));
+        }
         return Err(LauncherError::InvalidWorkerIdentity);
     }
-    spawned
-        .session
-        .write_all(&bootstrap.encode())
-        .map_err(|_| LauncherError::SessionProtocol)?;
-    let mut encoded_result = [0_u8; RESULT_RECORD_BYTES];
-    spawned
-        .session
-        .read_exact(&mut encoded_result)
-        .map_err(|_| LauncherError::SessionProtocol)?;
-    let result =
-        ProbeResult::decode(&encoded_result).map_err(|_| LauncherError::SessionProtocol)?;
-    if result.mode() != bootstrap.mode() || result.nonce() != bootstrap.nonce() {
+    match crate::macos::code_sign::validate_worker_process(spawned.worker.pid()) {
+        Ok(profile) if profile == expected_profile => {}
+        Ok(_) if inherited_root => {
+            return Ok(elevated_blocked(
+                ProbeStage::LiveIdentity,
+                ProbeErrorCategory::InvalidInput,
+            ));
+        }
+        Ok(_) => return Err(LauncherError::InvalidWorkerIdentity),
+        Err(_) if inherited_root => {
+            return Ok(elevated_blocked(
+                ProbeStage::LiveIdentity,
+                ProbeErrorCategory::Other,
+            ));
+        }
+        Err(error) => return Err(error),
+    }
+    if spawned.session.write_all(&bootstrap.encode()).is_err() {
+        if inherited_root {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::Other,
+            ));
+        }
         return Err(LauncherError::SessionProtocol);
     }
-    let status = spawned.worker.wait()?;
-    let exit = map_exit_status(status)?;
+    let mut encoded_result = [0_u8; RESULT_RECORD_BYTES];
+    if spawned.session.read_exact(&mut encoded_result).is_err() {
+        if inherited_root {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::Other,
+            ));
+        }
+        return Err(LauncherError::SessionProtocol);
+    }
+    let result = match ProbeResult::decode(&encoded_result) {
+        Ok(result) => result,
+        Err(_) if inherited_root => {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::InvalidInput,
+            ));
+        }
+        Err(_) => return Err(LauncherError::SessionProtocol),
+    };
+    if result.mode() != bootstrap.mode() || result.nonce() != bootstrap.nonce() {
+        if inherited_root {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::InvalidInput,
+            ));
+        }
+        return Err(LauncherError::SessionProtocol);
+    }
+    let status = match spawned.worker.wait() {
+        Ok(status) => status,
+        Err(error) if inherited_root => {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                probe_error_category(&error),
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    let exit = match map_exit_status(status) {
+        Ok(exit) => exit,
+        Err(_) if inherited_root => {
+            return Ok(elevated_blocked(
+                ProbeStage::WorkerBootstrap,
+                ProbeErrorCategory::Other,
+            ));
+        }
+        Err(error) => return Err(error),
+    };
     match result.outcome() {
         Ok(()) if exit.code() == 0 => {
             println!(
@@ -189,7 +384,43 @@ fn launch_elevated_prepared(
             );
             Ok(LauncherExit(3))
         }
+        Ok(()) | Err(_) if inherited_root => Ok(elevated_blocked(
+            ProbeStage::WorkerBootstrap,
+            ProbeErrorCategory::InvalidInput,
+        )),
         Ok(()) | Err(_) => Err(LauncherError::SessionProtocol),
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn elevated_blocked(
+    stage: bangbang_session::elevated_probe::ProbeStage,
+    category: bangbang_session::elevated_probe::ProbeErrorCategory,
+) -> LauncherExit {
+    println!(
+        "status: elevated bootstrap blocked stage={} error={}",
+        stage.name(),
+        category.name()
+    );
+    LauncherExit(3)
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn probe_error_category(
+    error: &LauncherError,
+) -> bangbang_session::elevated_probe::ProbeErrorCategory {
+    use bangbang_session::elevated_probe::ProbeErrorCategory;
+
+    match error {
+        LauncherError::WorkerSpawn(kind)
+        | LauncherError::SessionSetup(kind)
+        | LauncherError::WorkerWait(kind)
+        | LauncherError::SignalForward(kind) => ProbeErrorCategory::from_io_kind(*kind),
+        LauncherError::InvalidBundleLayout
+        | LauncherError::InvalidBundleEntry
+        | LauncherError::InvalidWorkerIdentity
+        | LauncherError::InvalidLaunchPolicy => ProbeErrorCategory::InvalidInput,
+        _ => ProbeErrorCategory::Other,
     }
 }
 

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -82,10 +82,12 @@ const GRANT_PROBE_READY: &str = "status: grant integration probe ready";
 const GRANT_DELAY_OPTION: &str = "--bangbang-internal-grant-delay-v1";
 const GRANT_DELAY_READY: &str = "status: grant integration delay ready";
 const GRANT_PROBE_MARKER: &str = "grant-integration-probe.enabled";
-const ELEVATED_PROBE_OPTION: &str = "--bangbang-internal-elevated-bootstrap-probe-v1";
-const ELEVATED_WORKER_OPTION: &[u8] = b"--bangbang-internal-elevated-bootstrap-worker-v1";
-const ELEVATED_READY_RECORD: &[u8] = b"BBEP-READY-V1";
+const ELEVATED_PROBE_OPTION: &str = "--bangbang-internal-elevated-bootstrap-probe-v2";
+const ELEVATED_WORKER_OPTION: &[u8] = b"--bangbang-internal-elevated-bootstrap-worker-v2";
+const ELEVATED_READY_RECORD: &[u8] = b"BBEP-READY-V2";
 const ELEVATED_BLOCKED_STATUS: &[u8] = b"status: elevated bootstrap blocked";
+const ELEVATED_INHERITED_MODE: &[u8] = b"inherited-root";
+const ELEVATED_HVF_STAGE: &[u8] = b"hvf-create";
 const ELEVATED_PROBE_MARKER: &str = "elevated-bootstrap-probe.enabled";
 const GRANT_PROBE_OUTSIDE: &str = "bangbang-grant-probe-outside";
 const RESTORE_ROOT_ID: &str = "restore-root-1601";
@@ -13041,20 +13043,22 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
     );
     let launcher_bytes = fs::read(launcher(&bundle)).expect("normal launcher should read");
     let worker_bytes = fs::read(worker_executable(&bundle)).expect("normal worker should read");
-    for marker in [ELEVATED_WORKER_OPTION, ELEVATED_BLOCKED_STATUS] {
-        assert!(
-            !launcher_bytes
-                .windows(marker.len())
-                .any(|window| window == marker),
-            "normal launcher must statically exclude the elevated probe"
-        );
+    for artifact in [&launcher_bytes, &worker_bytes] {
+        for marker in [
+            ELEVATED_WORKER_OPTION,
+            ELEVATED_READY_RECORD,
+            ELEVATED_BLOCKED_STATUS,
+            ELEVATED_INHERITED_MODE,
+            ELEVATED_HVF_STAGE,
+        ] {
+            assert!(
+                !artifact
+                    .windows(marker.len())
+                    .any(|window| window == marker),
+                "normal artifact must statically exclude the elevated probe"
+            );
+        }
     }
-    assert!(
-        !worker_bytes
-            .windows(ELEVATED_READY_RECORD.len())
-            .any(|window| window == ELEVATED_READY_RECORD),
-        "normal worker must statically exclude the elevated bootstrap"
-    );
 
     let output = run_launcher(
         &bundle,
@@ -13073,7 +13077,12 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
     );
     assert_eq!(output.status.code(), Some(ARGUMENT_PARSING_EXIT_CODE));
     let diagnostics = [output.stdout, output.stderr].concat();
-    for marker in [ELEVATED_READY_RECORD, ELEVATED_BLOCKED_STATUS] {
+    for marker in [
+        ELEVATED_READY_RECORD,
+        ELEVATED_BLOCKED_STATUS,
+        ELEVATED_INHERITED_MODE,
+        ELEVATED_HVF_STAGE,
+    ] {
         assert!(
             !diagnostics
                 .windows(marker.len())

--- a/crates/session/src/elevated_probe.rs
+++ b/crates/session/src/elevated_probe.rs
@@ -5,21 +5,21 @@ use std::fmt;
 use crate::{ObjectIdentity, SessionId};
 
 /// Launcher argv activation compiled only into the evidence bundle.
-pub const LAUNCHER_ACTIVATION: &str = "--bangbang-internal-elevated-bootstrap-probe-v1";
+pub const LAUNCHER_ACTIVATION: &str = "--bangbang-internal-elevated-bootstrap-probe-v2";
 /// Worker argv activation compiled only into the evidence bundle.
-pub const WORKER_ACTIVATION: &str = "--bangbang-internal-elevated-bootstrap-worker-v1";
+pub const WORKER_ACTIVATION: &str = "--bangbang-internal-elevated-bootstrap-worker-v2";
 /// Fixed inherited descriptor carrying the exact private root.
 pub const ROOT_FD: libc::c_int = 8;
 /// Fixed worker-ready record sent before live code validation completes.
-pub const READY_RECORD: [u8; 16] = *b"BBEP-READY-V1\0\0\0";
+pub const READY_RECORD: [u8; 16] = *b"BBEP-READY-V2\0\0\0";
 /// Encoded bootstrap record length.
 pub const BOOTSTRAP_RECORD_BYTES: usize = 64;
 /// Encoded terminal result record length.
 pub const RESULT_RECORD_BYTES: usize = 48;
 
-const VERSION: u16 = 1;
-const BOOTSTRAP_MAGIC: [u8; 4] = *b"BBE1";
-const RESULT_MAGIC: [u8; 4] = *b"BBR1";
+const VERSION: u16 = 2;
+const BOOTSTRAP_MAGIC: [u8; 4] = *b"BBE2";
+const RESULT_MAGIC: [u8; 4] = *b"BBR2";
 
 /// Exact evidence mode selected by the explicit root wrapper.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -33,6 +33,10 @@ pub enum ProbeMode {
     UnmappedSyscall = 3,
     /// Run the same chroot primitive in the unsandboxed launcher control process.
     Control = 4,
+    /// Run a real HVF create/destroy control in the unchrooted signed worker.
+    HvfControl = 5,
+    /// Inherit a launcher-entered root and run the sandbox/HVF evidence sequence.
+    InheritedRoot = 6,
 }
 
 impl ProbeMode {
@@ -43,6 +47,8 @@ impl ProbeMode {
             "retain-root" => Self::RetainRoot,
             "unmapped-syscall" => Self::UnmappedSyscall,
             "control" => Self::Control,
+            "hvf-control" => Self::HvfControl,
+            "inherited-root" => Self::InheritedRoot,
             _ => return None,
         };
         mode.accepts_target(uid, gid).then_some(mode)
@@ -56,6 +62,8 @@ impl ProbeMode {
             Self::RetainRoot => "retain-root",
             Self::UnmappedSyscall => "unmapped-syscall",
             Self::Control => "control",
+            Self::HvfControl => "hvf-control",
+            Self::InheritedRoot => "inherited-root",
         }
     }
 
@@ -64,7 +72,9 @@ impl ProbeMode {
     pub const fn accepts_target(self, uid: u32, gid: u32) -> bool {
         match self {
             Self::Drop | Self::UnmappedSyscall => uid != 0 && gid != 0,
-            Self::RetainRoot | Self::Control => uid == 0 && gid == 0,
+            Self::RetainRoot | Self::Control | Self::HvfControl | Self::InheritedRoot => {
+                uid == 0 && gid == 0
+            }
         }
     }
 
@@ -74,6 +84,8 @@ impl ProbeMode {
             2 => Ok(Self::RetainRoot),
             3 => Ok(Self::UnmappedSyscall),
             4 => Ok(Self::Control),
+            5 => Ok(Self::HvfControl),
+            6 => Ok(Self::InheritedRoot),
             _ => Err(ProbeProtocolError),
         }
     }
@@ -97,6 +109,26 @@ pub enum ProbeStage {
     ChangeDirectory = 6,
     /// Fail closed if a future platform unexpectedly permits continuation.
     UnexpectedContinuation = 7,
+    /// Validate the complete fixed signed bundle staged inside the root.
+    ValidateStagedBundle = 8,
+    /// Validate the fixed Darwin loader staged inside the root.
+    ValidateStagedLoader = 9,
+    /// Spawn the signed worker by its fixed path inside the inherited root.
+    SpawnWorker = 10,
+    /// Validate the newly spawned worker while it remains suspended.
+    SuspendedIdentity = 11,
+    /// Prove slash and cwd are the exact inherited private root.
+    InheritedRoot = 12,
+    /// Re-run direct chroot as an App Sandbox denial control.
+    SandboxChrootControl = 13,
+    /// Revalidate the live worker after its authenticated ready record.
+    LiveIdentity = 14,
+    /// Create one real process-local Hypervisor.framework VM.
+    HvfCreate = 15,
+    /// Destroy the real process-local Hypervisor.framework VM.
+    HvfDestroy = 16,
+    /// Observe the first authenticated application record from the spawned worker.
+    WorkerBootstrap = 17,
 }
 
 impl ProbeStage {
@@ -111,6 +143,16 @@ impl ProbeStage {
             Self::Chroot => "chroot",
             Self::ChangeDirectory => "change-directory",
             Self::UnexpectedContinuation => "unexpected-continuation",
+            Self::ValidateStagedBundle => "validate-staged-bundle",
+            Self::ValidateStagedLoader => "validate-staged-loader",
+            Self::SpawnWorker => "spawn-worker",
+            Self::SuspendedIdentity => "suspended-identity",
+            Self::InheritedRoot => "inherited-root",
+            Self::SandboxChrootControl => "sandbox-chroot-control",
+            Self::LiveIdentity => "live-identity",
+            Self::HvfCreate => "hvf-create",
+            Self::HvfDestroy => "hvf-destroy",
+            Self::WorkerBootstrap => "worker-bootstrap",
         }
     }
 
@@ -123,6 +165,16 @@ impl ProbeStage {
             5 => Ok(Self::Chroot),
             6 => Ok(Self::ChangeDirectory),
             7 => Ok(Self::UnexpectedContinuation),
+            8 => Ok(Self::ValidateStagedBundle),
+            9 => Ok(Self::ValidateStagedLoader),
+            10 => Ok(Self::SpawnWorker),
+            11 => Ok(Self::SuspendedIdentity),
+            12 => Ok(Self::InheritedRoot),
+            13 => Ok(Self::SandboxChrootControl),
+            14 => Ok(Self::LiveIdentity),
+            15 => Ok(Self::HvfCreate),
+            16 => Ok(Self::HvfDestroy),
+            17 => Ok(Self::WorkerBootstrap),
             _ => Err(ProbeProtocolError),
         }
     }
@@ -239,7 +291,7 @@ impl ProbeBootstrap {
         self.nonce
     }
 
-    /// Encodes the fixed v1 record.
+    /// Encodes the fixed v2 record.
     #[must_use]
     pub fn encode(self) -> [u8; BOOTSTRAP_RECORD_BYTES] {
         let mut bytes = [0_u8; BOOTSTRAP_RECORD_BYTES];
@@ -332,7 +384,7 @@ impl ProbeResult {
         self.nonce
     }
 
-    /// Encodes the fixed v1 terminal record.
+    /// Encodes the fixed v2 terminal record.
     #[must_use]
     pub fn encode(self) -> [u8; RESULT_RECORD_BYTES] {
         let mut bytes = [0_u8; RESULT_RECORD_BYTES];
@@ -459,6 +511,12 @@ mod tests {
             )
             .is_err()
         );
+        let mut version_one = encoded;
+        version_one[4..6].copy_from_slice(&1_u16.to_be_bytes());
+        assert_eq!(
+            ProbeBootstrap::decode(&version_one),
+            Err(ProbeProtocolError)
+        );
         assert!(
             ProbeBootstrap::new(
                 ProbeMode::Drop,
@@ -496,6 +554,36 @@ mod tests {
             .encode();
         malformed[8] = ProbeStage::Chroot as u8;
         assert_eq!(ProbeResult::decode(&malformed), Err(ProbeProtocolError));
+        for index in [0, 4, 10, 15] {
+            let mut malformed = ProbeResult::success(ProbeMode::Drop, nonce)
+                .expect("valid success")
+                .encode();
+            malformed[index] ^= 0xff;
+            assert_eq!(ProbeResult::decode(&malformed), Err(ProbeProtocolError));
+        }
+        let mut version_one = ProbeResult::success(ProbeMode::Drop, nonce)
+            .expect("valid success")
+            .encode();
+        version_one[4..6].copy_from_slice(&1_u16.to_be_bytes());
+        assert_eq!(ProbeResult::decode(&version_one), Err(ProbeProtocolError));
+        let mut unknown_mode = ProbeResult::success(ProbeMode::Drop, nonce)
+            .expect("valid success")
+            .encode();
+        unknown_mode[6] = u8::MAX;
+        assert_eq!(ProbeResult::decode(&unknown_mode), Err(ProbeProtocolError));
+        let mut unknown_failure = ProbeResult::failure(
+            ProbeMode::Drop,
+            nonce,
+            ProbeStage::Chroot,
+            ProbeErrorCategory::Other,
+        )
+        .expect("valid failure")
+        .encode();
+        unknown_failure[8] = u8::MAX;
+        assert_eq!(
+            ProbeResult::decode(&unknown_failure),
+            Err(ProbeProtocolError)
+        );
         assert!(ProbeResult::success(ProbeMode::Control, nonce).is_err());
         assert!(ProbeResult::success(ProbeMode::Drop, SessionId::pre_session()).is_err());
     }
@@ -509,6 +597,84 @@ mod tests {
             Some(ProbeMode::RetainRoot)
         );
         assert_eq!(ProbeMode::parse("retain-root", 501, 20), None);
+        assert_eq!(
+            ProbeMode::parse("hvf-control", 0, 0),
+            Some(ProbeMode::HvfControl)
+        );
+        assert_eq!(
+            ProbeMode::parse("inherited-root", 0, 0),
+            Some(ProbeMode::InheritedRoot)
+        );
+        assert_eq!(ProbeMode::parse("hvf-control", 501, 20), None);
+        assert_eq!(ProbeMode::parse("inherited-root", 501, 20), None);
         assert_eq!(ProbeMode::parse("unknown", 501, 20), None);
+    }
+
+    #[test]
+    fn every_stage_round_trips_through_a_failure_result() {
+        let nonce = SessionId::from_bytes([0x5a; 32]);
+        for stage in [
+            ProbeStage::InitialIdentity,
+            ProbeStage::TakeRoot,
+            ProbeStage::ValidateRoot,
+            ProbeStage::EnterRoot,
+            ProbeStage::Chroot,
+            ProbeStage::ChangeDirectory,
+            ProbeStage::UnexpectedContinuation,
+            ProbeStage::ValidateStagedBundle,
+            ProbeStage::ValidateStagedLoader,
+            ProbeStage::SpawnWorker,
+            ProbeStage::SuspendedIdentity,
+            ProbeStage::InheritedRoot,
+            ProbeStage::SandboxChrootControl,
+            ProbeStage::LiveIdentity,
+            ProbeStage::HvfCreate,
+            ProbeStage::HvfDestroy,
+            ProbeStage::WorkerBootstrap,
+        ] {
+            let result = ProbeResult::failure(
+                ProbeMode::InheritedRoot,
+                nonce,
+                stage,
+                ProbeErrorCategory::Other,
+            )
+            .expect("stage should produce a valid failure result");
+            assert_eq!(ProbeResult::decode(&result.encode()), Ok(result));
+        }
+    }
+
+    #[test]
+    fn every_worker_mode_and_error_category_round_trips() {
+        let nonce = SessionId::from_bytes([0x6b; 32]);
+        for (mode, uid, gid) in [
+            (ProbeMode::Drop, 501, 20),
+            (ProbeMode::RetainRoot, 0, 0),
+            (ProbeMode::UnmappedSyscall, u32::MAX, u32::MAX),
+            (ProbeMode::HvfControl, 0, 0),
+            (ProbeMode::InheritedRoot, 0, 0),
+        ] {
+            let bootstrap = ProbeBootstrap::new(
+                mode,
+                uid,
+                gid,
+                ObjectIdentity {
+                    device: 0x12,
+                    inode: 0x34,
+                },
+                nonce,
+            )
+            .expect("mode and target should construct");
+            assert_eq!(ProbeBootstrap::decode(&bootstrap.encode()), Ok(bootstrap));
+            for category in [
+                ProbeErrorCategory::PermissionDenied,
+                ProbeErrorCategory::InvalidInput,
+                ProbeErrorCategory::Other,
+            ] {
+                let result =
+                    ProbeResult::failure(mode, nonce, ProbeStage::WorkerBootstrap, category)
+                        .expect("mode and category should construct");
+                assert_eq!(ProbeResult::decode(&result.encode()), Ok(result));
+            }
+        }
     }
 }

--- a/docs/security.md
+++ b/docs/security.md
@@ -3434,24 +3434,36 @@ platform-feasible. Missing authority or credentials is not an impossibility
 proof. Global `--final` stays blocked until evidence is translated into an
 ID-specific disposition and the other external outcomes complete.
 
-The #1373 same-host gate has now been executed rather than inferred from split
-environments. On Apple Silicon macOS 26.5.2 / SDK 26.5 with exact root and
-`kern.hv_support=1`, the unsandboxed signed launcher successfully entered the
-private chroot. The separately signed worker—with mandatory App Sandbox and
-Hypervisor entitlements—accepted the same nonce-bound root descriptor and
-completed `fchdir`, but public `chroot(2)` returned permission denied for the
-ordinary-target, uid/gid-zero, high-unmapped, repeated, and concurrent shapes.
-No credential transition, API, resource, or HVF operation can occur after that
-ordered blocker. This proves the exact chroot-plus-mandatory-containment branch,
-not that public numeric credential syscalls alone are absent. The complete
-boundary, alternatives, cleanup rules, reproduction command, and future-OS
-nonclaim are in the checked
+The elevated same-host gates have now been executed rather than inferred from
+split environments. On Apple Silicon macOS 26.5.2 / SDK 26.5 with exact root
+and `kern.hv_support=1`, #1373's unsandboxed signed launcher entered the private
+chroot. The separately signed worker—with mandatory App Sandbox and Hypervisor
+entitlements—accepted the nonce-bound root descriptor and completed `fchdir`,
+but public `chroot(2)` returned permission denied for the ordinary-target,
+uid/gid-zero, high-unmapped, repeated, and concurrent shapes. This proves the
+direct-worker ordering, not that public numeric credential syscalls alone are
+absent.
+
+#1884 then measured the credible pre-spawn ordering. The root launcher staged
+and validated the complete signed bundle and current host dyld, prepared the
+closed suspended spawn, entered and reattested the root, and addressed only the
+fixed in-root worker. `posix_spawn` returned success, but the child exited
+before its earliest application Ready record in three repeated and two
+concurrent complete roots. The same unchrooted signed worker completed real HVF
+create/destroy, so the inherited failure is not a general signing or HVF
+failure. It occurs too early to prove inherited App Sandbox activation, root
+attestation, or HVF, and it does not rule out a separately challenged larger
+fixed Darwin dependency set. No credential transition, API, resource, or guest
+operation occurs in either blocked ordering. The complete boundary,
+alternatives, exact staged-entry cleanup rules, reproduction command, and
+future-OS nonclaim are in the checked
 [elevated bootstrap evidence](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
 
-The six rows remain audit outcomes until #1371 completes its fresh per-ID
-Challenge and an inventory transition lands. The evidence harness is test-only
-and statically absent from normal launcher and worker builds; it is not a root
-service, public jailer mode, daemon, setuid helper, or ambient path authority.
+The six rows remain audit outcomes until #1371 challenges the controlled result
+and remaining credible alternatives per ID and an inventory transition lands.
+The evidence harness is test-only and statically absent from normal launcher
+and worker builds; it is not a root service, public jailer mode, daemon, setuid
+helper, or ambient path authority.
 
 ## Current Non-Goals
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2089,16 +2089,19 @@ mandatory.
 
 Exactly six #1373 audit rows, two #1378 audit rows, and three #1351 feasible
 rows remain; the checked authority owns the machine-derived current totals.
-The global `--final` command deliberately continues to fail until those
-external root/HVF and approved-vmnet evidence gates pass. The Rust command is
+The root/HVF gate has produced controlled #1373 and #1884 evidence, but it does
+not rewrite inventory by itself. The global `--final` command deliberately
+continues to fail until #1371 challenges and transitions those rows and the
+approved-vmnet and remaining feasible gates complete. The Rust command is
 offline; live GitHub hierarchy, reviews, CI, branches, merge state, and
 merged-main OID are checked and recorded by the pull-request workflow.
 
 ## Explicit Elevated Bootstrap Evidence
 
-The #1373 root proof is deliberately separate from
-`scripts/run-integration-tests.sh`. Normal validation never invokes `sudo`,
-prompts for a password, or treats missing root/HVF support as a passing skip.
+The #1373 direct-worker and #1884 inherited-root proofs are deliberately
+separate from `scripts/run-integration-tests.sh`. Normal validation never
+invokes `sudo`, prompts for a password, or treats missing root/HVF support as a
+passing skip.
 First build the test-only bundle as an ordinary user at an absent absolute
 destination:
 
@@ -2108,10 +2111,10 @@ scripts/build-elevated-bootstrap-probe.sh \
 ```
 
 The build compiles normal launcher and worker artifacts first and verifies that
-the probe status/worker activation/ready bytes are absent. It then builds both
-ends with the same disabled-by-default feature, adds a visible test-only
-resource marker, and uses the normal production packager, signature split,
-entitlements, Hardened Runtime, and inspections.
+the V2 probe status, worker activation, Ready, inherited-root, and HVF markers
+are absent. It then builds both ends with the same disabled-by-default feature,
+adds a visible test-only resource marker, and uses the normal production
+packager, signature split, entitlements, Hardened Runtime, and inspections.
 
 On a capable Apple Silicon host, calculate the explicit numeric target before
 elevation and invoke the wrapper yourself:
@@ -2131,9 +2134,24 @@ Silicon, HVF, bundle identity, or cleanup is failure. The wrapper never reads
 `SUDO_UID`, `SUDO_GID`, `HOME`, `PATH`, account names, or a password; the
 caller owns the elevation mechanism. On entry it replaces inherited standard
 input with `/dev/null`, so elevation input cannot flow into the launcher or
-signed worker. It reports OS/SDK/architecture and only the value-free terminal
-result. The measured result and its limits are in the [elevated bootstrap
-evidence contract](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
+signed worker.
+
+The inherited branch stages exactly the complete signed evidence bundle and
+current `/usr/lib/dyld` in a root-owned private root. A 20-entry private ledger
+binds every device/inode/owner/group/type/mode; preactivation negatives cover a
+writable, missing, symlinked, and inode-replaced loader, a missing nested
+worker, and an unexpected entry. The wrapper retains the #1373 direct denial,
+an unsandboxed launcher root control, and an unchrooted signed-worker real-HVF
+create/destroy control; it repeats the inherited result three times and runs
+two complete roots concurrently. Cleanup validates all entries before any
+removal and uses only exact reverse `unlink`/`rmdir`, then an independent scan
+must find no root or workspace residue.
+
+It reports OS/SDK/architecture and only the value-free terminal result. The
+measured result is `worker-bootstrap` / `other`: in-root `posix_spawn` returned
+success but the worker exited before its earliest application record. Its
+supported conclusion and nonclaims are in the [elevated bootstrap evidence
+contract](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
 
 ## Running Tests
 

--- a/scripts/build-elevated-bootstrap-probe.sh
+++ b/scripts/build-elevated-bootstrap-probe.sh
@@ -73,9 +73,11 @@ cd "$repo_root"
 target_triple="aarch64-apple-darwin"
 launcher_bin="$repo_root/target/$target_triple/release/bangbang-launcher"
 worker_bin="$repo_root/target/$target_triple/release/bangbang"
-worker_activation="--bangbang-internal-elevated-bootstrap-worker-v1"
+worker_activation="--bangbang-internal-elevated-bootstrap-worker-v2"
 status_activation="status: elevated bootstrap blocked"
-ready_activation="BBEP-READY-V1"
+ready_activation="BBEP-READY-V2"
+inherited_mode="inherited-root"
+hvf_stage="hvf-create"
 
 cargo build \
   -p bangbang \
@@ -87,12 +89,21 @@ cargo build \
   --locked \
   --target "$target_triple"
 
-if LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$launcher_bin" \
-  || LC_ALL=C /usr/bin/grep -a -F -q -- "$status_activation" "$launcher_bin" \
-  || LC_ALL=C /usr/bin/grep -a -F -q -- "$ready_activation" "$worker_bin"; then
-  echo "normal artifact unexpectedly contains elevated probe code" >&2
-  exit 1
-fi
+probe_markers=(
+  "$worker_activation"
+  "$status_activation"
+  "$ready_activation"
+  "$inherited_mode"
+  "$hvf_stage"
+)
+for artifact in "$launcher_bin" "$worker_bin"; do
+  for marker_value in "${probe_markers[@]}"; do
+    if LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$artifact"; then
+      echo "normal artifact unexpectedly contains elevated probe code" >&2
+      exit 1
+    fi
+  done
+done
 
 cargo build \
   -p bangbang \
@@ -105,9 +116,17 @@ cargo build \
   --locked \
   --target "$target_triple"
 
-if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$worker_activation" "$launcher_bin" \
-  || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$status_activation" "$launcher_bin" \
-  || ! LC_ALL=C /usr/bin/grep -a -F -q -- "$ready_activation" "$worker_bin"; then
+for marker_value in \
+  "$worker_activation" \
+  "$status_activation" \
+  "$inherited_mode" \
+  "$hvf_stage"; do
+  if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$launcher_bin"; then
+    echo "evidence artifact is missing the elevated probe boundary" >&2
+    exit 1
+  fi
+done
+if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$ready_activation" "$worker_bin"; then
   echo "evidence artifact is missing the elevated probe boundary" >&2
   exit 1
 fi

--- a/scripts/run-elevated-bootstrap-probe.sh
+++ b/scripts/run-elevated-bootstrap-probe.sh
@@ -150,6 +150,18 @@ if ! /usr/bin/codesign --verify --deep --strict "$bundle" >/dev/null 2>&1; then
   echo "bangbang elevated bootstrap proof: bundle validation failed" >&2
   exit 1
 fi
+if [[ ! -f /usr/lib/dyld || -L /usr/lib/dyld \
+  || "$(/usr/bin/stat -f '%u:%g:%HT:%Lp:%l' /usr/lib/dyld 2>/dev/null || true)" \
+    != "0:0:Regular File:755:1" ]]; then
+  echo "bangbang elevated bootstrap proof: loader validation failed" >&2
+  exit 1
+fi
+loader_size="$(/usr/bin/stat -f '%z' /usr/lib/dyld)"
+if [[ "$loader_size" -le 0 || "$loader_size" -gt 16777216 ]] \
+  || ! /usr/bin/codesign --verify --strict /usr/lib/dyld >/dev/null 2>&1; then
+  echo "bangbang elevated bootstrap proof: loader validation failed" >&2
+  exit 1
+fi
 if [[ -n "$(/usr/bin/dscacheutil -q user -a uid 2147483647)" \
   || -n "$(/usr/bin/dscacheutil -q group -a gid 2147483647)" ]]; then
   echo "bangbang elevated bootstrap proof: unmapped numeric fixture unavailable" >&2
@@ -167,6 +179,18 @@ echo "platform: macos=$os_version sdk=$sdk_version arch=arm64 hvf=supported root
 
 probe_root=""
 probe_root_identity=""
+inherited_root=""
+inherited_root_identity=""
+inherited_ledger=""
+inherited_ledger_identity=""
+inherited_root_a=""
+inherited_root_a_identity=""
+inherited_ledger_a=""
+inherited_ledger_a_identity=""
+inherited_root_b=""
+inherited_root_b_identity=""
+inherited_ledger_b=""
+inherited_ledger_b_identity=""
 concurrent_root_a=""
 concurrent_root_a_identity=""
 concurrent_root_b=""
@@ -181,6 +205,254 @@ replacement_root=""
 replacement_root_identity=""
 replacement_candidate=""
 replacement_candidate_identity=""
+
+bundle_directories=(
+  "Contents"
+  "Contents/_CodeSignature"
+  "Contents/MacOS"
+  "Contents/Helpers"
+  "Contents/Helpers/BangbangWorker.app"
+  "Contents/Helpers/BangbangWorker.app/Contents"
+  "Contents/Helpers/BangbangWorker.app/Contents/_CodeSignature"
+  "Contents/Helpers/BangbangWorker.app/Contents/MacOS"
+  "Contents/Helpers/BangbangWorker.app/Contents/Resources"
+)
+bundle_files=(
+  "Contents/_CodeSignature/CodeResources"
+  "Contents/MacOS/bangbang"
+  "Contents/Helpers/BangbangWorker.app/Contents/_CodeSignature/CodeResources"
+  "Contents/Helpers/BangbangWorker.app/Contents/MacOS/bangbang-worker"
+  "Contents/Helpers/BangbangWorker.app/Contents/Resources/elevated-bootstrap-probe.enabled"
+  "Contents/Helpers/BangbangWorker.app/Contents/Info.plist"
+  "Contents/Info.plist"
+)
+
+is_staged_relative() {
+  case "$1" in
+    "Bangbang.app" \
+      | "Bangbang.app/Contents" \
+      | "Bangbang.app/Contents/_CodeSignature" \
+      | "Bangbang.app/Contents/_CodeSignature/CodeResources" \
+      | "Bangbang.app/Contents/MacOS" \
+      | "Bangbang.app/Contents/MacOS/bangbang" \
+      | "Bangbang.app/Contents/Helpers" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/_CodeSignature" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/_CodeSignature/CodeResources" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/MacOS" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/MacOS/bangbang-worker" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/Resources" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/Resources/elevated-bootstrap-probe.enabled" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/Info.plist" \
+      | "Bangbang.app/Contents/Info.plist" \
+      | "usr" \
+      | "usr/lib" \
+      | "usr/lib/dyld")
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+validate_source_bundle_shape() {
+  local relative
+  for relative in "${bundle_directories[@]}"; do
+    if [[ ! -d "$bundle/$relative" || -L "$bundle/$relative" ]]; then
+      return 1
+    fi
+  done
+  for relative in "${bundle_files[@]}"; do
+    if [[ ! -f "$bundle/$relative" || -L "$bundle/$relative" ]]; then
+      return 1
+    fi
+  done
+  local count
+  count="$(/usr/bin/find -x "$bundle" -mindepth 1 -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+  [[ "$count" == "$((${#bundle_directories[@]} + ${#bundle_files[@]}))" ]]
+}
+
+record_staged_entry() {
+  local root="$1"
+  local ledger="$2"
+  local relative="$3"
+  local kind="$4"
+  local identity
+  if ! is_staged_relative "$relative"; then
+    return 1
+  fi
+  identity="$(/usr/bin/stat -f '%d:%i:%u:%g:%Lp' "$root/$relative")"
+  /usr/bin/printf '%s\t%s\t%s\n' "$relative" "$identity" "$kind" >> "$ledger"
+}
+
+stage_directory() {
+  local root="$1"
+  local ledger="$2"
+  local relative="$3"
+  /bin/mkdir "$root/$relative"
+  /usr/sbin/chown 0:0 "$root/$relative"
+  /bin/chmod 0755 "$root/$relative"
+  record_staged_entry "$root" "$ledger" "$relative" directory
+}
+
+stage_file() {
+  local root="$1"
+  local ledger="$2"
+  local source="$3"
+  local relative="$4"
+  local mode="$5"
+  /bin/cp -X "$source" "$root/$relative"
+  /usr/sbin/chown 0:0 "$root/$relative"
+  /bin/chmod "$mode" "$root/$relative"
+  record_staged_entry "$root" "$ledger" "$relative" file
+}
+
+stage_inherited_root() {
+  local root="$1"
+  local ledger="$2"
+  local ledger_identity_variable="$3"
+  if ! validate_source_bundle_shape; then
+    return 1
+  fi
+  /usr/bin/touch "$ledger"
+  /usr/sbin/chown 0:0 "$ledger"
+  /bin/chmod 0600 "$ledger"
+  printf -v "$ledger_identity_variable" '%s' "$(/usr/bin/stat -f '%d:%i' "$ledger")"
+
+  stage_directory "$root" "$ledger" "Bangbang.app"
+  local relative
+  for relative in "${bundle_directories[@]}"; do
+    stage_directory "$root" "$ledger" "Bangbang.app/$relative"
+  done
+  for relative in "${bundle_files[@]}"; do
+    local mode=0644
+    case "$relative" in
+      "Contents/MacOS/bangbang" \
+        | "Contents/Helpers/BangbangWorker.app/Contents/MacOS/bangbang-worker")
+        mode=0755
+        ;;
+      "Contents/Helpers/BangbangWorker.app/Contents/Resources/elevated-bootstrap-probe.enabled")
+        mode=0600
+        ;;
+    esac
+    stage_file "$root" "$ledger" "$bundle/$relative" "Bangbang.app/$relative" "$mode"
+  done
+  stage_directory "$root" "$ledger" "usr"
+  stage_directory "$root" "$ledger" "usr/lib"
+  stage_file "$root" "$ledger" "/usr/lib/dyld" "usr/lib/dyld" 0755
+
+  if ! /usr/bin/cmp -s /usr/lib/dyld "$root/usr/lib/dyld" \
+    || ! /usr/bin/codesign --verify --strict "$root/usr/lib/dyld" >/dev/null 2>&1 \
+    || ! /usr/bin/codesign --verify --deep --strict "$root/Bangbang.app" >/dev/null 2>&1; then
+    return 1
+  fi
+}
+
+validate_staged_root() {
+  local root="$1"
+  local root_identity="$2"
+  local ledger="$3"
+  local ledger_identity="$4"
+  if [[ -z "$root" || ! -d "$root" || -L "$root" \
+    || "$(/usr/bin/stat -f '%d:%i' "$root" 2>/dev/null || true)" != "$root_identity" \
+    || "$(/usr/bin/stat -f '%u:%g:%HT:%Lp' "$root" 2>/dev/null || true)" != "0:0:Directory:700" ]]; then
+    return 1
+  fi
+  if [[ ! -f "$ledger" || -L "$ledger" \
+    || "$(/usr/bin/stat -f '%d:%i' "$ledger" 2>/dev/null || true)" != "$ledger_identity" \
+    || "$(/usr/bin/stat -f '%u:%g:%HT:%Lp' "$ledger" 2>/dev/null || true)" != "0:0:Regular File:600" ]]; then
+    return 1
+  fi
+
+  local lines=()
+  local relative
+  local identity
+  local kind
+  local seen="|"
+  while IFS=$'\t' read -r relative identity kind; do
+    if ! is_staged_relative "$relative" \
+      || [[ "$kind" != "file" && "$kind" != "directory" ]]; then
+      return 1
+    fi
+    case "$seen" in
+      *"|$relative|"*) return 1 ;;
+    esac
+    seen="${seen}${relative}|"
+    lines+=("$relative"$'\t'"$identity"$'\t'"$kind")
+  done < "$ledger"
+  if [[ "${#lines[@]}" -ne 20 ]]; then
+    return 1
+  fi
+
+  local line
+  local path
+  for line in "${lines[@]}"; do
+    IFS=$'\t' read -r relative identity kind <<< "$line"
+    path="$root/$relative"
+    if [[ -L "$path" \
+      || "$(/usr/bin/stat -f '%d:%i:%u:%g:%Lp' "$path" 2>/dev/null || true)" != "$identity" ]]; then
+      return 1
+    fi
+    if [[ "$kind" == "file" && ! -f "$path" ]] \
+      || [[ "$kind" == "directory" && ! -d "$path" ]]; then
+      return 1
+    fi
+    local links
+    links="$(/usr/bin/stat -f '%l' "$path" 2>/dev/null || true)"
+    if [[ "$kind" == "file" && "$links" != "1" ]] \
+      || [[ "$kind" == "directory" && ("$links" == "" || "$links" -lt 2) ]]; then
+      return 1
+    fi
+  done
+
+  local count
+  count="$(/usr/bin/find -x "$root" -mindepth 1 -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+  if [[ "$count" != "20" ]] \
+    || ! validate_source_bundle_shape \
+    || ! /usr/bin/cmp -s /usr/lib/dyld "$root/usr/lib/dyld" \
+    || ! /usr/bin/codesign --verify --strict "$root/usr/lib/dyld" >/dev/null 2>&1 \
+    || ! /usr/bin/codesign --verify --deep --strict "$root/Bangbang.app" >/dev/null 2>&1; then
+    return 1
+  fi
+  return 0
+}
+
+cleanup_staged_root() {
+  local root="$1"
+  local root_identity="$2"
+  local ledger="$3"
+  local ledger_identity="$4"
+  if [[ -z "$root" ]]; then
+    return 0
+  fi
+  if ! validate_staged_root "$root" "$root_identity" "$ledger" "$ledger_identity"; then
+    return 1
+  fi
+
+  local lines=()
+  local relative
+  local identity
+  local kind
+  while IFS=$'\t' read -r relative identity kind; do
+    lines+=("$relative"$'\t'"$identity"$'\t'"$kind")
+  done < "$ledger"
+
+  local index
+  local path
+  for ((index = ${#lines[@]} - 1; index >= 0; index--)); do
+    IFS=$'\t' read -r relative identity kind <<< "${lines[index]}"
+    path="$root/$relative"
+    if [[ "$kind" == "file" ]]; then
+      /bin/unlink "$path" || return 1
+    else
+      /bin/rmdir "$path" || return 1
+    fi
+  done
+  /bin/unlink "$ledger" || return 1
+  cleanup_directory "$root" "$root_identity"
+}
 
 create_private_directory() {
   local pattern="$1"
@@ -270,7 +542,11 @@ cleanup() {
       && "$workspace_current" == "$workspace_identity" \
       && "$workspace_ownership" == "0:0" \
       && "$workspace_shape" == "Directory:700" ]]; then
-      for output in "$workspace/case-a" "$workspace/case-b"; do
+      for output in \
+        "$workspace/case-a" \
+        "$workspace/case-b" \
+        "$workspace/inherited-case-a" \
+        "$workspace/inherited-case-b"; do
         if [[ -f "$output" && ! -L "$output" ]]; then
           /bin/unlink "$output" || cleanup_status=1
         fi
@@ -279,6 +555,24 @@ cleanup() {
       cleanup_status=1
     fi
   fi
+  cleanup_staged_root \
+    "$inherited_root" \
+    "$inherited_root_identity" \
+    "$inherited_ledger" \
+    "$inherited_ledger_identity" \
+    || cleanup_status=1
+  cleanup_staged_root \
+    "$inherited_root_a" \
+    "$inherited_root_a_identity" \
+    "$inherited_ledger_a" \
+    "$inherited_ledger_a_identity" \
+    || cleanup_status=1
+  cleanup_staged_root \
+    "$inherited_root_b" \
+    "$inherited_root_b_identity" \
+    "$inherited_ledger_b" \
+    "$inherited_ledger_b_identity" \
+    || cleanup_status=1
   cleanup_directory "$concurrent_root_a" "$concurrent_root_a_identity" || cleanup_status=1
   cleanup_directory "$concurrent_root_b" "$concurrent_root_b_identity" || cleanup_status=1
   cleanup_directory "$replacement_candidate" "$replacement_candidate_identity" || cleanup_status=1
@@ -298,6 +592,8 @@ trap 'exit 129' HUP
 
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
   probe_root probe_root_identity
+create_private_directory "/private/var/root/bangbang-elevated-work.XXXXXXXX" \
+  workspace workspace_identity
 
 invoke() {
   local root="$1"
@@ -306,12 +602,24 @@ invoke() {
   local mode="$4"
   /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
     "$launcher" \
-    --bangbang-internal-elevated-bootstrap-probe-v1 \
+    --bangbang-internal-elevated-bootstrap-probe-v2 \
     --root "$root" \
     --target-uid "$uid" \
     --target-gid "$gid" \
     --mode "$mode" \
     --
+}
+
+invoke_inherited() {
+  local root="$1"
+  local root_identity="$2"
+  local ledger="$3"
+  local ledger_identity="$4"
+  if ! validate_staged_root "$root" "$root_identity" "$ledger" "$ledger_identity"; then
+    echo "status: elevated bootstrap blocked stage=validate-staged-bundle error=invalid-input"
+    return 3
+  fi
+  invoke "$root" 0 0 inherited-root
 }
 
 assert_case() {
@@ -328,7 +636,28 @@ assert_case() {
   status=$?
   set -e
   if [[ "$status" -ne "$expected_status" || "$output" != "$expected_output" ]]; then
-    echo "bangbang elevated bootstrap proof: case failed" >&2
+    /usr/bin/printf 'bangbang elevated bootstrap proof: case failed mode=%s status=%s\n' \
+      "$mode" "$status" >&2
+    exit 1
+  fi
+}
+
+assert_inherited_case() {
+  local root="$1"
+  local root_identity="$2"
+  local ledger="$3"
+  local ledger_identity="$4"
+  local expected_status="$5"
+  local expected_output="$6"
+  local output
+  local status
+  set +e
+  output="$(invoke_inherited "$root" "$root_identity" "$ledger" "$ledger_identity" 2>&1)"
+  status=$?
+  set -e
+  if [[ "$status" -ne "$expected_status" || "$output" != "$expected_output" ]]; then
+    /usr/bin/printf 'bangbang elevated bootstrap proof: inherited case failed status=%s\n' \
+      "$status" >&2
     exit 1
   fi
 }
@@ -343,6 +672,124 @@ assert_case "$probe_root" 0 0 retain-root 3 \
   "status: elevated bootstrap blocked stage=chroot error=permission-denied"
 assert_case "$probe_root" 2147483647 2147483647 unmapped-syscall 3 \
   "status: elevated bootstrap blocked stage=chroot error=permission-denied"
+assert_case "$probe_root" 0 0 hvf-control 0 \
+  "status: elevated bootstrap hvf-control complete"
+
+create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  inherited_root inherited_root_identity
+inherited_ledger="$workspace/inherited-ledger"
+stage_inherited_root "$inherited_root" "$inherited_ledger" inherited_ledger_identity
+
+expected_inherited_block="status: elevated bootstrap blocked stage=worker-bootstrap error=other"
+for _ in 1 2 3; do
+  assert_inherited_case \
+    "$inherited_root" \
+    "$inherited_root_identity" \
+    "$inherited_ledger" \
+    "$inherited_ledger_identity" \
+    3 \
+    "$expected_inherited_block"
+done
+
+invalid_staged="status: elevated bootstrap blocked stage=validate-staged-bundle error=invalid-input"
+staged_dyld="$inherited_root/usr/lib/dyld"
+saved_dyld="$workspace/staged-dyld-original"
+
+/bin/chmod 0775 "$staged_dyld"
+assert_inherited_case \
+  "$inherited_root" \
+  "$inherited_root_identity" \
+  "$inherited_ledger" \
+  "$inherited_ledger_identity" \
+  3 \
+  "$invalid_staged"
+/bin/chmod 0755 "$staged_dyld"
+
+/bin/mv "$staged_dyld" "$saved_dyld"
+assert_inherited_case \
+  "$inherited_root" \
+  "$inherited_root_identity" \
+  "$inherited_ledger" \
+  "$inherited_ledger_identity" \
+  3 \
+  "$invalid_staged"
+/bin/mv "$saved_dyld" "$staged_dyld"
+
+/bin/mv "$staged_dyld" "$saved_dyld"
+/bin/ln -s /usr/lib/dyld "$staged_dyld"
+staged_symlink_identity="$(/usr/bin/stat -f '%d:%i' "$staged_dyld")"
+assert_inherited_case \
+  "$inherited_root" \
+  "$inherited_root_identity" \
+  "$inherited_ledger" \
+  "$inherited_ledger_identity" \
+  3 \
+  "$invalid_staged"
+cleanup_symlink "$staged_dyld" /usr/lib/dyld "$staged_symlink_identity"
+/bin/mv "$saved_dyld" "$staged_dyld"
+
+/bin/mv "$staged_dyld" "$saved_dyld"
+/bin/cp -X /usr/lib/dyld "$staged_dyld"
+/usr/sbin/chown 0:0 "$staged_dyld"
+/bin/chmod 0755 "$staged_dyld"
+replacement_dyld_identity="$(/usr/bin/stat -f '%d:%i' "$staged_dyld")"
+assert_inherited_case \
+  "$inherited_root" \
+  "$inherited_root_identity" \
+  "$inherited_ledger" \
+  "$inherited_ledger_identity" \
+  3 \
+  "$invalid_staged"
+if [[ ! -f "$staged_dyld" || -L "$staged_dyld" \
+  || "$(/usr/bin/stat -f '%d:%i:%u:%g:%Lp:%l' "$staged_dyld")" \
+    != "$replacement_dyld_identity:0:0:755:1" ]] \
+  || ! /usr/bin/cmp -s /usr/lib/dyld "$staged_dyld"; then
+  echo "bangbang elevated bootstrap proof: staged replacement changed" >&2
+  exit 1
+fi
+/bin/unlink "$staged_dyld"
+/bin/mv "$saved_dyld" "$staged_dyld"
+
+staged_worker="$inherited_root/Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/MacOS/bangbang-worker"
+saved_worker="$workspace/staged-worker-original"
+/bin/mv "$staged_worker" "$saved_worker"
+assert_inherited_case \
+  "$inherited_root" \
+  "$inherited_root_identity" \
+  "$inherited_ledger" \
+  "$inherited_ledger_identity" \
+  3 \
+  "$invalid_staged"
+/bin/mv "$saved_worker" "$staged_worker"
+
+unexpected_entry="$inherited_root/unexpected-entry"
+/usr/bin/touch "$unexpected_entry"
+/usr/sbin/chown 0:0 "$unexpected_entry"
+/bin/chmod 0600 "$unexpected_entry"
+unexpected_identity="$(/usr/bin/stat -f '%d:%i' "$unexpected_entry")"
+assert_inherited_case \
+  "$inherited_root" \
+  "$inherited_root_identity" \
+  "$inherited_ledger" \
+  "$inherited_ledger_identity" \
+  3 \
+  "$invalid_staged"
+if [[ ! -f "$unexpected_entry" || -L "$unexpected_entry" \
+  || "$(/usr/bin/stat -f '%d:%i:%u:%g:%Lp:%l' "$unexpected_entry")" \
+    != "$unexpected_identity:0:0:600:1" ]]; then
+  echo "bangbang elevated bootstrap proof: unexpected entry changed" >&2
+  exit 1
+fi
+/bin/unlink "$unexpected_entry"
+
+if ! validate_staged_root \
+  "$inherited_root" \
+  "$inherited_root_identity" \
+  "$inherited_ledger" \
+  "$inherited_ledger_identity"; then
+  echo "bangbang elevated bootstrap proof: staging restoration failed" >&2
+  exit 1
+fi
 
 /bin/chmod 0770 "$probe_root"
 assert_case "$probe_root" 0 0 control 1 \
@@ -399,8 +846,6 @@ create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
   concurrent_root_a concurrent_root_a_identity
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
   concurrent_root_b concurrent_root_b_identity
-create_private_directory "/private/var/root/bangbang-elevated-work.XXXXXXXX" \
-  workspace workspace_identity
 
 set +e
 invoke "$concurrent_root_a" "$target_uid" "$target_gid" drop > "$workspace/case-a" 2>&1 &
@@ -423,4 +868,50 @@ fi
 /bin/unlink "$workspace/case-a"
 /bin/unlink "$workspace/case-b"
 
-echo "result: app-sandbox-chroot=permission-denied control=success cleanup=exact"
+create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  inherited_root_a inherited_root_a_identity
+create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  inherited_root_b inherited_root_b_identity
+inherited_ledger_a="$workspace/inherited-ledger-a"
+inherited_ledger_b="$workspace/inherited-ledger-b"
+stage_inherited_root \
+  "$inherited_root_a" \
+  "$inherited_ledger_a" \
+  inherited_ledger_a_identity
+stage_inherited_root \
+  "$inherited_root_b" \
+  "$inherited_ledger_b" \
+  inherited_ledger_b_identity
+
+set +e
+invoke_inherited \
+  "$inherited_root_a" \
+  "$inherited_root_a_identity" \
+  "$inherited_ledger_a" \
+  "$inherited_ledger_a_identity" \
+  > "$workspace/inherited-case-a" 2>&1 &
+inherited_pid_a=$!
+invoke_inherited \
+  "$inherited_root_b" \
+  "$inherited_root_b_identity" \
+  "$inherited_ledger_b" \
+  "$inherited_ledger_b_identity" \
+  > "$workspace/inherited-case-b" 2>&1 &
+inherited_pid_b=$!
+wait "$inherited_pid_a"
+inherited_status_a=$?
+wait "$inherited_pid_b"
+inherited_status_b=$?
+set -e
+inherited_output_a="$(<"$workspace/inherited-case-a")"
+inherited_output_b="$(<"$workspace/inherited-case-b")"
+if [[ "$inherited_status_a" -ne 3 || "$inherited_status_b" -ne 3 \
+  || "$inherited_output_a" != "$expected_inherited_block" \
+  || "$inherited_output_b" != "$expected_inherited_block" ]]; then
+  echo "bangbang elevated bootstrap proof: inherited concurrency case failed" >&2
+  exit 1
+fi
+/bin/unlink "$workspace/inherited-case-a"
+/bin/unlink "$workspace/inherited-case-b"
+
+echo "result: inherited-root-worker=blocked stage=worker-bootstrap error=other controls=success cleanup=exact"


### PR DESCRIPTION
## Summary

- advance the disabled elevated-bootstrap probe to a closed V2 protocol with inherited-root and real-HVF control modes
- stage and validate the exact signed probe bundle plus the current host dyld, prepare the suspended worker before launcher chroot, and clean only ledger-bound entries with exact `unlink`/`rmdir`
- record the capable-host result and correct the earlier overclaim that pre-spawn chroot necessarily prevents `posix_spawn`

## Capable-host evidence

On Apple Silicon macOS 26.5.2 / SDK 26.5 with exact root and `kern.hv_support=1`, the same unchrooted signed App Sandbox + Hypervisor worker completed real HVF create/destroy. With the launcher inside an exact root containing the complete signed bundle and current dyld, `posix_spawn` returned success, but the child exited before its first authenticated Ready record. The fixed `worker-bootstrap` / `other` result repeated three times and across two concurrent complete roots; exact cleanup and an independent residue scan passed.

This PR is evidence only. It does not change capability inventory or ownership, prove inherited App Sandbox/HVF execution, or rule out a separately challenged larger Darwin dependency set. Parent #1371 remains open.

## Verification

- `cargo fmt --all -- --check`
- capability audit delivery validation and exact pinned Firecracker v1.16.0 comparison
- `cargo check --workspace --all-targets --all-features --locked`
- unsupported-target launcher check for `aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five signed Apple-target Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` without skips (including production bundle 76/76 and signed executable 81/81)
- ordinary-user evidence bundle build, explicit-root repeated/concurrent evidence matrix, and independent residue scan

Closes #1884
