### PR TITLE
test: prove no-chroot credential bootstrap

### DIFF
--- a/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
+++ b/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
@@ -1,10 +1,11 @@
 # Elevated macOS Bootstrap Evidence
 
-This contract records the #1373 direct-worker result and the #1884
-inherited-root follow-up beneath #1371. Together they test two public orderings
-for combining Firecracker's chroot-first model with Bangbang's mandatory
-production worker boundary. They do not add a public root mode, accept jailer
-uid/gid/chroot options, or change a capability disposition by themselves.
+This contract records the #1373 direct-worker result, the #1884 inherited-root
+follow-up, and the #1885 no-chroot credential-transition result beneath #1371.
+Together they test public chroot orderings and numeric credential bootstrap
+against Bangbang's mandatory production worker boundary. They do not add a
+public root mode, accept jailer uid/gid/chroot options, or change a capability
+disposition by themselves.
 
 ## Exact test boundary
 
@@ -18,9 +19,9 @@ The evidence bundle keeps the production layout and identity split:
   suspended/live worker identity checks whenever the child reaches them; and
 - both launcher and worker probe entries are compiled only with the
   `elevated-bootstrap-probe` feature. A normal `--no-default-features` build is
-  checked for absence of the launcher-owned worker activation, ready and status
-  records, and the marker resource, and the normal signed bundle rejects the
-  internal launcher argv.
+  checked for absence of the launcher-owned worker activation, ready/status
+  records, credential modes/phases/steps, and marker resource. The normal signed
+  bundle dynamically rejects both historical and credential internal argv.
 
 The root wrapper never invokes `sudo`. It requires exact real/effective
 uid/gid zero, accepts explicit numeric target uid/gid values, runs with a
@@ -46,15 +47,38 @@ loader through no-follow descriptors, prepares every spawn object, enters the
 root with public `fchdir`/`chroot`/`chdir`, reattests `/`, and only then calls
 public `posix_spawn` with the fixed in-root worker path.
 
-In direct modes, the signed worker verifies initial root identity, the
+In direct chroot modes, the signed worker verifies initial root identity, the
 nonce-bound descriptor identity, and exact mode before `fchdir`, public
 `chroot(2)`, or `chdir("/")`. If the inherited worker reaches application
 entry, it must additionally attest that `/` and cwd are the same exact root,
 observe the direct App Sandbox chroot retry denial, and create then destroy one
-real HVF VM. No mode executes `setgroups`, `setgid`, or `setuid`. The launcher
-reports only fixed mode, stage, and error categories. Target IDs, paths,
-nonces, device/inode values, descriptor numbers, signing values, account data,
-and environment values are never reported.
+real HVF VM. Those historical modes never execute `setgroups`, `setgid`, or
+`setuid`, and their output remains unchanged.
+
+The separate no-chroot credential modes reuse the same static, suspended, and
+live code validation, root descriptor, closed environment, fixed lifecycle
+stream, and fixed grant datagram. A nonce-bound three-message datagram barrier
+proves endpoint possession before the first transition. The worker transitions
+first, reports its self-state and initial/worker-only observations, then the
+launcher transitions and responds; the worker sends the final after-both
+observation before both processes exit. The external root wrapper retains only
+bounded supervision and exact cleanup.
+
+For a nonzero target, each endpoint executes public `setgroups(0, null)`,
+`setgid`, and `setuid` in that order. Darwin's legacy `getgroups` surface reports
+the current effective gid as the sole access-list entry after supplementary
+groups are cleared, so the checked postcondition is `effective-only`, not a
+literal zero-length list. Real/effective ids must equal the target, and attempts
+to restore uid zero, gid zero, or a root group must all return permission denied
+before any later work. Retained-root performs no credential mutation and is
+reported as no-drop. The SDK-maximum unmapped numeric class is measured only at
+the syscall/postcondition boundary.
+
+Stream `getpeereid` and `LOCAL_PEERCRED`, live `LOCAL_PEERPID`, datagram
+`LOCAL_PEERCRED`, and opaque `LOCAL_PEERTOKEN` comparison remain separate
+fields. Raw IDs, paths, PIDs, tokens, nonces, descriptor numbers, signatures,
+account data, and environment values never enter records, diagnostics, or the
+checked result.
 
 ## Capable-host result
 
@@ -72,32 +96,47 @@ root authority. The complete matrix produced these results:
 | same signed App Sandbox + Hypervisor worker, unchrooted | HVF control | exact worker validation and real HVF create/destroy succeeded |
 | launcher enters staged root before spawn | inherited-root, repeated three times | static bundle/loader validation and launcher root entry succeeded; `posix_spawn` returned success, but the worker exited before the earliest Ready record (`worker-bootstrap` / `other`) |
 | two concurrent complete inherited roots | distinct staged bundle/loader trees | both returned the same `worker-bootstrap` / `other` blocker |
+| unsandboxed signed launcher credential control | mapped ordinary target and SDK-maximum unmapped target | ordered transition, `effective-only` postcondition, and all three restoration denials completed |
+| same launcher control | uid/gid-zero retained-root | initial credentials/groups remained exact with no mutating credential call |
+| fixed signed launcher + App Sandbox/Hypervisor worker, no chroot | mapped ordinary target, repeated three times | worker-first and launcher-second transitions both completed irreversibly |
+| same fixed pair | uid/gid-zero retained-root, repeated three times | both endpoints retained exact root without claiming privilege separation |
+| same fixed pair | SDK-maximum unmapped numeric target | both endpoint syscalls, postconditions, and restoration denials completed independently of account-backed runtime feasibility |
+| two concurrent fixed credential pairs | distinct exact roots/workspaces | both ordinary-target transitions completed with byte-identical bounded results |
 
 Focused negative cases reject a group-writable root and a symlink root. The
 staged manifest also rejects a writable, missing, symlinked, or inode-replaced
 loader, a missing nested worker, and an unexpected entry before worker
-activation. Every successful, rejected, repeated, and concurrent case leaves
-no root or workspace residue. Nonempty-root cleanup preflights all 20 ledger
+activation. Every successful, rejected, repeated, and concurrent case leaves no
+process, root, workspace, or named-socket residue. Nonempty-root cleanup
+preflights all 20 ledger
 entries before removing any, then uses only reverse exact `unlink`/`rmdir`;
 root cleanup rechecks device, inode, owner, group, and mode and refuses to
 remove a replacement.
+
+Across the completed nonzero transitions, both stream credential surfaces kept
+their documented connection-time root snapshot while live stream PID remained
+exact. Connected-datagram `LOCAL_PEERCRED` returned the bounded unsupported
+class; `LOCAL_PEERTOKEN` changed after a credential transition and remained
+unchanged for retained-root; datagram `LOCAL_PEERPID` remained exact after the
+nonce-bound possession barrier. No datagram `getpeereid` claim is made.
 
 The inherited result is not a missing-HVF or generally invalid-signature
 result: the same exact unchrooted signed worker completed real HVF
 create/destroy in the same wrapper run. The inherited branch nevertheless
 never reached application entry, root attestation, the direct-chroot sandbox
-control, or HVF. No guest, credential transition, lifecycle/API, or typed
-resource consumption was attempted.
+control, or HVF. The no-chroot credential branch separately reached both signed
+application endpoints, but no target-owned runtime/resource tree, typed grant,
+public lifecycle/API, guest, or post-transition HVF operation was attempted.
 
 After those results were established, the checked harness remained at the
 evidence boundary: it contains no credential-changing product path. If a
 future platform permits the direct sandboxed `chroot`, that branch reports
 `unexpected-continuation` before later work. If an inherited worker reaches
 entry, it must pass exact root, sandbox-denial, and HVF checks before success.
-Either changed result forces fresh implementation research and Challenge.
-Connected-socket credentials never cross a credential change in these measured
-branches; the harness leaves the normal peer verifier unchanged and makes no
-dynamic-versus-snapshot credential claim for #1374.
+Either changed result forces fresh implementation research and Challenge. The
+harness leaves the normal peer verifier and public launch policy unchanged.
+#1885 records bootstrap semantics only; #1374 cannot reuse its stale assumptions
+without the target-runtime/resource/lifecycle continuation selected by #1371.
 
 ## Supported conclusion and nonclaims
 
@@ -125,13 +164,16 @@ Seatbelt APIs, or switching to a different VMM process changes the challenged
 product/security model; any credible public in-root dependency alternative
 must instead be evaluated explicitly by the parent.
 
-This does not prove that numeric `setgroups`/`setgid`/`setuid` alone are
-unavailable on macOS, that no larger fixed in-root Darwin dependency set can
-bootstrap, or that inherited-root success would supply full resources,
-lifecycle, API, guest boot, daemon/crash, grant, or credential semantics. It
-does not claim Linux mount/PID/user namespace parity, certify notarized
-distribution, or generalize beyond the recorded OS/SDK behavior. A changed
-root content or future public platform requires rerunning the wrapper and a
+The measured public credential primitives are available in the exact signed
+no-chroot process shape: mapped ordinary and SDK-maximum unmapped transitions
+both completed, while zero remained an explicit no-drop class. This is not yet
+a Firecracker uid/gid implementation. It does not establish target-owned
+runtime namespace and resource ownership, typed grants, lifecycle/API,
+daemon/crash cleanup, real guest/HVF work after transition, public policy, or
+aggregate jailer behavior. It also does not prove that a larger fixed in-root
+Darwin dependency set cannot bootstrap, claim Linux mount/PID/user namespace
+parity, certify notarized distribution, or generalize beyond the recorded
+OS/SDK behavior. A future public platform requires rerunning the wrapper and a
 fresh ID-by-ID Challenge.
 
 ## Reproduction
@@ -155,8 +197,12 @@ sudo /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
   --target-gid "$target_gid"
 ```
 
-The required terminal summary is value-free:
+The required terminal summary remains value-free and includes the credential,
+observation, residue, and nonclaim classes:
 
 ```text
-result: inherited-root-worker=blocked stage=worker-bootstrap error=other controls=success cleanup=exact
+result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete controls=complete cleanup=exact
+observations: stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed-or-unchanged datagram-pid=exact
+residue: roots=zero workspaces=zero sockets=zero launchers=zero workers=zero
+nonclaims: target-runtime=unmeasured target-resources=unmeasured grants=unmeasured lifecycle-api=unmeasured daemon-crash=unmeasured guest-hvf=unmeasured public-policy=unchanged uid-gid=nonterminal chroot=unresolved aggregate-jailer=nonterminal
 ```

--- a/compat/firecracker/v1.16.0/wave8-certification-contract.md
+++ b/compat/firecracker/v1.16.0/wave8-certification-contract.md
@@ -102,13 +102,17 @@ handoffs and are not platform-impossible classifications.
 That same-host execution gate has since run on the controlled Apple Silicon
 host. The [elevated bootstrap evidence](elevated-bootstrap-evidence.md) records
 #1373's successful unsandboxed root control and repeated direct-worker chroot
-denial, plus #1884's follow-up. In the follow-up, the same unchrooted signed
+denial, plus #1884 and #1885 follow-ups. In #1884, the same unchrooted signed
 worker completed real HVF create/destroy; after the launcher entered an exact
 root containing the complete signed bundle and current dyld, `posix_spawn`
 returned success but the worker exited before the first application record.
+#1885 separately completed worker-first and launcher-second public credential
+transitions without chroot for mapped ordinary and SDK-maximum unmapped classes;
+zero remained retained-root/no-drop. Target runtime/resources, lifecycle/API,
+guest/HVF continuation, and final uid/gid disposition remain unmeasured.
 The six rows remain `audit-required` in this Wave 8 snapshot until #1371
 challenges the result and any remaining credible public alternative per ID and
-an authoritative inventory transition lands. Neither evidence PR silently
+an authoritative inventory transition lands. No evidence PR silently
 rewrites this checked historical boundary.
 
 The direct #1348 delivery-parent policy retains #1351 open and requires the

--- a/crates/bangbang/src/elevated_bootstrap_probe.rs
+++ b/crates/bangbang/src/elevated_bootstrap_probe.rs
@@ -3,16 +3,25 @@ use std::ffi::OsStr;
 use std::io::{self, Read, Write};
 use std::mem::MaybeUninit;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
-use std::os::unix::net::UnixStream;
+use std::os::unix::net::{UnixDatagram, UnixStream};
 use std::process::ExitCode;
+use std::time::Duration;
 
 use bangbang_hvf::HvfBackend;
 use bangbang_runtime::VmBackend;
 use bangbang_session::elevated_probe::{
-    BOOTSTRAP_RECORD_BYTES, ProbeBootstrap, ProbeErrorCategory, ProbeResult, ProbeStage,
-    READY_RECORD, RESULT_RECORD_BYTES, ROOT_FD, WORKER_ACTIVATION,
+    BOOTSTRAP_RECORD_BYTES, CREDENTIAL_DATAGRAM_BYTES, CREDENTIAL_RECORD_BYTES,
+    CredentialDatagramPhase, CredentialDatagramProof, CredentialFailureValue, CredentialGroupClass,
+    CredentialIdentityClass, CredentialPrefix, CredentialRecord, CredentialRecordKind,
+    CredentialRole, CredentialSelfState, CredentialStep, PeerObservation, ProbeBootstrap,
+    ProbeErrorCategory, ProbeResult, ProbeStage, READY_RECORD, RESULT_RECORD_BYTES, ROOT_FD,
+    WORKER_ACTIVATION,
 };
-use bangbang_session::{ObjectIdentity, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD};
+use bangbang_session::{GRANT_FD, ObjectIdentity, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD};
+
+const CREDENTIAL_TIMEOUT: Duration = Duration::from_secs(5);
+const CREDENTIAL_WORKER_ARTIFACT: &str =
+    "bangbang-elevated-credential-worker-v1-credential-drop-BBC1-BBG1-restore-groups";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ProbeError {
@@ -27,10 +36,13 @@ pub(crate) fn is_requested() -> bool {
 }
 
 pub(crate) fn run() -> ExitCode {
-    let (mut stream, bootstrap) = match probe_session() {
+    let (mut stream, bootstrap, parent) = match probe_session() {
         Ok(session) => session,
         Err(_) => return ExitCode::FAILURE,
     };
+    if bootstrap.mode().is_credential_pair() {
+        return run_credential_pair(stream, bootstrap, parent);
+    }
     let outcome = execute(bootstrap);
     let result = match outcome {
         Ok(()) => ProbeResult::success(bootstrap.mode(), bootstrap.nonce()),
@@ -56,7 +68,7 @@ pub(crate) fn run() -> ExitCode {
     }
 }
 
-fn probe_session() -> Result<(UnixStream, ProbeBootstrap), ProbeError> {
+fn probe_session() -> Result<(UnixStream, ProbeBootstrap, libc::pid_t), ProbeError> {
     let arguments = env::args_os().skip(1).collect::<Vec<_>>();
     if arguments.as_slice() != [OsStr::new(WORKER_ACTIVATION)] {
         return Err(invalid(ProbeStage::InitialIdentity));
@@ -87,17 +99,379 @@ fn probe_session() -> Result<(UnixStream, ProbeBootstrap), ProbeError> {
         .map_err(|error| with_kind(ProbeStage::InitialIdentity, error.kind()))?;
     let bootstrap =
         ProbeBootstrap::decode(&encoded).map_err(|_| invalid(ProbeStage::InitialIdentity))?;
-    Ok((stream, bootstrap))
+    Ok((stream, bootstrap, parent))
 }
 
-fn execute(config: ProbeBootstrap) -> Result<(), ProbeError> {
-    validate_initial_identity()?;
+fn run_credential_pair(
+    mut stream: UnixStream,
+    bootstrap: ProbeBootstrap,
+    parent: libc::pid_t,
+) -> ExitCode {
+    std::hint::black_box(CREDENTIAL_WORKER_ARTIFACT);
+    if stream.set_read_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
+        || stream.set_write_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
+    {
+        return ExitCode::FAILURE;
+    }
+    if let Err(error) = validate_initial_identity() {
+        return write_credential_failure(
+            &mut stream,
+            bootstrap,
+            CredentialFailureValue::new(
+                CredentialStep::InitialIdentity,
+                ProbeErrorCategory::from_io_kind(error.kind),
+                CredentialPrefix::None,
+                initial_credential_state(bootstrap),
+            ),
+            PeerObservation::NONE,
+        );
+    }
+    let root = match take_root(bootstrap) {
+        Ok(root) => root,
+        Err(error) => {
+            return write_credential_failure(
+                &mut stream,
+                bootstrap,
+                CredentialFailureValue::new(
+                    CredentialStep::InitialIdentity,
+                    ProbeErrorCategory::from_io_kind(error.kind),
+                    CredentialPrefix::None,
+                    initial_credential_state(bootstrap),
+                ),
+                PeerObservation::NONE,
+            );
+        }
+    };
+    drop(root);
+    let grants = match take_grants() {
+        Ok(grants) => grants,
+        Err(category) => {
+            return write_credential_failure(
+                &mut stream,
+                bootstrap,
+                credential_failure(
+                    CredentialStep::Protocol,
+                    category,
+                    CredentialPrefix::None,
+                    initial_credential_state(bootstrap),
+                ),
+                PeerObservation::NONE,
+            );
+        }
+    };
+    if grants.set_read_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
+        || grants.set_write_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
+    {
+        return write_credential_failure(
+            &mut stream,
+            bootstrap,
+            credential_failure(
+                CredentialStep::Protocol,
+                ProbeErrorCategory::Other,
+                CredentialPrefix::None,
+                initial_credential_state(bootstrap),
+            ),
+            PeerObservation::NONE,
+        );
+    }
+    match receive_credential_datagram(&grants) {
+        Ok(proof)
+            if proof.matches_expected(
+                bootstrap.mode(),
+                CredentialDatagramPhase::Challenge,
+                CredentialRole::Launcher,
+                bootstrap.nonce(),
+            ) => {}
+        Ok(_) | Err(_) => {
+            return write_credential_failure(
+                &mut stream,
+                bootstrap,
+                credential_failure(
+                    CredentialStep::Protocol,
+                    ProbeErrorCategory::InvalidInput,
+                    CredentialPrefix::None,
+                    initial_credential_state(bootstrap),
+                ),
+                PeerObservation::NONE,
+            );
+        }
+    }
+    let Ok(worker_ready) =
+        CredentialDatagramProof::worker_ready(bootstrap.mode(), bootstrap.nonce())
+    else {
+        return ExitCode::FAILURE;
+    };
+    if send_credential_datagram(&grants, worker_ready).is_err() {
+        return ExitCode::FAILURE;
+    }
+    match receive_credential_datagram(&grants) {
+        Ok(proof)
+            if proof.matches_expected(
+                bootstrap.mode(),
+                CredentialDatagramPhase::LauncherRelease,
+                CredentialRole::Launcher,
+                bootstrap.nonce(),
+            ) => {}
+        Ok(_) | Err(_) => {
+            return write_credential_failure(
+                &mut stream,
+                bootstrap,
+                credential_failure(
+                    CredentialStep::Protocol,
+                    ProbeErrorCategory::InvalidInput,
+                    CredentialPrefix::None,
+                    initial_credential_state(bootstrap),
+                ),
+                PeerObservation::NONE,
+            );
+        }
+    }
+    let (initial, baseline) = match bangbang_session::elevated_credential::observe_initial_peer(
+        stream.as_raw_fd(),
+        grants.as_raw_fd(),
+        parent,
+        parent,
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+    ) {
+        Ok(observation) => observation,
+        Err(category) => {
+            return write_credential_failure(
+                &mut stream,
+                bootstrap,
+                credential_failure(
+                    CredentialStep::PeerObservation,
+                    category,
+                    CredentialPrefix::None,
+                    initial_credential_state(bootstrap),
+                ),
+                PeerObservation::NONE,
+            );
+        }
+    };
+    let transition = match bangbang_session::elevated_credential::transition_process(
+        bootstrap.mode(),
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+    ) {
+        Ok(transition) => transition,
+        Err(failure) => {
+            return write_credential_failure(&mut stream, bootstrap, failure, initial);
+        }
+    };
+    let after_worker = match bangbang_session::elevated_credential::observe_later_peer(
+        stream.as_raw_fd(),
+        grants.as_raw_fd(),
+        parent,
+        parent,
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+        &baseline,
+    ) {
+        Ok(observation) => observation,
+        Err(category) => {
+            return write_credential_failure(
+                &mut stream,
+                bootstrap,
+                credential_failure(
+                    CredentialStep::PeerObservation,
+                    category,
+                    transition.prefix(),
+                    transition.state(),
+                ),
+                initial,
+            );
+        }
+    };
+    let Ok(record) = CredentialRecord::worker_transitioned(
+        bootstrap.mode(),
+        transition.state(),
+        initial,
+        after_worker,
+        bootstrap.nonce(),
+    ) else {
+        return ExitCode::FAILURE;
+    };
+    if stream.write_all(&record.encode()).is_err() {
+        return ExitCode::FAILURE;
+    }
+
+    let launcher = match read_credential_record(&mut stream) {
+        Ok(record)
+            if record.matches_exchange(
+                bootstrap.mode(),
+                CredentialRole::Launcher,
+                bootstrap.nonce(),
+            ) =>
+        {
+            record
+        }
+        Ok(_) | Err(_) => {
+            return write_credential_failure(
+                &mut stream,
+                bootstrap,
+                credential_failure(
+                    CredentialStep::Protocol,
+                    ProbeErrorCategory::InvalidInput,
+                    transition.prefix(),
+                    transition.state(),
+                ),
+                initial,
+            );
+        }
+    };
+    match launcher.kind() {
+        CredentialRecordKind::Failure => return ExitCode::FAILURE,
+        CredentialRecordKind::LauncherTransitioned => {}
+        CredentialRecordKind::WorkerTransitioned | CredentialRecordKind::WorkerFinal => {
+            return write_credential_failure(
+                &mut stream,
+                bootstrap,
+                credential_failure(
+                    CredentialStep::Protocol,
+                    ProbeErrorCategory::InvalidInput,
+                    transition.prefix(),
+                    transition.state(),
+                ),
+                initial,
+            );
+        }
+    }
+    let after_both = match bangbang_session::elevated_credential::observe_later_peer(
+        stream.as_raw_fd(),
+        grants.as_raw_fd(),
+        parent,
+        parent,
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+        &baseline,
+    ) {
+        Ok(observation) => observation,
+        Err(category) => {
+            return write_credential_failure(
+                &mut stream,
+                bootstrap,
+                credential_failure(
+                    CredentialStep::PeerObservation,
+                    category,
+                    transition.prefix(),
+                    transition.state(),
+                ),
+                initial,
+            );
+        }
+    };
+    let Ok(final_record) = CredentialRecord::worker_final(
+        bootstrap.mode(),
+        transition.state(),
+        [initial, after_worker, after_both],
+        bootstrap.nonce(),
+    ) else {
+        return ExitCode::FAILURE;
+    };
+    if stream.write_all(&final_record.encode()).is_err() {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn take_root(bootstrap: ProbeBootstrap) -> Result<OwnedFd, ProbeError> {
     bangbang_session::macos::set_cloexec(ROOT_FD)
         .map_err(|error| with_kind(ProbeStage::TakeRoot, error.kind()))?;
     // SAFETY: The feature-gated production spawn contract transfers fixed fd 8
     // exactly once to this process.
     let root = unsafe { OwnedFd::from_raw_fd(ROOT_FD) };
-    validate_root(root.as_raw_fd(), config.root())?;
+    validate_root(root.as_raw_fd(), bootstrap.root())?;
+    Ok(root)
+}
+
+fn take_grants() -> Result<UnixDatagram, ProbeErrorCategory> {
+    bangbang_session::macos::set_cloexec(GRANT_FD)
+        .map_err(|error| ProbeErrorCategory::from_io_kind(error.kind()))?;
+    // SAFETY: The production spawn contract transfers fixed fd 4 exactly once
+    // to this process, and credential mode consumes it instead of normal grants.
+    let owned = unsafe { OwnedFd::from_raw_fd(GRANT_FD) };
+    Ok(UnixDatagram::from(owned))
+}
+
+fn receive_credential_datagram(
+    grants: &UnixDatagram,
+) -> Result<CredentialDatagramProof, ProbeErrorCategory> {
+    let mut encoded = [0_u8; CREDENTIAL_DATAGRAM_BYTES + 1];
+    let length = grants
+        .recv(&mut encoded)
+        .map_err(|error| ProbeErrorCategory::from_io_kind(error.kind()))?;
+    if length != CREDENTIAL_DATAGRAM_BYTES {
+        return Err(ProbeErrorCategory::InvalidInput);
+    }
+    let exact = encoded[..CREDENTIAL_DATAGRAM_BYTES]
+        .try_into()
+        .map_err(|_| ProbeErrorCategory::InvalidInput)?;
+    CredentialDatagramProof::decode(exact).map_err(|_| ProbeErrorCategory::InvalidInput)
+}
+
+fn send_credential_datagram(
+    grants: &UnixDatagram,
+    proof: CredentialDatagramProof,
+) -> Result<(), ProbeErrorCategory> {
+    let encoded = proof.encode();
+    let length = grants
+        .send(&encoded)
+        .map_err(|error| ProbeErrorCategory::from_io_kind(error.kind()))?;
+    if length == encoded.len() {
+        Ok(())
+    } else {
+        Err(ProbeErrorCategory::InvalidInput)
+    }
+}
+
+fn read_credential_record(stream: &mut UnixStream) -> Result<CredentialRecord, ()> {
+    let mut encoded = [0_u8; CREDENTIAL_RECORD_BYTES];
+    stream.read_exact(&mut encoded).map_err(|_| ())?;
+    CredentialRecord::decode(&encoded).map_err(|_| ())
+}
+
+fn write_credential_failure(
+    stream: &mut UnixStream,
+    bootstrap: ProbeBootstrap,
+    failure: CredentialFailureValue,
+    initial: PeerObservation,
+) -> ExitCode {
+    let Ok(record) = CredentialRecord::failure(
+        bootstrap.mode(),
+        CredentialRole::Worker,
+        failure,
+        initial,
+        bootstrap.nonce(),
+    ) else {
+        return ExitCode::FAILURE;
+    };
+    let _ = stream.write_all(&record.encode());
+    ExitCode::FAILURE
+}
+
+const fn credential_failure(
+    step: CredentialStep,
+    category: ProbeErrorCategory,
+    prefix: CredentialPrefix,
+    state: CredentialSelfState,
+) -> CredentialFailureValue {
+    CredentialFailureValue::new(step, category, prefix, state)
+}
+
+const fn initial_credential_state(bootstrap: ProbeBootstrap) -> CredentialSelfState {
+    let identity = if bootstrap.mode().retains_root() {
+        CredentialIdentityClass::InitialAndTarget
+    } else {
+        CredentialIdentityClass::InitialRoot
+    };
+    CredentialSelfState::new(identity, CredentialGroupClass::Other)
+}
+
+fn execute(config: ProbeBootstrap) -> Result<(), ProbeError> {
+    validate_initial_identity()?;
+    let root = take_root(config)?;
     match config.mode() {
         bangbang_session::elevated_probe::ProbeMode::HvfControl => {
             drop(root);
@@ -112,7 +486,11 @@ fn execute(config: ProbeBootstrap) -> Result<(), ProbeError> {
         bangbang_session::elevated_probe::ProbeMode::Drop
         | bangbang_session::elevated_probe::ProbeMode::RetainRoot
         | bangbang_session::elevated_probe::ProbeMode::UnmappedSyscall => {}
-        bangbang_session::elevated_probe::ProbeMode::Control => {
+        bangbang_session::elevated_probe::ProbeMode::Control
+        | bangbang_session::elevated_probe::ProbeMode::CredentialDrop
+        | bangbang_session::elevated_probe::ProbeMode::CredentialRetainRoot
+        | bangbang_session::elevated_probe::ProbeMode::CredentialUnmapped
+        | bangbang_session::elevated_probe::ProbeMode::CredentialControl => {
             return Err(invalid(ProbeStage::InitialIdentity));
         }
     }
@@ -430,5 +808,33 @@ mod tests {
             .expect_err("destroy failure should be reported");
         assert_eq!(failure.stage, ProbeStage::HvfDestroy);
         assert_eq!(destroy_failure.calls, ["create", "destroy"]);
+    }
+
+    #[test]
+    fn credential_transport_rejects_disconnect_timeout_and_wrong_length() {
+        let (mut stream, peer) = UnixStream::pair().expect("stream pair should construct");
+        drop(peer);
+        assert!(
+            read_credential_record(&mut stream).is_err(),
+            "stream endpoint death must not produce a phase record"
+        );
+
+        let (datagram, peer) = UnixDatagram::pair().expect("datagram pair should construct");
+        peer.send(&[0; CREDENTIAL_DATAGRAM_BYTES - 1])
+            .expect("short datagram should send");
+        assert_eq!(
+            receive_credential_datagram(&datagram),
+            Err(ProbeErrorCategory::InvalidInput)
+        );
+
+        let (datagram, peer) = UnixDatagram::pair().expect("datagram pair should construct");
+        datagram
+            .set_read_timeout(Some(Duration::from_millis(10)))
+            .expect("datagram timeout should configure");
+        drop(peer);
+        assert!(
+            receive_credential_datagram(&datagram).is_err(),
+            "a dead datagram endpoint must fail or time out without advancing"
+        );
     }
 }

--- a/crates/launcher/src/elevated_probe.rs
+++ b/crates/launcher/src/elevated_probe.rs
@@ -180,6 +180,35 @@ impl Config {
         Ok(())
     }
 
+    pub(crate) fn run_credential_control(
+        &self,
+    ) -> Result<
+        bangbang_session::elevated_credential::CredentialTransition,
+        bangbang_session::elevated_probe::CredentialFailureValue,
+    > {
+        use bangbang_session::elevated_probe::{
+            CredentialFailureValue, CredentialGroupClass, CredentialIdentityClass,
+            CredentialPrefix, CredentialSelfState, CredentialStep,
+        };
+
+        if self.mode != ProbeMode::CredentialControl {
+            return Err(CredentialFailureValue::new(
+                CredentialStep::InitialIdentity,
+                ProbeErrorCategory::InvalidInput,
+                CredentialPrefix::None,
+                CredentialSelfState::new(
+                    CredentialIdentityClass::Other,
+                    CredentialGroupClass::Other,
+                ),
+            ));
+        }
+        bangbang_session::elevated_credential::transition_process(
+            self.mode,
+            self.target_uid,
+            self.target_gid,
+        )
+    }
+
     pub(crate) fn enter_inherited_root(&self) -> Result<(), ProbeFailure> {
         if self.mode != ProbeMode::InheritedRoot {
             return Err(ProbeFailure {

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -64,6 +64,29 @@ where
             println!("status: elevated bootstrap control complete");
             return Ok(LauncherExit(0));
         }
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        if elevated_probe.as_ref().is_some_and(|probe| {
+            probe.mode() == bangbang_session::elevated_probe::ProbeMode::CredentialControl
+        }) {
+            let probe = elevated_probe
+                .as_ref()
+                .ok_or(LauncherError::InvalidLaunchPolicy)?;
+            return match probe.run_credential_control() {
+                Ok(transition) => {
+                    println!(
+                        "status: elevated credential credential-control complete prefix={} identity={} groups={}",
+                        transition.prefix().name(),
+                        transition.state().identity().name(),
+                        transition.state().groups().name()
+                    );
+                    Ok(LauncherExit(0))
+                }
+                Err(failure) => Ok(credential_blocked_value(
+                    bangbang_session::elevated_probe::CredentialRole::Launcher,
+                    failure,
+                )),
+            };
+        }
         if let Some(mut bootstrap) = child_bootstrap {
             let result = (|| {
                 if !request.requests_daemonize()
@@ -319,6 +342,18 @@ fn finish_elevated_exchange(
         }
         return Err(LauncherError::SessionProtocol);
     }
+    if bootstrap.mode().is_credential_pair() {
+        let (initial, baseline) = match begin_credential_exchange(&mut spawned, bootstrap) {
+            Ok(initial) => initial,
+            Err(failure) => {
+                return Ok(credential_blocked_value(
+                    bangbang_session::elevated_probe::CredentialRole::Launcher,
+                    failure,
+                ));
+            }
+        };
+        return finish_credential_exchange(spawned, bootstrap, initial, baseline);
+    }
     let mut encoded_result = [0_u8; RESULT_RECORD_BYTES];
     if spawned.session.read_exact(&mut encoded_result).is_err() {
         if inherited_root {
@@ -390,6 +425,575 @@ fn finish_elevated_exchange(
         )),
         Ok(()) | Err(_) => Err(LauncherError::SessionProtocol),
     }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+const fn credential_initial_state(
+    bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
+) -> bangbang_session::elevated_probe::CredentialSelfState {
+    use bangbang_session::elevated_probe::{
+        CredentialGroupClass, CredentialIdentityClass, CredentialSelfState,
+    };
+
+    CredentialSelfState::new(
+        if bootstrap.mode().retains_root() {
+            CredentialIdentityClass::InitialAndTarget
+        } else {
+            CredentialIdentityClass::InitialRoot
+        },
+        CredentialGroupClass::Other,
+    )
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn begin_credential_exchange(
+    spawned: &mut crate::macos::spawn::SuspendedWorker,
+    bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
+) -> Result<
+    (
+        bangbang_session::elevated_probe::PeerObservation,
+        bangbang_session::elevated_credential::PeerBaseline,
+    ),
+    bangbang_session::elevated_probe::CredentialFailureValue,
+> {
+    use std::os::fd::AsRawFd;
+    use std::time::Duration;
+
+    use bangbang_session::elevated_probe::{
+        CredentialDatagramPhase, CredentialDatagramProof, CredentialFailureValue, CredentialPrefix,
+        CredentialRole, CredentialStep, ProbeErrorCategory,
+    };
+
+    const TIMEOUT: Duration = Duration::from_secs(5);
+    const CREDENTIAL_LAUNCHER_ARTIFACT: &str =
+        "bangbang-elevated-credential-launcher-v1-credential-drop-BBC1-BBG1-restore-groups";
+
+    std::hint::black_box(CREDENTIAL_LAUNCHER_ARTIFACT);
+
+    let protocol_failure = |category| {
+        CredentialFailureValue::new(
+            CredentialStep::Protocol,
+            category,
+            CredentialPrefix::None,
+            credential_initial_state(bootstrap),
+        )
+    };
+    spawned
+        .grants
+        .set_read_timeout(Some(TIMEOUT))
+        .map_err(|error| protocol_failure(ProbeErrorCategory::from_io_kind(error.kind())))?;
+    spawned
+        .grants
+        .set_write_timeout(Some(TIMEOUT))
+        .map_err(|error| protocol_failure(ProbeErrorCategory::from_io_kind(error.kind())))?;
+    let challenge = CredentialDatagramProof::challenge(bootstrap.mode(), bootstrap.nonce())
+        .map_err(|_| protocol_failure(ProbeErrorCategory::InvalidInput))?;
+    send_credential_datagram(&spawned.grants, challenge).map_err(protocol_failure)?;
+    let worker_ready = receive_credential_datagram(&spawned.grants).map_err(protocol_failure)?;
+    if !worker_ready.matches_expected(
+        bootstrap.mode(),
+        CredentialDatagramPhase::WorkerReady,
+        CredentialRole::Worker,
+        bootstrap.nonce(),
+    ) {
+        return Err(protocol_failure(ProbeErrorCategory::InvalidInput));
+    }
+    // SAFETY: `getpid` has no pointer or ownership contract.
+    let socket_creator = unsafe { libc::getpid() };
+    let (initial, baseline) = bangbang_session::elevated_credential::observe_initial_peer(
+        spawned.session.as_raw_fd(),
+        spawned.grants.as_raw_fd(),
+        spawned.worker.pid(),
+        socket_creator,
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+    )
+    .map_err(|category| {
+        CredentialFailureValue::new(
+            CredentialStep::PeerObservation,
+            category,
+            CredentialPrefix::None,
+            credential_initial_state(bootstrap),
+        )
+    })?;
+    let release = CredentialDatagramProof::launcher_release(bootstrap.mode(), bootstrap.nonce())
+        .map_err(|_| protocol_failure(ProbeErrorCategory::InvalidInput))?;
+    send_credential_datagram(&spawned.grants, release).map_err(protocol_failure)?;
+    Ok((initial, baseline))
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn receive_credential_datagram(
+    grants: &std::os::unix::net::UnixDatagram,
+) -> Result<
+    bangbang_session::elevated_probe::CredentialDatagramProof,
+    bangbang_session::elevated_probe::ProbeErrorCategory,
+> {
+    use bangbang_session::elevated_probe::{
+        CREDENTIAL_DATAGRAM_BYTES, CredentialDatagramProof, ProbeErrorCategory,
+    };
+
+    let mut encoded = [0_u8; CREDENTIAL_DATAGRAM_BYTES + 1];
+    let length = grants
+        .recv(&mut encoded)
+        .map_err(|error| ProbeErrorCategory::from_io_kind(error.kind()))?;
+    if length != CREDENTIAL_DATAGRAM_BYTES {
+        return Err(ProbeErrorCategory::InvalidInput);
+    }
+    let exact = encoded[..CREDENTIAL_DATAGRAM_BYTES]
+        .try_into()
+        .map_err(|_| ProbeErrorCategory::InvalidInput)?;
+    CredentialDatagramProof::decode(exact).map_err(|_| ProbeErrorCategory::InvalidInput)
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn send_credential_datagram(
+    grants: &std::os::unix::net::UnixDatagram,
+    proof: bangbang_session::elevated_probe::CredentialDatagramProof,
+) -> Result<(), bangbang_session::elevated_probe::ProbeErrorCategory> {
+    use bangbang_session::elevated_probe::ProbeErrorCategory;
+
+    let encoded = proof.encode();
+    let length = grants
+        .send(&encoded)
+        .map_err(|error| ProbeErrorCategory::from_io_kind(error.kind()))?;
+    if length == encoded.len() {
+        Ok(())
+    } else {
+        Err(ProbeErrorCategory::InvalidInput)
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn finish_credential_exchange(
+    mut spawned: crate::macos::spawn::SuspendedWorker,
+    bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
+    initial: bangbang_session::elevated_probe::PeerObservation,
+    baseline: bangbang_session::elevated_credential::PeerBaseline,
+) -> Result<LauncherExit, LauncherError> {
+    use std::io::{Read, Write};
+    use std::os::fd::AsRawFd;
+
+    use bangbang_session::elevated_probe::{
+        CREDENTIAL_RECORD_BYTES, CredentialFailureValue, CredentialPrefix, CredentialRecord,
+        CredentialRecordKind, CredentialRole, CredentialSelfState, CredentialStep, PeerObservation,
+        ProbeErrorCategory,
+    };
+
+    // SAFETY: `getpid` has no pointer or ownership contract and remains stable
+    // across this process's credential transition.
+    let socket_creator = unsafe { libc::getpid() };
+
+    let worker_transitioned = match read_credential_record(&mut spawned.session) {
+        Ok(record)
+            if record.matches_exchange(
+                bootstrap.mode(),
+                CredentialRole::Worker,
+                bootstrap.nonce(),
+            ) =>
+        {
+            match record.kind() {
+                CredentialRecordKind::WorkerTransitioned => record,
+                CredentialRecordKind::Failure => {
+                    credential_wait_for_exit(&mut spawned, 1)?;
+                    return credential_blocked_record(record);
+                }
+                CredentialRecordKind::LauncherTransitioned | CredentialRecordKind::WorkerFinal => {
+                    return send_launcher_failure_and_wait(
+                        &mut spawned,
+                        bootstrap,
+                        protocol_failure(credential_initial_state(bootstrap)),
+                        initial,
+                    );
+                }
+            }
+        }
+        Ok(_) | Err(_) => {
+            return send_launcher_failure_and_wait(
+                &mut spawned,
+                bootstrap,
+                protocol_failure(credential_initial_state(bootstrap)),
+                initial,
+            );
+        }
+    };
+
+    let after_worker = match bangbang_session::elevated_credential::observe_later_peer(
+        spawned.session.as_raw_fd(),
+        spawned.grants.as_raw_fd(),
+        spawned.worker.pid(),
+        socket_creator,
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+        &baseline,
+    ) {
+        Ok(observation) => observation,
+        Err(category) => {
+            return send_launcher_failure_and_wait(
+                &mut spawned,
+                bootstrap,
+                CredentialFailureValue::new(
+                    CredentialStep::PeerObservation,
+                    category,
+                    CredentialPrefix::None,
+                    credential_initial_state(bootstrap),
+                ),
+                initial,
+            );
+        }
+    };
+    let transition = match bangbang_session::elevated_credential::transition_process(
+        bootstrap.mode(),
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+    ) {
+        Ok(transition) => transition,
+        Err(failure) => {
+            return send_launcher_failure_and_wait(&mut spawned, bootstrap, failure, initial);
+        }
+    };
+    let after_both = match bangbang_session::elevated_credential::observe_later_peer(
+        spawned.session.as_raw_fd(),
+        spawned.grants.as_raw_fd(),
+        spawned.worker.pid(),
+        socket_creator,
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+        &baseline,
+    ) {
+        Ok(observation) => observation,
+        Err(category) => {
+            return send_launcher_failure_and_wait(
+                &mut spawned,
+                bootstrap,
+                CredentialFailureValue::new(
+                    CredentialStep::PeerObservation,
+                    category,
+                    transition.prefix(),
+                    transition.state(),
+                ),
+                initial,
+            );
+        }
+    };
+    let launcher_observations = [initial, after_worker, after_both];
+    let launcher_record = CredentialRecord::launcher_transitioned(
+        bootstrap.mode(),
+        transition.state(),
+        launcher_observations,
+        bootstrap.nonce(),
+    )
+    .map_err(|_| LauncherError::SessionProtocol)?;
+    if spawned
+        .session
+        .write_all(&launcher_record.encode())
+        .is_err()
+    {
+        return Err(LauncherError::SessionProtocol);
+    }
+
+    let worker_final = match read_credential_record(&mut spawned.session) {
+        Ok(record)
+            if record.matches_exchange(
+                bootstrap.mode(),
+                CredentialRole::Worker,
+                bootstrap.nonce(),
+            ) =>
+        {
+            match record.kind() {
+                CredentialRecordKind::WorkerFinal => record,
+                CredentialRecordKind::Failure => {
+                    credential_wait_for_exit(&mut spawned, 1)?;
+                    return credential_blocked_record(record);
+                }
+                CredentialRecordKind::WorkerTransitioned
+                | CredentialRecordKind::LauncherTransitioned => {
+                    credential_wait_for_exit(&mut spawned, 1)?;
+                    return Ok(credential_blocked_value(
+                        CredentialRole::Launcher,
+                        protocol_failure(transition.state()),
+                    ));
+                }
+            }
+        }
+        Ok(_) | Err(_) => {
+            credential_wait_for_exit(&mut spawned, 1)?;
+            return Ok(credential_blocked_value(
+                CredentialRole::Launcher,
+                protocol_failure(transition.state()),
+            ));
+        }
+    };
+    credential_wait_for_exit(&mut spawned, 0)?;
+
+    let worker_initial = worker_transitioned.observations();
+    let worker_observations = worker_final.observations();
+    if worker_initial[0] != worker_observations[0]
+        || worker_initial[1] != worker_observations[1]
+        || !worker_initial[2].is_none()
+    {
+        return Ok(credential_blocked_value(
+            CredentialRole::Launcher,
+            protocol_failure(transition.state()),
+        ));
+    }
+    let semantics =
+        credential_semantics(bootstrap.mode(), launcher_observations, worker_observations)
+            .ok_or(LauncherError::SessionProtocol)?;
+    println!(
+        "status: elevated credential {} complete stream-eid={} stream-cred={} stream-pid=exact datagram-cred={} datagram-token={} datagram-pid={}",
+        bootstrap.mode().name(),
+        semantics.stream_eid,
+        semantics.stream_cred,
+        semantics.datagram_cred,
+        semantics.datagram_token,
+        semantics.datagram_pid
+    );
+    return Ok(LauncherExit(0));
+
+    fn read_credential_record(
+        stream: &mut std::os::unix::net::UnixStream,
+    ) -> Result<CredentialRecord, ()> {
+        let mut encoded = [0_u8; CREDENTIAL_RECORD_BYTES];
+        stream.read_exact(&mut encoded).map_err(|_| ())?;
+        CredentialRecord::decode(&encoded).map_err(|_| ())
+    }
+
+    const fn protocol_failure(state: CredentialSelfState) -> CredentialFailureValue {
+        CredentialFailureValue::new(
+            CredentialStep::Protocol,
+            ProbeErrorCategory::InvalidInput,
+            CredentialPrefix::None,
+            state,
+        )
+    }
+
+    fn send_launcher_failure_and_wait(
+        spawned: &mut crate::macos::spawn::SuspendedWorker,
+        bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
+        failure: CredentialFailureValue,
+        initial: PeerObservation,
+    ) -> Result<LauncherExit, LauncherError> {
+        let record = CredentialRecord::failure(
+            bootstrap.mode(),
+            CredentialRole::Launcher,
+            failure,
+            initial,
+            bootstrap.nonce(),
+        )
+        .map_err(|_| LauncherError::SessionProtocol)?;
+        let _ = spawned.session.write_all(&record.encode());
+        credential_wait_for_exit(spawned, 1)?;
+        Ok(credential_blocked_value(CredentialRole::Launcher, failure))
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn credential_wait_for_exit(
+    spawned: &mut crate::macos::spawn::SuspendedWorker,
+    expected: u8,
+) -> Result<(), LauncherError> {
+    use std::time::{Duration, Instant};
+
+    const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+    const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+    let deadline = Instant::now()
+        .checked_add(WAIT_TIMEOUT)
+        .ok_or(LauncherError::SessionProtocol)?;
+    loop {
+        if let Some(status) = spawned.worker.try_wait()? {
+            let exit = map_exit_status(status)?;
+            return if exit.code() == expected {
+                Ok(())
+            } else {
+                Err(LauncherError::SessionProtocol)
+            };
+        }
+        if Instant::now() >= deadline {
+            spawned.worker.terminate_and_reap();
+            return Err(LauncherError::SessionProtocol);
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn credential_blocked_record(
+    record: bangbang_session::elevated_probe::CredentialRecord,
+) -> Result<LauncherExit, LauncherError> {
+    use bangbang_session::elevated_probe::{CredentialFailureValue, CredentialSelfState};
+
+    let (step, category, prefix) = record
+        .failure_value()
+        .ok_or(LauncherError::SessionProtocol)?;
+    Ok(credential_blocked_value(
+        record.role(),
+        CredentialFailureValue::new(
+            step,
+            category,
+            prefix,
+            CredentialSelfState::new(record.identity(), record.groups()),
+        ),
+    ))
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn credential_blocked_value(
+    role: bangbang_session::elevated_probe::CredentialRole,
+    failure: bangbang_session::elevated_probe::CredentialFailureValue,
+) -> LauncherExit {
+    println!(
+        "status: elevated credential blocked role={} step={} error={} prefix={} identity={} groups={}",
+        role.name(),
+        failure.step().name(),
+        failure.category().name(),
+        failure.prefix().name(),
+        failure.state().identity().name(),
+        failure.state().groups().name()
+    );
+    LauncherExit(3)
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+struct CredentialSemantics {
+    stream_eid: &'static str,
+    stream_cred: &'static str,
+    datagram_cred: &'static str,
+    datagram_token: &'static str,
+    datagram_pid: &'static str,
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn credential_semantics(
+    mode: bangbang_session::elevated_probe::ProbeMode,
+    launcher: [bangbang_session::elevated_probe::PeerObservation; 3],
+    worker: [bangbang_session::elevated_probe::PeerObservation; 3],
+) -> Option<CredentialSemantics> {
+    use bangbang_session::elevated_probe::{PeerPidClass, PeerTokenClass};
+
+    if launcher
+        .iter()
+        .chain(worker.iter())
+        .any(|observation| observation.stream_pid() != PeerPidClass::Exact)
+    {
+        return None;
+    }
+    let datagram_pid = if launcher
+        .iter()
+        .all(|observation| observation.datagram_pid() == PeerPidClass::Exact)
+        && worker
+            .iter()
+            .all(|observation| observation.datagram_pid() == PeerPidClass::Exact)
+    {
+        "exact"
+    } else if launcher
+        .iter()
+        .all(|observation| observation.datagram_pid() == PeerPidClass::SocketCreator)
+        && worker
+            .iter()
+            .all(|observation| observation.datagram_pid() == PeerPidClass::Exact)
+    {
+        "creator-snapshot"
+    } else {
+        return None;
+    };
+    let stream_eid = identity_semantic(mode, launcher, worker, |value| value.stream_eid())?;
+    let stream_cred = identity_semantic(mode, launcher, worker, |value| value.stream_cred())?;
+    let datagram_cred = identity_semantic(mode, launcher, worker, |value| value.datagram_cred())?;
+    let tokens = [
+        launcher[0].datagram_token(),
+        launcher[1].datagram_token(),
+        launcher[2].datagram_token(),
+        worker[0].datagram_token(),
+        worker[1].datagram_token(),
+        worker[2].datagram_token(),
+    ];
+    let datagram_token = if tokens
+        .iter()
+        .all(|value| *value == PeerTokenClass::Unsupported)
+    {
+        "unsupported"
+    } else if tokens[0] == PeerTokenClass::Baseline
+        && tokens[3] == PeerTokenClass::Baseline
+        && tokens[1..3]
+            .iter()
+            .chain(tokens[4..6].iter())
+            .all(|value| *value == PeerTokenClass::Unchanged)
+    {
+        "unchanged"
+    } else if tokens[0] == PeerTokenClass::Baseline
+        && tokens[3] == PeerTokenClass::Baseline
+        && tokens[1..3]
+            .iter()
+            .chain(tokens[4..6].iter())
+            .all(|value| matches!(value, PeerTokenClass::Unchanged | PeerTokenClass::Changed))
+        && tokens.contains(&PeerTokenClass::Changed)
+    {
+        "changed"
+    } else {
+        return None;
+    };
+    Some(CredentialSemantics {
+        stream_eid,
+        stream_cred,
+        datagram_cred,
+        datagram_token,
+        datagram_pid,
+    })
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn identity_semantic<F>(
+    mode: bangbang_session::elevated_probe::ProbeMode,
+    launcher: [bangbang_session::elevated_probe::PeerObservation; 3],
+    worker: [bangbang_session::elevated_probe::PeerObservation; 3],
+    select: F,
+) -> Option<&'static str>
+where
+    F: Fn(
+        bangbang_session::elevated_probe::PeerObservation,
+    ) -> bangbang_session::elevated_probe::CredentialIdentityClass,
+{
+    use bangbang_session::elevated_probe::CredentialIdentityClass::{
+        InitialAndTarget, InitialRoot, Other, Target, Unsupported,
+    };
+
+    let launcher = launcher.map(&select);
+    let worker = worker.map(&select);
+    let values = [
+        launcher[0],
+        launcher[1],
+        launcher[2],
+        worker[0],
+        worker[1],
+        worker[2],
+    ];
+    if values.iter().all(|value| *value == Unsupported) {
+        return Some("unsupported");
+    }
+    if values
+        .iter()
+        .any(|value| matches!(value, Other | Unsupported))
+    {
+        return None;
+    }
+    if mode.retains_root() {
+        return values
+            .iter()
+            .all(|value| *value == InitialAndTarget)
+            .then_some("stable-root");
+    }
+    if values.iter().all(|value| *value == InitialRoot) {
+        return Some("snapshot");
+    }
+    if launcher == [InitialRoot, Target, Target] && worker == [InitialRoot, InitialRoot, Target] {
+        return Some("dynamic");
+    }
+    values
+        .iter()
+        .all(|value| matches!(value, InitialRoot | Target))
+        .then_some("mixed")
 }
 
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
@@ -514,5 +1118,146 @@ mod tests {
             map_exit_status(status).expect("signal status should map"),
             LauncherExit(128 + u8::try_from(libc::SIGTERM).expect("signal should fit"))
         );
+    }
+
+    #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+    fn peer_observation(
+        identity: bangbang_session::elevated_probe::CredentialIdentityClass,
+        datagram_pid: bangbang_session::elevated_probe::PeerPidClass,
+        token: bangbang_session::elevated_probe::PeerTokenClass,
+    ) -> bangbang_session::elevated_probe::PeerObservation {
+        use bangbang_session::elevated_probe::{
+            CredentialIdentityClass, PeerObservation, PeerPidClass,
+        };
+
+        PeerObservation::new(
+            identity,
+            identity,
+            PeerPidClass::Exact,
+            CredentialIdentityClass::Unsupported,
+            datagram_pid,
+            token,
+        )
+        .expect("complete peer observation")
+    }
+
+    #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+    #[test]
+    fn credential_semantics_distinguish_snapshot_dynamic_and_retained_root() {
+        use bangbang_session::elevated_probe::{
+            CredentialIdentityClass::{InitialAndTarget, InitialRoot, Other, Target},
+            PeerPidClass, PeerTokenClass, ProbeMode,
+        };
+
+        let snapshot = [
+            peer_observation(InitialRoot, PeerPidClass::Exact, PeerTokenClass::Baseline),
+            peer_observation(InitialRoot, PeerPidClass::Exact, PeerTokenClass::Unchanged),
+            peer_observation(InitialRoot, PeerPidClass::Exact, PeerTokenClass::Unchanged),
+        ];
+        assert_eq!(
+            identity_semantic(ProbeMode::CredentialDrop, snapshot, snapshot, |value| value
+                .stream_eid()),
+            Some("snapshot")
+        );
+
+        let launcher = [
+            peer_observation(InitialRoot, PeerPidClass::Exact, PeerTokenClass::Baseline),
+            peer_observation(Target, PeerPidClass::Exact, PeerTokenClass::Changed),
+            peer_observation(Target, PeerPidClass::Exact, PeerTokenClass::Changed),
+        ];
+        let worker = [
+            peer_observation(InitialRoot, PeerPidClass::Exact, PeerTokenClass::Baseline),
+            peer_observation(InitialRoot, PeerPidClass::Exact, PeerTokenClass::Unchanged),
+            peer_observation(Target, PeerPidClass::Exact, PeerTokenClass::Changed),
+        ];
+        assert_eq!(
+            identity_semantic(ProbeMode::CredentialDrop, launcher, worker, |value| value
+                .stream_eid()),
+            Some("dynamic")
+        );
+
+        let retained = [
+            peer_observation(
+                InitialAndTarget,
+                PeerPidClass::Exact,
+                PeerTokenClass::Baseline,
+            ),
+            peer_observation(
+                InitialAndTarget,
+                PeerPidClass::Exact,
+                PeerTokenClass::Unchanged,
+            ),
+            peer_observation(
+                InitialAndTarget,
+                PeerPidClass::Exact,
+                PeerTokenClass::Unchanged,
+            ),
+        ];
+        assert_eq!(
+            identity_semantic(
+                ProbeMode::CredentialRetainRoot,
+                retained,
+                retained,
+                |value| value.stream_eid(),
+            ),
+            Some("stable-root")
+        );
+
+        let invalid = [
+            peer_observation(Other, PeerPidClass::Exact, PeerTokenClass::Baseline),
+            peer_observation(Other, PeerPidClass::Exact, PeerTokenClass::Unchanged),
+            peer_observation(Other, PeerPidClass::Exact, PeerTokenClass::Unchanged),
+        ];
+        assert_eq!(
+            identity_semantic(ProbeMode::CredentialDrop, invalid, snapshot, |value| value
+                .stream_eid()),
+            None
+        );
+    }
+
+    #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+    #[test]
+    fn credential_summary_requires_exact_stream_pid_and_bounded_datagram_creator_shape() {
+        use bangbang_session::elevated_probe::{
+            CredentialIdentityClass::InitialRoot, PeerPidClass, PeerTokenClass, ProbeMode,
+        };
+
+        let launcher = [
+            peer_observation(
+                InitialRoot,
+                PeerPidClass::SocketCreator,
+                PeerTokenClass::Baseline,
+            ),
+            peer_observation(
+                InitialRoot,
+                PeerPidClass::SocketCreator,
+                PeerTokenClass::Changed,
+            ),
+            peer_observation(
+                InitialRoot,
+                PeerPidClass::SocketCreator,
+                PeerTokenClass::Changed,
+            ),
+        ];
+        let worker = [
+            peer_observation(InitialRoot, PeerPidClass::Exact, PeerTokenClass::Baseline),
+            peer_observation(InitialRoot, PeerPidClass::Exact, PeerTokenClass::Unchanged),
+            peer_observation(InitialRoot, PeerPidClass::Exact, PeerTokenClass::Changed),
+        ];
+        let summary = credential_semantics(ProbeMode::CredentialDrop, launcher, worker)
+            .expect("bounded creator snapshot should summarize");
+        assert_eq!(summary.stream_eid, "snapshot");
+        assert_eq!(summary.datagram_cred, "unsupported");
+        assert_eq!(summary.datagram_token, "changed");
+        assert_eq!(summary.datagram_pid, "creator-snapshot");
+
+        let mismatched = launcher.map(|value| {
+            peer_observation(
+                value.stream_eid(),
+                PeerPidClass::Mismatch,
+                value.datagram_token(),
+            )
+        });
+        assert!(credential_semantics(ProbeMode::CredentialDrop, mismatched, worker).is_none());
     }
 }

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -899,6 +899,12 @@ fn credential_semantics(
     }
     let datagram_pid = if launcher
         .iter()
+        .chain(worker.iter())
+        .all(|observation| observation.datagram_pid() == PeerPidClass::Unsupported)
+    {
+        "unsupported"
+    } else if launcher
+        .iter()
         .all(|observation| observation.datagram_pid() == PeerPidClass::Exact)
         && worker
             .iter()
@@ -1291,6 +1297,31 @@ mod tests {
         assert_eq!(summary.datagram_cred, "unsupported");
         assert_eq!(summary.datagram_token, "changed");
         assert_eq!(summary.datagram_pid, "creator-snapshot");
+
+        let unsupported_pid = launcher.map(|value| {
+            peer_observation(
+                value.stream_eid(),
+                PeerPidClass::Unsupported,
+                value.datagram_token(),
+            )
+        });
+        let unsupported_worker_pid = worker.map(|value| {
+            peer_observation(
+                value.stream_eid(),
+                PeerPidClass::Unsupported,
+                value.datagram_token(),
+            )
+        });
+        assert_eq!(
+            credential_semantics(
+                ProbeMode::CredentialDrop,
+                unsupported_pid,
+                unsupported_worker_pid,
+            )
+            .expect("uniform unsupported datagram PID should summarize")
+            .datagram_pid,
+            "unsupported"
+        );
 
         let mismatched = launcher.map(|value| {
             peer_observation(

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -614,7 +614,7 @@ fn finish_credential_exchange(
             match record.kind() {
                 CredentialRecordKind::WorkerTransitioned => record,
                 CredentialRecordKind::Failure => {
-                    credential_wait_for_exit(&mut spawned, 1)?;
+                    let _ = credential_wait_for_exit(&mut spawned, 1);
                     return credential_blocked_record(record);
                 }
                 CredentialRecordKind::LauncherTransitioned | CredentialRecordKind::WorkerFinal => {
@@ -702,19 +702,31 @@ fn finish_credential_exchange(
         }
     };
     let launcher_observations = [initial, after_worker, after_both];
-    let launcher_record = CredentialRecord::launcher_transitioned(
+    let launcher_record = match CredentialRecord::launcher_transitioned(
         bootstrap.mode(),
         transition.state(),
         launcher_observations,
         bootstrap.nonce(),
-    )
-    .map_err(|_| LauncherError::SessionProtocol)?;
+    ) {
+        Ok(record) => record,
+        Err(_) => {
+            return Ok(credential_protocol_blocked_after_reap(
+                &mut spawned,
+                transition.prefix(),
+                transition.state(),
+            ));
+        }
+    };
     if spawned
         .session
         .write_all(&launcher_record.encode())
         .is_err()
     {
-        return Err(LauncherError::SessionProtocol);
+        return Ok(credential_protocol_blocked_after_reap(
+            &mut spawned,
+            transition.prefix(),
+            transition.state(),
+        ));
     }
 
     let worker_final = match read_credential_record(&mut spawned.session) {
@@ -728,28 +740,34 @@ fn finish_credential_exchange(
             match record.kind() {
                 CredentialRecordKind::WorkerFinal => record,
                 CredentialRecordKind::Failure => {
-                    credential_wait_for_exit(&mut spawned, 1)?;
+                    let _ = credential_wait_for_exit(&mut spawned, 1);
                     return credential_blocked_record(record);
                 }
                 CredentialRecordKind::WorkerTransitioned
                 | CredentialRecordKind::LauncherTransitioned => {
-                    credential_wait_for_exit(&mut spawned, 1)?;
-                    return Ok(credential_blocked_value(
-                        CredentialRole::Launcher,
-                        credential_protocol_failure(transition.prefix(), transition.state()),
+                    return Ok(credential_protocol_blocked_after_reap(
+                        &mut spawned,
+                        transition.prefix(),
+                        transition.state(),
                     ));
                 }
             }
         }
         Ok(_) | Err(_) => {
-            credential_wait_for_exit(&mut spawned, 1)?;
-            return Ok(credential_blocked_value(
-                CredentialRole::Launcher,
-                credential_protocol_failure(transition.prefix(), transition.state()),
+            return Ok(credential_protocol_blocked_after_reap(
+                &mut spawned,
+                transition.prefix(),
+                transition.state(),
             ));
         }
     };
-    credential_wait_for_exit(&mut spawned, 0)?;
+    if credential_wait_for_exit(&mut spawned, 0).is_err() {
+        return Ok(credential_protocol_blocked_after_reap(
+            &mut spawned,
+            transition.prefix(),
+            transition.state(),
+        ));
+    }
 
     let worker_initial = worker_transitioned.observations();
     let worker_observations = worker_final.observations();
@@ -795,18 +813,38 @@ fn finish_credential_exchange(
         failure: CredentialFailureValue,
         initial: PeerObservation,
     ) -> Result<LauncherExit, LauncherError> {
-        let record = CredentialRecord::failure(
+        let record = match CredentialRecord::failure(
             bootstrap.mode(),
             CredentialRole::Launcher,
             failure,
             initial,
             bootstrap.nonce(),
-        )
-        .map_err(|_| LauncherError::SessionProtocol)?;
+        ) {
+            Ok(record) => record,
+            Err(_) => {
+                spawned.worker.terminate_and_reap();
+                return Ok(credential_blocked_value(CredentialRole::Launcher, failure));
+            }
+        };
         let _ = spawned.session.write_all(&record.encode());
-        credential_wait_for_exit(spawned, 1)?;
+        let _ = credential_wait_for_exit(spawned, 1);
         Ok(credential_blocked_value(CredentialRole::Launcher, failure))
     }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn credential_protocol_blocked_after_reap(
+    spawned: &mut crate::macos::spawn::SuspendedWorker,
+    prefix: bangbang_session::elevated_probe::CredentialPrefix,
+    state: bangbang_session::elevated_probe::CredentialSelfState,
+) -> LauncherExit {
+    use bangbang_session::elevated_probe::CredentialRole;
+
+    spawned.worker.terminate_and_reap();
+    credential_blocked_value(
+        CredentialRole::Launcher,
+        credential_protocol_failure(prefix, state),
+    )
 }
 
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
@@ -819,24 +857,29 @@ fn credential_wait_for_exit(
     const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
     const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
-    let deadline = Instant::now()
-        .checked_add(WAIT_TIMEOUT)
-        .ok_or(LauncherError::SessionProtocol)?;
-    loop {
-        if let Some(status) = spawned.worker.try_wait()? {
-            let exit = map_exit_status(status)?;
-            return if exit.code() == expected {
-                Ok(())
-            } else {
-                Err(LauncherError::SessionProtocol)
-            };
+    let result = (|| {
+        let deadline = Instant::now()
+            .checked_add(WAIT_TIMEOUT)
+            .ok_or(LauncherError::SessionProtocol)?;
+        loop {
+            if let Some(status) = spawned.worker.try_wait()? {
+                let exit = map_exit_status(status)?;
+                return if exit.code() == expected {
+                    Ok(())
+                } else {
+                    Err(LauncherError::SessionProtocol)
+                };
+            }
+            if Instant::now() >= deadline {
+                return Err(LauncherError::SessionProtocol);
+            }
+            std::thread::sleep(POLL_INTERVAL);
         }
-        if Instant::now() >= deadline {
-            spawned.worker.terminate_and_reap();
-            return Err(LauncherError::SessionProtocol);
-        }
-        std::thread::sleep(POLL_INTERVAL);
+    })();
+    if result.is_err() {
+        spawned.worker.terminate_and_reap();
     }
+    result
 }
 
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
@@ -1170,25 +1213,32 @@ mod tests {
 
     #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
     #[test]
-    fn credential_protocol_failure_preserves_the_completed_transition_prefix() {
+    fn credential_protocol_failure_preserves_each_completed_transition_prefix() {
         use bangbang_session::elevated_probe::{
             CredentialGroupClass, CredentialIdentityClass, CredentialPrefix, CredentialSelfState,
         };
 
-        let failure = credential_protocol_failure(
-            CredentialPrefix::Irreversible,
-            CredentialSelfState::new(
-                CredentialIdentityClass::Target,
-                CredentialGroupClass::EffectiveOnly,
+        for (prefix, state) in [
+            (
+                CredentialPrefix::Irreversible,
+                CredentialSelfState::new(
+                    CredentialIdentityClass::Target,
+                    CredentialGroupClass::EffectiveOnly,
+                ),
             ),
-        );
+            (
+                CredentialPrefix::RetainedRoot,
+                CredentialSelfState::new(
+                    CredentialIdentityClass::InitialAndTarget,
+                    CredentialGroupClass::Initial,
+                ),
+            ),
+        ] {
+            let failure = credential_protocol_failure(prefix, state);
 
-        assert_eq!(failure.prefix(), CredentialPrefix::Irreversible);
-        assert_eq!(failure.state().identity(), CredentialIdentityClass::Target);
-        assert_eq!(
-            failure.state().groups(),
-            CredentialGroupClass::EffectiveOnly
-        );
+            assert_eq!(failure.prefix(), prefix);
+            assert_eq!(failure.state(), state);
+        }
     }
 
     #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -147,6 +147,9 @@ fn launch_elevated_prepared(
         elevated_probe.root_fd(),
     )?
     .spawn()?;
+    // The completed spawn copied the fixed root descriptor into the worker.
+    // Close the launcher-owned copy before any credential transition begins.
+    drop(elevated_probe);
     finish_elevated_exchange(spawned, launch.worker_profile, bootstrap, false)
 }
 

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -446,6 +446,23 @@ const fn credential_initial_state(
 }
 
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+const fn credential_protocol_failure(
+    prefix: bangbang_session::elevated_probe::CredentialPrefix,
+    state: bangbang_session::elevated_probe::CredentialSelfState,
+) -> bangbang_session::elevated_probe::CredentialFailureValue {
+    use bangbang_session::elevated_probe::{
+        CredentialFailureValue, CredentialStep, ProbeErrorCategory,
+    };
+
+    CredentialFailureValue::new(
+        CredentialStep::Protocol,
+        ProbeErrorCategory::InvalidInput,
+        prefix,
+        state,
+    )
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
 fn begin_credential_exchange(
     spawned: &mut crate::macos::spawn::SuspendedWorker,
     bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
@@ -576,8 +593,7 @@ fn finish_credential_exchange(
 
     use bangbang_session::elevated_probe::{
         CREDENTIAL_RECORD_BYTES, CredentialFailureValue, CredentialPrefix, CredentialRecord,
-        CredentialRecordKind, CredentialRole, CredentialSelfState, CredentialStep, PeerObservation,
-        ProbeErrorCategory,
+        CredentialRecordKind, CredentialRole, CredentialStep, PeerObservation,
     };
 
     // SAFETY: `getpid` has no pointer or ownership contract and remains stable
@@ -602,7 +618,10 @@ fn finish_credential_exchange(
                     return send_launcher_failure_and_wait(
                         &mut spawned,
                         bootstrap,
-                        protocol_failure(credential_initial_state(bootstrap)),
+                        credential_protocol_failure(
+                            CredentialPrefix::None,
+                            credential_initial_state(bootstrap),
+                        ),
                         initial,
                     );
                 }
@@ -612,7 +631,10 @@ fn finish_credential_exchange(
             return send_launcher_failure_and_wait(
                 &mut spawned,
                 bootstrap,
-                protocol_failure(credential_initial_state(bootstrap)),
+                credential_protocol_failure(
+                    CredentialPrefix::None,
+                    credential_initial_state(bootstrap),
+                ),
                 initial,
             );
         }
@@ -711,7 +733,7 @@ fn finish_credential_exchange(
                     credential_wait_for_exit(&mut spawned, 1)?;
                     return Ok(credential_blocked_value(
                         CredentialRole::Launcher,
-                        protocol_failure(transition.state()),
+                        credential_protocol_failure(transition.prefix(), transition.state()),
                     ));
                 }
             }
@@ -720,7 +742,7 @@ fn finish_credential_exchange(
             credential_wait_for_exit(&mut spawned, 1)?;
             return Ok(credential_blocked_value(
                 CredentialRole::Launcher,
-                protocol_failure(transition.state()),
+                credential_protocol_failure(transition.prefix(), transition.state()),
             ));
         }
     };
@@ -734,12 +756,17 @@ fn finish_credential_exchange(
     {
         return Ok(credential_blocked_value(
             CredentialRole::Launcher,
-            protocol_failure(transition.state()),
+            credential_protocol_failure(transition.prefix(), transition.state()),
         ));
     }
-    let semantics =
+    let Some(semantics) =
         credential_semantics(bootstrap.mode(), launcher_observations, worker_observations)
-            .ok_or(LauncherError::SessionProtocol)?;
+    else {
+        return Ok(credential_blocked_value(
+            CredentialRole::Launcher,
+            credential_protocol_failure(transition.prefix(), transition.state()),
+        ));
+    };
     println!(
         "status: elevated credential {} complete stream-eid={} stream-cred={} stream-pid=exact datagram-cred={} datagram-token={} datagram-pid={}",
         bootstrap.mode().name(),
@@ -757,15 +784,6 @@ fn finish_credential_exchange(
         let mut encoded = [0_u8; CREDENTIAL_RECORD_BYTES];
         stream.read_exact(&mut encoded).map_err(|_| ())?;
         CredentialRecord::decode(&encoded).map_err(|_| ())
-    }
-
-    const fn protocol_failure(state: CredentialSelfState) -> CredentialFailureValue {
-        CredentialFailureValue::new(
-            CredentialStep::Protocol,
-            ProbeErrorCategory::InvalidInput,
-            CredentialPrefix::None,
-            state,
-        )
     }
 
     fn send_launcher_failure_and_wait(
@@ -1139,6 +1157,29 @@ mod tests {
             token,
         )
         .expect("complete peer observation")
+    }
+
+    #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+    #[test]
+    fn credential_protocol_failure_preserves_the_completed_transition_prefix() {
+        use bangbang_session::elevated_probe::{
+            CredentialGroupClass, CredentialIdentityClass, CredentialPrefix, CredentialSelfState,
+        };
+
+        let failure = credential_protocol_failure(
+            CredentialPrefix::Irreversible,
+            CredentialSelfState::new(
+                CredentialIdentityClass::Target,
+                CredentialGroupClass::EffectiveOnly,
+            ),
+        );
+
+        assert_eq!(failure.prefix(), CredentialPrefix::Irreversible);
+        assert_eq!(failure.state().identity(), CredentialIdentityClass::Target);
+        assert_eq!(
+            failure.state().groups(),
+            CredentialGroupClass::EffectiveOnly
+        );
     }
 
     #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -88,6 +88,11 @@ const ELEVATED_READY_RECORD: &[u8] = b"BBEP-READY-V2";
 const ELEVATED_BLOCKED_STATUS: &[u8] = b"status: elevated bootstrap blocked";
 const ELEVATED_INHERITED_MODE: &[u8] = b"inherited-root";
 const ELEVATED_HVF_STAGE: &[u8] = b"hvf-create";
+const ELEVATED_CREDENTIAL_MODE: &[u8] = b"credential-drop";
+const ELEVATED_CREDENTIAL_STATUS: &[u8] = b"status: elevated credential";
+const ELEVATED_CREDENTIAL_RECORD: &[u8] = b"BBC1";
+const ELEVATED_CREDENTIAL_DATAGRAM: &[u8] = b"BBG1";
+const ELEVATED_CREDENTIAL_STEP: &[u8] = b"restore-groups";
 const ELEVATED_PROBE_MARKER: &str = "elevated-bootstrap-probe.enabled";
 const GRANT_PROBE_OUTSIDE: &str = "bangbang-grant-probe-outside";
 const RESTORE_ROOT_ID: &str = "restore-root-1601";
@@ -13050,6 +13055,11 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             ELEVATED_BLOCKED_STATUS,
             ELEVATED_INHERITED_MODE,
             ELEVATED_HVF_STAGE,
+            ELEVATED_CREDENTIAL_MODE,
+            ELEVATED_CREDENTIAL_STATUS,
+            ELEVATED_CREDENTIAL_RECORD,
+            ELEVATED_CREDENTIAL_DATAGRAM,
+            ELEVATED_CREDENTIAL_STEP,
         ] {
             assert!(
                 !artifact
@@ -13060,35 +13070,41 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
         }
     }
 
-    let output = run_launcher(
-        &bundle,
-        &[
-            OsStr::new(ELEVATED_PROBE_OPTION),
-            OsStr::new("--root"),
-            OsStr::new("/private/var/root/bangbang-elevated-probe.Disabled"),
-            OsStr::new("--target-uid"),
-            OsStr::new("501"),
-            OsStr::new("--target-gid"),
-            OsStr::new("20"),
-            OsStr::new("--mode"),
-            OsStr::new("drop"),
-            OsStr::new("--"),
-        ],
-    );
-    assert_eq!(output.status.code(), Some(ARGUMENT_PARSING_EXIT_CODE));
-    let diagnostics = [output.stdout, output.stderr].concat();
-    for marker in [
-        ELEVATED_READY_RECORD,
-        ELEVATED_BLOCKED_STATUS,
-        ELEVATED_INHERITED_MODE,
-        ELEVATED_HVF_STAGE,
-    ] {
-        assert!(
-            !diagnostics
-                .windows(marker.len())
-                .any(|window| window == marker),
-            "normal bundle must not activate elevated probe behavior"
+    for mode in ["drop", "credential-drop"] {
+        let output = run_launcher(
+            &bundle,
+            &[
+                OsStr::new(ELEVATED_PROBE_OPTION),
+                OsStr::new("--root"),
+                OsStr::new("/private/var/root/bangbang-elevated-probe.Disabled"),
+                OsStr::new("--target-uid"),
+                OsStr::new("501"),
+                OsStr::new("--target-gid"),
+                OsStr::new("20"),
+                OsStr::new("--mode"),
+                OsStr::new(mode),
+                OsStr::new("--"),
+            ],
         );
+        assert_eq!(output.status.code(), Some(ARGUMENT_PARSING_EXIT_CODE));
+        let diagnostics = [output.stdout, output.stderr].concat();
+        for marker in [
+            ELEVATED_READY_RECORD,
+            ELEVATED_BLOCKED_STATUS,
+            ELEVATED_INHERITED_MODE,
+            ELEVATED_HVF_STAGE,
+            ELEVATED_CREDENTIAL_STATUS,
+            ELEVATED_CREDENTIAL_RECORD,
+            ELEVATED_CREDENTIAL_DATAGRAM,
+            ELEVATED_CREDENTIAL_STEP,
+        ] {
+            assert!(
+                !diagnostics
+                    .windows(marker.len())
+                    .any(|window| window == marker),
+                "normal bundle must not activate elevated probe behavior"
+            );
+        }
     }
 }
 

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -88,11 +88,18 @@ const ELEVATED_READY_RECORD: &[u8] = b"BBEP-READY-V2";
 const ELEVATED_BLOCKED_STATUS: &[u8] = b"status: elevated bootstrap blocked";
 const ELEVATED_INHERITED_MODE: &[u8] = b"inherited-root";
 const ELEVATED_HVF_STAGE: &[u8] = b"hvf-create";
-const ELEVATED_CREDENTIAL_MODE: &[u8] = b"credential-drop";
+const ELEVATED_CREDENTIAL_DROP_MODE: &[u8] = b"credential-drop";
+const ELEVATED_CREDENTIAL_RETAIN_MODE: &[u8] = b"credential-retain-root";
+const ELEVATED_CREDENTIAL_UNMAPPED_MODE: &[u8] = b"credential-unmapped";
+const ELEVATED_CREDENTIAL_CONTROL_MODE: &[u8] = b"credential-control";
 const ELEVATED_CREDENTIAL_STATUS: &[u8] = b"status: elevated credential";
 const ELEVATED_CREDENTIAL_RECORD: &[u8] = b"BBC1";
 const ELEVATED_CREDENTIAL_DATAGRAM: &[u8] = b"BBG1";
 const ELEVATED_CREDENTIAL_STEP: &[u8] = b"restore-groups";
+const ELEVATED_CREDENTIAL_LAUNCHER_ARTIFACT: &[u8] =
+    b"bangbang-elevated-credential-launcher-v1-credential-drop-BBC1-BBG1-restore-groups";
+const ELEVATED_CREDENTIAL_WORKER_ARTIFACT: &[u8] =
+    b"bangbang-elevated-credential-worker-v1-credential-drop-BBC1-BBG1-restore-groups";
 const ELEVATED_PROBE_MARKER: &str = "elevated-bootstrap-probe.enabled";
 const GRANT_PROBE_OUTSIDE: &str = "bangbang-grant-probe-outside";
 const RESTORE_ROOT_ID: &str = "restore-root-1601";
@@ -13055,11 +13062,16 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             ELEVATED_BLOCKED_STATUS,
             ELEVATED_INHERITED_MODE,
             ELEVATED_HVF_STAGE,
-            ELEVATED_CREDENTIAL_MODE,
+            ELEVATED_CREDENTIAL_DROP_MODE,
+            ELEVATED_CREDENTIAL_RETAIN_MODE,
+            ELEVATED_CREDENTIAL_UNMAPPED_MODE,
+            ELEVATED_CREDENTIAL_CONTROL_MODE,
             ELEVATED_CREDENTIAL_STATUS,
             ELEVATED_CREDENTIAL_RECORD,
             ELEVATED_CREDENTIAL_DATAGRAM,
             ELEVATED_CREDENTIAL_STEP,
+            ELEVATED_CREDENTIAL_LAUNCHER_ARTIFACT,
+            ELEVATED_CREDENTIAL_WORKER_ARTIFACT,
         ] {
             assert!(
                 !artifact
@@ -13097,6 +13109,8 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             ELEVATED_CREDENTIAL_RECORD,
             ELEVATED_CREDENTIAL_DATAGRAM,
             ELEVATED_CREDENTIAL_STEP,
+            ELEVATED_CREDENTIAL_LAUNCHER_ARTIFACT,
+            ELEVATED_CREDENTIAL_WORKER_ARTIFACT,
         ] {
             assert!(
                 !diagnostics

--- a/crates/session/src/elevated_credential.rs
+++ b/crates/session/src/elevated_credential.rs
@@ -593,10 +593,21 @@ fn exact_peer_pid(
     expected: libc::pid_t,
     socket_creator: Option<libc::pid_t>,
 ) -> Result<PeerPidClass, ProbeErrorCategory> {
-    match crate::macos::peer_pid(fd) {
+    classify_peer_pid(crate::macos::peer_pid(fd), expected, socket_creator)
+}
+
+fn classify_peer_pid(
+    result: io::Result<libc::pid_t>,
+    expected: libc::pid_t,
+    socket_creator: Option<libc::pid_t>,
+) -> Result<PeerPidClass, ProbeErrorCategory> {
+    match result {
         Ok(pid) if pid == expected => Ok(PeerPidClass::Exact),
         Ok(pid) if Some(pid) == socket_creator => Ok(PeerPidClass::SocketCreator),
         Ok(_) => Err(ProbeErrorCategory::PermissionDenied),
+        Err(error) if socket_creator.is_some() && unsupported_errno(error.raw_os_error()) => {
+            Ok(PeerPidClass::Unsupported)
+        }
         Err(error) => Err(ProbeErrorCategory::from_io_kind(error.kind())),
     }
 }
@@ -1030,6 +1041,23 @@ mod tests {
             Ok(PeerPidClass::SocketCreator)
         );
         assert!(exact_peer_pid(datagram.as_raw_fd(), pid.wrapping_add(1), None).is_err());
+        assert_eq!(
+            classify_peer_pid(
+                Err(io::Error::from_raw_os_error(libc::ENOPROTOOPT)),
+                pid,
+                Some(pid),
+            ),
+            Ok(PeerPidClass::Unsupported)
+        );
+        assert!(
+            classify_peer_pid(
+                Err(io::Error::from_raw_os_error(libc::ENOPROTOOPT)),
+                pid,
+                None,
+            )
+            .is_err(),
+            "stream LOCAL_PEERPID remains a required surface"
+        );
         assert!(stream_eid(datagram.as_raw_fd(), uid, gid).is_err());
         assert!(
             matches!(

--- a/crates/session/src/elevated_credential.rs
+++ b/crates/session/src/elevated_credential.rs
@@ -1,0 +1,1042 @@
+//! Darwin credential-transition and peer-observation primitives for the test-only probe.
+
+use std::io;
+use std::mem::MaybeUninit;
+use std::os::fd::RawFd;
+
+use crate::elevated_probe::{
+    CredentialFailureValue, CredentialGroupClass, CredentialIdentityClass, CredentialPrefix,
+    CredentialSelfState, CredentialStep, PeerObservation, PeerPidClass, PeerTokenClass,
+    ProbeErrorCategory, ProbeMode,
+};
+
+const MAX_SUPPLEMENTARY_GROUPS: usize = 1_024;
+const XUCRED_VERSION: libc::c_uint = 0;
+const AUDIT_TOKEN_WORDS: usize = 8;
+
+/// Complete value-free postcondition of one process credential transition.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CredentialTransition {
+    state: CredentialSelfState,
+    prefix: CredentialPrefix,
+}
+
+impl CredentialTransition {
+    /// Returns the exact final self-state class.
+    #[must_use]
+    pub const fn state(self) -> CredentialSelfState {
+        self.state
+    }
+
+    /// Returns the complete ordered prefix.
+    #[must_use]
+    pub const fn prefix(self) -> CredentialPrefix {
+        self.prefix
+    }
+}
+
+impl std::fmt::Debug for CredentialTransition {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("CredentialTransition(<redacted>)")
+    }
+}
+
+/// Opaque initial peer state retained only for later semantic comparison.
+pub struct PeerBaseline {
+    datagram_token: TokenBaseline,
+}
+
+impl std::fmt::Debug for PeerBaseline {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("PeerBaseline(<redacted>)")
+    }
+}
+
+enum TokenBaseline {
+    Unsupported,
+    Value([u32; AUDIT_TOKEN_WORDS]),
+}
+
+/// Performs the exact no-chroot credential transition for one evidence endpoint.
+pub fn transition_process(
+    mode: ProbeMode,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<CredentialTransition, CredentialFailureValue> {
+    transition_with(&mut DarwinCredentialOps, mode, target_uid, target_gid)
+}
+
+/// Captures the initial connected stream/datagram peer observation.
+pub fn observe_initial_peer(
+    stream: RawFd,
+    datagram: RawFd,
+    expected_pid: libc::pid_t,
+    socket_creator_pid: libc::pid_t,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<(PeerObservation, PeerBaseline), ProbeErrorCategory> {
+    validate_socket_type(stream, libc::SOCK_STREAM)?;
+    validate_socket_type(datagram, libc::SOCK_DGRAM)?;
+    let stream_eid = stream_eid(stream, target_uid, target_gid)?;
+    let stream_cred = local_peercred(stream, false, target_uid, target_gid)?;
+    let stream_pid = exact_peer_pid(stream, expected_pid, None)?;
+    let datagram_cred = local_peercred(datagram, true, target_uid, target_gid)?;
+    let datagram_pid = exact_peer_pid(datagram, expected_pid, Some(socket_creator_pid))?;
+    let (datagram_token, baseline) = initial_token(datagram)?;
+    let observation = PeerObservation::new(
+        stream_eid,
+        stream_cred,
+        stream_pid,
+        datagram_cred,
+        datagram_pid,
+        datagram_token,
+    )
+    .map_err(|_| ProbeErrorCategory::InvalidInput)?;
+    Ok((
+        observation,
+        PeerBaseline {
+            datagram_token: baseline,
+        },
+    ))
+}
+
+/// Captures one later peer observation relative to the exact initial baseline.
+pub fn observe_later_peer(
+    stream: RawFd,
+    datagram: RawFd,
+    expected_pid: libc::pid_t,
+    socket_creator_pid: libc::pid_t,
+    target_uid: u32,
+    target_gid: u32,
+    baseline: &PeerBaseline,
+) -> Result<PeerObservation, ProbeErrorCategory> {
+    validate_socket_type(stream, libc::SOCK_STREAM)?;
+    validate_socket_type(datagram, libc::SOCK_DGRAM)?;
+    PeerObservation::new(
+        stream_eid(stream, target_uid, target_gid)?,
+        local_peercred(stream, false, target_uid, target_gid)?,
+        exact_peer_pid(stream, expected_pid, None)?,
+        local_peercred(datagram, true, target_uid, target_gid)?,
+        exact_peer_pid(datagram, expected_pid, Some(socket_creator_pid))?,
+        later_token(datagram, &baseline.datagram_token)?,
+    )
+    .map_err(|_| ProbeErrorCategory::InvalidInput)
+}
+
+trait CredentialOps {
+    fn ids(&mut self) -> (u32, u32, u32, u32);
+    fn groups(&mut self) -> Result<Vec<u32>, io::ErrorKind>;
+    fn clear_groups(&mut self) -> Result<(), io::ErrorKind>;
+    fn set_gid(&mut self, gid: u32) -> Result<(), io::ErrorKind>;
+    fn set_uid(&mut self, uid: u32) -> Result<(), io::ErrorKind>;
+    fn restore_groups(&mut self) -> Result<(), io::ErrorKind>;
+}
+
+struct DarwinCredentialOps;
+
+impl CredentialOps for DarwinCredentialOps {
+    fn ids(&mut self) -> (u32, u32, u32, u32) {
+        // SAFETY: Credential getters have no pointer or ownership contract.
+        unsafe {
+            (
+                libc::getuid(),
+                libc::geteuid(),
+                libc::getgid(),
+                libc::getegid(),
+            )
+        }
+    }
+
+    fn groups(&mut self) -> Result<Vec<u32>, io::ErrorKind> {
+        // SAFETY: A zero-length query does not dereference the null pointer.
+        let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+        let count = usize::try_from(count).map_err(|_| io::Error::last_os_error().kind())?;
+        if count > MAX_SUPPLEMENTARY_GROUPS {
+            return Err(io::ErrorKind::InvalidData);
+        }
+        let mut groups = vec![0; count];
+        let pointer = if groups.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            groups.as_mut_ptr()
+        };
+        let capacity =
+            libc::c_int::try_from(groups.len()).map_err(|_| io::ErrorKind::InvalidData)?;
+        // SAFETY: `pointer` is null for zero capacity or points to `capacity`
+        // writable gid slots for the duration of the synchronous call.
+        let actual = unsafe { libc::getgroups(capacity, pointer) };
+        let actual = usize::try_from(actual).map_err(|_| io::Error::last_os_error().kind())?;
+        if actual != groups.len() {
+            return Err(io::ErrorKind::InvalidData);
+        }
+        Ok(groups)
+    }
+
+    fn clear_groups(&mut self) -> Result<(), io::ErrorKind> {
+        // SAFETY: A zero-length group update does not dereference the null pointer.
+        cvt(unsafe { libc::setgroups(0, std::ptr::null()) })
+    }
+
+    fn set_gid(&mut self, gid: u32) -> Result<(), io::ErrorKind> {
+        // SAFETY: The numeric gid is passed by value and no state is borrowed.
+        cvt(unsafe { libc::setgid(gid) })
+    }
+
+    fn set_uid(&mut self, uid: u32) -> Result<(), io::ErrorKind> {
+        // SAFETY: The numeric uid is passed by value and no state is borrowed.
+        cvt(unsafe { libc::setuid(uid) })
+    }
+
+    fn restore_groups(&mut self) -> Result<(), io::ErrorKind> {
+        let root: libc::gid_t = 0;
+        // SAFETY: `root` is one live gid value for the synchronous call.
+        cvt(unsafe { libc::setgroups(1, &raw const root) })
+    }
+}
+
+fn transition_with<O: CredentialOps>(
+    ops: &mut O,
+    mode: ProbeMode,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<CredentialTransition, CredentialFailureValue> {
+    let retains_root = match mode {
+        ProbeMode::CredentialRetainRoot => true,
+        ProbeMode::CredentialDrop | ProbeMode::CredentialUnmapped => false,
+        ProbeMode::CredentialControl => target_uid == 0 && target_gid == 0,
+        _ => {
+            return Err(CredentialFailureValue::new(
+                CredentialStep::InitialIdentity,
+                ProbeErrorCategory::InvalidInput,
+                CredentialPrefix::None,
+                CredentialSelfState::new(
+                    CredentialIdentityClass::Other,
+                    CredentialGroupClass::Other,
+                ),
+            ));
+        }
+    };
+    if !mode.accepts_target(target_uid, target_gid) {
+        return Err(CredentialFailureValue::new(
+            CredentialStep::InitialIdentity,
+            ProbeErrorCategory::InvalidInput,
+            CredentialPrefix::None,
+            CredentialSelfState::new(CredentialIdentityClass::Other, CredentialGroupClass::Other),
+        ));
+    }
+
+    let initial_groups = ops.groups().map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::InitialIdentity,
+            kind,
+            CredentialPrefix::None,
+            target_uid,
+            target_gid,
+            &[],
+        )
+    })?;
+    if ops.ids() != (0, 0, 0, 0) {
+        return Err(failure_category(
+            ops,
+            CredentialStep::InitialIdentity,
+            ProbeErrorCategory::PermissionDenied,
+            CredentialPrefix::None,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        ));
+    }
+
+    if retains_root {
+        let final_groups = ops.groups().map_err(|kind| {
+            failure(
+                ops,
+                CredentialStep::ValidateFinalIdentity,
+                kind,
+                CredentialPrefix::Initial,
+                target_uid,
+                target_gid,
+                &initial_groups,
+            )
+        })?;
+        if ops.ids() != (0, 0, 0, 0) || final_groups != initial_groups {
+            return Err(failure_category(
+                ops,
+                CredentialStep::ValidateFinalIdentity,
+                ProbeErrorCategory::InvalidInput,
+                CredentialPrefix::Initial,
+                target_uid,
+                target_gid,
+                &initial_groups,
+            ));
+        }
+        return Ok(CredentialTransition {
+            state: CredentialSelfState::new(
+                CredentialIdentityClass::InitialAndTarget,
+                CredentialGroupClass::Initial,
+            ),
+            prefix: CredentialPrefix::RetainedRoot,
+        });
+    }
+
+    ops.clear_groups().map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::ClearGroups,
+            kind,
+            CredentialPrefix::Initial,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    let groups = ops.groups().map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::ValidateClearedGroups,
+            kind,
+            CredentialPrefix::Initial,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    if groups.as_slice() != [0] {
+        return Err(failure_category(
+            ops,
+            CredentialStep::ValidateClearedGroups,
+            ProbeErrorCategory::InvalidInput,
+            CredentialPrefix::Initial,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        ));
+    }
+
+    ops.set_gid(target_gid).map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::SetGid,
+            kind,
+            CredentialPrefix::GroupsCleared,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    ops.set_uid(target_uid).map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::SetUid,
+            kind,
+            CredentialPrefix::GidSet,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+
+    validate_target(ops, target_uid, target_gid).map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::ValidateFinalIdentity,
+            kind,
+            CredentialPrefix::UidSet,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+
+    expect_permission_denied(ops.set_uid(0)).map_err(|category| {
+        failure_category(
+            ops,
+            CredentialStep::RestoreUid,
+            category,
+            CredentialPrefix::FinalIdentity,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    expect_permission_denied(ops.set_gid(0)).map_err(|category| {
+        failure_category(
+            ops,
+            CredentialStep::RestoreGid,
+            category,
+            CredentialPrefix::FinalIdentity,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    expect_permission_denied(ops.restore_groups()).map_err(|category| {
+        failure_category(
+            ops,
+            CredentialStep::RestoreGroups,
+            category,
+            CredentialPrefix::FinalIdentity,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    validate_target(ops, target_uid, target_gid).map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::ValidateFinalIdentity,
+            kind,
+            CredentialPrefix::FinalIdentity,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+
+    Ok(CredentialTransition {
+        state: CredentialSelfState::new(
+            CredentialIdentityClass::Target,
+            CredentialGroupClass::EffectiveOnly,
+        ),
+        prefix: CredentialPrefix::Irreversible,
+    })
+}
+
+fn validate_target<O: CredentialOps>(
+    ops: &mut O,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<(), io::ErrorKind> {
+    if ops.ids() != (target_uid, target_uid, target_gid, target_gid) {
+        return Err(io::ErrorKind::InvalidData);
+    }
+    if ops.groups()?.as_slice() != [target_gid] {
+        return Err(io::ErrorKind::InvalidData);
+    }
+    Ok(())
+}
+
+fn expect_permission_denied(result: Result<(), io::ErrorKind>) -> Result<(), ProbeErrorCategory> {
+    match result {
+        Err(io::ErrorKind::PermissionDenied) => Ok(()),
+        Ok(()) => Err(ProbeErrorCategory::Other),
+        Err(kind) => Err(ProbeErrorCategory::from_io_kind(kind)),
+    }
+}
+
+fn failure<O: CredentialOps>(
+    ops: &mut O,
+    step: CredentialStep,
+    kind: io::ErrorKind,
+    prefix: CredentialPrefix,
+    target_uid: u32,
+    target_gid: u32,
+    initial_groups: &[u32],
+) -> CredentialFailureValue {
+    failure_category(
+        ops,
+        step,
+        ProbeErrorCategory::from_io_kind(kind),
+        prefix,
+        target_uid,
+        target_gid,
+        initial_groups,
+    )
+}
+
+fn failure_category<O: CredentialOps>(
+    ops: &mut O,
+    step: CredentialStep,
+    category: ProbeErrorCategory,
+    prefix: CredentialPrefix,
+    target_uid: u32,
+    target_gid: u32,
+    initial_groups: &[u32],
+) -> CredentialFailureValue {
+    CredentialFailureValue::new(
+        step,
+        category,
+        prefix,
+        classify_self(ops, target_uid, target_gid, initial_groups),
+    )
+}
+
+fn classify_self<O: CredentialOps>(
+    ops: &mut O,
+    target_uid: u32,
+    target_gid: u32,
+    initial_groups: &[u32],
+) -> CredentialSelfState {
+    let (uid, euid, gid, egid) = ops.ids();
+    let identity = if (uid, euid, gid, egid) == (0, 0, 0, 0) {
+        if target_uid == 0 && target_gid == 0 {
+            CredentialIdentityClass::InitialAndTarget
+        } else {
+            CredentialIdentityClass::InitialRoot
+        }
+    } else if (uid, euid, gid, egid) == (target_uid, target_uid, target_gid, target_gid) {
+        CredentialIdentityClass::Target
+    } else {
+        CredentialIdentityClass::Other
+    };
+    let groups = match ops.groups() {
+        Ok(groups) if groups == initial_groups => CredentialGroupClass::Initial,
+        Ok(groups) if groups.as_slice() == [gid] => CredentialGroupClass::EffectiveOnly,
+        Ok(_) | Err(_) => CredentialGroupClass::Other,
+    };
+    CredentialSelfState::new(identity, groups)
+}
+
+fn cvt(result: libc::c_int) -> Result<(), io::ErrorKind> {
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error().kind())
+    }
+}
+
+fn validate_socket_type(fd: RawFd, expected: libc::c_int) -> Result<(), ProbeErrorCategory> {
+    let mut actual = 0;
+    let mut length = libc::socklen_t::try_from(std::mem::size_of::<libc::c_int>())
+        .map_err(|_| ProbeErrorCategory::InvalidInput)?;
+    // SAFETY: `actual` and `length` are writable for the synchronous option query.
+    if unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_TYPE,
+            (&raw mut actual).cast(),
+            &raw mut length,
+        )
+    } != 0
+    {
+        return Err(ProbeErrorCategory::from_io_kind(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    if usize::try_from(length).ok() != Some(std::mem::size_of::<libc::c_int>())
+        || actual != expected
+    {
+        return Err(ProbeErrorCategory::InvalidInput);
+    }
+    Ok(())
+}
+
+fn stream_eid(
+    fd: RawFd,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<CredentialIdentityClass, ProbeErrorCategory> {
+    let mut uid = 0;
+    let mut gid = 0;
+    // SAFETY: Both credential outputs are writable and `fd` remains owned by the caller.
+    if unsafe { libc::getpeereid(fd, &raw mut uid, &raw mut gid) } != 0 {
+        return Err(ProbeErrorCategory::from_io_kind(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    Ok(classify_peer(uid, gid, target_uid, target_gid))
+}
+
+fn local_peercred(
+    fd: RawFd,
+    allow_unsupported: bool,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<CredentialIdentityClass, ProbeErrorCategory> {
+    let mut credential = MaybeUninit::<libc::xucred>::zeroed();
+    let mut length = libc::socklen_t::try_from(std::mem::size_of::<libc::xucred>())
+        .map_err(|_| ProbeErrorCategory::InvalidInput)?;
+    // SAFETY: The output points to `length` writable bytes and neither pointer is retained.
+    if unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERCRED,
+            credential.as_mut_ptr().cast(),
+            &raw mut length,
+        )
+    } != 0
+    {
+        let error = io::Error::last_os_error();
+        if allow_unsupported && unsupported_errno(error.raw_os_error()) {
+            return Ok(CredentialIdentityClass::Unsupported);
+        }
+        return Err(ProbeErrorCategory::from_io_kind(error.kind()));
+    }
+    if usize::try_from(length).ok() != Some(std::mem::size_of::<libc::xucred>()) {
+        return Err(ProbeErrorCategory::InvalidInput);
+    }
+    // SAFETY: Successful `getsockopt` initialized the complete fixed-size structure.
+    let credential = unsafe { credential.assume_init() };
+    let group_count = usize::try_from(credential.cr_ngroups)
+        .ok()
+        .filter(|count| *count <= credential.cr_groups.len())
+        .ok_or(ProbeErrorCategory::InvalidInput)?;
+    if credential.cr_version != XUCRED_VERSION {
+        return Err(ProbeErrorCategory::InvalidInput);
+    }
+    if group_count == 0 {
+        return Ok(CredentialIdentityClass::Other);
+    }
+    Ok(classify_peer(
+        credential.cr_uid,
+        credential.cr_groups[0],
+        target_uid,
+        target_gid,
+    ))
+}
+
+fn exact_peer_pid(
+    fd: RawFd,
+    expected: libc::pid_t,
+    socket_creator: Option<libc::pid_t>,
+) -> Result<PeerPidClass, ProbeErrorCategory> {
+    match crate::macos::peer_pid(fd) {
+        Ok(pid) if pid == expected => Ok(PeerPidClass::Exact),
+        Ok(pid) if Some(pid) == socket_creator => Ok(PeerPidClass::SocketCreator),
+        Ok(_) => Err(ProbeErrorCategory::PermissionDenied),
+        Err(error) => Err(ProbeErrorCategory::from_io_kind(error.kind())),
+    }
+}
+
+fn initial_token(fd: RawFd) -> Result<(PeerTokenClass, TokenBaseline), ProbeErrorCategory> {
+    match peer_token(fd)? {
+        Some(token) => Ok((PeerTokenClass::Baseline, TokenBaseline::Value(token))),
+        None => Ok((PeerTokenClass::Unsupported, TokenBaseline::Unsupported)),
+    }
+}
+
+fn later_token(fd: RawFd, baseline: &TokenBaseline) -> Result<PeerTokenClass, ProbeErrorCategory> {
+    match (baseline, peer_token(fd)?) {
+        (TokenBaseline::Unsupported, None) => Ok(PeerTokenClass::Unsupported),
+        (TokenBaseline::Value(expected), Some(actual)) if expected == &actual => {
+            Ok(PeerTokenClass::Unchanged)
+        }
+        (TokenBaseline::Value(_), Some(_)) => Ok(PeerTokenClass::Changed),
+        (TokenBaseline::Unsupported, Some(_)) | (TokenBaseline::Value(_), None) => {
+            Err(ProbeErrorCategory::InvalidInput)
+        }
+    }
+}
+
+fn peer_token(fd: RawFd) -> Result<Option<[u32; AUDIT_TOKEN_WORDS]>, ProbeErrorCategory> {
+    let mut token = [0_u32; AUDIT_TOKEN_WORDS];
+    let mut length = libc::socklen_t::try_from(std::mem::size_of_val(&token))
+        .map_err(|_| ProbeErrorCategory::InvalidInput)?;
+    // SAFETY: `token` points to `length` writable bytes and no pointer is retained.
+    if unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERTOKEN,
+            token.as_mut_ptr().cast(),
+            &raw mut length,
+        )
+    } != 0
+    {
+        let error = io::Error::last_os_error();
+        if unsupported_errno(error.raw_os_error()) {
+            return Ok(None);
+        }
+        return Err(ProbeErrorCategory::from_io_kind(error.kind()));
+    }
+    if usize::try_from(length).ok() != Some(std::mem::size_of_val(&token)) {
+        return Err(ProbeErrorCategory::InvalidInput);
+    }
+    Ok(Some(token))
+}
+
+const fn unsupported_errno(errno: Option<libc::c_int>) -> bool {
+    matches!(
+        errno,
+        Some(libc::EINVAL) | Some(libc::ENOPROTOOPT) | Some(libc::EOPNOTSUPP)
+    )
+}
+
+const fn classify_peer(
+    uid: u32,
+    gid: u32,
+    target_uid: u32,
+    target_gid: u32,
+) -> CredentialIdentityClass {
+    if uid == 0 && gid == 0 {
+        if target_uid == 0 && target_gid == 0 {
+            CredentialIdentityClass::InitialAndTarget
+        } else {
+            CredentialIdentityClass::InitialRoot
+        }
+    } else if uid == target_uid && gid == target_gid {
+        CredentialIdentityClass::Target
+    } else {
+        CredentialIdentityClass::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::{UnixDatagram, UnixStream};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct FakeOps {
+        ids: (u32, u32, u32, u32),
+        groups: Vec<u32>,
+        fail_step: Option<CredentialStep>,
+        groups_fail_at: Option<usize>,
+        group_calls: usize,
+        clear_postcondition_mismatch: bool,
+        target_postcondition_mismatch: bool,
+        restore_uid_result: Result<(), io::ErrorKind>,
+        restore_gid_result: Result<(), io::ErrorKind>,
+        restore_groups_result: Result<(), io::ErrorKind>,
+        calls: Vec<&'static str>,
+    }
+
+    impl FakeOps {
+        fn root() -> Self {
+            Self {
+                ids: (0, 0, 0, 0),
+                groups: vec![0, 1],
+                fail_step: None,
+                groups_fail_at: None,
+                group_calls: 0,
+                clear_postcondition_mismatch: false,
+                target_postcondition_mismatch: false,
+                restore_uid_result: Err(io::ErrorKind::PermissionDenied),
+                restore_gid_result: Err(io::ErrorKind::PermissionDenied),
+                restore_groups_result: Err(io::ErrorKind::PermissionDenied),
+                calls: Vec::new(),
+            }
+        }
+
+        fn fail(&self, step: CredentialStep) -> Result<(), io::ErrorKind> {
+            if self.fail_step == Some(step) {
+                Err(io::ErrorKind::PermissionDenied)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl CredentialOps for FakeOps {
+        fn ids(&mut self) -> (u32, u32, u32, u32) {
+            self.ids
+        }
+
+        fn groups(&mut self) -> Result<Vec<u32>, io::ErrorKind> {
+            self.group_calls += 1;
+            if self.groups_fail_at == Some(self.group_calls) {
+                return Err(io::ErrorKind::InvalidData);
+            }
+            Ok(self.groups.clone())
+        }
+
+        fn clear_groups(&mut self) -> Result<(), io::ErrorKind> {
+            self.calls.push("setgroups-empty");
+            self.fail(CredentialStep::ClearGroups)?;
+            self.groups = if self.clear_postcondition_mismatch {
+                vec![self.ids.3, 7]
+            } else {
+                vec![self.ids.3]
+            };
+            Ok(())
+        }
+
+        fn set_gid(&mut self, gid: u32) -> Result<(), io::ErrorKind> {
+            if gid == 0 && self.ids.0 != 0 {
+                self.calls.push("setgid-root");
+                if self.restore_gid_result.is_ok() {
+                    self.ids.2 = 0;
+                    self.ids.3 = 0;
+                    if self.groups.len() == 1 {
+                        self.groups[0] = 0;
+                    }
+                }
+                return self.restore_gid_result;
+            }
+            self.calls.push("setgid-target");
+            self.fail(CredentialStep::SetGid)?;
+            self.ids.2 = gid;
+            self.ids.3 = gid;
+            if self.groups.len() == 1 {
+                self.groups[0] = gid;
+            }
+            Ok(())
+        }
+
+        fn set_uid(&mut self, uid: u32) -> Result<(), io::ErrorKind> {
+            if uid == 0 {
+                self.calls.push("setuid-root");
+                if self.restore_uid_result.is_ok() {
+                    self.ids.0 = 0;
+                    self.ids.1 = 0;
+                }
+                return self.restore_uid_result;
+            }
+            self.calls.push("setuid-target");
+            self.fail(CredentialStep::SetUid)?;
+            self.ids.0 = uid;
+            self.ids.1 = if self.target_postcondition_mismatch {
+                uid.wrapping_add(1)
+            } else {
+                uid
+            };
+            Ok(())
+        }
+
+        fn restore_groups(&mut self) -> Result<(), io::ErrorKind> {
+            self.calls.push("setgroups-root");
+            if self.restore_groups_result.is_ok() {
+                self.groups = vec![0];
+            }
+            self.restore_groups_result
+        }
+    }
+
+    #[test]
+    fn ordered_drop_clears_groups_sets_gid_then_uid_and_proves_irreversibility() {
+        let mut ops = FakeOps::root();
+        let result = transition_with(&mut ops, ProbeMode::CredentialDrop, 501, 20)
+            .expect("complete transition should succeed");
+        assert_eq!(result.prefix(), CredentialPrefix::Irreversible);
+        assert_eq!(
+            result.state(),
+            CredentialSelfState::new(
+                CredentialIdentityClass::Target,
+                CredentialGroupClass::EffectiveOnly,
+            )
+        );
+        assert_eq!(
+            ops.calls,
+            [
+                "setgroups-empty",
+                "setgid-target",
+                "setuid-target",
+                "setuid-root",
+                "setgid-root",
+                "setgroups-root"
+            ]
+        );
+    }
+
+    #[test]
+    fn retained_root_calls_no_mutating_credential_operation() {
+        let mut ops = FakeOps::root();
+        let result = transition_with(&mut ops, ProbeMode::CredentialRetainRoot, 0, 0)
+            .expect("retained root should validate");
+        assert_eq!(result.prefix(), CredentialPrefix::RetainedRoot);
+        assert!(ops.calls.is_empty());
+    }
+
+    #[test]
+    fn every_mutating_failure_stops_at_the_exact_prefix() {
+        for (step, prefix) in [
+            (CredentialStep::ClearGroups, CredentialPrefix::Initial),
+            (CredentialStep::SetGid, CredentialPrefix::GroupsCleared),
+            (CredentialStep::SetUid, CredentialPrefix::GidSet),
+        ] {
+            let mut ops = FakeOps::root();
+            ops.fail_step = Some(step);
+            let failure = transition_with(&mut ops, ProbeMode::CredentialDrop, 501, 20)
+                .expect_err("injected failure should stop");
+            assert_eq!(failure.step(), step);
+            assert_eq!(failure.prefix(), prefix);
+        }
+    }
+
+    #[test]
+    fn every_group_query_boundary_stops_with_its_exact_prefix() {
+        for (call, step, prefix) in [
+            (1, CredentialStep::InitialIdentity, CredentialPrefix::None),
+            (
+                2,
+                CredentialStep::ValidateClearedGroups,
+                CredentialPrefix::Initial,
+            ),
+            (
+                3,
+                CredentialStep::ValidateFinalIdentity,
+                CredentialPrefix::UidSet,
+            ),
+            (
+                4,
+                CredentialStep::ValidateFinalIdentity,
+                CredentialPrefix::FinalIdentity,
+            ),
+        ] {
+            let mut ops = FakeOps::root();
+            ops.groups_fail_at = Some(call);
+            let failure = transition_with(&mut ops, ProbeMode::CredentialDrop, 501, 20)
+                .expect_err("injected group query failure should stop");
+            assert_eq!(failure.step(), step);
+            assert_eq!(failure.prefix(), prefix);
+            assert_eq!(failure.category(), ProbeErrorCategory::InvalidInput);
+        }
+    }
+
+    #[test]
+    fn postcondition_mismatches_stop_before_restoration_or_ordinary_work() {
+        let mut clear_mismatch = FakeOps::root();
+        clear_mismatch.clear_postcondition_mismatch = true;
+        let failure = transition_with(&mut clear_mismatch, ProbeMode::CredentialDrop, 501, 20)
+            .expect_err("extra supplementary groups must fail");
+        assert_eq!(failure.step(), CredentialStep::ValidateClearedGroups);
+        assert_eq!(failure.prefix(), CredentialPrefix::Initial);
+        assert_eq!(clear_mismatch.calls, ["setgroups-empty"]);
+
+        let mut target_mismatch = FakeOps::root();
+        target_mismatch.target_postcondition_mismatch = true;
+        let failure = transition_with(&mut target_mismatch, ProbeMode::CredentialDrop, 501, 20)
+            .expect_err("mixed target identity must fail");
+        assert_eq!(failure.step(), CredentialStep::ValidateFinalIdentity);
+        assert_eq!(failure.prefix(), CredentialPrefix::UidSet);
+        assert_eq!(
+            target_mismatch.calls,
+            ["setgroups-empty", "setgid-target", "setuid-target"]
+        );
+    }
+
+    #[test]
+    fn every_root_restoration_outcome_other_than_permission_denied_fails_closed() {
+        let mut uid_restored = FakeOps::root();
+        uid_restored.restore_uid_result = Ok(());
+        let failure = transition_with(&mut uid_restored, ProbeMode::CredentialDrop, 501, 20)
+            .expect_err("restored uid zero must fail closed");
+        assert_eq!(failure.step(), CredentialStep::RestoreUid);
+        assert_eq!(failure.category(), ProbeErrorCategory::Other);
+        assert_eq!(failure.prefix(), CredentialPrefix::FinalIdentity);
+
+        let mut uid_other_error = FakeOps::root();
+        uid_other_error.restore_uid_result = Err(io::ErrorKind::InvalidData);
+        let failure = transition_with(&mut uid_other_error, ProbeMode::CredentialDrop, 501, 20)
+            .expect_err("non-permission uid failure remains distinct");
+        assert_eq!(failure.step(), CredentialStep::RestoreUid);
+        assert_eq!(failure.category(), ProbeErrorCategory::InvalidInput);
+
+        let mut gid_restored = FakeOps::root();
+        gid_restored.restore_gid_result = Ok(());
+        let failure = transition_with(&mut gid_restored, ProbeMode::CredentialDrop, 501, 20)
+            .expect_err("restored gid zero must fail closed");
+        assert_eq!(failure.step(), CredentialStep::RestoreGid);
+        assert_eq!(failure.category(), ProbeErrorCategory::Other);
+
+        let mut groups_restored = FakeOps::root();
+        groups_restored.restore_groups_result = Ok(());
+        let failure = transition_with(&mut groups_restored, ProbeMode::CredentialDrop, 501, 20)
+            .expect_err("restored root access group must fail closed");
+        assert_eq!(failure.step(), CredentialStep::RestoreGroups);
+        assert_eq!(failure.category(), ProbeErrorCategory::Other);
+    }
+
+    #[test]
+    fn initial_identity_and_retained_root_postconditions_are_exact() {
+        let mut nonroot = FakeOps::root();
+        nonroot.ids = (501, 501, 20, 20);
+        let failure = transition_with(&mut nonroot, ProbeMode::CredentialDrop, 501, 20)
+            .expect_err("nonroot initial identity must fail");
+        assert_eq!(failure.step(), CredentialStep::InitialIdentity);
+        assert_eq!(failure.category(), ProbeErrorCategory::PermissionDenied);
+        assert!(nonroot.calls.is_empty());
+
+        let mut retained_query_failure = FakeOps::root();
+        retained_query_failure.groups_fail_at = Some(2);
+        let failure = transition_with(
+            &mut retained_query_failure,
+            ProbeMode::CredentialRetainRoot,
+            0,
+            0,
+        )
+        .expect_err("retained-root final group query must be exact");
+        assert_eq!(failure.step(), CredentialStep::ValidateFinalIdentity);
+        assert_eq!(failure.prefix(), CredentialPrefix::Initial);
+        assert!(retained_query_failure.calls.is_empty());
+    }
+
+    #[test]
+    fn peer_classification_never_exposes_numeric_values() {
+        assert_eq!(
+            classify_peer(0, 0, 501, 20),
+            CredentialIdentityClass::InitialRoot
+        );
+        assert_eq!(
+            classify_peer(501, 20, 501, 20),
+            CredentialIdentityClass::Target
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                CredentialTransition {
+                    state: CredentialSelfState::new(
+                        CredentialIdentityClass::Target,
+                        CredentialGroupClass::EffectiveOnly
+                    ),
+                    prefix: CredentialPrefix::Irreversible,
+                }
+            ),
+            "CredentialTransition(<redacted>)"
+        );
+    }
+
+    #[test]
+    fn connected_stream_and_datagram_observations_keep_identity_surfaces_separate() {
+        let (stream, _stream_peer) = UnixStream::pair().expect("stream pair");
+        let (datagram, datagram_peer) = UnixDatagram::pair().expect("datagram pair");
+        datagram.send(b"p").expect("datagram possession send");
+        let mut possession = [0_u8; 1];
+        datagram_peer
+            .recv(&mut possession)
+            .expect("datagram possession receive");
+        // SAFETY: Credential/PID getters have no pointer or ownership contract.
+        let (pid, uid, gid) = unsafe { (libc::getpid(), libc::geteuid(), libc::getegid()) };
+        let (initial, baseline) =
+            observe_initial_peer(stream.as_raw_fd(), datagram.as_raw_fd(), pid, pid, uid, gid)
+                .expect("current-process peer observations should succeed");
+        assert_eq!(initial.stream_eid(), CredentialIdentityClass::Target);
+        assert_eq!(initial.stream_cred(), CredentialIdentityClass::Target);
+        assert_eq!(initial.stream_pid(), PeerPidClass::Exact);
+        assert!(matches!(
+            initial.datagram_cred(),
+            CredentialIdentityClass::Target | CredentialIdentityClass::Unsupported
+        ));
+        assert_eq!(initial.datagram_pid(), PeerPidClass::Exact);
+        assert!(matches!(
+            initial.datagram_token(),
+            PeerTokenClass::Baseline | PeerTokenClass::Unsupported
+        ));
+        let later = observe_later_peer(
+            stream.as_raw_fd(),
+            datagram.as_raw_fd(),
+            pid,
+            pid,
+            uid,
+            gid,
+            &baseline,
+        )
+        .expect("later current-process observation should succeed");
+        assert_eq!(later.stream_pid(), PeerPidClass::Exact);
+        assert_eq!(later.datagram_pid(), PeerPidClass::Exact);
+        assert!(matches!(
+            later.datagram_token(),
+            PeerTokenClass::Unchanged | PeerTokenClass::Unsupported
+        ));
+        assert_eq!(format!("{baseline:?}"), "PeerBaseline(<redacted>)");
+
+        assert_eq!(
+            exact_peer_pid(datagram.as_raw_fd(), pid.wrapping_add(1), Some(pid)),
+            Ok(PeerPidClass::SocketCreator)
+        );
+        assert!(exact_peer_pid(datagram.as_raw_fd(), pid.wrapping_add(1), None).is_err());
+        assert!(stream_eid(datagram.as_raw_fd(), uid, gid).is_err());
+        assert!(
+            matches!(
+                observe_initial_peer(datagram.as_raw_fd(), stream.as_raw_fd(), pid, pid, uid, gid,),
+                Err(ProbeErrorCategory::InvalidInput)
+            ),
+            "stream and datagram descriptor roles must not be interchangeable"
+        );
+    }
+}

--- a/crates/session/src/elevated_probe.rs
+++ b/crates/session/src/elevated_probe.rs
@@ -16,10 +16,17 @@ pub const READY_RECORD: [u8; 16] = *b"BBEP-READY-V2\0\0\0";
 pub const BOOTSTRAP_RECORD_BYTES: usize = 64;
 /// Encoded terminal result record length.
 pub const RESULT_RECORD_BYTES: usize = 48;
+/// Encoded credential phase record length.
+pub const CREDENTIAL_RECORD_BYTES: usize = 80;
+/// Encoded credential datagram-possession record length.
+pub const CREDENTIAL_DATAGRAM_BYTES: usize = 48;
 
 const VERSION: u16 = 2;
 const BOOTSTRAP_MAGIC: [u8; 4] = *b"BBE2";
 const RESULT_MAGIC: [u8; 4] = *b"BBR2";
+const CREDENTIAL_VERSION: u16 = 1;
+const CREDENTIAL_MAGIC: [u8; 4] = *b"BBC1";
+const CREDENTIAL_DATAGRAM_MAGIC: [u8; 4] = *b"BBG1";
 
 /// Exact evidence mode selected by the explicit root wrapper.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -37,6 +44,14 @@ pub enum ProbeMode {
     HvfControl = 5,
     /// Inherit a launcher-entered root and run the sandbox/HVF evidence sequence.
     InheritedRoot = 6,
+    /// Drop both signed endpoints to one mapped nonzero numeric identity without chroot.
+    CredentialDrop = 7,
+    /// Retain exact root on both signed endpoints without calling credential mutators.
+    CredentialRetainRoot = 8,
+    /// Exercise the SDK-maximum unmapped numeric identity without chroot.
+    CredentialUnmapped = 9,
+    /// Run the same no-chroot credential primitive in the unsandboxed launcher.
+    CredentialControl = 10,
 }
 
 impl ProbeMode {
@@ -49,6 +64,10 @@ impl ProbeMode {
             "control" => Self::Control,
             "hvf-control" => Self::HvfControl,
             "inherited-root" => Self::InheritedRoot,
+            "credential-drop" => Self::CredentialDrop,
+            "credential-retain-root" => Self::CredentialRetainRoot,
+            "credential-unmapped" => Self::CredentialUnmapped,
+            "credential-control" => Self::CredentialControl,
             _ => return None,
         };
         mode.accepts_target(uid, gid).then_some(mode)
@@ -64,6 +83,10 @@ impl ProbeMode {
             Self::Control => "control",
             Self::HvfControl => "hvf-control",
             Self::InheritedRoot => "inherited-root",
+            Self::CredentialDrop => "credential-drop",
+            Self::CredentialRetainRoot => "credential-retain-root",
+            Self::CredentialUnmapped => "credential-unmapped",
+            Self::CredentialControl => "credential-control",
         }
     }
 
@@ -71,11 +94,29 @@ impl ProbeMode {
     #[must_use]
     pub const fn accepts_target(self, uid: u32, gid: u32) -> bool {
         match self {
-            Self::Drop | Self::UnmappedSyscall => uid != 0 && gid != 0,
+            Self::Drop | Self::UnmappedSyscall | Self::CredentialDrop => uid != 0 && gid != 0,
+            Self::CredentialUnmapped => uid == 2_147_483_647 && gid == 2_147_483_647,
             Self::RetainRoot | Self::Control | Self::HvfControl | Self::InheritedRoot => {
                 uid == 0 && gid == 0
             }
+            Self::CredentialRetainRoot => uid == 0 && gid == 0,
+            Self::CredentialControl => (uid == 0) == (gid == 0),
         }
+    }
+
+    /// Returns whether this mode runs the paired no-chroot credential protocol.
+    #[must_use]
+    pub const fn is_credential_pair(self) -> bool {
+        matches!(
+            self,
+            Self::CredentialDrop | Self::CredentialRetainRoot | Self::CredentialUnmapped
+        )
+    }
+
+    /// Returns whether this mode retains exact root without credential mutation.
+    #[must_use]
+    pub const fn retains_root(self) -> bool {
+        matches!(self, Self::CredentialRetainRoot)
     }
 
     fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
@@ -86,6 +127,10 @@ impl ProbeMode {
             4 => Ok(Self::Control),
             5 => Ok(Self::HvfControl),
             6 => Ok(Self::InheritedRoot),
+            7 => Ok(Self::CredentialDrop),
+            8 => Ok(Self::CredentialRetainRoot),
+            9 => Ok(Self::CredentialUnmapped),
+            10 => Ok(Self::CredentialControl),
             _ => Err(ProbeProtocolError),
         }
     }
@@ -225,6 +270,1017 @@ impl ProbeErrorCategory {
     }
 }
 
+/// Fixed process role in the credential evidence exchange.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialRole {
+    /// The unsandboxed outer launcher endpoint.
+    Launcher = 1,
+    /// The mandatory App Sandbox and Hypervisor worker endpoint.
+    Worker = 2,
+}
+
+impl CredentialRole {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            1 => Ok(Self::Launcher),
+            2 => Ok(Self::Worker),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free role spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Launcher => "launcher",
+            Self::Worker => "worker",
+        }
+    }
+}
+
+/// Exact phase in the credential datagram possession barrier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialDatagramPhase {
+    /// Launcher proves possession after sending the stream bootstrap.
+    Challenge = 1,
+    /// Worker proves possession while both endpoints remain root.
+    WorkerReady = 2,
+    /// Launcher releases the worker only after its own initial observation.
+    LauncherRelease = 3,
+}
+
+impl CredentialDatagramPhase {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            1 => Ok(Self::Challenge),
+            2 => Ok(Self::WorkerReady),
+            3 => Ok(Self::LauncherRelease),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+/// Nonce-bound proof that the expected process owns the inherited datagram endpoint.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CredentialDatagramProof {
+    mode: ProbeMode,
+    phase: CredentialDatagramPhase,
+    role: CredentialRole,
+    nonce: SessionId,
+}
+
+impl CredentialDatagramProof {
+    /// Constructs the launcher challenge.
+    pub fn challenge(mode: ProbeMode, nonce: SessionId) -> Result<Self, ProbeProtocolError> {
+        Self::new(
+            mode,
+            CredentialDatagramPhase::Challenge,
+            CredentialRole::Launcher,
+            nonce,
+        )
+    }
+
+    /// Constructs the worker possession response.
+    pub fn worker_ready(mode: ProbeMode, nonce: SessionId) -> Result<Self, ProbeProtocolError> {
+        Self::new(
+            mode,
+            CredentialDatagramPhase::WorkerReady,
+            CredentialRole::Worker,
+            nonce,
+        )
+    }
+
+    /// Constructs the launcher release barrier.
+    pub fn launcher_release(mode: ProbeMode, nonce: SessionId) -> Result<Self, ProbeProtocolError> {
+        Self::new(
+            mode,
+            CredentialDatagramPhase::LauncherRelease,
+            CredentialRole::Launcher,
+            nonce,
+        )
+    }
+
+    fn new(
+        mode: ProbeMode,
+        phase: CredentialDatagramPhase,
+        role: CredentialRole,
+        nonce: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
+        let expected_role = match phase {
+            CredentialDatagramPhase::Challenge | CredentialDatagramPhase::LauncherRelease => {
+                CredentialRole::Launcher
+            }
+            CredentialDatagramPhase::WorkerReady => CredentialRole::Worker,
+        };
+        if !mode.is_credential_pair() || nonce.is_pre_session() || role != expected_role {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            mode,
+            phase,
+            role,
+            nonce,
+        })
+    }
+
+    /// Returns the selected credential mode.
+    #[must_use]
+    pub const fn mode(self) -> ProbeMode {
+        self.mode
+    }
+
+    /// Returns the exact barrier phase.
+    #[must_use]
+    pub const fn phase(self) -> CredentialDatagramPhase {
+        self.phase
+    }
+
+    /// Returns the sending process role.
+    #[must_use]
+    pub const fn role(self) -> CredentialRole {
+        self.role
+    }
+
+    /// Returns the command nonce.
+    #[must_use]
+    pub const fn nonce(self) -> SessionId {
+        self.nonce
+    }
+
+    /// Returns whether this proof is the exact next barrier frame.
+    #[must_use]
+    pub fn matches_expected(
+        self,
+        mode: ProbeMode,
+        phase: CredentialDatagramPhase,
+        role: CredentialRole,
+        nonce: SessionId,
+    ) -> bool {
+        self.mode == mode && self.phase == phase && self.role == role && self.nonce == nonce
+    }
+
+    /// Encodes the exact datagram record.
+    #[must_use]
+    pub fn encode(self) -> [u8; CREDENTIAL_DATAGRAM_BYTES] {
+        let mut bytes = [0_u8; CREDENTIAL_DATAGRAM_BYTES];
+        bytes[0..4].copy_from_slice(&CREDENTIAL_DATAGRAM_MAGIC);
+        bytes[4..6].copy_from_slice(&CREDENTIAL_VERSION.to_be_bytes());
+        bytes[6] = self.mode as u8;
+        bytes[7] = self.phase as u8;
+        bytes[8] = self.role as u8;
+        bytes[16..48].copy_from_slice(self.nonce.as_bytes());
+        bytes
+    }
+
+    /// Decodes and validates one exact datagram record.
+    pub fn decode(bytes: &[u8; CREDENTIAL_DATAGRAM_BYTES]) -> Result<Self, ProbeProtocolError> {
+        if bytes[0..4] != CREDENTIAL_DATAGRAM_MAGIC
+            || bytes[4..6] != CREDENTIAL_VERSION.to_be_bytes()
+            || bytes[9..16] != [0; 7]
+        {
+            return Err(ProbeProtocolError);
+        }
+        Self::new(
+            ProbeMode::from_byte(bytes[6])?,
+            CredentialDatagramPhase::from_byte(bytes[7])?,
+            CredentialRole::from_byte(bytes[8])?,
+            SessionId::from_bytes(array(bytes, 16)?),
+        )
+    }
+}
+
+impl fmt::Debug for CredentialDatagramProof {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialDatagramProof(<redacted>)")
+    }
+}
+
+/// Stable credential operation or validation step.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialStep {
+    /// Validate initial real/effective root and capture supplementary groups.
+    InitialIdentity = 1,
+    /// Clear the supplementary group list.
+    ClearGroups = 2,
+    /// Validate the cleared supplementary group list.
+    ValidateClearedGroups = 3,
+    /// Set the target real/effective/saved group identity.
+    SetGid = 4,
+    /// Set the target real/effective/saved user identity.
+    SetUid = 5,
+    /// Validate final real/effective identity and supplementary groups.
+    ValidateFinalIdentity = 6,
+    /// Prove user identity zero cannot be restored.
+    RestoreUid = 7,
+    /// Prove group identity zero cannot be restored.
+    RestoreGid = 8,
+    /// Prove root supplementary groups cannot be restored.
+    RestoreGroups = 9,
+    /// Observe connected stream and datagram peer surfaces.
+    PeerObservation = 10,
+    /// Validate the closed multi-phase credential exchange.
+    Protocol = 11,
+}
+
+impl CredentialStep {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            1 => Ok(Self::InitialIdentity),
+            2 => Ok(Self::ClearGroups),
+            3 => Ok(Self::ValidateClearedGroups),
+            4 => Ok(Self::SetGid),
+            5 => Ok(Self::SetUid),
+            6 => Ok(Self::ValidateFinalIdentity),
+            7 => Ok(Self::RestoreUid),
+            8 => Ok(Self::RestoreGid),
+            9 => Ok(Self::RestoreGroups),
+            10 => Ok(Self::PeerObservation),
+            11 => Ok(Self::Protocol),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free step spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::InitialIdentity => "initial-identity",
+            Self::ClearGroups => "clear-groups",
+            Self::ValidateClearedGroups => "validate-cleared-groups",
+            Self::SetGid => "set-gid",
+            Self::SetUid => "set-uid",
+            Self::ValidateFinalIdentity => "validate-final-identity",
+            Self::RestoreUid => "restore-uid",
+            Self::RestoreGid => "restore-gid",
+            Self::RestoreGroups => "restore-groups",
+            Self::PeerObservation => "peer-observation",
+            Self::Protocol => "protocol",
+        }
+    }
+}
+
+/// Last complete prefix of the ordered credential transition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialPrefix {
+    /// No credential transition step completed.
+    None = 0,
+    /// Initial root identity and groups were validated.
+    Initial = 1,
+    /// Supplementary groups were cleared and revalidated.
+    GroupsCleared = 2,
+    /// Target gid was installed.
+    GidSet = 3,
+    /// Target uid was installed.
+    UidSet = 4,
+    /// Final target identity and effective-group-only access list were validated.
+    FinalIdentity = 5,
+    /// Root restoration attempts all failed and final state remained exact.
+    Irreversible = 6,
+    /// Retained-root state remained identical without credential mutation.
+    RetainedRoot = 7,
+}
+
+impl CredentialPrefix {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            0 => Ok(Self::None),
+            1 => Ok(Self::Initial),
+            2 => Ok(Self::GroupsCleared),
+            3 => Ok(Self::GidSet),
+            4 => Ok(Self::UidSet),
+            5 => Ok(Self::FinalIdentity),
+            6 => Ok(Self::Irreversible),
+            7 => Ok(Self::RetainedRoot),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free prefix spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Initial => "initial",
+            Self::GroupsCleared => "groups-cleared",
+            Self::GidSet => "gid-set",
+            Self::UidSet => "uid-set",
+            Self::FinalIdentity => "final-identity",
+            Self::Irreversible => "irreversible",
+            Self::RetainedRoot => "retained-root",
+        }
+    }
+}
+
+/// Value-free classification of one process or peer identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialIdentityClass {
+    /// No identity was observed in this record slot.
+    NotObserved = 0,
+    /// Exact initial root identity.
+    InitialRoot = 1,
+    /// Exact requested nonzero target identity.
+    Target = 2,
+    /// Root is both the initial and requested retained identity.
+    InitialAndTarget = 3,
+    /// A supported query returned another identity class.
+    Other = 4,
+    /// The public query is unsupported for this socket surface.
+    Unsupported = 5,
+}
+
+impl CredentialIdentityClass {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            0 => Ok(Self::NotObserved),
+            1 => Ok(Self::InitialRoot),
+            2 => Ok(Self::Target),
+            3 => Ok(Self::InitialAndTarget),
+            4 => Ok(Self::Other),
+            5 => Ok(Self::Unsupported),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free identity spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::NotObserved => "not-observed",
+            Self::InitialRoot => "initial-root",
+            Self::Target => "target",
+            Self::InitialAndTarget => "initial-and-target",
+            Self::Other => "other",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// Value-free classification of one process supplementary-group state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialGroupClass {
+    /// No group state was observed in this record slot.
+    NotObserved = 0,
+    /// Exact initial supplementary groups were retained.
+    Initial = 1,
+    /// Darwin reports only the current effective gid after supplementary groups are cleared.
+    EffectiveOnly = 2,
+    /// Another group state was observed.
+    Other = 3,
+}
+
+impl CredentialGroupClass {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            0 => Ok(Self::NotObserved),
+            1 => Ok(Self::Initial),
+            2 => Ok(Self::EffectiveOnly),
+            3 => Ok(Self::Other),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free supplementary-group spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::NotObserved => "not-observed",
+            Self::Initial => "initial",
+            Self::EffectiveOnly => "effective-only",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// Value-free final self state reported by one credential endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CredentialSelfState {
+    identity: CredentialIdentityClass,
+    groups: CredentialGroupClass,
+}
+
+impl CredentialSelfState {
+    /// Constructs one final self-state classification.
+    #[must_use]
+    pub const fn new(identity: CredentialIdentityClass, groups: CredentialGroupClass) -> Self {
+        Self { identity, groups }
+    }
+
+    /// Returns the identity class.
+    #[must_use]
+    pub const fn identity(self) -> CredentialIdentityClass {
+        self.identity
+    }
+
+    /// Returns the supplementary-group class.
+    #[must_use]
+    pub const fn groups(self) -> CredentialGroupClass {
+        self.groups
+    }
+}
+
+/// Value-free failure details carried by a credential phase record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CredentialFailureValue {
+    step: CredentialStep,
+    category: ProbeErrorCategory,
+    prefix: CredentialPrefix,
+    state: CredentialSelfState,
+}
+
+impl CredentialFailureValue {
+    /// Constructs one exact failure value.
+    #[must_use]
+    pub const fn new(
+        step: CredentialStep,
+        category: ProbeErrorCategory,
+        prefix: CredentialPrefix,
+        state: CredentialSelfState,
+    ) -> Self {
+        Self {
+            step,
+            category,
+            prefix,
+            state,
+        }
+    }
+
+    /// Returns the failed operation or validation step.
+    #[must_use]
+    pub const fn step(self) -> CredentialStep {
+        self.step
+    }
+
+    /// Returns the redacted operating-system category.
+    #[must_use]
+    pub const fn category(self) -> ProbeErrorCategory {
+        self.category
+    }
+
+    /// Returns the last complete ordered prefix.
+    #[must_use]
+    pub const fn prefix(self) -> CredentialPrefix {
+        self.prefix
+    }
+
+    /// Returns the value-free self state at failure.
+    #[must_use]
+    pub const fn state(self) -> CredentialSelfState {
+        self.state
+    }
+}
+
+/// Live PID observation for one connected local socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PeerPidClass {
+    /// No PID query was made in this record slot.
+    NotObserved = 0,
+    /// The public query returned the exact expected live PID.
+    Exact = 1,
+    /// The public query retained the fixed socketpair creator PID.
+    SocketCreator = 2,
+    /// The public query returned another positive PID.
+    Mismatch = 3,
+    /// The public query is unsupported for this socket surface.
+    Unsupported = 4,
+}
+
+impl PeerPidClass {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            0 => Ok(Self::NotObserved),
+            1 => Ok(Self::Exact),
+            2 => Ok(Self::SocketCreator),
+            3 => Ok(Self::Mismatch),
+            4 => Ok(Self::Unsupported),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+/// Opaque audit-token observation relative to the initial connected peer token.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PeerTokenClass {
+    /// No token query was made in this record slot.
+    NotObserved = 0,
+    /// The initial opaque peer token was captured.
+    Baseline = 1,
+    /// The later opaque peer token is byte-for-byte unchanged.
+    Unchanged = 2,
+    /// The later opaque peer token changed without decoding its fields.
+    Changed = 3,
+    /// The public query is unsupported for this socket surface.
+    Unsupported = 4,
+}
+
+impl PeerTokenClass {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            0 => Ok(Self::NotObserved),
+            1 => Ok(Self::Baseline),
+            2 => Ok(Self::Unchanged),
+            3 => Ok(Self::Changed),
+            4 => Ok(Self::Unsupported),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+/// Bounded semantic observations for one stream/datagram peer boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PeerObservation {
+    stream_eid: CredentialIdentityClass,
+    stream_cred: CredentialIdentityClass,
+    stream_pid: PeerPidClass,
+    datagram_cred: CredentialIdentityClass,
+    datagram_pid: PeerPidClass,
+    datagram_token: PeerTokenClass,
+}
+
+impl PeerObservation {
+    /// The exact empty observation used for a phase that has not run.
+    pub const NONE: Self = Self {
+        stream_eid: CredentialIdentityClass::NotObserved,
+        stream_cred: CredentialIdentityClass::NotObserved,
+        stream_pid: PeerPidClass::NotObserved,
+        datagram_cred: CredentialIdentityClass::NotObserved,
+        datagram_pid: PeerPidClass::NotObserved,
+        datagram_token: PeerTokenClass::NotObserved,
+    };
+
+    /// Constructs one complete value-free observation.
+    pub fn new(
+        stream_eid: CredentialIdentityClass,
+        stream_cred: CredentialIdentityClass,
+        stream_pid: PeerPidClass,
+        datagram_cred: CredentialIdentityClass,
+        datagram_pid: PeerPidClass,
+        datagram_token: PeerTokenClass,
+    ) -> Result<Self, ProbeProtocolError> {
+        if matches!(stream_eid, CredentialIdentityClass::NotObserved)
+            || matches!(stream_cred, CredentialIdentityClass::NotObserved)
+            || matches!(stream_pid, PeerPidClass::NotObserved)
+            || matches!(datagram_cred, CredentialIdentityClass::NotObserved)
+            || matches!(datagram_pid, PeerPidClass::NotObserved)
+            || matches!(datagram_token, PeerTokenClass::NotObserved)
+        {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            stream_eid,
+            stream_cred,
+            stream_pid,
+            datagram_cred,
+            datagram_pid,
+            datagram_token,
+        })
+    }
+
+    /// Returns whether no observation was recorded.
+    #[must_use]
+    pub const fn is_none(self) -> bool {
+        matches!(self.stream_eid, CredentialIdentityClass::NotObserved)
+            && matches!(self.stream_cred, CredentialIdentityClass::NotObserved)
+            && matches!(self.stream_pid, PeerPidClass::NotObserved)
+            && matches!(self.datagram_cred, CredentialIdentityClass::NotObserved)
+            && matches!(self.datagram_pid, PeerPidClass::NotObserved)
+            && matches!(self.datagram_token, PeerTokenClass::NotObserved)
+    }
+
+    /// Returns the stream `getpeereid` class.
+    #[must_use]
+    pub const fn stream_eid(self) -> CredentialIdentityClass {
+        self.stream_eid
+    }
+
+    /// Returns the stream `LOCAL_PEERCRED` class.
+    #[must_use]
+    pub const fn stream_cred(self) -> CredentialIdentityClass {
+        self.stream_cred
+    }
+
+    /// Returns the stream live-PID class.
+    #[must_use]
+    pub const fn stream_pid(self) -> PeerPidClass {
+        self.stream_pid
+    }
+
+    /// Returns the datagram `LOCAL_PEERCRED` class.
+    #[must_use]
+    pub const fn datagram_cred(self) -> CredentialIdentityClass {
+        self.datagram_cred
+    }
+
+    /// Returns the datagram live-PID class.
+    #[must_use]
+    pub const fn datagram_pid(self) -> PeerPidClass {
+        self.datagram_pid
+    }
+
+    /// Returns the opaque datagram token class.
+    #[must_use]
+    pub const fn datagram_token(self) -> PeerTokenClass {
+        self.datagram_token
+    }
+
+    fn encode(self) -> [u8; 6] {
+        [
+            self.stream_eid as u8,
+            self.stream_cred as u8,
+            self.stream_pid as u8,
+            self.datagram_cred as u8,
+            self.datagram_pid as u8,
+            self.datagram_token as u8,
+        ]
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, ProbeProtocolError> {
+        let [
+            stream_eid,
+            stream_cred,
+            stream_pid,
+            datagram_cred,
+            datagram_pid,
+            datagram_token,
+        ] = array::<6>(bytes, 0)?;
+        let observation = Self {
+            stream_eid: CredentialIdentityClass::from_byte(stream_eid)?,
+            stream_cred: CredentialIdentityClass::from_byte(stream_cred)?,
+            stream_pid: PeerPidClass::from_byte(stream_pid)?,
+            datagram_cred: CredentialIdentityClass::from_byte(datagram_cred)?,
+            datagram_pid: PeerPidClass::from_byte(datagram_pid)?,
+            datagram_token: PeerTokenClass::from_byte(datagram_token)?,
+        };
+        if observation.is_none()
+            || (!matches!(observation.stream_eid, CredentialIdentityClass::NotObserved)
+                && !matches!(
+                    observation.stream_cred,
+                    CredentialIdentityClass::NotObserved
+                )
+                && !matches!(observation.stream_pid, PeerPidClass::NotObserved)
+                && !matches!(
+                    observation.datagram_cred,
+                    CredentialIdentityClass::NotObserved
+                )
+                && !matches!(observation.datagram_pid, PeerPidClass::NotObserved)
+                && !matches!(observation.datagram_token, PeerTokenClass::NotObserved))
+        {
+            Ok(observation)
+        } else {
+            Err(ProbeProtocolError)
+        }
+    }
+}
+
+/// Fixed state carried by one credential phase record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialRecordKind {
+    /// Worker completed its transition and first two observations.
+    WorkerTransitioned = 1,
+    /// Launcher completed its transition and all three local observations.
+    LauncherTransitioned = 2,
+    /// Worker completed its final after-both observation.
+    WorkerFinal = 3,
+    /// One role stopped at an exact credential or protocol step.
+    Failure = 4,
+}
+
+impl CredentialRecordKind {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            1 => Ok(Self::WorkerTransitioned),
+            2 => Ok(Self::LauncherTransitioned),
+            3 => Ok(Self::WorkerFinal),
+            4 => Ok(Self::Failure),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+/// One authenticated, value-free credential phase or failure record.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CredentialRecord {
+    mode: ProbeMode,
+    kind: CredentialRecordKind,
+    role: CredentialRole,
+    failure: Option<(CredentialStep, ProbeErrorCategory, CredentialPrefix)>,
+    identity: CredentialIdentityClass,
+    groups: CredentialGroupClass,
+    observations: [PeerObservation; 3],
+    nonce: SessionId,
+}
+
+impl CredentialRecord {
+    /// Constructs a successful worker-transition record.
+    pub fn worker_transitioned(
+        mode: ProbeMode,
+        state: CredentialSelfState,
+        initial: PeerObservation,
+        after_worker: PeerObservation,
+        nonce: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
+        Self::success(
+            mode,
+            CredentialRecordKind::WorkerTransitioned,
+            CredentialRole::Worker,
+            state,
+            [initial, after_worker, PeerObservation::NONE],
+            nonce,
+        )
+    }
+
+    /// Constructs a successful launcher-transition record.
+    pub fn launcher_transitioned(
+        mode: ProbeMode,
+        state: CredentialSelfState,
+        observations: [PeerObservation; 3],
+        nonce: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
+        Self::success(
+            mode,
+            CredentialRecordKind::LauncherTransitioned,
+            CredentialRole::Launcher,
+            state,
+            observations,
+            nonce,
+        )
+    }
+
+    /// Constructs a successful worker-final record.
+    pub fn worker_final(
+        mode: ProbeMode,
+        state: CredentialSelfState,
+        observations: [PeerObservation; 3],
+        nonce: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
+        Self::success(
+            mode,
+            CredentialRecordKind::WorkerFinal,
+            CredentialRole::Worker,
+            state,
+            observations,
+            nonce,
+        )
+    }
+
+    /// Constructs a value-free failure record.
+    pub fn failure(
+        mode: ProbeMode,
+        role: CredentialRole,
+        failure: CredentialFailureValue,
+        initial: PeerObservation,
+        nonce: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
+        if !mode.is_credential_pair()
+            || nonce.is_pre_session()
+            || matches!(
+                failure.state().identity(),
+                CredentialIdentityClass::NotObserved | CredentialIdentityClass::Unsupported
+            )
+            || matches!(failure.state().groups(), CredentialGroupClass::NotObserved)
+            || (failure.prefix() != CredentialPrefix::None && initial.is_none())
+        {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            mode,
+            kind: CredentialRecordKind::Failure,
+            role,
+            failure: Some((failure.step(), failure.category(), failure.prefix())),
+            identity: failure.state().identity(),
+            groups: failure.state().groups(),
+            observations: [initial, PeerObservation::NONE, PeerObservation::NONE],
+            nonce,
+        })
+    }
+
+    fn success(
+        mode: ProbeMode,
+        kind: CredentialRecordKind,
+        role: CredentialRole,
+        state: CredentialSelfState,
+        observations: [PeerObservation; 3],
+        nonce: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
+        let expected = if mode.retains_root() {
+            (
+                CredentialIdentityClass::InitialAndTarget,
+                CredentialGroupClass::Initial,
+            )
+        } else {
+            (
+                CredentialIdentityClass::Target,
+                CredentialGroupClass::EffectiveOnly,
+            )
+        };
+        let observation_shape = match kind {
+            CredentialRecordKind::WorkerTransitioned => {
+                !observations[0].is_none()
+                    && !observations[1].is_none()
+                    && observations[2].is_none()
+                    && role == CredentialRole::Worker
+            }
+            CredentialRecordKind::LauncherTransitioned => {
+                observations
+                    .iter()
+                    .all(|observation| !observation.is_none())
+                    && role == CredentialRole::Launcher
+            }
+            CredentialRecordKind::WorkerFinal => {
+                observations
+                    .iter()
+                    .all(|observation| !observation.is_none())
+                    && role == CredentialRole::Worker
+            }
+            CredentialRecordKind::Failure => false,
+        };
+        if !mode.is_credential_pair()
+            || nonce.is_pre_session()
+            || (state.identity(), state.groups()) != expected
+            || !observation_shape
+        {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            mode,
+            kind,
+            role,
+            failure: None,
+            identity: state.identity(),
+            groups: state.groups(),
+            observations,
+            nonce,
+        })
+    }
+
+    /// Returns the selected probe mode.
+    #[must_use]
+    pub const fn mode(self) -> ProbeMode {
+        self.mode
+    }
+
+    /// Returns the exact phase kind.
+    #[must_use]
+    pub const fn kind(self) -> CredentialRecordKind {
+        self.kind
+    }
+
+    /// Returns the sender or failing process role.
+    #[must_use]
+    pub const fn role(self) -> CredentialRole {
+        self.role
+    }
+
+    /// Returns the fixed failure triple, if this is a failure record.
+    #[must_use]
+    pub const fn failure_value(
+        self,
+    ) -> Option<(CredentialStep, ProbeErrorCategory, CredentialPrefix)> {
+        self.failure
+    }
+
+    /// Returns the sender's final identity class.
+    #[must_use]
+    pub const fn identity(self) -> CredentialIdentityClass {
+        self.identity
+    }
+
+    /// Returns the sender's final supplementary-group class.
+    #[must_use]
+    pub const fn groups(self) -> CredentialGroupClass {
+        self.groups
+    }
+
+    /// Returns the phase-ordered peer observations.
+    #[must_use]
+    pub const fn observations(self) -> [PeerObservation; 3] {
+        self.observations
+    }
+
+    /// Returns the command nonce.
+    #[must_use]
+    pub const fn nonce(self) -> SessionId {
+        self.nonce
+    }
+
+    /// Returns whether this record belongs to the exact exchange and sender.
+    #[must_use]
+    pub fn matches_exchange(self, mode: ProbeMode, role: CredentialRole, nonce: SessionId) -> bool {
+        self.mode == mode && self.role == role && self.nonce == nonce
+    }
+
+    /// Returns whether this record is the exact next successful phase.
+    #[must_use]
+    pub fn matches_expected(
+        self,
+        mode: ProbeMode,
+        kind: CredentialRecordKind,
+        role: CredentialRole,
+        nonce: SessionId,
+    ) -> bool {
+        self.matches_exchange(mode, role, nonce) && self.kind == kind
+    }
+
+    /// Encodes the exact credential phase record.
+    #[must_use]
+    pub fn encode(self) -> [u8; CREDENTIAL_RECORD_BYTES] {
+        let mut bytes = [0_u8; CREDENTIAL_RECORD_BYTES];
+        bytes[0..4].copy_from_slice(&CREDENTIAL_MAGIC);
+        bytes[4..6].copy_from_slice(&CREDENTIAL_VERSION.to_be_bytes());
+        bytes[6] = self.mode as u8;
+        bytes[7] = self.kind as u8;
+        bytes[8] = self.role as u8;
+        bytes[9] = u8::from(self.failure.is_none());
+        if let Some((step, category, prefix)) = self.failure {
+            bytes[10] = step as u8;
+            bytes[11] = category as u8;
+            bytes[12] = prefix as u8;
+        }
+        bytes[13] = self.identity as u8;
+        bytes[14] = self.groups as u8;
+        for (index, observation) in self.observations.into_iter().enumerate() {
+            let start = 16 + index * 6;
+            if let Some(slot) = bytes.get_mut(start..start + 6) {
+                slot.copy_from_slice(&observation.encode());
+            }
+        }
+        bytes[48..80].copy_from_slice(self.nonce.as_bytes());
+        bytes
+    }
+
+    /// Decodes and validates one exact credential phase record.
+    pub fn decode(bytes: &[u8; CREDENTIAL_RECORD_BYTES]) -> Result<Self, ProbeProtocolError> {
+        if bytes[0..4] != CREDENTIAL_MAGIC
+            || bytes[4..6] != CREDENTIAL_VERSION.to_be_bytes()
+            || bytes[15] != 0
+            || bytes[34..48] != [0; 14]
+        {
+            return Err(ProbeProtocolError);
+        }
+        let mode = ProbeMode::from_byte(bytes[6])?;
+        let kind = CredentialRecordKind::from_byte(bytes[7])?;
+        let role = CredentialRole::from_byte(bytes[8])?;
+        let identity = CredentialIdentityClass::from_byte(bytes[13])?;
+        let groups = CredentialGroupClass::from_byte(bytes[14])?;
+        let observations = [
+            PeerObservation::decode(&bytes[16..22])?,
+            PeerObservation::decode(&bytes[22..28])?,
+            PeerObservation::decode(&bytes[28..34])?,
+        ];
+        let nonce = SessionId::from_bytes(array(bytes, 48)?);
+        match (kind, bytes[9], bytes[10], bytes[11], bytes[12]) {
+            (CredentialRecordKind::Failure, 0, step, category, prefix) => Self::failure(
+                mode,
+                role,
+                CredentialFailureValue::new(
+                    CredentialStep::from_byte(step)?,
+                    ProbeErrorCategory::from_byte(category)?,
+                    CredentialPrefix::from_byte(prefix)?,
+                    CredentialSelfState::new(identity, groups),
+                ),
+                observations[0],
+                nonce,
+            ),
+            (CredentialRecordKind::WorkerTransitioned, 1, 0, 0, 0) => Self::worker_transitioned(
+                mode,
+                CredentialSelfState::new(identity, groups),
+                observations[0],
+                observations[1],
+                nonce,
+            ),
+            (CredentialRecordKind::LauncherTransitioned, 1, 0, 0, 0) => {
+                Self::launcher_transitioned(
+                    mode,
+                    CredentialSelfState::new(identity, groups),
+                    observations,
+                    nonce,
+                )
+            }
+            (CredentialRecordKind::WorkerFinal, 1, 0, 0, 0) => Self::worker_final(
+                mode,
+                CredentialSelfState::new(identity, groups),
+                observations,
+                nonce,
+            ),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+impl fmt::Debug for CredentialRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialRecord(<redacted>)")
+    }
+}
+
 /// One nonce-bound exact-root bootstrap command.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ProbeBootstrap {
@@ -244,7 +1300,7 @@ impl ProbeBootstrap {
         root: ObjectIdentity,
         nonce: SessionId,
     ) -> Result<Self, ProbeProtocolError> {
-        if mode == ProbeMode::Control
+        if matches!(mode, ProbeMode::Control | ProbeMode::CredentialControl)
             || !mode.accepts_target(target_uid, target_gid)
             || root.device == 0
             || root.inode == 0
@@ -340,7 +1396,9 @@ pub struct ProbeResult {
 impl ProbeResult {
     /// Constructs a successful terminal result.
     pub fn success(mode: ProbeMode, nonce: SessionId) -> Result<Self, ProbeProtocolError> {
-        if mode == ProbeMode::Control || nonce.is_pre_session() {
+        if matches!(mode, ProbeMode::Control | ProbeMode::CredentialControl)
+            || nonce.is_pre_session()
+        {
             return Err(ProbeProtocolError);
         }
         Ok(Self {
@@ -357,7 +1415,9 @@ impl ProbeResult {
         stage: ProbeStage,
         category: ProbeErrorCategory,
     ) -> Result<Self, ProbeProtocolError> {
-        if mode == ProbeMode::Control || nonce.is_pre_session() {
+        if matches!(mode, ProbeMode::Control | ProbeMode::CredentialControl)
+            || nonce.is_pre_session()
+        {
             return Err(ProbeProtocolError);
         }
         Ok(Self {
@@ -411,7 +1471,7 @@ impl ProbeResult {
             return Err(ProbeProtocolError);
         }
         let mode = ProbeMode::from_byte(bytes[6])?;
-        if mode == ProbeMode::Control {
+        if matches!(mode, ProbeMode::Control | ProbeMode::CredentialControl) {
             return Err(ProbeProtocolError);
         }
         let nonce = SessionId::from_bytes(array(bytes, 16)?);
@@ -607,6 +1667,32 @@ mod tests {
         );
         assert_eq!(ProbeMode::parse("hvf-control", 501, 20), None);
         assert_eq!(ProbeMode::parse("inherited-root", 501, 20), None);
+        assert_eq!(
+            ProbeMode::parse("credential-drop", 501, 20),
+            Some(ProbeMode::CredentialDrop)
+        );
+        assert_eq!(ProbeMode::parse("credential-drop", 0, 0), None);
+        assert_eq!(
+            ProbeMode::parse("credential-retain-root", 0, 0),
+            Some(ProbeMode::CredentialRetainRoot)
+        );
+        assert_eq!(
+            ProbeMode::parse("credential-unmapped", 2_147_483_647, 2_147_483_647),
+            Some(ProbeMode::CredentialUnmapped)
+        );
+        assert_eq!(
+            ProbeMode::parse("credential-unmapped", u32::MAX, u32::MAX),
+            None
+        );
+        assert_eq!(
+            ProbeMode::parse("credential-control", 501, 20),
+            Some(ProbeMode::CredentialControl)
+        );
+        assert_eq!(
+            ProbeMode::parse("credential-control", 0, 0),
+            Some(ProbeMode::CredentialControl)
+        );
+        assert_eq!(ProbeMode::parse("credential-control", 501, 0), None);
         assert_eq!(ProbeMode::parse("unknown", 501, 20), None);
     }
 
@@ -652,6 +1738,9 @@ mod tests {
             (ProbeMode::UnmappedSyscall, u32::MAX, u32::MAX),
             (ProbeMode::HvfControl, 0, 0),
             (ProbeMode::InheritedRoot, 0, 0),
+            (ProbeMode::CredentialDrop, 501, 20),
+            (ProbeMode::CredentialRetainRoot, 0, 0),
+            (ProbeMode::CredentialUnmapped, 2_147_483_647, 2_147_483_647),
         ] {
             let bootstrap = ProbeBootstrap::new(
                 mode,
@@ -676,5 +1765,298 @@ mod tests {
                 assert_eq!(ProbeResult::decode(&result.encode()), Ok(result));
             }
         }
+    }
+
+    fn observation(identity: CredentialIdentityClass, token: PeerTokenClass) -> PeerObservation {
+        PeerObservation::new(
+            identity,
+            identity,
+            PeerPidClass::Exact,
+            CredentialIdentityClass::Unsupported,
+            PeerPidClass::Exact,
+            token,
+        )
+        .expect("complete observation")
+    }
+
+    #[test]
+    fn credential_datagram_proofs_are_closed_nonce_bound_and_redacted() {
+        let nonce = SessionId::from_bytes([0x31; 32]);
+        for proof in [
+            CredentialDatagramProof::challenge(ProbeMode::CredentialDrop, nonce)
+                .expect("valid challenge"),
+            CredentialDatagramProof::worker_ready(ProbeMode::CredentialDrop, nonce)
+                .expect("valid worker response"),
+            CredentialDatagramProof::launcher_release(ProbeMode::CredentialDrop, nonce)
+                .expect("valid release"),
+        ] {
+            let encoded = proof.encode();
+            assert_eq!(encoded.len(), CREDENTIAL_DATAGRAM_BYTES);
+            assert_eq!(CredentialDatagramProof::decode(&encoded), Ok(proof));
+            assert_eq!(format!("{proof:?}"), "CredentialDatagramProof(<redacted>)");
+            for index in [0, 4, 9, 15] {
+                let mut malformed = encoded;
+                malformed[index] ^= 0xff;
+                assert_eq!(
+                    CredentialDatagramProof::decode(&malformed),
+                    Err(ProbeProtocolError)
+                );
+            }
+        }
+        assert!(
+            CredentialDatagramProof::challenge(ProbeMode::Drop, nonce).is_err(),
+            "historical modes must not enter the credential barrier"
+        );
+        assert!(
+            CredentialDatagramProof::challenge(ProbeMode::CredentialDrop, SessionId::pre_session())
+                .is_err()
+        );
+        let mut wrong_role = CredentialDatagramProof::challenge(ProbeMode::CredentialDrop, nonce)
+            .expect("valid challenge")
+            .encode();
+        wrong_role[8] = CredentialRole::Worker as u8;
+        assert_eq!(
+            CredentialDatagramProof::decode(&wrong_role),
+            Err(ProbeProtocolError)
+        );
+
+        let challenge = CredentialDatagramProof::challenge(ProbeMode::CredentialDrop, nonce)
+            .expect("valid challenge");
+        let worker_ready = CredentialDatagramProof::worker_ready(ProbeMode::CredentialDrop, nonce)
+            .expect("valid worker response");
+        let release = CredentialDatagramProof::launcher_release(ProbeMode::CredentialDrop, nonce)
+            .expect("valid release");
+        assert!(challenge.matches_expected(
+            ProbeMode::CredentialDrop,
+            CredentialDatagramPhase::Challenge,
+            CredentialRole::Launcher,
+            nonce,
+        ));
+        assert!(worker_ready.matches_expected(
+            ProbeMode::CredentialDrop,
+            CredentialDatagramPhase::WorkerReady,
+            CredentialRole::Worker,
+            nonce,
+        ));
+        assert!(release.matches_expected(
+            ProbeMode::CredentialDrop,
+            CredentialDatagramPhase::LauncherRelease,
+            CredentialRole::Launcher,
+            nonce,
+        ));
+        assert!(
+            !challenge.matches_expected(
+                ProbeMode::CredentialDrop,
+                CredentialDatagramPhase::WorkerReady,
+                CredentialRole::Worker,
+                nonce,
+            ),
+            "a replayed challenge must not advance the barrier"
+        );
+        assert!(
+            !release.matches_expected(
+                ProbeMode::CredentialDrop,
+                CredentialDatagramPhase::Challenge,
+                CredentialRole::Launcher,
+                nonce,
+            ),
+            "an out-of-order release must not start a barrier"
+        );
+        assert!(!worker_ready.matches_expected(
+            ProbeMode::CredentialDrop,
+            CredentialDatagramPhase::WorkerReady,
+            CredentialRole::Worker,
+            SessionId::from_bytes([0x32; 32]),
+        ));
+        assert!(!worker_ready.matches_expected(
+            ProbeMode::CredentialRetainRoot,
+            CredentialDatagramPhase::WorkerReady,
+            CredentialRole::Worker,
+            nonce,
+        ));
+    }
+
+    #[test]
+    fn credential_phase_records_round_trip_and_reject_contradictory_shapes() {
+        let nonce = SessionId::from_bytes([0x42; 32]);
+        let initial = observation(
+            CredentialIdentityClass::InitialRoot,
+            PeerTokenClass::Baseline,
+        );
+        let snapshot = observation(
+            CredentialIdentityClass::InitialRoot,
+            PeerTokenClass::Unchanged,
+        );
+        let target = observation(CredentialIdentityClass::Target, PeerTokenClass::Changed);
+        let state = CredentialSelfState::new(
+            CredentialIdentityClass::Target,
+            CredentialGroupClass::EffectiveOnly,
+        );
+        for record in [
+            CredentialRecord::worker_transitioned(
+                ProbeMode::CredentialDrop,
+                state,
+                initial,
+                snapshot,
+                nonce,
+            )
+            .expect("valid worker transition"),
+            CredentialRecord::launcher_transitioned(
+                ProbeMode::CredentialDrop,
+                state,
+                [initial, target, target],
+                nonce,
+            )
+            .expect("valid launcher transition"),
+            CredentialRecord::worker_final(
+                ProbeMode::CredentialDrop,
+                state,
+                [initial, snapshot, target],
+                nonce,
+            )
+            .expect("valid worker final"),
+            CredentialRecord::failure(
+                ProbeMode::CredentialDrop,
+                CredentialRole::Worker,
+                CredentialFailureValue::new(
+                    CredentialStep::SetUid,
+                    ProbeErrorCategory::PermissionDenied,
+                    CredentialPrefix::GidSet,
+                    CredentialSelfState::new(
+                        CredentialIdentityClass::Other,
+                        CredentialGroupClass::EffectiveOnly,
+                    ),
+                ),
+                initial,
+                nonce,
+            )
+            .expect("valid partial failure"),
+        ] {
+            let encoded = record.encode();
+            assert_eq!(encoded.len(), CREDENTIAL_RECORD_BYTES);
+            assert_eq!(CredentialRecord::decode(&encoded), Ok(record));
+            assert_eq!(format!("{record:?}"), "CredentialRecord(<redacted>)");
+            for index in [0, 4, 15, 34, 47] {
+                let mut malformed = encoded;
+                malformed[index] ^= 0xff;
+                assert_eq!(
+                    CredentialRecord::decode(&malformed),
+                    Err(ProbeProtocolError)
+                );
+            }
+        }
+
+        assert!(
+            CredentialRecord::worker_transitioned(
+                ProbeMode::CredentialDrop,
+                CredentialSelfState::new(
+                    CredentialIdentityClass::InitialRoot,
+                    CredentialGroupClass::Initial,
+                ),
+                initial,
+                snapshot,
+                nonce,
+            )
+            .is_err(),
+            "success self-attestation must match the selected mode"
+        );
+        assert!(
+            CredentialRecord::failure(
+                ProbeMode::CredentialDrop,
+                CredentialRole::Worker,
+                CredentialFailureValue::new(
+                    CredentialStep::SetUid,
+                    ProbeErrorCategory::PermissionDenied,
+                    CredentialPrefix::GidSet,
+                    state,
+                ),
+                PeerObservation::NONE,
+                nonce,
+            )
+            .is_err(),
+            "partial transition failures require the initial observation"
+        );
+        assert!(
+            CredentialRecord::failure(
+                ProbeMode::CredentialDrop,
+                CredentialRole::Worker,
+                CredentialFailureValue::new(
+                    CredentialStep::Protocol,
+                    ProbeErrorCategory::InvalidInput,
+                    CredentialPrefix::None,
+                    CredentialSelfState::new(
+                        CredentialIdentityClass::NotObserved,
+                        CredentialGroupClass::NotObserved,
+                    ),
+                ),
+                PeerObservation::NONE,
+                nonce,
+            )
+            .is_err(),
+            "failure self-attestation must remain meaningful"
+        );
+
+        let worker_transitioned = CredentialRecord::worker_transitioned(
+            ProbeMode::CredentialDrop,
+            state,
+            initial,
+            snapshot,
+            nonce,
+        )
+        .expect("valid worker transition");
+        let worker_final = CredentialRecord::worker_final(
+            ProbeMode::CredentialDrop,
+            state,
+            [initial, snapshot, target],
+            nonce,
+        )
+        .expect("valid worker final");
+        assert!(worker_transitioned.matches_expected(
+            ProbeMode::CredentialDrop,
+            CredentialRecordKind::WorkerTransitioned,
+            CredentialRole::Worker,
+            nonce,
+        ));
+        assert!(
+            !worker_transitioned.matches_expected(
+                ProbeMode::CredentialDrop,
+                CredentialRecordKind::WorkerFinal,
+                CredentialRole::Worker,
+                nonce,
+            ),
+            "a replayed transition record must not satisfy the final phase"
+        );
+        assert!(
+            !worker_final.matches_exchange(
+                ProbeMode::CredentialDrop,
+                CredentialRole::Worker,
+                SessionId::from_bytes([0x43; 32]),
+            ),
+            "a record from another session must not bind to this exchange"
+        );
+        assert!(!worker_final.matches_exchange(
+            ProbeMode::CredentialDrop,
+            CredentialRole::Launcher,
+            nonce,
+        ));
+
+        let datagram = CredentialDatagramProof::challenge(ProbeMode::CredentialDrop, nonce)
+            .expect("valid challenge")
+            .encode();
+        let mut wrong_stream_family = [0_u8; CREDENTIAL_RECORD_BYTES];
+        wrong_stream_family[..CREDENTIAL_DATAGRAM_BYTES].copy_from_slice(&datagram);
+        assert_eq!(
+            CredentialRecord::decode(&wrong_stream_family),
+            Err(ProbeProtocolError)
+        );
+        let record = worker_transitioned.encode();
+        let wrong_datagram_family: &[u8; CREDENTIAL_DATAGRAM_BYTES] = record
+            .get(..CREDENTIAL_DATAGRAM_BYTES)
+            .and_then(|bytes| bytes.try_into().ok())
+            .expect("fixed record prefix");
+        assert_eq!(
+            CredentialDatagramProof::decode(wrong_datagram_family),
+            Err(ProbeProtocolError)
+        );
     }
 }

--- a/crates/session/src/elevated_probe.rs
+++ b/crates/session/src/elevated_probe.rs
@@ -1236,7 +1236,7 @@ impl CredentialRecord {
             PeerObservation::decode(&bytes[28..34])?,
         ];
         let nonce = SessionId::from_bytes(array(bytes, 48)?);
-        match (kind, bytes[9], bytes[10], bytes[11], bytes[12]) {
+        let record = match (kind, bytes[9], bytes[10], bytes[11], bytes[12]) {
             (CredentialRecordKind::Failure, 0, step, category, prefix) => Self::failure(
                 mode,
                 role,
@@ -1271,6 +1271,11 @@ impl CredentialRecord {
                 nonce,
             ),
             _ => Err(ProbeProtocolError),
+        }?;
+        if record.encode() == *bytes {
+            Ok(record)
+        } else {
+            Err(ProbeProtocolError)
         }
     }
 }
@@ -2011,6 +2016,39 @@ mod tests {
             nonce,
         )
         .expect("valid worker final");
+        let mut worker_with_unexpected_final_observation = worker_transitioned.encode();
+        let unexpected_observation: [u8; 6] = worker_with_unexpected_final_observation[16..22]
+            .try_into()
+            .expect("fixed observation slot");
+        worker_with_unexpected_final_observation[28..34].copy_from_slice(&unexpected_observation);
+        assert_eq!(
+            CredentialRecord::decode(&worker_with_unexpected_final_observation),
+            Err(ProbeProtocolError),
+            "ignored observation slots must remain canonical zeroes"
+        );
+        let failure = CredentialRecord::failure(
+            ProbeMode::CredentialDrop,
+            CredentialRole::Worker,
+            CredentialFailureValue::new(
+                CredentialStep::SetUid,
+                ProbeErrorCategory::PermissionDenied,
+                CredentialPrefix::GidSet,
+                CredentialSelfState::new(
+                    CredentialIdentityClass::Other,
+                    CredentialGroupClass::EffectiveOnly,
+                ),
+            ),
+            initial,
+            nonce,
+        )
+        .expect("valid partial failure");
+        let mut failure_with_unexpected_later_observation = failure.encode();
+        failure_with_unexpected_later_observation[22..28].copy_from_slice(&unexpected_observation);
+        assert_eq!(
+            CredentialRecord::decode(&failure_with_unexpected_later_observation),
+            Err(ProbeProtocolError),
+            "failure records must reject ignored later observations"
+        );
         assert!(worker_transitioned.matches_expected(
             ProbeMode::CredentialDrop,
             CredentialRecordKind::WorkerTransitioned,

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -3,6 +3,9 @@
 mod codec;
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
 #[doc(hidden)]
+pub mod elevated_credential;
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+#[doc(hidden)]
 pub mod elevated_probe;
 mod grant;
 #[cfg(target_os = "macos")]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -1230,6 +1230,20 @@ parent loss before acknowledgment cancels the unpublished session, while later
 SIGINT/SIGTERM to that PID follows normal reap and cleanup. Signed evidence also
 covers two simultaneous daemon supervisors and peer survival after one stops.
 
+The disabled-by-default elevated evidence bundle additionally proves a
+no-chroot credential bootstrap boundary on Apple Silicon macOS 26.5.2 / SDK
+26.5. With explicit operator root, both fixed signed endpoints complete
+worker-first then launcher-second mapped ordinary and SDK-maximum unmapped
+credential transitions. Public `setgroups`/`setgid`/`setuid` order, the Darwin
+`effective-only` access-group postcondition, exact real/effective target ids,
+and failed root restoration are checked; zero is retained-root/no-drop. Stream
+credentials remain connection-time snapshots, datagram peer credentials are
+unsupported, opaque datagram tokens distinguish changed from retained-root,
+and live PIDs remain exact. This is evidence for #1371, not a public launch
+policy or capability disposition: target-owned runtime/resources, typed grants,
+lifecycle/API, daemon/crash, guest/HVF continuation, and final uid/gid semantics
+remain unmeasured.
+
 This is macOS containment, not direct Linux jailer/seccomp equivalence. The
 session namespace itself grants no host resource. The bounded startup channel
 provides external descriptor authority, and contained config, metadata, kernel,
@@ -1245,9 +1259,10 @@ describe/state/memory consumers adopt exact files, and frozen native-v1 load
 may additionally adopt its persisted root; create retains
 repeatable output anchors with bounded children and strict crash-cleanup
 records. General dynamic post-Ready delivery, hard revocation, cross-filesystem
-socket publication, vmnet provisioning and policy, arbitrary uid/gid transition,
-configurable chroot, launch constraints, Developer ID possession, automatic
-restart, and notarization remain later work. The exact Linux seccomp, cgroup,
+socket publication, vmnet provisioning and policy, productized arbitrary
+uid/gid transition beyond the measured bootstrap boundary, configurable chroot,
+launch constraints, Developer ID possession, automatic restart, and
+notarization remain later work. The exact Linux seccomp, cgroup,
 network-namespace, and PID-namespace mechanisms now have terminal macOS
 platform exclusions; this does not make the surrounding aggregate jailer or
 production-host records complete.

--- a/docs/security.md
+++ b/docs/security.md
@@ -57,8 +57,10 @@ handoff, and socket-broker channels. Contained startup config, startup metadata,
 adopt exact read-only grants; block and pmem devices adopt exact repeatable
 read-only/read-write backing grants; logger, metrics, and serial adopt exact
 singleton write-only sink grants; vhost-user endpoints require repeatable
-connect-only directory grants and launcher-returned streams. Arbitrary uid/gid transition, configurable
-chroot ownership, and complete distribution-signing policy remain absent. The
+connect-only directory grants and launcher-returned streams. Public product
+uid/gid transition, configurable chroot ownership, and complete
+distribution-signing policy remain absent; a disabled evidence bundle has
+measured credential bootstrap only. The
 exact seccomp, cgroup, network-namespace, and PID-namespace mechanisms are now
 certified public-macOS exclusions rather than unresolved or silently accepted
 inputs.
@@ -237,7 +239,7 @@ Use this checklist when reviewing Firecracker-facing host isolation changes:
 
 | Area | Current status | Review expectation |
 | --- | --- | --- |
-| Linux jailer, seccomp, namespaces, cgroups, chroot, and privilege dropping | Direct mechanisms unsupported; fixed-code/current-user/private-root/rlimit/daemon observable subset implemented | Preserve the exact macOS launch-policy contract and reject unsupported Linux controls. Do not equate current-user checks with arbitrary uid/gid transition or a private cwd with chroot. |
+| Linux jailer, seccomp, namespaces, cgroups, chroot, and privilege dropping | Direct mechanisms unsupported; fixed-code/current-user/private-root/rlimit/daemon observable subset implemented; no-chroot credential bootstrap measured only in a disabled evidence bundle | Preserve the exact macOS launch-policy contract and reject unsupported Linux controls. Do not equate measured bootstrap with target-owned runtime/resource continuation or a private cwd with chroot. |
 | API socket ownership | Implemented subset | Keep owner-only socket permissions, final-path ownership checks, and owner-only cleanup tests current when API socket behavior changes. |
 | Host path policy | Operator-owned with per-resource validation | Redact sensitive path details in errors, avoid opening paths during pre-boot storage unless the resource explicitly requires it, and test cleanup for owned resources. |
 | HVF entitlement and code signing | Implemented direct, App Sandbox, and production nested-worker validation paths | Keep real HVF tests in signed targets, inspect entitlement separation and nested signatures, and keep unsupported CI hosts on explicit compile/sign-only validation, not silent skips. |
@@ -498,7 +500,7 @@ Use the following boundaries when designing or reviewing macOS isolation work:
 | HVF entitlement and code signing | The production worker alone receives the Hypervisor entitlement; the outer launcher cannot enter HVF. Both code objects use Hardened Runtime and are separately inspectable. | Developer ID possession, team policy, launch constraints, and notarization still require deployment evidence. |
 | macOS App Sandbox | The production worker is sandboxed; the ordinary direct CLI and outer launcher are not. Container/sealed resources plus granted config, metadata, kernel, initrd, block, pmem, logger, metrics, serial, snapshot, API-socket, vsock-socket, and connect-only vhost-user-socket authority form the current contained mode. Lifecycle v5 binds vmnet policy to exact networkless or caller-approved vmnet signature profiles. | The real restricted-entitlement credential and connectivity evidence remain operator-owned gates; general dynamic delivery still requires explicit design. |
 | Launcher or resource broker | The production launcher validates fixed/live nested code, starts one closed-environment/default-close worker, authenticates lifecycle v5 credential/resource-limit/vmnet policy, applies worker-local limits before `Prepared`, owns cancellation/status, coordinates and enters the private namespace, atomically transfers a bounded typed startup batch, supports adopted file/directory/block-special consumers, offers signed daemon detach, and exposes separate fixed vsock, vhost-user, and retained-descriptor block-control facets. | Keep each private protocol fixed and redacted; separately challenge any broader dynamic broker and never infer hard revocation from closing a duplicate descriptor. |
-| Firecracker Linux jailer model | Direct port unsupported; exact fixed executable/current-user/rlimit/version/daemon outcomes implemented through the versioned macOS policy envelope. | Keep arbitrary uid/gid, configurable chroot, seccomp, namespaces, cgroups, and parent-cgroup controls rejected until separately challenged macOS outcomes exist. |
+| Firecracker Linux jailer model | Direct port unsupported; exact fixed executable/current-user/rlimit/version/daemon outcomes implemented through the versioned macOS policy envelope; public credential syscalls measured only in the disabled bootstrap harness. | Keep product uid/gid pending target-owned runtime/resource/lifecycle continuation, and keep configurable chroot, seccomp, namespaces, cgroups, and parent-cgroup controls rejected until separately challenged macOS outcomes exist. |
 
 This document intentionally does not define a sandbox profile, broker protocol,
 privilege-dropping flow, or new public API. PRs that add host resource types
@@ -3454,9 +3456,28 @@ create/destroy, so the inherited failure is not a general signing or HVF
 failure. It occurs too early to prove inherited App Sandbox activation, root
 attestation, or HVF, and it does not rule out a separately challenged larger
 fixed Darwin dependency set. No credential transition, API, resource, or guest
-operation occurs in either blocked ordering. The complete boundary,
-alternatives, exact staged-entry cleanup rules, reproduction command, and
-future-OS nonclaim are in the checked
+operation occurs in either blocked chroot ordering.
+
+#1885 separately measured public numeric credential transition without chroot.
+Both fixed signed endpoints completed the ordered supplementary-group clear,
+gid transition, uid transition, exact real/effective postcondition, and denied
+root-restoration checks for mapped ordinary and SDK-maximum unmapped classes.
+Darwin reports the cleared group access list as the current effective gid only;
+the harness therefore requires the value-free `effective-only` class rather
+than misreporting a literal empty list. Zero/zero retained exact root without
+calling a mutating credential primitive and is explicitly no-drop.
+
+The worker transitions first and the launcher second after a nonce-bound
+datagram-possession barrier. Stream `getpeereid` and `LOCAL_PEERCRED` retained
+their documented connection-time root snapshot; connected-datagram
+`LOCAL_PEERCRED` was unsupported; opaque `LOCAL_PEERTOKEN` changed for a real
+transition and remained unchanged for retained-root; live stream/datagram PIDs
+remained exact. Repeated and concurrent runs left no exact process, private
+root, workspace, or named-socket residue. This proves bootstrap syscalls and
+observation classes only, not target-owned runtime/resources, typed grants,
+lifecycle/API, daemon/crash behavior, guest/HVF after transition, public policy,
+or an implemented uid/gid disposition. The complete boundary, alternatives,
+exact cleanup rules, reproduction command, and future-OS nonclaim are in the checked
 [elevated bootstrap evidence](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
 
 The six rows remain audit outcomes until #1371 challenges the controlled result

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2098,7 +2098,8 @@ merged-main OID are checked and recorded by the pull-request workflow.
 
 ## Explicit Elevated Bootstrap Evidence
 
-The #1373 direct-worker and #1884 inherited-root proofs are deliberately
+The #1373 direct-worker, #1884 inherited-root, and #1885 no-chroot credential
+proofs are deliberately
 separate from `scripts/run-integration-tests.sh`. Normal validation never
 invokes `sudo`, prompts for a password, or treats missing root/HVF support as a
 passing skip.
@@ -2111,10 +2112,12 @@ scripts/build-elevated-bootstrap-probe.sh \
 ```
 
 The build compiles normal launcher and worker artifacts first and verifies that
-the V2 probe status, worker activation, Ready, inherited-root, and HVF markers
-are absent. It then builds both ends with the same disabled-by-default feature,
-adds a visible test-only resource marker, and uses the normal production
-packager, signature split, entitlements, Hardened Runtime, and inspections.
+the V2 probe status, worker activation, Ready, inherited-root, HVF, credential
+mode, credential phase, and restoration-step markers are absent. It then builds
+both ends with the same disabled-by-default feature, checks role-specific
+credential markers, adds a visible test-only resource marker, and uses the
+normal production packager, signature split, entitlements, Hardened Runtime,
+and inspections.
 
 On a capable Apple Silicon host, calculate the explicit numeric target before
 elevation and invoke the wrapper yourself:
@@ -2144,13 +2147,27 @@ worker, and an unexpected entry. The wrapper retains the #1373 direct denial,
 an unsandboxed launcher root control, and an unchrooted signed-worker real-HVF
 create/destroy control; it repeats the inherited result three times and runs
 two complete roots concurrently. Cleanup validates all entries before any
-removal and uses only exact reverse `unlink`/`rmdir`, then an independent scan
-must find no root or workspace residue.
+removal and uses only exact reverse `unlink`/`rmdir`.
 
-It reports OS/SDK/architecture and only the value-free terminal result. The
-measured result is `worker-bootstrap` / `other`: in-root `posix_spawn` returned
-success but the worker exited before its earliest application record. Its
-supported conclusion and nonclaims are in the [elevated bootstrap evidence
+The credential branch never calls chroot. It first runs mapped ordinary,
+retained-root, and SDK-maximum unmapped controls in the unsandboxed signed
+launcher. It then transitions the mandatory signed worker first and the fixed
+launcher second over nonce-bound stream and datagram phases. Nonzero cases
+require `setgroups` → `setgid` → `setuid`, exact real/effective target identity,
+Darwin's `effective-only` group-access-list postcondition, and denied uid/gid/
+group restoration. Ordinary and retained-root cases repeat, and two ordinary
+pairs run concurrently against distinct private roots. Final independent scans
+must find no launcher, worker, root, workspace, or named-socket residue.
+
+It reports OS/SDK/architecture and only value-free terminal classes. The
+inherited result remains `worker-bootstrap` / `other`: in-root `posix_spawn`
+returned success but the worker exited before its earliest application record.
+The no-chroot credential result completed mapped ordinary, retained-root
+no-drop, and SDK-maximum unmapped transitions. Stream credentials remained
+connection-time snapshots, datagram credentials were unsupported, opaque
+datagram tokens changed only for credential transitions, and live peer PIDs
+remained exact. Its supported conclusion and nonclaims are in the
+[elevated bootstrap evidence
 contract](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
 
 ## Running Tests

--- a/scripts/build-elevated-bootstrap-probe.sh
+++ b/scripts/build-elevated-bootstrap-probe.sh
@@ -78,11 +78,16 @@ status_activation="status: elevated bootstrap blocked"
 ready_activation="BBEP-READY-V2"
 inherited_mode="inherited-root"
 hvf_stage="hvf-create"
-credential_mode="credential-drop"
+credential_drop_mode="credential-drop"
+credential_retain_mode="credential-retain-root"
+credential_unmapped_mode="credential-unmapped"
+credential_control_mode="credential-control"
 credential_status="status: elevated credential"
 credential_record="BBC1"
 credential_datagram="BBG1"
 credential_step="restore-groups"
+credential_launcher_artifact="bangbang-elevated-credential-launcher-v1-credential-drop-BBC1-BBG1-restore-groups"
+credential_worker_artifact="bangbang-elevated-credential-worker-v1-credential-drop-BBC1-BBG1-restore-groups"
 
 cargo build \
   -p bangbang \
@@ -100,11 +105,16 @@ probe_markers=(
   "$ready_activation"
   "$inherited_mode"
   "$hvf_stage"
-  "$credential_mode"
+  "$credential_drop_mode"
+  "$credential_retain_mode"
+  "$credential_unmapped_mode"
+  "$credential_control_mode"
   "$credential_status"
   "$credential_record"
   "$credential_datagram"
   "$credential_step"
+  "$credential_launcher_artifact"
+  "$credential_worker_artifact"
 )
 for artifact in "$launcher_bin" "$worker_bin"; do
   for marker_value in "${probe_markers[@]}"; do
@@ -131,11 +141,15 @@ for marker_value in \
   "$status_activation" \
   "$inherited_mode" \
   "$hvf_stage" \
-  "$credential_mode" \
+  "$credential_drop_mode" \
+  "$credential_retain_mode" \
+  "$credential_unmapped_mode" \
+  "$credential_control_mode" \
   "$credential_status" \
   "$credential_record" \
   "$credential_datagram" \
-  "$credential_step"; do
+  "$credential_step" \
+  "$credential_launcher_artifact"; do
   if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$launcher_bin"; then
     echo "evidence artifact is missing the elevated probe boundary" >&2
     exit 1
@@ -143,10 +157,11 @@ for marker_value in \
 done
 for marker_value in \
   "$ready_activation" \
-  "$credential_mode" \
+  "$credential_drop_mode" \
   "$credential_record" \
   "$credential_datagram" \
-  "$credential_step"; do
+  "$credential_step" \
+  "$credential_worker_artifact"; do
   if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$worker_bin"; then
     echo "evidence artifact is missing the elevated probe boundary" >&2
     exit 1

--- a/scripts/build-elevated-bootstrap-probe.sh
+++ b/scripts/build-elevated-bootstrap-probe.sh
@@ -78,6 +78,11 @@ status_activation="status: elevated bootstrap blocked"
 ready_activation="BBEP-READY-V2"
 inherited_mode="inherited-root"
 hvf_stage="hvf-create"
+credential_mode="credential-drop"
+credential_status="status: elevated credential"
+credential_record="BBC1"
+credential_datagram="BBG1"
+credential_step="restore-groups"
 
 cargo build \
   -p bangbang \
@@ -95,6 +100,11 @@ probe_markers=(
   "$ready_activation"
   "$inherited_mode"
   "$hvf_stage"
+  "$credential_mode"
+  "$credential_status"
+  "$credential_record"
+  "$credential_datagram"
+  "$credential_step"
 )
 for artifact in "$launcher_bin" "$worker_bin"; do
   for marker_value in "${probe_markers[@]}"; do
@@ -120,16 +130,28 @@ for marker_value in \
   "$worker_activation" \
   "$status_activation" \
   "$inherited_mode" \
-  "$hvf_stage"; do
+  "$hvf_stage" \
+  "$credential_mode" \
+  "$credential_status" \
+  "$credential_record" \
+  "$credential_datagram" \
+  "$credential_step"; do
   if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$launcher_bin"; then
     echo "evidence artifact is missing the elevated probe boundary" >&2
     exit 1
   fi
 done
-if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$ready_activation" "$worker_bin"; then
-  echo "evidence artifact is missing the elevated probe boundary" >&2
-  exit 1
-fi
+for marker_value in \
+  "$ready_activation" \
+  "$credential_mode" \
+  "$credential_record" \
+  "$credential_datagram" \
+  "$credential_step"; do
+  if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$worker_bin"; then
+    echo "evidence artifact is missing the elevated probe boundary" >&2
+    exit 1
+  fi
+done
 
 cargo build \
   -p bangbang-launcher \

--- a/scripts/run-elevated-bootstrap-probe.sh
+++ b/scripts/run-elevated-bootstrap-probe.sh
@@ -205,6 +205,7 @@ replacement_root=""
 replacement_root_identity=""
 replacement_candidate=""
 replacement_candidate_identity=""
+cleanup_return=false
 
 bundle_directories=(
   "Contents"
@@ -583,6 +584,9 @@ cleanup() {
     echo "bangbang elevated bootstrap proof: exact cleanup failed" >&2
     exit 5
   fi
+  if [[ "$cleanup_return" == true ]]; then
+    return "$prior_status"
+  fi
   exit "$prior_status"
 }
 trap cleanup EXIT
@@ -674,6 +678,29 @@ assert_case "$probe_root" 2147483647 2147483647 unmapped-syscall 3 \
   "status: elevated bootstrap blocked stage=chroot error=permission-denied"
 assert_case "$probe_root" 0 0 hvf-control 0 \
   "status: elevated bootstrap hvf-control complete"
+
+expected_credential_control="status: elevated credential credential-control complete prefix=irreversible identity=target groups=effective-only"
+expected_credential_retain_control="status: elevated credential credential-control complete prefix=retained-root identity=initial-and-target groups=initial"
+expected_credential_drop="status: elevated credential credential-drop complete stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed datagram-pid=exact"
+expected_credential_retain="status: elevated credential credential-retain-root complete stream-eid=stable-root stream-cred=stable-root stream-pid=exact datagram-cred=unsupported datagram-token=unchanged datagram-pid=exact"
+expected_credential_unmapped="status: elevated credential credential-unmapped complete stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed datagram-pid=exact"
+
+assert_case "$probe_root" "$target_uid" "$target_gid" credential-control 0 \
+  "$expected_credential_control"
+assert_case "$probe_root" 0 0 credential-control 0 \
+  "$expected_credential_retain_control"
+assert_case "$probe_root" 2147483647 2147483647 credential-control 0 \
+  "$expected_credential_control"
+for _ in 1 2 3; do
+  assert_case "$probe_root" "$target_uid" "$target_gid" credential-drop 0 \
+    "$expected_credential_drop"
+done
+for _ in 1 2 3; do
+  assert_case "$probe_root" 0 0 credential-retain-root 0 \
+    "$expected_credential_retain"
+done
+assert_case "$probe_root" 2147483647 2147483647 credential-unmapped 0 \
+  "$expected_credential_unmapped"
 
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
   inherited_root inherited_root_identity
@@ -868,6 +895,29 @@ fi
 /bin/unlink "$workspace/case-a"
 /bin/unlink "$workspace/case-b"
 
+set +e
+invoke "$concurrent_root_a" "$target_uid" "$target_gid" credential-drop \
+  > "$workspace/case-a" 2>&1 &
+pid_a=$!
+invoke "$concurrent_root_b" "$target_uid" "$target_gid" credential-drop \
+  > "$workspace/case-b" 2>&1 &
+pid_b=$!
+wait "$pid_a"
+status_a=$?
+wait "$pid_b"
+status_b=$?
+set -e
+output_a="$(<"$workspace/case-a")"
+output_b="$(<"$workspace/case-b")"
+if [[ "$status_a" -ne 0 || "$status_b" -ne 0 \
+  || "$output_a" != "$expected_credential_drop" \
+  || "$output_b" != "$expected_credential_drop" ]]; then
+  echo "bangbang elevated bootstrap proof: credential concurrency case failed" >&2
+  exit 1
+fi
+/bin/unlink "$workspace/case-a"
+/bin/unlink "$workspace/case-b"
+
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
   inherited_root_a inherited_root_a_identity
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
@@ -914,4 +964,38 @@ fi
 /bin/unlink "$workspace/inherited-case-a"
 /bin/unlink "$workspace/inherited-case-b"
 
-echo "result: inherited-root-worker=blocked stage=worker-bootstrap error=other controls=success cleanup=exact"
+socket_residue=0
+for path in \
+  "$probe_root" \
+  "$inherited_root" \
+  "$inherited_root_a" \
+  "$inherited_root_b" \
+  "$concurrent_root_a" \
+  "$concurrent_root_b" \
+  "$replacement_root" \
+  "$workspace"; do
+  if [[ -d "$path" && ! -L "$path" ]]; then
+    count="$(/usr/bin/find -x "$path" -type s -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+    socket_residue="$((socket_residue + count))"
+  fi
+done
+cleanup_return=true
+cleanup
+
+root_residue="$(/usr/bin/find /private/var/root -maxdepth 1 \
+  \( -name 'bangbang-elevated-probe.*' -o -name 'bangbang-elevated-work.*' \) \
+  -print 2>/dev/null | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+launcher_residue="$({ /usr/bin/pgrep -x bangbang-launcher 2>/dev/null || true; } \
+  | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+worker_residue="$({ /usr/bin/pgrep -x bangbang 2>/dev/null || true; } \
+  | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+if [[ "$socket_residue" -ne 0 || "$root_residue" -ne 0 \
+  || "$launcher_residue" -ne 0 || "$worker_residue" -ne 0 ]]; then
+  echo "bangbang elevated bootstrap proof: final residue scan failed" >&2
+  exit 1
+fi
+
+echo "result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete controls=complete cleanup=exact"
+echo "observations: stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed-or-unchanged datagram-pid=exact"
+echo "residue: roots=zero workspaces=zero sockets=zero launchers=zero workers=zero"
+echo "nonclaims: target-runtime=unmeasured target-resources=unmeasured grants=unmeasured lifecycle-api=unmeasured daemon-crash=unmeasured guest-hvf=unmeasured public-policy=unchanged uid-gid=nonterminal chroot=unresolved aggregate-jailer=nonterminal"


### PR DESCRIPTION
## Summary

- add a disabled-by-default no-chroot credential bootstrap harness with fixed, nonce-bound stream and datagram protocols
- prove worker-first and launcher-second credential transitions for mapped ordinary, retained-root, and SDK-maximum unmapped classes
- record Darwin's effective-GID-only group semantics, restoration denial, peer-observation classes, static artifact isolation, and exact cleanup evidence

## Scope exclusions

- does not add public uid/gid policy or change a Firecracker capability disposition
- does not claim target-owned runtime/resources, typed grants, lifecycle/API, daemon/crash, post-transition guest/HVF, or aggregate jailer completion
- leaves configurable chroot unresolved

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple-target signed integration-test Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` on Apple Silicon without `--allow-unsupported`
- signed elevated probe build and root wrapper across ordinary, retained-root, maximum-unmapped, repeated, and concurrent credential cases
- independent post-run process/root/workspace/socket residue scan

Closes #1885
Relates to #1371
