### PR TITLE
test: prove target-owned runtime continuation

### DIFF
--- a/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
+++ b/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
@@ -1,11 +1,12 @@
 # Elevated macOS Bootstrap Evidence
 
 This contract records the #1373 direct-worker result, the #1884 inherited-root
-follow-up, and the #1885 no-chroot credential-transition result beneath #1371.
-Together they test public chroot orderings and numeric credential bootstrap
-against Bangbang's mandatory production worker boundary. They do not add a
-public root mode, accept jailer uid/gid/chroot options, or change a capability
-disposition by themselves.
+follow-up, the #1885 no-chroot credential-transition result, and the #1889
+target-owned runtime continuation result beneath #1371. Together they test
+public chroot orderings, numeric credential bootstrap, and same-process
+continuation into the ordinary production lifecycle against Bangbang's
+mandatory worker boundary. They do not add a public root mode, accept jailer
+uid/gid/chroot options, or change a capability disposition by themselves.
 
 ## Exact test boundary
 
@@ -18,10 +19,13 @@ The evidence bundle keeps the production layout and identity split:
 - the launcher retains normal static bundle validation and performs the
   suspended/live worker identity checks whenever the child reaches them; and
 - both launcher and worker probe entries are compiled only with the
-  `elevated-bootstrap-probe` feature. A normal `--no-default-features` build is
-  checked for absence of the launcher-owned worker activation, ready/status
-  records, credential modes/phases/steps, and marker resource. The normal signed
-  bundle dynamically rejects both historical and credential internal argv.
+  `elevated-bootstrap-probe` feature, while the representative target-runtime
+  grant consumer additionally requires `grant-integration-probe`. A normal
+  `--no-default-features` build is checked for absence of launcher-owned worker
+  activation, ready/status records, credential and runtime modes/phases/steps,
+  the `BBA1` continuation, grant activation, boundary vocabulary, and all
+  evidence marker resources. The normal signed bundle dynamically rejects the
+  historical, credential, runtime, and grant-probe internal argv.
 
 The root wrapper never invokes `sudo`. It requires exact real/effective
 uid/gid zero, accepts explicit numeric target uid/gid values, runs with a
@@ -39,7 +43,7 @@ the worker receives no host path and cannot reopen the root by name.
 For the inherited-root branch, the wrapper copies exactly the complete signed
 probe bundle plus the current host's Apple-signed `/usr/lib/dyld` into fixed
 `/Bangbang.app` and `/usr/lib/dyld` locations inside a separate private root.
-It admits exactly 20 manifest entries, normalizes and records each original
+It admits exactly 22 manifest entries, normalizes and records each original
 device/inode/owner/group/type/mode tuple, proves the loader bytes match the
 host file, and revalidates the loader and complete nested code signatures. The
 launcher independently validates the host-visible staged layout/profile and
@@ -64,6 +68,28 @@ launcher transitions and responds; the worker sends the final after-both
 observation before both processes exit. The external root wrapper retains only
 bounded supervision and exact cleanup.
 
+The three runtime-continuation modes perform that same credential exchange but
+do not respawn either endpoint. The launcher sends one fixed, canonical,
+nonce-bound `BBA1` acknowledgment only after the credential transcript is
+complete and both the lifecycle stream and grant datagram are live and empty.
+The same launcher and worker PIDs then continue over those same transports. The
+worker reattests the exact parent and target/no-drop identity, emits ordinary
+lifecycle `Hello`, receives the ordinary `Start` policy, and attempts to create
+the random locked session beneath the already-opened exact target-owned root.
+If that succeeds, the unchanged production supervisor is prepared to validate
+the namespace, transfer and commit the representative read-only, write-only,
+and create-children grant batch, cross `Proceed`, validate terminal ownership,
+and perform exact recovery. Feature-only closed fault points cover pre/post
+acknowledgment and the later namespace/grant/lifecycle boundaries without
+changing normal bundle behavior.
+
+Each runtime case uses a mode-0700 root and a separate bounded workspace with a
+root-owned traversal-only ancestry and exact target-owned fixtures. A root-owned
+ledger binds the workspace, its input, output, create-children directory,
+outside-denial sentinel, and manifest by identity and metadata. Cleanup only
+removes the exact unchanged objects and independent final scans cover roots,
+workspaces, sockets, launchers, and workers.
+
 For a nonzero target, each endpoint executes public `setgroups(0, null)`,
 `setgid`, and `setuid` in that order. Darwin's legacy `getgroups` surface reports
 the current effective gid as the sole access-list entry after supplementary
@@ -82,7 +108,7 @@ checked result.
 
 ## Capable-host result
 
-The final evidence shape was executed on 2026-08-08 on Apple Silicon with
+The final evidence shape was executed on 2026-08-09 on Apple Silicon with
 macOS 26.5.2, macOS SDK 26.5, and `kern.hv_support=1`, under explicit operator
 root authority. The complete matrix produced these results:
 
@@ -102,13 +128,17 @@ root authority. The complete matrix produced these results:
 | same fixed pair | uid/gid-zero retained-root, repeated three times | both endpoints retained exact root without claiming privilege separation |
 | same fixed pair | SDK-maximum unmapped numeric target | both endpoint syscalls, postconditions, and restoration denials completed independently of account-backed runtime feasibility |
 | two concurrent fixed credential pairs | distinct exact roots/workspaces | both ordinary-target transitions completed with byte-identical bounded results |
+| same fixed pair continued in place | mapped ordinary target, repeated three times | credential exchange and `BBA1` acknowledgment completed; ordinary `Hello`/`Start` completed; App Sandbox denied `mkdirat` for the target-owned session (`runtime-namespace` / `permission-denied` / `namespace-boundary`) |
+| same fixed pair continued in place | uid/gid-zero retained-root, repeated three times | no-drop credential exchange, acknowledgment, and ordinary `Hello`/`Start` completed; the same target-owned session creation was denied |
+| same fixed pair continued in place | SDK-maximum unmapped numeric target | credential exchange and acknowledgment completed; live code-identity revalidation stopped before lifecycle `Hello` (`live-identity` / `other` / `identity-boundary`) |
+| two concurrent runtime-continuation pairs | distinct exact roots and workspaces | both mapped-target pairs returned the same namespace boundary with byte-identical bounded result lines |
 
 Focused negative cases reject a group-writable root and a symlink root. The
 staged manifest also rejects a writable, missing, symlinked, or inode-replaced
 loader, a missing nested worker, and an unexpected entry before worker
 activation. Every successful, rejected, repeated, and concurrent case leaves no
 process, root, workspace, or named-socket residue. Nonempty-root cleanup
-preflights all 20 ledger
+preflights all 22 ledger
 entries before removing any, then uses only reverse exact `unlink`/`rmdir`;
 root cleanup rechecks device, inode, owner, group, and mode and refuses to
 remove a replacement.
@@ -124,9 +154,14 @@ The inherited result is not a missing-HVF or generally invalid-signature
 result: the same exact unchrooted signed worker completed real HVF
 create/destroy in the same wrapper run. The inherited branch nevertheless
 never reached application entry, root attestation, the direct-chroot sandbox
-control, or HVF. The no-chroot credential branch separately reached both signed
-application endpoints, but no target-owned runtime/resource tree, typed grant,
-public lifecycle/API, guest, or post-transition HVF operation was attempted.
+control, or HVF. The runtime continuation separately reached both signed
+application endpoints, completed the exact acknowledgment, and reached ordinary
+`Hello`/`Start` for mapped and retained-root modes. It then stopped at the exact
+target-owned session-directory creation call. The representative typed grants,
+`Prepared`/grant commitment, `Proceed`/`Starting`/terminal sequence, API, guest,
+daemon/crash recovery, and post-transition HVF therefore remained unreached or
+unmeasured. The high unmapped runtime case stopped earlier at live code-identity
+revalidation, so it makes no lifecycle claim.
 
 After those results were established, the checked harness remained at the
 evidence boundary: it contains no credential-changing product path. If a
@@ -135,8 +170,13 @@ future platform permits the direct sandboxed `chroot`, that branch reports
 entry, it must pass exact root, sandbox-denial, and HVF checks before success.
 Either changed result forces fresh implementation research and Challenge. The
 harness leaves the normal peer verifier and public launch policy unchanged.
-#1885 records bootstrap semantics only; #1374 cannot reuse its stale assumptions
-without the target-runtime/resource/lifecycle continuation selected by #1371.
+Pre/post-acknowledgment fault cases reached their exact closed boundaries; the
+natural namespace denial masks grant-transfer, `Proceed`, and terminal fault
+points on this host, so those later hooks are only feature-isolation and unit/
+artifact validated here. A launcher-precreated session would change the
+authority ordering and remains a separately challenged follow-up rather than a
+hidden fallback in this result. #1885 and #1889 are evidence results; product
+uid/gid behavior still requires the parent-selected continuation.
 
 ## Supported conclusion and nonclaims
 
@@ -167,14 +207,19 @@ must instead be evaluated explicitly by the parent.
 The measured public credential primitives are available in the exact signed
 no-chroot process shape: mapped ordinary and SDK-maximum unmapped transitions
 both completed, while zero remained an explicit no-drop class. This is not yet
-a Firecracker uid/gid implementation. It does not establish target-owned
-runtime namespace and resource ownership, typed grants, lifecycle/API,
-daemon/crash cleanup, real guest/HVF work after transition, public policy, or
-aggregate jailer behavior. It also does not prove that a larger fixed in-root
-Darwin dependency set cannot bootstrap, claim Linux mount/PID/user namespace
-parity, certify notarized distribution, or generalize beyond the recorded
-OS/SDK behavior. A future public platform requires rerunning the wrapper and a
-fresh ID-by-ID Challenge.
+a Firecracker uid/gid implementation. Same-process continuation is viable
+through exact acknowledgment and ordinary `Hello`/`Start` for mapped and
+retained-root identities, but the measured App Sandbox profile denies creation
+of a session beneath the target-owned root even when the process owns the
+validated descriptor and numeric identity. It therefore does not establish a
+target-owned session, grant commitment or consumption, lifecycle completion,
+API, daemon/crash cleanup, real guest/HVF work after transition, public policy,
+or aggregate jailer behavior. It also does not prove that a separately
+challenged launcher-precreated session, a larger fixed in-root Darwin dependency
+set, or a materially different security model cannot work; nor does it claim
+Linux mount/PID/user namespace parity, notarized distribution, or behavior
+beyond the recorded OS/SDK. A changed platform result requires rerunning the
+wrapper and a fresh ID-by-ID Challenge.
 
 ## Reproduction
 
@@ -197,12 +242,12 @@ sudo /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
   --target-gid "$target_gid"
 ```
 
-The required terminal summary remains value-free and includes the credential,
-observation, residue, and nonclaim classes:
+The required terminal summary remains value-free and includes credential and
+runtime results, observations, residue, and nonclaim classes:
 
 ```text
-result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete controls=complete cleanup=exact
+result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete runtime-mapped=namespace-boundary runtime-retained-root=namespace-boundary runtime-unmapped=identity-boundary grants=unreached lifecycle=hello-start controls=complete cleanup=exact
 observations: stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed-or-unchanged datagram-pid=exact
 residue: roots=zero workspaces=zero sockets=zero launchers=zero workers=zero
-nonclaims: target-runtime=unmeasured target-resources=unmeasured grants=unmeasured lifecycle-api=unmeasured daemon-crash=unmeasured guest-hvf=unmeasured public-policy=unchanged uid-gid=nonterminal chroot=unresolved aggregate-jailer=nonterminal
+nonclaims: target-session=unreached grants=unreached proceed-starting-terminal=unreached api-no-api-real-guest=unmeasured daemon-crash=unmeasured post-drop-guest-hvf=unmeasured public-policy=unchanged chroot=unresolved aggregate-jailer=nonterminal
 ```

--- a/crates/bangbang/src/contained_session.rs
+++ b/crates/bangbang/src/contained_session.rs
@@ -330,6 +330,8 @@ mod platform {
         GrantedFile, StagedGrantBatch,
     };
     use bangbang_session::macos::grant_transport::receive_grant;
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    use bangbang_session::macos::runtime::RuntimeError;
     use bangbang_session::macos::runtime::{
         SnapshotStagingKind, SnapshotStagingName, SnapshotStagingOwnershipRecord, WorkerNamespace,
         WorkerSocketNamespace,
@@ -361,6 +363,39 @@ mod platform {
     const GRANT_DELAY_PROBE: &str = "--bangbang-internal-grant-delay-v1";
     #[cfg(feature = "grant-integration-probe")]
     const GRANT_DELAY_READY: &str = "status: grant integration delay ready";
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum ContainedBootstrapError {
+        Session,
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        RuntimeNamespace(RuntimeError),
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    impl ContainedBootstrapError {
+        pub(crate) const fn is_runtime_namespace_permission_denied(self) -> bool {
+            matches!(
+                self,
+                Self::RuntimeNamespace(RuntimeError::NamespaceCreate(
+                    io::ErrorKind::PermissionDenied
+                ))
+            )
+        }
+    }
+
+    impl From<ContainedSessionError> for ContainedBootstrapError {
+        fn from(_: ContainedSessionError) -> Self {
+            Self::Session
+        }
+    }
+
+    impl fmt::Display for ContainedBootstrapError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("private launcher session failed")
+        }
+    }
+
+    impl std::error::Error for ContainedBootstrapError {}
 
     #[cfg(feature = "grant-integration-probe")]
     fn grant_delay_requested() -> bool {
@@ -3490,8 +3525,108 @@ mod platform {
         restore_generations: ContainedSnapshotRestoreGenerationAuthority,
         restore_wakeup: Option<Rc<UnixStream>>,
         policy: WorkerPolicy,
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        runtime_fault: bangbang_session::elevated_probe::RuntimeFault,
         started: bool,
         closed: bool,
+    }
+
+    enum BootstrapSource {
+        Ordinary,
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        Elevated {
+            root: Option<bangbang_session::macos::runtime::ExplicitRuntimeRoot>,
+            bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
+            parent: libc::pid_t,
+        },
+    }
+
+    struct BootstrapChannels {
+        stream: UnixStream,
+        grant_socket: UnixDatagram,
+        socket_broker: UnixDatagram,
+        vhost_user_broker: UnixDatagram,
+        block_control_broker: UnixDatagram,
+    }
+
+    impl BootstrapSource {
+        fn verify_peer(
+            &self,
+            stream: &UnixStream,
+            _grant_socket: &UnixDatagram,
+            parent: libc::pid_t,
+        ) -> Result<(), ContainedSessionError> {
+            match self {
+                Self::Ordinary => verify_peer(stream.as_raw_fd(), parent)
+                    .map(|_| ())
+                    .map_err(|_| ContainedSessionError),
+                #[cfg(feature = "elevated-bootstrap-probe")]
+                Self::Elevated {
+                    bootstrap,
+                    parent: expected_parent,
+                    ..
+                } => {
+                    // SAFETY: `getppid` has no pointer or ownership contract.
+                    let live_parent = unsafe { libc::getppid() };
+                    if parent != *expected_parent
+                        || live_parent != *expected_parent
+                        || verify_peer_pid(stream.as_raw_fd(), *expected_parent).is_err()
+                        || verify_peer_pid(_grant_socket.as_raw_fd(), *expected_parent).is_err()
+                        || bangbang_session::elevated_credential::attest_current_process(
+                            bootstrap.mode(),
+                            bootstrap.target_uid(),
+                            bootstrap.target_gid(),
+                        )
+                        .is_err()
+                    {
+                        return Err(ContainedSessionError);
+                    }
+                    Ok(())
+                }
+            }
+        }
+
+        fn create_namespace(
+            &mut self,
+            session: SessionId,
+        ) -> Result<WorkerNamespace, ContainedBootstrapError> {
+            match self {
+                Self::Ordinary => {
+                    WorkerNamespace::create(session).map_err(|_| ContainedBootstrapError::Session)
+                }
+                #[cfg(feature = "elevated-bootstrap-probe")]
+                Self::Elevated {
+                    root, bootstrap, ..
+                } => {
+                    if bootstrap.fault()
+                        == bangbang_session::elevated_probe::RuntimeFault::Namespace
+                    {
+                        return Err(ContainedBootstrapError::Session);
+                    }
+                    WorkerNamespace::create_from_explicit_root(
+                        root.take().ok_or(ContainedBootstrapError::Session)?,
+                        session,
+                    )
+                    .map_err(ContainedBootstrapError::RuntimeNamespace)
+                }
+            }
+        }
+
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        fn has_fault(&self, expected: bangbang_session::elevated_probe::RuntimeFault) -> bool {
+            matches!(
+                self,
+                Self::Elevated { bootstrap, .. } if bootstrap.fault() == expected
+            )
+        }
+
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        fn fault(&self) -> bangbang_session::elevated_probe::RuntimeFault {
+            match self {
+                Self::Ordinary => bangbang_session::elevated_probe::RuntimeFault::None,
+                Self::Elevated { bootstrap, .. } => bootstrap.fault(),
+            }
+        }
     }
 
     impl std::fmt::Debug for ContainedSession {
@@ -3526,7 +3661,7 @@ mod platform {
             // SAFETY: The validated private bootstrap contract transfers the
             // fixed descriptor exactly once into this process object.
             let owned = unsafe { OwnedFd::from_raw_fd(SESSION_FD) };
-            let mut stream = UnixStream::from(owned);
+            let stream = UnixStream::from(owned);
             // SAFETY: The same validated bootstrap contract transfers fixed
             // grant descriptor 4 exactly once into this process object.
             let grant_owned = unsafe { OwnedFd::from_raw_fd(GRANT_FD) };
@@ -3554,6 +3689,86 @@ mod platform {
             verify_peer_pid(block_control_socket.as_raw_fd(), parent)
                 .map_err(|_| ContainedSessionError)?;
 
+            Self::bootstrap_session(
+                BootstrapChannels {
+                    stream,
+                    grant_socket,
+                    socket_broker: broker_socket,
+                    vhost_user_broker: vhost_broker_socket,
+                    block_control_broker: block_control_socket,
+                },
+                parent,
+                BootstrapSource::Ordinary,
+            )
+            .map_err(|_| ContainedSessionError)
+        }
+
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        pub(crate) fn bootstrap_with_continuation(
+            continuation: Option<crate::elevated_bootstrap_probe::RuntimeContinuation>,
+        ) -> Result<Option<Self>, ContainedBootstrapError> {
+            let Some(continuation) = continuation else {
+                return Self::bootstrap().map_err(ContainedBootstrapError::from);
+            };
+            if env::var_os(SESSION_ENV_KEY).is_some() || continuation.verify_witness().is_err() {
+                return Err(ContainedSessionError.into());
+            }
+            set_cloexec(SOCKET_BROKER_FD).map_err(|_| ContainedSessionError)?;
+            set_cloexec(VHOST_USER_BROKER_FD).map_err(|_| ContainedSessionError)?;
+            set_cloexec(BLOCK_CONTROL_BROKER_FD).map_err(|_| ContainedSessionError)?;
+            // SAFETY: The continuation owns fd 3 and fd 4. The original spawn
+            // still transfers each dormant broker descriptor exactly once.
+            let broker_socket =
+                UnixDatagram::from(unsafe { OwnedFd::from_raw_fd(SOCKET_BROKER_FD) });
+            // SAFETY: Same fixed one-time bootstrap ownership for fd 6.
+            let vhost_broker_socket =
+                UnixDatagram::from(unsafe { OwnedFd::from_raw_fd(VHOST_USER_BROKER_FD) });
+            // SAFETY: Same fixed one-time bootstrap ownership for fd 7.
+            let block_control_socket =
+                UnixDatagram::from(unsafe { OwnedFd::from_raw_fd(BLOCK_CONTROL_BROKER_FD) });
+            for descriptor in [
+                broker_socket.as_raw_fd(),
+                vhost_broker_socket.as_raw_fd(),
+                block_control_socket.as_raw_fd(),
+            ] {
+                verify_peer_pid(descriptor, continuation.parent)
+                    .map_err(|_| ContainedSessionError)?;
+            }
+            let source = BootstrapSource::Elevated {
+                root: Some(continuation.root),
+                bootstrap: continuation.bootstrap,
+                parent: continuation.parent,
+            };
+            Self::bootstrap_session(
+                BootstrapChannels {
+                    stream: continuation.stream,
+                    grant_socket: continuation.grants,
+                    socket_broker: broker_socket,
+                    vhost_user_broker: vhost_broker_socket,
+                    block_control_broker: block_control_socket,
+                },
+                continuation.parent,
+                source,
+            )
+        }
+
+        fn bootstrap_session(
+            channels: BootstrapChannels,
+            parent: libc::pid_t,
+            mut source: BootstrapSource,
+        ) -> Result<Option<Self>, ContainedBootstrapError> {
+            let BootstrapChannels {
+                mut stream,
+                grant_socket,
+                socket_broker: broker_socket,
+                vhost_user_broker: vhost_broker_socket,
+                block_control_broker: block_control_socket,
+            } = channels;
+            stream
+                .set_write_timeout(Some(HANDSHAKE_TIMEOUT))
+                .map_err(|_| ContainedSessionError)?;
+            source.verify_peer(&stream, &grant_socket, parent)?;
+
             let mut decoder = FrameDecoder::default();
             let mut lifecycle = WorkerLifecycle::new();
             let hello = lifecycle.hello().map_err(|_| ContainedSessionError)?;
@@ -3564,11 +3779,11 @@ mod platform {
                 .map_err(|_| ContainedSessionError)?
             {
                 Message::Start(policy) => policy,
-                _ => return Err(ContainedSessionError),
+                _ => return Err(ContainedSessionError.into()),
             };
             install_worker_policy(policy, parent)?;
             let session = lifecycle.session().ok_or(ContainedSessionError)?;
-            let namespace = WorkerNamespace::create(session).map_err(|_| ContainedSessionError)?;
+            let namespace = source.create_namespace(session)?;
             namespace.enter().map_err(|_| ContainedSessionError)?;
             let identity = namespace.identity();
             let socket_namespace = Rc::new(
@@ -3580,6 +3795,11 @@ mod platform {
                 .prepared(identity.device, identity.inode)
                 .map_err(|_| ContainedSessionError)?;
             write_frame(&mut stream, prepared)?;
+
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            if source.has_fault(bangbang_session::elevated_probe::RuntimeFault::GrantTransfer) {
+                return Err(ContainedSessionError.into());
+            }
 
             #[cfg(feature = "grant-integration-probe")]
             let receive_grants = if grant_delay_requested() {
@@ -3603,7 +3823,6 @@ mod platform {
                 handshake_deadline()?,
                 receive_grants,
             )?;
-            drop(grant_socket);
             let (mut grants, cancelled) = match grant_outcome {
                 GrantPhaseOutcome::Committed(committed) => {
                     let accepted = lifecycle
@@ -3625,16 +3844,21 @@ mod platform {
                 let next = lifecycle.receive(next).map_err(|_| ContainedSessionError)?;
                 match next {
                     Message::Proceed => {
-                        verify_peer(stream.as_raw_fd(), parent)
-                            .map_err(|_| ContainedSessionError)?;
+                        #[cfg(feature = "elevated-bootstrap-probe")]
+                        if source.has_fault(bangbang_session::elevated_probe::RuntimeFault::Proceed)
+                        {
+                            return Err(ContainedSessionError.into());
+                        }
+                        source.verify_peer(&stream, &grant_socket, parent)?;
                         let starting = lifecycle.starting().map_err(|_| ContainedSessionError)?;
                         write_frame(&mut stream, starting)?;
                         true
                     }
                     Message::Cancel(_) => false,
-                    _ => return Err(ContainedSessionError),
+                    _ => return Err(ContainedSessionError.into()),
                 }
             };
+            drop(grant_socket);
             stream
                 .set_read_timeout(None)
                 .map_err(|_| ContainedSessionError)?;
@@ -3658,6 +3882,8 @@ mod platform {
             let vhost_user_broker =
                 VhostUserBrokerAuthority::new(vhost_broker_socket, session, parent);
             let restore_generations = ContainedSnapshotRestoreGenerationAuthority::new(session);
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            let runtime_fault = source.fault();
             let lifecycle = Arc::new(Mutex::new(lifecycle));
             let namespace = Arc::new(Mutex::new(Some(namespace)));
             let (wakeup_reader, mut wakeup_writer) =
@@ -3704,6 +3930,8 @@ mod platform {
                 restore_generations,
                 restore_wakeup: None,
                 policy,
+                #[cfg(feature = "elevated-bootstrap-probe")]
+                runtime_fault,
                 started,
                 closed: false,
             }))
@@ -3873,6 +4101,11 @@ mod platform {
         ) -> Result<(), ContainedSessionError> {
             if self.closed {
                 return Ok(());
+            }
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            if self.runtime_fault == bangbang_session::elevated_probe::RuntimeFault::Terminal {
+                self.close();
+                return Err(ContainedSessionError);
             }
             let terminal_result = if self.started {
                 let frame = self
@@ -4316,6 +4549,30 @@ mod platform {
         };
 
         static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        #[test]
+        fn runtime_permission_boundary_is_exactly_namespace_creation() {
+            use bangbang_session::macos::runtime::RuntimeError;
+
+            assert!(
+                super::ContainedBootstrapError::RuntimeNamespace(RuntimeError::NamespaceCreate(
+                    io::ErrorKind::PermissionDenied
+                ))
+                .is_runtime_namespace_permission_denied()
+            );
+            for error in [
+                super::ContainedBootstrapError::Session,
+                super::ContainedBootstrapError::RuntimeNamespace(RuntimeError::Filesystem(
+                    io::ErrorKind::PermissionDenied,
+                )),
+                super::ContainedBootstrapError::RuntimeNamespace(RuntimeError::NamespaceCreate(
+                    io::ErrorKind::Other,
+                )),
+            ] {
+                assert!(!error.is_runtime_namespace_permission_denied());
+            }
+        }
 
         pub(crate) struct TestDirectory(PathBuf);
 

--- a/crates/bangbang/src/elevated_bootstrap_probe.rs
+++ b/crates/bangbang/src/elevated_bootstrap_probe.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, Read, Write};
 use std::mem::MaybeUninit;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
@@ -10,23 +10,77 @@ use std::time::Duration;
 use bangbang_hvf::HvfBackend;
 use bangbang_runtime::VmBackend;
 use bangbang_session::elevated_probe::{
-    BOOTSTRAP_RECORD_BYTES, CREDENTIAL_DATAGRAM_BYTES, CREDENTIAL_RECORD_BYTES,
-    CredentialDatagramPhase, CredentialDatagramProof, CredentialFailureValue, CredentialGroupClass,
-    CredentialIdentityClass, CredentialPrefix, CredentialRecord, CredentialRecordKind,
-    CredentialRole, CredentialSelfState, CredentialStep, PeerObservation, ProbeBootstrap,
-    ProbeErrorCategory, ProbeResult, ProbeStage, READY_RECORD, RESULT_RECORD_BYTES, ROOT_FD,
-    WORKER_ACTIVATION,
+    BOOTSTRAP_RECORD_BYTES, CONTINUATION_ACK_BYTES, CREDENTIAL_DATAGRAM_BYTES,
+    CREDENTIAL_RECORD_BYTES, ContinuationAck, CredentialDatagramPhase, CredentialDatagramProof,
+    CredentialFailureValue, CredentialGroupClass, CredentialIdentityClass, CredentialPrefix,
+    CredentialRecord, CredentialRecordKind, CredentialRole, CredentialSelfState, CredentialStep,
+    PeerObservation, ProbeBootstrap, ProbeErrorCategory, ProbeResult, ProbeStage, READY_RECORD,
+    RESULT_RECORD_BYTES, ROOT_FD, RuntimeFault, WORKER_ACTIVATION,
 };
 use bangbang_session::{GRANT_FD, ObjectIdentity, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD};
+
+use bangbang_session::macos::runtime::ExplicitRuntimeRoot;
 
 const CREDENTIAL_TIMEOUT: Duration = Duration::from_secs(5);
 const CREDENTIAL_WORKER_ARTIFACT: &str =
     "bangbang-elevated-credential-worker-v1-credential-drop-BBC1-BBG1-restore-groups";
+const RUNTIME_WORKER_ARTIFACT: &str = "bangbang-elevated-runtime-worker-v1-runtime-drop-runtime-retain-root-runtime-unmapped-BBA1---bangbang-internal-grant-probe-v1-target-runtime";
+const RUNTIME_WORKER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-runtime-worker-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ProbeError {
     stage: ProbeStage,
     kind: io::ErrorKind,
+}
+
+/// Result of the feature-only process-entry probe.
+pub(crate) enum ProbeEntry {
+    /// A historical mode or a failed continuation terminates at the probe boundary.
+    Terminal(ExitCode),
+    /// The same process and transports continue into the ordinary lifecycle.
+    Continue(RuntimeContinuation),
+}
+
+/// Single-use authority carried from credential transition into contained bootstrap.
+pub(crate) struct RuntimeContinuation {
+    pub(crate) stream: UnixStream,
+    pub(crate) grants: UnixDatagram,
+    pub(crate) root: ExplicitRuntimeRoot,
+    pub(crate) bootstrap: ProbeBootstrap,
+    pub(crate) parent: libc::pid_t,
+    worker_args: Option<Vec<OsString>>,
+}
+
+impl std::fmt::Debug for RuntimeContinuation {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RuntimeContinuation(<redacted>)")
+    }
+}
+
+impl RuntimeContinuation {
+    pub(crate) fn take_worker_args(&mut self) -> Result<Vec<OsString>, ()> {
+        self.worker_args.take().ok_or(())
+    }
+
+    pub(crate) fn verify_witness(&self) -> Result<(), ()> {
+        // SAFETY: `getppid` has no pointer or ownership contract.
+        let live_parent = unsafe { libc::getppid() };
+        if live_parent != self.parent
+            || bangbang_session::macos::verify_peer_pid(self.stream.as_raw_fd(), self.parent)
+                .is_err()
+            || bangbang_session::macos::verify_peer_pid(self.grants.as_raw_fd(), self.parent)
+                .is_err()
+            || bangbang_session::elevated_credential::attest_current_process(
+                self.bootstrap.mode(),
+                self.bootstrap.target_uid(),
+                self.bootstrap.target_gid(),
+            )
+            .is_err()
+        {
+            return Err(());
+        }
+        Ok(())
+    }
 }
 
 pub(crate) fn is_requested() -> bool {
@@ -35,13 +89,13 @@ pub(crate) fn is_requested() -> bool {
         .is_some_and(|argument| argument == OsStr::new(WORKER_ACTIVATION))
 }
 
-pub(crate) fn run() -> ExitCode {
-    let (mut stream, bootstrap, parent) = match probe_session() {
+pub(crate) fn run() -> ProbeEntry {
+    let (mut stream, bootstrap, parent, worker_args) = match probe_session() {
         Ok(session) => session,
-        Err(_) => return ExitCode::FAILURE,
+        Err(_) => return ProbeEntry::Terminal(ExitCode::FAILURE),
     };
     if bootstrap.mode().is_credential_pair() {
-        return run_credential_pair(stream, bootstrap, parent);
+        return run_credential_pair(stream, bootstrap, parent, worker_args);
     }
     let outcome = execute(bootstrap);
     let result = match outcome {
@@ -54,23 +108,26 @@ pub(crate) fn run() -> ExitCode {
         ),
     };
     let Ok(result) = result else {
-        return ExitCode::FAILURE;
+        return ProbeEntry::Terminal(ExitCode::FAILURE);
     };
     let encoded = result.encode();
     debug_assert_eq!(encoded.len(), RESULT_RECORD_BYTES);
     if stream.write_all(&encoded).is_err() {
-        return ExitCode::FAILURE;
+        return ProbeEntry::Terminal(ExitCode::FAILURE);
     }
-    if outcome.is_ok() {
+    ProbeEntry::Terminal(if outcome.is_ok() {
         ExitCode::SUCCESS
     } else {
         ExitCode::FAILURE
-    }
+    })
 }
 
-fn probe_session() -> Result<(UnixStream, ProbeBootstrap, libc::pid_t), ProbeError> {
+fn probe_session() -> Result<(UnixStream, ProbeBootstrap, libc::pid_t, Vec<OsString>), ProbeError> {
     let arguments = env::args_os().skip(1).collect::<Vec<_>>();
-    if arguments.as_slice() != [OsStr::new(WORKER_ACTIVATION)] {
+    if arguments
+        .first()
+        .is_none_or(|arg| arg != OsStr::new(WORKER_ACTIVATION))
+    {
         return Err(invalid(ProbeStage::InitialIdentity));
     }
     let value = env::var_os(SESSION_ENV_KEY).ok_or_else(|| invalid(ProbeStage::InitialIdentity))?;
@@ -99,22 +156,29 @@ fn probe_session() -> Result<(UnixStream, ProbeBootstrap, libc::pid_t), ProbeErr
         .map_err(|error| with_kind(ProbeStage::InitialIdentity, error.kind()))?;
     let bootstrap =
         ProbeBootstrap::decode(&encoded).map_err(|_| invalid(ProbeStage::InitialIdentity))?;
-    Ok((stream, bootstrap, parent))
+    let worker_args = arguments.into_iter().skip(1).collect::<Vec<_>>();
+    if !bootstrap.mode().continues_runtime() && !worker_args.is_empty() {
+        return Err(invalid(ProbeStage::InitialIdentity));
+    }
+    Ok((stream, bootstrap, parent, worker_args))
 }
 
 fn run_credential_pair(
     mut stream: UnixStream,
     bootstrap: ProbeBootstrap,
     parent: libc::pid_t,
-) -> ExitCode {
+    worker_args: Vec<OsString>,
+) -> ProbeEntry {
     std::hint::black_box(CREDENTIAL_WORKER_ARTIFACT);
+    std::hint::black_box(RUNTIME_WORKER_ARTIFACT);
+    std::hint::black_box(RUNTIME_WORKER_BOUNDARY_ARTIFACT);
     if stream.set_read_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
         || stream.set_write_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
     {
-        return ExitCode::FAILURE;
+        return terminal(ExitCode::FAILURE);
     }
     if let Err(error) = validate_initial_identity() {
-        return write_credential_failure(
+        return terminal(write_credential_failure(
             &mut stream,
             bootstrap,
             CredentialFailureValue::new(
@@ -124,12 +188,12 @@ fn run_credential_pair(
                 initial_credential_state(bootstrap),
             ),
             PeerObservation::NONE,
-        );
+        ));
     }
-    let root = match take_root(bootstrap) {
+    let runtime_root_descriptor = match take_credential_root(bootstrap) {
         Ok(root) => root,
         Err(error) => {
-            return write_credential_failure(
+            return terminal(write_credential_failure(
                 &mut stream,
                 bootstrap,
                 CredentialFailureValue::new(
@@ -139,14 +203,13 @@ fn run_credential_pair(
                     initial_credential_state(bootstrap),
                 ),
                 PeerObservation::NONE,
-            );
+            ));
         }
     };
-    drop(root);
     let grants = match take_grants() {
         Ok(grants) => grants,
         Err(category) => {
-            return write_credential_failure(
+            return terminal(write_credential_failure(
                 &mut stream,
                 bootstrap,
                 credential_failure(
@@ -156,13 +219,13 @@ fn run_credential_pair(
                     initial_credential_state(bootstrap),
                 ),
                 PeerObservation::NONE,
-            );
+            ));
         }
     };
     if grants.set_read_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
         || grants.set_write_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
     {
-        return write_credential_failure(
+        return terminal(write_credential_failure(
             &mut stream,
             bootstrap,
             credential_failure(
@@ -172,7 +235,7 @@ fn run_credential_pair(
                 initial_credential_state(bootstrap),
             ),
             PeerObservation::NONE,
-        );
+        ));
     }
     match receive_credential_datagram(&grants) {
         Ok(proof)
@@ -183,7 +246,7 @@ fn run_credential_pair(
                 bootstrap.nonce(),
             ) => {}
         Ok(_) | Err(_) => {
-            return write_credential_failure(
+            return terminal(write_credential_failure(
                 &mut stream,
                 bootstrap,
                 credential_failure(
@@ -193,16 +256,16 @@ fn run_credential_pair(
                     initial_credential_state(bootstrap),
                 ),
                 PeerObservation::NONE,
-            );
+            ));
         }
     }
     let Ok(worker_ready) =
         CredentialDatagramProof::worker_ready(bootstrap.mode(), bootstrap.nonce())
     else {
-        return ExitCode::FAILURE;
+        return terminal(ExitCode::FAILURE);
     };
     if send_credential_datagram(&grants, worker_ready).is_err() {
-        return ExitCode::FAILURE;
+        return terminal(ExitCode::FAILURE);
     }
     match receive_credential_datagram(&grants) {
         Ok(proof)
@@ -213,7 +276,7 @@ fn run_credential_pair(
                 bootstrap.nonce(),
             ) => {}
         Ok(_) | Err(_) => {
-            return write_credential_failure(
+            return terminal(write_credential_failure(
                 &mut stream,
                 bootstrap,
                 credential_failure(
@@ -223,9 +286,37 @@ fn run_credential_pair(
                     initial_credential_state(bootstrap),
                 ),
                 PeerObservation::NONE,
-            );
+            ));
         }
     }
+    let runtime_root = match runtime_root_descriptor
+        .map(|root| {
+            ExplicitRuntimeRoot::from_owned_fd(
+                root,
+                bootstrap.root(),
+                bootstrap.target_uid(),
+                bootstrap.target_gid(),
+                true,
+            )
+            .map_err(|_| permission(ProbeStage::ValidateRoot))
+        })
+        .transpose()
+    {
+        Ok(root) => root,
+        Err(error) => {
+            return terminal(write_credential_failure(
+                &mut stream,
+                bootstrap,
+                CredentialFailureValue::new(
+                    CredentialStep::InitialIdentity,
+                    ProbeErrorCategory::from_io_kind(error.kind),
+                    CredentialPrefix::None,
+                    initial_credential_state(bootstrap),
+                ),
+                PeerObservation::NONE,
+            ));
+        }
+    };
     let (initial, baseline) = match bangbang_session::elevated_credential::observe_initial_peer(
         stream.as_raw_fd(),
         grants.as_raw_fd(),
@@ -236,7 +327,7 @@ fn run_credential_pair(
     ) {
         Ok(observation) => observation,
         Err(category) => {
-            return write_credential_failure(
+            return terminal(write_credential_failure(
                 &mut stream,
                 bootstrap,
                 credential_failure(
@@ -246,7 +337,7 @@ fn run_credential_pair(
                     initial_credential_state(bootstrap),
                 ),
                 PeerObservation::NONE,
-            );
+            ));
         }
     };
     let transition = match bangbang_session::elevated_credential::transition_process(
@@ -256,7 +347,12 @@ fn run_credential_pair(
     ) {
         Ok(transition) => transition,
         Err(failure) => {
-            return write_credential_failure(&mut stream, bootstrap, failure, initial);
+            return terminal(write_credential_failure(
+                &mut stream,
+                bootstrap,
+                failure,
+                initial,
+            ));
         }
     };
     let after_worker = match bangbang_session::elevated_credential::observe_later_peer(
@@ -270,7 +366,7 @@ fn run_credential_pair(
     ) {
         Ok(observation) => observation,
         Err(category) => {
-            return write_credential_failure(
+            return terminal(write_credential_failure(
                 &mut stream,
                 bootstrap,
                 credential_failure(
@@ -280,7 +376,7 @@ fn run_credential_pair(
                     transition.state(),
                 ),
                 initial,
-            );
+            ));
         }
     };
     let Ok(record) = CredentialRecord::worker_transitioned(
@@ -290,10 +386,10 @@ fn run_credential_pair(
         after_worker,
         bootstrap.nonce(),
     ) else {
-        return ExitCode::FAILURE;
+        return terminal(ExitCode::FAILURE);
     };
     if stream.write_all(&record.encode()).is_err() {
-        return ExitCode::FAILURE;
+        return terminal(ExitCode::FAILURE);
     }
 
     let launcher = match read_credential_record(&mut stream) {
@@ -307,7 +403,7 @@ fn run_credential_pair(
             record
         }
         Ok(_) | Err(_) => {
-            return write_credential_failure(
+            return terminal(write_credential_failure(
                 &mut stream,
                 bootstrap,
                 credential_failure(
@@ -317,14 +413,14 @@ fn run_credential_pair(
                     transition.state(),
                 ),
                 initial,
-            );
+            ));
         }
     };
     match launcher.kind() {
-        CredentialRecordKind::Failure => return ExitCode::FAILURE,
+        CredentialRecordKind::Failure => return terminal(ExitCode::FAILURE),
         CredentialRecordKind::LauncherTransitioned => {}
         CredentialRecordKind::WorkerTransitioned | CredentialRecordKind::WorkerFinal => {
-            return write_credential_failure(
+            return terminal(write_credential_failure(
                 &mut stream,
                 bootstrap,
                 credential_failure(
@@ -334,7 +430,7 @@ fn run_credential_pair(
                     transition.state(),
                 ),
                 initial,
-            );
+            ));
         }
     }
     let after_both = match bangbang_session::elevated_credential::observe_later_peer(
@@ -348,7 +444,7 @@ fn run_credential_pair(
     ) {
         Ok(observation) => observation,
         Err(category) => {
-            return write_credential_failure(
+            return terminal(write_credential_failure(
                 &mut stream,
                 bootstrap,
                 credential_failure(
@@ -358,7 +454,7 @@ fn run_credential_pair(
                     transition.state(),
                 ),
                 initial,
-            );
+            ));
         }
     };
     let Ok(final_record) = CredentialRecord::worker_final(
@@ -367,23 +463,102 @@ fn run_credential_pair(
         [initial, after_worker, after_both],
         bootstrap.nonce(),
     ) else {
-        return ExitCode::FAILURE;
+        return terminal(ExitCode::FAILURE);
     };
     if stream.write_all(&final_record.encode()).is_err() {
-        ExitCode::FAILURE
+        return terminal(ExitCode::FAILURE);
+    }
+    if !bootstrap.mode().continues_runtime() {
+        return terminal(ExitCode::SUCCESS);
+    }
+    let Some(root) = runtime_root else {
+        return terminal(ExitCode::FAILURE);
+    };
+    if bootstrap.fault() == RuntimeFault::PreAck {
+        return terminal(ExitCode::FAILURE);
+    }
+    let mut encoded = [0_u8; CONTINUATION_ACK_BYTES];
+    if stream.read_exact(&mut encoded).is_err() {
+        return terminal(ExitCode::FAILURE);
+    }
+    let Ok(ack) = ContinuationAck::decode(&encoded) else {
+        return terminal(ExitCode::FAILURE);
+    };
+    if !ack.matches_expected(bootstrap.mode(), bootstrap.nonce())
+        || stream.set_read_timeout(None).is_err()
+        || stream.set_write_timeout(None).is_err()
+        || grants.set_read_timeout(None).is_err()
+        || grants.set_write_timeout(None).is_err()
+        || !transport_is_empty(stream.as_raw_fd())
+        || !transport_is_empty(grants.as_raw_fd())
+    {
+        return terminal(ExitCode::FAILURE);
+    }
+    if bootstrap.fault() == RuntimeFault::PostAck {
+        return terminal(ExitCode::FAILURE);
+    }
+    let continuation = RuntimeContinuation {
+        stream,
+        grants,
+        root,
+        bootstrap,
+        parent,
+        worker_args: Some(worker_args),
+    };
+    if continuation.verify_witness().is_err() {
+        terminal(ExitCode::FAILURE)
     } else {
-        ExitCode::SUCCESS
+        ProbeEntry::Continue(continuation)
     }
 }
 
+const fn terminal(code: ExitCode) -> ProbeEntry {
+    ProbeEntry::Terminal(code)
+}
+
+fn take_credential_root(bootstrap: ProbeBootstrap) -> Result<Option<OwnedFd>, ProbeError> {
+    let root = take_root_descriptor()?;
+    if bootstrap.mode().continues_runtime() {
+        return Ok(Some(root));
+    }
+    validate_root(root.as_raw_fd(), bootstrap.root())?;
+    Ok(None)
+}
+
 fn take_root(bootstrap: ProbeBootstrap) -> Result<OwnedFd, ProbeError> {
+    let root = take_root_descriptor()?;
+    validate_root(root.as_raw_fd(), bootstrap.root())?;
+    Ok(root)
+}
+
+fn take_root_descriptor() -> Result<OwnedFd, ProbeError> {
     bangbang_session::macos::set_cloexec(ROOT_FD)
         .map_err(|error| with_kind(ProbeStage::TakeRoot, error.kind()))?;
     // SAFETY: The feature-gated production spawn contract transfers fixed fd 8
     // exactly once to this process.
     let root = unsafe { OwnedFd::from_raw_fd(ROOT_FD) };
-    validate_root(root.as_raw_fd(), bootstrap.root())?;
     Ok(root)
+}
+
+fn transport_is_empty(fd: libc::c_int) -> bool {
+    let mut byte = 0_u8;
+    // SAFETY: `byte` is one writable byte, `fd` is a live connected local
+    // socket, and PEEK never consumes application bytes.
+    let result = unsafe {
+        libc::recv(
+            fd,
+            (&raw mut byte).cast(),
+            1,
+            libc::MSG_PEEK | libc::MSG_DONTWAIT,
+        )
+    };
+    if result < 0 {
+        let error = io::Error::last_os_error();
+        return error
+            .raw_os_error()
+            .is_some_and(|code| code == libc::EAGAIN || code == libc::EWOULDBLOCK);
+    }
+    false
 }
 
 fn take_grants() -> Result<UnixDatagram, ProbeErrorCategory> {
@@ -490,7 +665,10 @@ fn execute(config: ProbeBootstrap) -> Result<(), ProbeError> {
         | bangbang_session::elevated_probe::ProbeMode::CredentialDrop
         | bangbang_session::elevated_probe::ProbeMode::CredentialRetainRoot
         | bangbang_session::elevated_probe::ProbeMode::CredentialUnmapped
-        | bangbang_session::elevated_probe::ProbeMode::CredentialControl => {
+        | bangbang_session::elevated_probe::ProbeMode::CredentialControl
+        | bangbang_session::elevated_probe::ProbeMode::RuntimeDrop
+        | bangbang_session::elevated_probe::ProbeMode::RuntimeRetainRoot
+        | bangbang_session::elevated_probe::ProbeMode::RuntimeUnmapped => {
             return Err(invalid(ProbeStage::InitialIdentity));
         }
     }
@@ -835,6 +1013,55 @@ mod tests {
         assert!(
             receive_credential_datagram(&datagram).is_err(),
             "a dead datagram endpoint must fail or time out without advancing"
+        );
+    }
+
+    #[test]
+    fn continuation_requires_empty_live_stream_and_datagram_transports() {
+        let (mut stream, mut stream_peer) =
+            UnixStream::pair().expect("stream pair should construct");
+        assert!(transport_is_empty(stream.as_raw_fd()));
+        stream_peer
+            .write_all(&[0x41, 0x42])
+            .expect("replay bytes should send");
+        assert!(!transport_is_empty(stream.as_raw_fd()));
+        let mut byte = [0_u8; 1];
+        stream
+            .read_exact(&mut byte)
+            .expect("first replay byte should consume");
+        assert!(!transport_is_empty(stream.as_raw_fd()));
+        stream
+            .read_exact(&mut byte)
+            .expect("second replay byte should consume");
+        assert!(transport_is_empty(stream.as_raw_fd()));
+        drop(stream_peer);
+        assert!(
+            !transport_is_empty(stream.as_raw_fd()),
+            "EOF must not be mistaken for an empty live transport"
+        );
+
+        let (datagram, datagram_peer) =
+            UnixDatagram::pair().expect("datagram pair should construct");
+        assert!(transport_is_empty(datagram.as_raw_fd()));
+        datagram_peer
+            .send(&[0x51])
+            .expect("first datagram should send");
+        datagram_peer
+            .send(&[0x52])
+            .expect("second datagram should send");
+        assert!(!transport_is_empty(datagram.as_raw_fd()));
+        datagram
+            .recv(&mut byte)
+            .expect("first datagram should consume");
+        assert!(!transport_is_empty(datagram.as_raw_fd()));
+        datagram
+            .recv(&mut byte)
+            .expect("second datagram should consume");
+        assert!(transport_is_empty(datagram.as_raw_fd()));
+        drop(datagram_peer);
+        assert!(
+            !transport_is_empty(datagram.as_raw_fd()),
+            "dead datagram transport must fail closed"
         );
     }
 }

--- a/crates/bangbang/src/grant_integration_probe.rs
+++ b/crates/bangbang/src/grant_integration_probe.rs
@@ -1,11 +1,12 @@
 //! Test-bundle-only exercise of committed startup grant authority.
 
 use std::cell::Cell;
-use std::ffi::OsString;
+use std::ffi::{CString, OsString};
 use std::fs::{File, OpenOptions};
 use std::io::{Cursor, Read, Write};
+use std::mem::MaybeUninit;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
-use std::os::unix::fs::{FileExt, OpenOptionsExt};
+use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -32,7 +33,7 @@ use bangbang_runtime::snapshot_restore::{
 };
 use bangbang_runtime::virtio_queue::VirtqueueAvailableRing;
 use bangbang_runtime::vsock::VsockBackendSelector;
-use bangbang_session::{GrantAccess, GrantId, GrantObjectKind, ResourceRole};
+use bangbang_session::{GrantAccess, GrantId, GrantObjectKind, ObjectIdentity, ResourceRole};
 
 use crate::contained_session::{
     ContainedSession, ContainedSessionError, ContainedSnapshotRestoreAuthority,
@@ -192,19 +193,27 @@ pub(crate) fn run(
         Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {}
         Ok(_) | Err(_) => return Err(ContainedSessionError),
     }
-    let child = directory
-        .path()
-        .join(format!("bangbang-grant-{}.out", probe.name));
-    let mut output = OpenOptions::new();
-    output
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW_ANY);
-    output
-        .open(child)
-        .and_then(|mut file| file.write_all(expected_write.as_bytes()))
-        .map_err(|_| ContainedSessionError)?;
+    if probe.verifies_target_runtime() {
+        create_validate_remove_child(
+            directory.anchor_fd(),
+            &format!("bangbang-grant-{}.out", probe.name),
+            expected_write.as_bytes(),
+        )?;
+    } else {
+        let child = directory
+            .path()
+            .join(format!("bangbang-grant-{}.out", probe.name));
+        let mut output = OpenOptions::new();
+        output
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW_ANY);
+        output
+            .open(child)
+            .and_then(|mut file| file.write_all(expected_write.as_bytes()))
+            .map_err(|_| ContainedSessionError)?;
+    }
 
     if probe.verifies_shared_memory() {
         verify_shared_guest_memory_in_containment()?;
@@ -224,6 +233,172 @@ pub(crate) fn run(
         }
     }
     Ok(())
+}
+
+fn create_validate_remove_child(
+    directory: RawFd,
+    name: &str,
+    expected: &[u8],
+) -> Result<(), ContainedSessionError> {
+    let mut child = ExactGrantChild::create(directory, name)?;
+    child
+        .file
+        .write_all(expected)
+        .and_then(|()| child.file.sync_all())
+        .map_err(|_| ContainedSessionError)?;
+    let expected_identity = child.identity()?;
+
+    // SAFETY: Same retained anchor and exact component; no path fallback.
+    let descriptor = unsafe {
+        libc::openat(
+            directory,
+            child.name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if descriptor < 0 {
+        return Err(ContainedSessionError);
+    }
+    // SAFETY: `descriptor` is a fresh successful result owned by this scope.
+    let mut input = File::from(unsafe { OwnedFd::from_raw_fd(descriptor) });
+    let metadata = input.metadata().map_err(|_| ContainedSessionError)?;
+    // SAFETY: Identity getters have no pointer or ownership contract.
+    let (uid, gid) = unsafe { (libc::geteuid(), libc::getegid()) };
+    if !metadata.is_file()
+        || metadata.permissions().mode() & 0o7777 != 0o600
+        || metadata.uid() != uid
+        || metadata.gid() != gid
+        || metadata.nlink() != 1
+        || (ObjectIdentity {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        }) != expected_identity
+    {
+        return Err(ContainedSessionError);
+    }
+    let mut actual = Vec::new();
+    input
+        .read_to_end(&mut actual)
+        .map_err(|_| ContainedSessionError)?;
+    if actual != expected {
+        return Err(ContainedSessionError);
+    }
+    drop(input);
+    child.remove()
+}
+
+struct ExactGrantChild {
+    directory: RawFd,
+    name: CString,
+    file: File,
+    armed: bool,
+}
+
+impl ExactGrantChild {
+    fn create(directory: RawFd, name: &str) -> Result<Self, ContainedSessionError> {
+        let name = CString::new(name).map_err(|_| ContainedSessionError)?;
+        // SAFETY: `directory` is the retained granted anchor, `name` is one
+        // bounded component, and success transfers the fresh descriptor.
+        let descriptor = unsafe {
+            libc::openat(
+                directory,
+                name.as_ptr(),
+                libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+                0o600,
+            )
+        };
+        if descriptor < 0 {
+            return Err(ContainedSessionError);
+        }
+        // SAFETY: `descriptor` is a fresh successful result owned by this scope.
+        let file = File::from(unsafe { OwnedFd::from_raw_fd(descriptor) });
+        Ok(Self {
+            directory,
+            name,
+            file,
+            armed: true,
+        })
+    }
+
+    fn identity(&self) -> Result<ObjectIdentity, ContainedSessionError> {
+        let metadata = self.file.metadata().map_err(|_| ContainedSessionError)?;
+        Ok(ObjectIdentity {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        })
+    }
+
+    fn remove(&mut self) -> Result<(), ContainedSessionError> {
+        self.remove_if_same()
+    }
+
+    fn remove_if_same(&mut self) -> Result<(), ContainedSessionError> {
+        if !self.armed {
+            return Ok(());
+        }
+        if !self.current_name_is_exact()? {
+            return Err(ContainedSessionError);
+        }
+        // SAFETY: The exact live child identity was revalidated beneath the retained anchor.
+        if unsafe { libc::unlinkat(self.directory, self.name.as_ptr(), 0) } != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::NotFound {
+                return Err(ContainedSessionError);
+            }
+        }
+        self.armed = false;
+        Ok(())
+    }
+
+    fn current_name_is_exact(&mut self) -> Result<bool, ContainedSessionError> {
+        let mut source = MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: The guard owns the live source descriptor and stat is writable.
+        if unsafe { libc::fstat(self.file.as_raw_fd(), source.as_mut_ptr()) } != 0 {
+            return Err(ContainedSessionError);
+        }
+        // SAFETY: Successful fstat initialized the complete result.
+        let source = unsafe { source.assume_init() };
+        let mut stat = MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: The retained anchor and bounded name remain live; stat is writable.
+        if unsafe {
+            libc::fstatat(
+                self.directory,
+                self.name.as_ptr(),
+                stat.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        } != 0
+        {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::NotFound {
+                self.armed = false;
+                return Ok(true);
+            }
+            return Err(ContainedSessionError);
+        }
+        // SAFETY: Successful fstatat initialized the complete result.
+        let stat = unsafe { stat.assume_init() };
+        if source.st_mode & libc::S_IFMT != libc::S_IFREG
+            || source.st_mode & 0o7777 != 0o600
+            || source.st_nlink != 1
+            || stat.st_dev != source.st_dev
+            || stat.st_ino != source.st_ino
+            || stat.st_mode & libc::S_IFMT != libc::S_IFREG
+            || stat.st_mode & 0o7777 != 0o600
+            || stat.st_uid != source.st_uid
+            || stat.st_gid != source.st_gid
+            || stat.st_nlink != 1
+        {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+}
+
+impl Drop for ExactGrantChild {
+    fn drop(&mut self) {
+        let _ = self.remove_if_same();
+    }
 }
 
 fn verify_pager_in_containment(
@@ -1318,6 +1493,12 @@ impl ProbeCase {
                 expected_no_file: 2048,
                 expected_file_size: None,
             }),
+            Some("target-runtime") => Ok(Self {
+                name: "target-runtime",
+                hold: false,
+                expected_no_file: 2048,
+                expected_file_size: None,
+            }),
             _ => Err(ContainedSessionError),
         }
     }
@@ -1337,6 +1518,10 @@ impl ProbeCase {
     fn verifies_block_control(self) -> bool {
         self.name == "block-control"
     }
+
+    fn verifies_target_runtime(self) -> bool {
+        self.name == "target-runtime"
+    }
 }
 
 fn probe_args(args: &[OsString]) -> Option<&[OsString]> {
@@ -1351,4 +1536,142 @@ fn probe_args(args: &[OsString]) -> Option<&[OsString]> {
         && start_cpu == "--start-time-cpu-us"
         && parent_cpu == "--parent-cpu-time-us")
         .then_some(rest)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDirectory {
+        path: std::path::PathBuf,
+        anchor: File,
+    }
+
+    impl TestDirectory {
+        fn new() -> Self {
+            loop {
+                let suffix = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+                let path = std::path::PathBuf::from("/tmp").join(format!(
+                    "bangbang-exact-grant-child-{}-{suffix}",
+                    std::process::id()
+                ));
+                match fs::create_dir(&path) {
+                    Ok(()) => {
+                        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+                            .expect("test directory mode should set");
+                        let anchor = File::open(&path).expect("test directory should open");
+                        return Self { path, anchor };
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                    Err(error) => panic!("test directory should create: {error}"),
+                }
+            }
+        }
+
+        fn child(&self) -> std::path::PathBuf {
+            self.path.join("owned-child")
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            if self.child().exists() {
+                fs::remove_file(self.child()).expect("test child should clean");
+            }
+            fs::remove_dir(&self.path).expect("test directory should clean");
+        }
+    }
+
+    #[test]
+    fn exact_grant_child_removes_success_and_failure_paths() {
+        let directory = TestDirectory::new();
+        let mut child = ExactGrantChild::create(directory.anchor.as_raw_fd(), "owned-child")
+            .expect("exact child should create");
+        child
+            .file
+            .write_all(b"complete")
+            .expect("exact child should write");
+        let source = child.file.metadata().expect("source metadata should read");
+        let named = fs::symlink_metadata(directory.child()).expect("named metadata should read");
+        assert_eq!(
+            (source.dev(), source.ino(), source.uid(), source.gid()),
+            (named.dev(), named.ino(), named.uid(), named.gid())
+        );
+        assert_eq!(named.permissions().mode() & 0o7777, 0o600);
+        assert_eq!(named.nlink(), 1);
+        let mut source_stat = MaybeUninit::<libc::stat>::uninit();
+        let mut named_stat = MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: The source descriptor is live and the output is writable.
+        let source_status =
+            unsafe { libc::fstat(child.file.as_raw_fd(), source_stat.as_mut_ptr()) };
+        assert_eq!(source_status, 0);
+        // SAFETY: The anchor/name are live and the output is writable.
+        let named_status = unsafe {
+            libc::fstatat(
+                directory.anchor.as_raw_fd(),
+                child.name.as_ptr(),
+                named_stat.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        assert_eq!(named_status, 0);
+        // SAFETY: Both successful stat calls initialized their outputs.
+        let (source_stat, named_stat) =
+            unsafe { (source_stat.assume_init(), named_stat.assume_init()) };
+        assert_eq!(
+            (
+                source_stat.st_dev,
+                source_stat.st_ino,
+                source_stat.st_mode & 0o7777,
+                source_stat.st_uid,
+                source_stat.st_gid,
+                source_stat.st_nlink,
+            ),
+            (
+                named_stat.st_dev,
+                named_stat.st_ino,
+                named_stat.st_mode & 0o7777,
+                named_stat.st_uid,
+                named_stat.st_gid,
+                named_stat.st_nlink,
+            )
+        );
+        assert!(
+            child
+                .current_name_is_exact()
+                .expect("exact name validation should run")
+        );
+        child.remove().expect("exact child should remove");
+        assert!(!directory.child().exists());
+
+        let mut child = ExactGrantChild::create(directory.anchor.as_raw_fd(), "owned-child")
+            .expect("failure-path child should create");
+        child
+            .file
+            .write_all(b"partial")
+            .expect("failure-path child should write");
+        drop(child);
+        assert!(!directory.child().exists());
+    }
+
+    #[test]
+    fn exact_grant_child_drop_refuses_a_replacement() {
+        let directory = TestDirectory::new();
+        let child = ExactGrantChild::create(directory.anchor.as_raw_fd(), "owned-child")
+            .expect("exact child should create");
+        fs::remove_file(directory.child()).expect("original child should unlink");
+        fs::write(directory.child(), b"replacement").expect("replacement should create");
+
+        drop(child);
+
+        assert_eq!(
+            fs::read(directory.child()).expect("replacement should remain"),
+            b"replacement"
+        );
+    }
 }

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -97,6 +97,11 @@ const FIRECRACKER_DEFAULT_NOFILE_LIMIT: RawFd = 2048;
 const PROCESS_STDOUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 const UNSUPPORTED_FIRECRACKER_ARGS: &[&str] = &["no-seccomp", "seccomp-filter"];
 
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+type ProcessContinuation = Option<elevated_bootstrap_probe::RuntimeContinuation>;
+#[cfg(not(all(target_os = "macos", feature = "elevated-bootstrap-probe")))]
+type ProcessContinuation = ();
+
 fn write_process_stdout_line(
     arguments: fmt::Arguments<'_>,
     mut stdout: Option<ProcessStdoutLogger>,
@@ -116,9 +121,21 @@ fn write_process_stdout_line(
 
 fn main() -> ExitCode {
     #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
-    if elevated_bootstrap_probe::is_requested() {
-        return elevated_bootstrap_probe::run();
-    }
+    let (continuation, elevated_args) = if elevated_bootstrap_probe::is_requested() {
+        match elevated_bootstrap_probe::run() {
+            elevated_bootstrap_probe::ProbeEntry::Terminal(code) => return code,
+            elevated_bootstrap_probe::ProbeEntry::Continue(mut continuation) => {
+                let Ok(args) = continuation.take_worker_args() else {
+                    return ExitCode::FAILURE;
+                };
+                (Some(continuation), Some(args))
+            }
+        }
+    } else {
+        (None, None)
+    };
+    #[cfg(not(all(target_os = "macos", feature = "elevated-bootstrap-probe")))]
+    let (continuation, elevated_args) = ((), None);
     #[cfg(target_os = "macos")]
     if anchored_socket::is_binder_invocation() {
         return if anchored_socket::run_binder() {
@@ -130,7 +147,7 @@ fn main() -> ExitCode {
     let bridge = panic_bridge::PanicBridge::install();
     let mut contained = None;
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        run_process_lifecycle(&bridge, &mut contained)
+        run_process_lifecycle(&bridge, &mut contained, continuation, elevated_args)
     }));
     match outcome {
         Ok(exit_code) => {
@@ -157,15 +174,30 @@ fn main() -> ExitCode {
 fn run_process_lifecycle(
     bridge: &panic_bridge::PanicBridge,
     contained: &mut Option<ContainedSession>,
+    continuation: ProcessContinuation,
+    raw_args: Option<Vec<OsString>>,
 ) -> ExitCode {
-    *contained = match ContainedSession::bootstrap() {
+    #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+    let bootstrap = ContainedSession::bootstrap_with_continuation(continuation);
+    #[cfg(not(all(target_os = "macos", feature = "elevated-bootstrap-probe")))]
+    let bootstrap = {
+        let () = continuation;
+        ContainedSession::bootstrap()
+    };
+    *contained = match bootstrap {
         Ok(contained) => contained,
         Err(err) => {
+            #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+            if err.is_runtime_namespace_permission_denied() {
+                return ExitCode::from(
+                    bangbang_session::elevated_probe::RUNTIME_NAMESPACE_PERMISSION_EXIT_CODE,
+                );
+            }
             eprintln!("bangbang: {err}");
             return ProcessExitCode::ProcessFailure.into_exit_code();
         }
     };
-    let result = run(bridge, contained);
+    let result = run(bridge, contained, raw_args);
     let (category, exit_code) = terminal_result(&result, contained.as_ref());
     if let Some(session) = contained.as_mut() {
         let _ = session.finish(category, exit_code);
@@ -185,6 +217,7 @@ fn run_process_lifecycle(
 fn run(
     bridge: &panic_bridge::PanicBridge,
     contained: &mut Option<ContainedSession>,
+    raw_args: Option<Vec<OsString>>,
 ) -> Result<(), ProcessError> {
     let snapshot_cancellation = NativeV1SnapshotCaptureCancellation::default();
     let mut contained_shutdown = if let Some(session) = contained.as_mut() {
@@ -202,7 +235,7 @@ fn run(
     if contained_shutdown_requested(contained)? {
         return Ok(());
     }
-    let raw_args = env::args_os().skip(1).collect::<Vec<_>>();
+    let raw_args = raw_args.unwrap_or_else(|| env::args_os().skip(1).collect::<Vec<_>>());
     #[cfg(all(target_os = "macos", feature = "grant-integration-probe"))]
     let mut raw_args = raw_args;
     #[cfg(all(target_os = "macos", feature = "grant-integration-probe"))]

--- a/crates/launcher/src/elevated_probe.rs
+++ b/crates/launcher/src/elevated_probe.rs
@@ -5,9 +5,10 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 
 use bangbang_session::elevated_probe::{
-    LAUNCHER_ACTIVATION, ProbeBootstrap, ProbeErrorCategory, ProbeMode, ProbeStage,
+    LAUNCHER_ACTIVATION, ProbeBootstrap, ProbeErrorCategory, ProbeMode, ProbeStage, RuntimeFault,
     WORKER_ACTIVATION,
 };
+use bangbang_session::macos::runtime::ExplicitRuntimeRoot;
 use bangbang_session::{ObjectIdentity, SessionId};
 
 use crate::{BundleLayout, LauncherError};
@@ -16,6 +17,7 @@ const ROOT_OPTION: &str = "--root";
 const TARGET_UID_OPTION: &str = "--target-uid";
 const TARGET_GID_OPTION: &str = "--target-gid";
 const MODE_OPTION: &str = "--mode";
+const FAULT_OPTION: &str = "--fault";
 const DELIMITER: &str = "--";
 const MAX_ROOT_PATH_BYTES: usize = 1024;
 const ROOT_CHILD_PREFIX: &str = "bangbang-elevated-probe.";
@@ -35,10 +37,12 @@ pub(crate) struct Config {
     root: OwnedFd,
     root_path: PathBuf,
     root_identity: ObjectIdentity,
+    runtime_root: Option<ExplicitRuntimeRoot>,
     staged_loader_identity: Option<ObjectIdentity>,
     target_uid: u32,
     target_gid: u32,
     mode: ProbeMode,
+    fault: RuntimeFault,
 }
 
 impl std::fmt::Debug for Config {
@@ -57,12 +61,11 @@ impl Config {
         {
             return Ok((None, args));
         }
-        if args.len() != 10
+        if args.len() < 10
             || args.get(1) != Some(&OsString::from(ROOT_OPTION))
             || args.get(3) != Some(&OsString::from(TARGET_UID_OPTION))
             || args.get(5) != Some(&OsString::from(TARGET_GID_OPTION))
             || args.get(7) != Some(&OsString::from(MODE_OPTION))
-            || args.get(9) != Some(&OsString::from(DELIMITER))
         {
             return Err(LauncherError::InvalidLaunchPolicy);
         }
@@ -84,8 +87,51 @@ impl Config {
             .and_then(|value| value.to_str())
             .and_then(|value| ProbeMode::parse(value, target_uid, target_gid))
             .ok_or(LauncherError::InvalidLaunchPolicy)?;
+        let (fault, delimiter) = if args.get(9) == Some(&OsString::from(DELIMITER)) {
+            (RuntimeFault::None, 9)
+        } else if mode.continues_runtime()
+            && args.get(9) == Some(&OsString::from(FAULT_OPTION))
+            && args.get(11) == Some(&OsString::from(DELIMITER))
+        {
+            let fault = args
+                .get(10)
+                .and_then(|value| value.to_str())
+                .and_then(RuntimeFault::parse)
+                .ok_or(LauncherError::InvalidLaunchPolicy)?;
+            (fault, 11)
+        } else {
+            return Err(LauncherError::InvalidLaunchPolicy);
+        };
+        if !mode.continues_runtime() && fault != RuntimeFault::None {
+            return Err(LauncherError::InvalidLaunchPolicy);
+        }
+        if !mode.continues_runtime() && delimiter + 1 != args.len() {
+            return Err(LauncherError::InvalidLaunchPolicy);
+        }
         validate_initial_root()?;
-        let (root, root_identity) = open_private_root(&root_path)?;
+        let (root, root_identity) = open_private_root(
+            &root_path,
+            if mode.continues_runtime() {
+                (target_uid, target_gid)
+            } else {
+                (0, 0)
+            },
+        )?;
+        let runtime_root = if mode.continues_runtime() {
+            let independent = openat_directory(root.as_raw_fd(), c".")?;
+            Some(
+                ExplicitRuntimeRoot::from_owned_fd(
+                    independent,
+                    root_identity,
+                    target_uid,
+                    target_gid,
+                    true,
+                )
+                .map_err(|_| LauncherError::InvalidLaunchPolicy)?,
+            )
+        } else {
+            None
+        };
         let staged_loader_identity = if mode == ProbeMode::InheritedRoot {
             Some(validate_staged_loader(root.as_raw_fd(), None)?)
         } else {
@@ -96,12 +142,14 @@ impl Config {
                 root,
                 root_path,
                 root_identity,
+                runtime_root,
                 staged_loader_identity,
                 target_uid,
                 target_gid,
                 mode,
+                fault,
             }),
-            Vec::new(),
+            args.into_iter().skip(delimiter + 1).collect(),
         ))
     }
 
@@ -109,10 +157,10 @@ impl Config {
         &self,
         worker_args: &mut Vec<OsString>,
     ) -> Result<(), LauncherError> {
-        if !worker_args.is_empty() {
+        if !self.mode.continues_runtime() && !worker_args.is_empty() {
             return Err(LauncherError::InvalidLaunchPolicy);
         }
-        worker_args.push(OsString::from(WORKER_ACTIVATION));
+        worker_args.insert(0, OsString::from(WORKER_ACTIVATION));
         Ok(())
     }
 
@@ -122,6 +170,12 @@ impl Config {
 
     pub(crate) const fn mode(&self) -> ProbeMode {
         self.mode
+    }
+
+    pub(crate) fn take_runtime_root(&mut self) -> Result<ExplicitRuntimeRoot, LauncherError> {
+        self.runtime_root
+            .take()
+            .ok_or(LauncherError::InvalidLaunchPolicy)
     }
 
     pub(crate) fn staged_layout(&self) -> Result<BundleLayout, LauncherError> {
@@ -148,8 +202,9 @@ impl Config {
 
     pub(crate) fn bootstrap(&self) -> Result<ProbeBootstrap, LauncherError> {
         let nonce = SessionId::generate().map_err(|_| LauncherError::SessionProtocol)?;
-        ProbeBootstrap::new(
+        ProbeBootstrap::new_with_fault(
             self.mode,
+            self.fault,
             self.target_uid,
             self.target_gid,
             self.root_identity,
@@ -357,7 +412,10 @@ fn validate_initial_root() -> Result<(), LauncherError> {
     }
 }
 
-fn open_private_root(path: &Path) -> Result<(OwnedFd, ObjectIdentity), LauncherError> {
+fn open_private_root(
+    path: &Path,
+    expected_owner: (u32, u32),
+) -> Result<(OwnedFd, ObjectIdentity), LauncherError> {
     let child = private_root_child(path).ok_or(LauncherError::InvalidLaunchPolicy)?;
     let mut directory = open_directory(c"/")?;
     validate_ancestor(directory.as_raw_fd())?;
@@ -371,8 +429,8 @@ fn open_private_root(path: &Path) -> Result<(OwnedFd, ObjectIdentity), LauncherE
     let stat = descriptor_stat(root.as_raw_fd())?;
     if stat.st_mode & libc::S_IFMT != libc::S_IFDIR
         || stat.st_mode & 0o7777 != 0o700
-        || stat.st_uid != 0
-        || stat.st_gid != 0
+        || stat.st_uid != expected_owner.0
+        || stat.st_gid != expected_owner.1
         || stat.st_nlink < 2
     {
         return Err(LauncherError::InvalidLaunchPolicy);
@@ -522,10 +580,12 @@ mod tests {
                 device: 123,
                 inode: 456,
             },
+            runtime_root: None,
             staged_loader_identity: None,
             target_uid: 1_234_567_891,
             target_gid: 1_234_567_893,
             mode: ProbeMode::Drop,
+            fault: RuntimeFault::None,
         };
         let output = format!("{config:?}");
         assert_eq!(output, "ElevatedProbeConfig(<redacted>)");

--- a/crates/launcher/src/macos/supervise.rs
+++ b/crates/launcher/src/macos/supervise.rs
@@ -9,6 +9,8 @@ use std::ptr;
 use std::time::{Duration, Instant};
 
 use bangbang_session::macos::grant_transport::{GrantTransportError, send_grant};
+#[cfg(feature = "elevated-bootstrap-probe")]
+use bangbang_session::macos::runtime::ExplicitRuntimeRoot;
 use bangbang_session::macos::runtime::{
     LauncherNamespace, NamespaceIdentity, RuntimeError, SnapshotStagingOwnershipRecord,
     SocketOwnershipRecord,
@@ -165,12 +167,102 @@ pub(crate) fn read_bootstrap_hello(
 pub(crate) fn wait_session(
     worker: &mut OwnedWorker,
     session: &mut UnixStream,
+    auxiliary: AuxiliaryChannels<'_>,
+    lifecycle: LauncherLifecycle,
+    wakeups: SignalWakeups,
+    grants: &PreparedGrantBatch,
+    notifier: Option<&mut DaemonNotifier>,
+) -> Result<ExitStatus, LauncherError> {
+    wait_session_with_roots(
+        worker,
+        session,
+        auxiliary,
+        lifecycle,
+        wakeups,
+        grants,
+        SessionOptions {
+            notifier,
+            roots: NamespaceRoots::Ordinary,
+        },
+    )
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub(crate) struct ExplicitSessionStart {
+    root: ExplicitRuntimeRoot,
+    frame: Frame,
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl ExplicitSessionStart {
+    pub(crate) const fn new(root: ExplicitRuntimeRoot, frame: Frame) -> Self {
+        Self { root, frame }
+    }
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub(crate) fn wait_session_with_explicit_root(
+    worker: &mut OwnedWorker,
+    session: &mut UnixStream,
+    auxiliary: AuxiliaryChannels<'_>,
+    lifecycle: LauncherLifecycle,
+    wakeups: SignalWakeups,
+    grants: &PreparedGrantBatch,
+    start: ExplicitSessionStart,
+) -> Result<ExitStatus, LauncherError> {
+    let ExplicitSessionStart { root, frame } = start;
+    // Establish both independent namespace authorities before the worker can
+    // observe Start and publish a session. No failure after this point can
+    // strand a namespace solely because its recovery handle was unavailable.
+    let validation = root
+        .try_reopen(false)
+        .map_err(|_| LauncherError::RuntimeNamespace)?;
+    let recovery = root
+        .try_reopen(false)
+        .map_err(|_| LauncherError::RuntimeNamespace)?;
+    let mut roots = NamespaceRoots::Explicit {
+        validation: Some(validation),
+        recovery: Some(recovery),
+    };
+    if let Err(error) = write_frame(session, frame) {
+        terminate_session(worker, session, &auxiliary);
+        roots
+            .recover_after_worker_exit(lifecycle.session())
+            .and_then(|recovered| {
+                recovered.map_or(Ok(()), |mut namespace| {
+                    cleanup_namespace_after_worker(&mut namespace, grants)
+                })
+            })
+            .map_err(|_| LauncherError::RuntimeNamespace)?;
+        return Err(error);
+    }
+    wait_session_with_roots(
+        worker,
+        session,
+        auxiliary,
+        lifecycle,
+        wakeups,
+        grants,
+        SessionOptions {
+            notifier: None,
+            roots,
+        },
+    )
+}
+
+fn wait_session_with_roots(
+    worker: &mut OwnedWorker,
+    session: &mut UnixStream,
     mut auxiliary: AuxiliaryChannels<'_>,
     mut lifecycle: LauncherLifecycle,
     mut wakeups: SignalWakeups,
     grants: &PreparedGrantBatch,
-    notifier: Option<&mut DaemonNotifier>,
+    options: SessionOptions<'_>,
 ) -> Result<ExitStatus, LauncherError> {
+    let SessionOptions {
+        notifier,
+        mut roots,
+    } = options;
     let session_id = lifecycle.session();
     let mut observation = SessionObservation::default();
     let result = wait_session_inner(
@@ -183,29 +275,23 @@ pub(crate) fn wait_session(
         SessionHooks {
             observation: &mut observation,
             notifier,
+            roots: &mut roots,
         },
     );
     if result.is_err() {
-        let _ = session.shutdown(std::net::Shutdown::Both);
-        shutdown_grants(auxiliary.grant_socket);
-        let _ = auxiliary.socket_broker.shutdown(std::net::Shutdown::Both);
-        let _ = auxiliary
-            .vhost_user_broker
-            .shutdown(std::net::Shutdown::Both);
-        let _ = auxiliary
-            .block_control_broker
-            .shutdown(std::net::Shutdown::Both);
-        worker.terminate_and_reap();
+        terminate_session(worker, session, &auxiliary);
     }
 
     let cleanup = if let Some(namespace) = observation.namespace.as_mut() {
         cleanup_namespace_after_worker(namespace, grants)
     } else {
-        LauncherNamespace::recover_after_worker_exit(session_id).and_then(|recovered| {
-            recovered.map_or(Ok(()), |mut namespace| {
-                cleanup_namespace_after_worker(&mut namespace, grants)
+        roots
+            .recover_after_worker_exit(session_id)
+            .and_then(|recovered| {
+                recovered.map_or(Ok(()), |mut namespace| {
+                    cleanup_namespace_after_worker(&mut namespace, grants)
+                })
             })
-        })
     }
     .map_err(|_| LauncherError::RuntimeNamespace);
 
@@ -218,6 +304,71 @@ pub(crate) fn wait_session(
         Err(error) => {
             let _ = cleanup;
             Err(error)
+        }
+    }
+}
+
+fn terminate_session(
+    worker: &mut OwnedWorker,
+    session: &UnixStream,
+    auxiliary: &AuxiliaryChannels<'_>,
+) {
+    let _ = session.shutdown(std::net::Shutdown::Both);
+    shutdown_grants(auxiliary.grant_socket);
+    let _ = auxiliary.socket_broker.shutdown(std::net::Shutdown::Both);
+    let _ = auxiliary
+        .vhost_user_broker
+        .shutdown(std::net::Shutdown::Both);
+    let _ = auxiliary
+        .block_control_broker
+        .shutdown(std::net::Shutdown::Both);
+    worker.terminate_and_reap();
+}
+
+struct SessionOptions<'a> {
+    notifier: Option<&'a mut DaemonNotifier>,
+    roots: NamespaceRoots,
+}
+
+enum NamespaceRoots {
+    Ordinary,
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    Explicit {
+        validation: Option<ExplicitRuntimeRoot>,
+        recovery: Option<ExplicitRuntimeRoot>,
+    },
+}
+
+impl NamespaceRoots {
+    fn validate(
+        &mut self,
+        session: bangbang_session::SessionId,
+        expected: NamespaceIdentity,
+    ) -> Result<LauncherNamespace, RuntimeError> {
+        match self {
+            Self::Ordinary => LauncherNamespace::validate(session, expected),
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            Self::Explicit { validation, .. } => LauncherNamespace::validate_from_explicit_root(
+                validation.take().ok_or(RuntimeError::InvalidRoot)?,
+                session,
+                expected,
+            ),
+        }
+    }
+
+    fn recover_after_worker_exit(
+        &mut self,
+        session: bangbang_session::SessionId,
+    ) -> Result<Option<LauncherNamespace>, RuntimeError> {
+        match self {
+            Self::Ordinary => LauncherNamespace::recover_after_worker_exit(session),
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            Self::Explicit { recovery, .. } => {
+                LauncherNamespace::recover_after_worker_exit_from_explicit_root(
+                    recovery.take().ok_or(RuntimeError::InvalidRoot)?,
+                    session,
+                )
+            }
         }
     }
 }
@@ -380,6 +531,7 @@ impl<'a> AuxiliaryChannels<'a> {
 struct SessionHooks<'a> {
     observation: &'a mut SessionObservation,
     notifier: Option<&'a mut DaemonNotifier>,
+    roots: &'a mut NamespaceRoots,
 }
 
 fn wait_session_inner(
@@ -398,6 +550,7 @@ fn wait_session_inner(
     let SessionHooks {
         observation,
         mut notifier,
+        roots,
     } = hooks;
     session
         .set_nonblocking(true)
@@ -534,6 +687,7 @@ fn wait_session_inner(
                     lifecycle,
                     observation,
                     &mut grant_send,
+                    roots,
                 )?;
                 if session_closed {
                     exit_deadline.get_or_insert(Instant::now() + SESSION_EXIT_GRACE);
@@ -720,6 +874,7 @@ fn wait_session_inner(
                     lifecycle,
                     observation,
                     &mut grant_send,
+                    roots,
                 )?;
             }
             break;
@@ -806,6 +961,7 @@ fn drain_session(
     lifecycle: &mut LauncherLifecycle,
     observation: &mut SessionObservation,
     grant_send: &mut GrantSendState,
+    roots: &mut NamespaceRoots,
 ) -> Result<bool, LauncherError> {
     let mut buffer = [0_u8; 4096];
     loop {
@@ -840,11 +996,9 @@ fn drain_session(
                             if observation.namespace.is_some() {
                                 return Err(LauncherError::SessionProtocol);
                             }
-                            let validated = LauncherNamespace::validate(
-                                lifecycle.session(),
-                                NamespaceIdentity { device, inode },
-                            )
-                            .map_err(|_| LauncherError::RuntimeNamespace)?;
+                            let validated = roots
+                                .validate(lifecycle.session(), NamespaceIdentity { device, inode })
+                                .map_err(|_| LauncherError::RuntimeNamespace)?;
                             observation.namespace = Some(validated);
                             if !lifecycle.is_cancelled() {
                                 lifecycle

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -134,28 +134,44 @@ where
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
 fn launch_elevated_prepared(
     layout: &BundleLayout,
-    launch: crate::launch_policy::PreparedLaunch,
-    elevated_probe: crate::elevated_probe::Config,
+    mut launch: crate::launch_policy::PreparedLaunch,
+    mut elevated_probe: crate::elevated_probe::Config,
 ) -> Result<LauncherExit, LauncherError> {
     let bootstrap = elevated_probe.bootstrap()?;
     if elevated_probe.mode() == bangbang_session::elevated_probe::ProbeMode::InheritedRoot {
         return launch_inherited_prepared(launch, elevated_probe, bootstrap);
     }
+    let runtime = if bootstrap.mode().continues_runtime() {
+        launch.worker_policy = launch
+            .worker_policy
+            .with_identity(bootstrap.target_uid(), bootstrap.target_gid());
+        Some(ElevatedRuntimeLaunch {
+            root: elevated_probe.take_runtime_root()?,
+        })
+    } else {
+        None
+    };
+    let worker_args = std::mem::take(&mut launch.worker_args);
     let spawned = crate::macos::spawn::prepare_suspended_elevated(
         layout.worker_executable(),
-        launch.worker_args,
+        worker_args,
         elevated_probe.root_fd(),
     )?
     .spawn()?;
     // The completed spawn copied the fixed root descriptor into the worker.
     // Close the launcher-owned copy before any credential transition begins.
     drop(elevated_probe);
-    finish_elevated_exchange(spawned, launch.worker_profile, bootstrap, false)
+    finish_elevated_exchange(spawned, launch, bootstrap, false, runtime)
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+struct ElevatedRuntimeLaunch {
+    root: bangbang_session::macos::runtime::ExplicitRuntimeRoot,
 }
 
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
 fn launch_inherited_prepared(
-    launch: crate::launch_policy::PreparedLaunch,
+    mut launch: crate::launch_policy::PreparedLaunch,
     elevated_probe: crate::elevated_probe::Config,
     bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
 ) -> Result<LauncherExit, LauncherError> {
@@ -200,9 +216,10 @@ fn launch_inherited_prepared(
             ));
         }
     };
+    let worker_args = std::mem::take(&mut launch.worker_args);
     let prepared = match crate::macos::spawn::prepare_suspended_elevated(
         worker,
-        launch.worker_args,
+        worker_args,
         elevated_probe.root_fd(),
     ) {
         Ok(prepared) => prepared,
@@ -225,15 +242,16 @@ fn launch_inherited_prepared(
             ));
         }
     };
-    finish_elevated_exchange(spawned, launch.worker_profile, bootstrap, true)
+    finish_elevated_exchange(spawned, launch, bootstrap, true, None)
 }
 
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
 fn finish_elevated_exchange(
     mut spawned: crate::macos::spawn::SuspendedWorker,
-    expected_profile: crate::macos::code_sign::WorkerProfile,
+    launch: crate::launch_policy::PreparedLaunch,
     bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
     inherited_root: bool,
+    runtime: Option<ElevatedRuntimeLaunch>,
 ) -> Result<LauncherExit, LauncherError> {
     use std::io::{Read, Write};
     use std::os::fd::AsRawFd;
@@ -244,6 +262,7 @@ fn finish_elevated_exchange(
     };
 
     const TIMEOUT: Duration = Duration::from_secs(5);
+    let expected_profile = launch.worker_profile.clone();
 
     match crate::macos::code_sign::validate_worker_process(spawned.worker.pid()) {
         Ok(profile) if profile == expected_profile => {}
@@ -355,7 +374,7 @@ fn finish_elevated_exchange(
                 ));
             }
         };
-        return finish_credential_exchange(spawned, bootstrap, initial, baseline);
+        return finish_credential_exchange(spawned, launch, bootstrap, initial, baseline, runtime);
     }
     let mut encoded_result = [0_u8; RESULT_RECORD_BYTES];
     if spawned.session.read_exact(&mut encoded_result).is_err() {
@@ -587,9 +606,11 @@ fn send_credential_datagram(
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
 fn finish_credential_exchange(
     mut spawned: crate::macos::spawn::SuspendedWorker,
+    launch: crate::launch_policy::PreparedLaunch,
     bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
     initial: bangbang_session::elevated_probe::PeerObservation,
     baseline: bangbang_session::elevated_credential::PeerBaseline,
+    runtime: Option<ElevatedRuntimeLaunch>,
 ) -> Result<LauncherExit, LauncherError> {
     use std::io::{Read, Write};
     use std::os::fd::AsRawFd;
@@ -761,14 +782,6 @@ fn finish_credential_exchange(
             ));
         }
     };
-    if credential_wait_for_exit(&mut spawned, 0).is_err() {
-        return Ok(credential_protocol_blocked_after_reap(
-            &mut spawned,
-            transition.prefix(),
-            transition.state(),
-        ));
-    }
-
     let worker_initial = worker_transitioned.observations();
     let worker_observations = worker_final.observations();
     if worker_initial[0] != worker_observations[0]
@@ -788,6 +801,23 @@ fn finish_credential_exchange(
             credential_protocol_failure(transition.prefix(), transition.state()),
         ));
     };
+    if bootstrap.mode().continues_runtime() {
+        let Some(runtime) = runtime else {
+            return Ok(credential_protocol_blocked_after_reap(
+                &mut spawned,
+                transition.prefix(),
+                transition.state(),
+            ));
+        };
+        return continue_runtime_session(spawned, launch, runtime, bootstrap, semantics);
+    }
+    if runtime.is_some() || credential_wait_for_exit(&mut spawned, 0).is_err() {
+        return Ok(credential_protocol_blocked_after_reap(
+            &mut spawned,
+            transition.prefix(),
+            transition.state(),
+        ));
+    }
     println!(
         "status: elevated credential {} complete stream-eid={} stream-cred={} stream-pid=exact datagram-cred={} datagram-token={} datagram-pid={}",
         bootstrap.mode().name(),
@@ -829,6 +859,181 @@ fn finish_credential_exchange(
         let _ = spawned.session.write_all(&record.encode());
         let _ = credential_wait_for_exit(spawned, 1);
         Ok(credential_blocked_value(CredentialRole::Launcher, failure))
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn continue_runtime_session(
+    mut spawned: crate::macos::spawn::SuspendedWorker,
+    launch: crate::launch_policy::PreparedLaunch,
+    runtime: ElevatedRuntimeLaunch,
+    bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
+    semantics: CredentialSemantics,
+) -> Result<LauncherExit, LauncherError> {
+    const RUNTIME_LAUNCHER_ARTIFACT: &str = "bangbang-elevated-runtime-launcher-v1-runtime-drop-runtime-retain-root-runtime-unmapped-status: elevated runtime-BBA1";
+    const RUNTIME_LAUNCHER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-runtime-launcher-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
+
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
+
+    use bangbang_session::elevated_probe::{
+        ContinuationAck, ProbeErrorCategory, ProbeStage, RuntimeFault,
+    };
+    use bangbang_session::{LauncherLifecycle, SessionId};
+
+    std::hint::black_box(RUNTIME_LAUNCHER_ARTIFACT);
+    std::hint::black_box(RUNTIME_LAUNCHER_BOUNDARY_ARTIFACT);
+    let blocked = |stage, category| {
+        Ok(elevated_runtime_blocked(
+            bootstrap, &semantics, stage, category,
+        ))
+    };
+    if bootstrap.fault() == RuntimeFault::PreAck {
+        let _ = credential_wait_for_exit(&mut spawned, 1);
+        return blocked(ProbeStage::ContinuationAck, ProbeErrorCategory::Other);
+    }
+    let ack = ContinuationAck::launcher(bootstrap.mode(), bootstrap.nonce())
+        .map_err(|_| LauncherError::SessionProtocol)?;
+    if spawned.session.write_all(&ack.encode()).is_err() {
+        return blocked(ProbeStage::ContinuationAck, ProbeErrorCategory::Other);
+    }
+    if spawned.session.set_read_timeout(None).is_err()
+        || spawned.session.set_write_timeout(None).is_err()
+        || spawned.grants.set_read_timeout(None).is_err()
+        || spawned.grants.set_write_timeout(None).is_err()
+    {
+        return blocked(ProbeStage::ContinuationAck, ProbeErrorCategory::Other);
+    }
+    if bootstrap.fault() == RuntimeFault::PostAck {
+        let _ = credential_wait_for_exit(&mut spawned, 1);
+        return blocked(ProbeStage::LifecycleHello, ProbeErrorCategory::Other);
+    }
+    if bangbang_session::elevated_credential::attest_current_process(
+        bootstrap.mode(),
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+    )
+    .is_err()
+        || bangbang_session::macos::verify_peer_pid(
+            spawned.session.as_raw_fd(),
+            spawned.worker.pid(),
+        )
+        .is_err()
+    {
+        return blocked(
+            ProbeStage::LiveIdentity,
+            ProbeErrorCategory::PermissionDenied,
+        );
+    }
+    if let Err(category) = validate_runtime_worker(spawned.worker.pid(), &launch.worker_profile) {
+        return blocked(ProbeStage::LiveIdentity, category);
+    }
+
+    let wakeups = match crate::macos::supervise::SignalWakeups::install() {
+        Ok(wakeups) => wakeups,
+        Err(_) => return blocked(ProbeStage::LifecycleHello, ProbeErrorCategory::Other),
+    };
+    let session_id = SessionId::generate().map_err(|_| LauncherError::SessionProtocol)?;
+    let mut lifecycle = LauncherLifecycle::new(session_id);
+    if crate::macos::supervise::read_bootstrap_hello(&mut spawned.session, &mut lifecycle).is_err()
+    {
+        return blocked(ProbeStage::LifecycleHello, ProbeErrorCategory::Other);
+    }
+    if bangbang_session::macos::verify_peer_pid(spawned.session.as_raw_fd(), spawned.worker.pid())
+        .is_err()
+        || bangbang_session::elevated_credential::attest_current_process(
+            bootstrap.mode(),
+            bootstrap.target_uid(),
+            bootstrap.target_gid(),
+        )
+        .is_err()
+    {
+        return blocked(
+            ProbeStage::LiveIdentity,
+            ProbeErrorCategory::PermissionDenied,
+        );
+    }
+    if let Err(category) = validate_runtime_worker(spawned.worker.pid(), &launch.worker_profile) {
+        return blocked(ProbeStage::LiveIdentity, category);
+    }
+    let start = lifecycle
+        .start(launch.worker_policy)
+        .map_err(|_| LauncherError::SessionProtocol)?;
+    let status = match crate::macos::supervise::wait_session_with_explicit_root(
+        &mut spawned.worker,
+        &mut spawned.session,
+        crate::macos::supervise::AuxiliaryChannels::new(
+            &mut spawned.grants,
+            &mut spawned.socket_broker,
+            &mut spawned.vhost_user_broker,
+            &mut spawned.block_control_broker,
+        ),
+        lifecycle,
+        wakeups,
+        &launch.grants,
+        crate::macos::supervise::ExplicitSessionStart::new(runtime.root, start),
+    ) {
+        Ok(status) => status,
+        Err(error) => {
+            let stage = match bootstrap.fault() {
+                RuntimeFault::Namespace => ProbeStage::RuntimeNamespace,
+                RuntimeFault::GrantTransfer => ProbeStage::GrantTransfer,
+                RuntimeFault::Proceed => ProbeStage::LifecycleProceed,
+                RuntimeFault::Terminal => ProbeStage::LifecycleTerminal,
+                RuntimeFault::None | RuntimeFault::PreAck | RuntimeFault::PostAck => match error {
+                    LauncherError::RuntimeNamespace => ProbeStage::RuntimeNamespace,
+                    LauncherError::GrantProtocol | LauncherError::GrantPreparation => {
+                        ProbeStage::GrantAccepted
+                    }
+                    _ => ProbeStage::LifecycleTerminal,
+                },
+            };
+            return blocked(stage, probe_error_category(&error));
+        }
+    };
+    let exit = map_exit_status(status)?;
+    if exit.code() == bangbang_session::elevated_probe::RUNTIME_NAMESPACE_PERMISSION_EXIT_CODE {
+        return blocked(
+            ProbeStage::RuntimeNamespace,
+            ProbeErrorCategory::PermissionDenied,
+        );
+    }
+    if bootstrap.fault() != RuntimeFault::None || exit.code() != 0 {
+        let stage = match bootstrap.fault() {
+            RuntimeFault::Namespace => ProbeStage::RuntimeNamespace,
+            RuntimeFault::GrantTransfer => ProbeStage::GrantTransfer,
+            RuntimeFault::Proceed => ProbeStage::LifecycleProceed,
+            RuntimeFault::Terminal => ProbeStage::LifecycleTerminal,
+            RuntimeFault::None | RuntimeFault::PreAck | RuntimeFault::PostAck => {
+                ProbeStage::LifecycleTerminal
+            }
+        };
+        return blocked(stage, ProbeErrorCategory::Other);
+    }
+    println!(
+        "status: elevated runtime {} complete result={} stream-eid={} stream-cred={} stream-pid=exact datagram-cred={} datagram-token={} datagram-pid={} namespace=target-owned grants=committed lifecycle=terminal cleanup=complete",
+        bootstrap.mode().name(),
+        bangbang_session::elevated_probe::RuntimeResultClass::Complete.name(),
+        semantics.stream_eid,
+        semantics.stream_cred,
+        semantics.datagram_cred,
+        semantics.datagram_token,
+        semantics.datagram_pid
+    );
+    Ok(exit)
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn validate_runtime_worker(
+    pid: libc::pid_t,
+    expected: &crate::macos::code_sign::WorkerProfile,
+) -> Result<(), bangbang_session::elevated_probe::ProbeErrorCategory> {
+    use bangbang_session::elevated_probe::ProbeErrorCategory;
+
+    match crate::macos::code_sign::validate_worker_process(pid) {
+        Ok(profile) if &profile == expected => Ok(()),
+        Ok(_) => Err(ProbeErrorCategory::InvalidInput),
+        Err(_) => Err(ProbeErrorCategory::Other),
     }
 }
 
@@ -920,6 +1125,7 @@ fn credential_blocked_value(
 }
 
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+#[derive(Clone, Copy)]
 struct CredentialSemantics {
     stream_eid: &'static str,
     stream_cred: &'static str,
@@ -1075,6 +1281,57 @@ fn elevated_blocked(
         "status: elevated bootstrap blocked stage={} error={}",
         stage.name(),
         category.name()
+    );
+    LauncherExit(3)
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn elevated_runtime_blocked(
+    bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
+    semantics: &CredentialSemantics,
+    stage: bangbang_session::elevated_probe::ProbeStage,
+    category: bangbang_session::elevated_probe::ProbeErrorCategory,
+) -> LauncherExit {
+    use bangbang_session::elevated_probe::{ProbeStage, RuntimeResultClass};
+
+    let result = match stage {
+        ProbeStage::ContinuationAck => RuntimeResultClass::ContinuationBoundary,
+        ProbeStage::RuntimeNamespace => RuntimeResultClass::NamespaceBoundary,
+        ProbeStage::GrantTransfer | ProbeStage::GrantAccepted => RuntimeResultClass::GrantBoundary,
+        ProbeStage::LifecycleHello
+        | ProbeStage::LifecycleProceed
+        | ProbeStage::LifecycleTerminal
+        | ProbeStage::RuntimeCleanup => RuntimeResultClass::LifecycleBoundary,
+        ProbeStage::InitialIdentity | ProbeStage::LiveIdentity => {
+            RuntimeResultClass::IdentityBoundary
+        }
+        ProbeStage::TakeRoot
+        | ProbeStage::ValidateRoot
+        | ProbeStage::EnterRoot
+        | ProbeStage::Chroot
+        | ProbeStage::ChangeDirectory
+        | ProbeStage::UnexpectedContinuation
+        | ProbeStage::ValidateStagedBundle
+        | ProbeStage::ValidateStagedLoader
+        | ProbeStage::SpawnWorker
+        | ProbeStage::SuspendedIdentity
+        | ProbeStage::InheritedRoot
+        | ProbeStage::SandboxChrootControl
+        | ProbeStage::HvfCreate
+        | ProbeStage::HvfDestroy
+        | ProbeStage::WorkerBootstrap => RuntimeResultClass::ExplicitRootBoundary,
+    };
+    println!(
+        "status: elevated runtime {} blocked stage={} error={} result={} stream-eid={} stream-cred={} stream-pid=exact datagram-cred={} datagram-token={} datagram-pid={}",
+        bootstrap.mode().name(),
+        stage.name(),
+        category.name(),
+        result.name(),
+        semantics.stream_eid,
+        semantics.stream_cred,
+        semantics.datagram_cred,
+        semantics.datagram_token,
+        semantics.datagram_pid,
     );
     LauncherExit(3)
 }

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -100,7 +100,16 @@ const ELEVATED_CREDENTIAL_LAUNCHER_ARTIFACT: &[u8] =
     b"bangbang-elevated-credential-launcher-v1-credential-drop-BBC1-BBG1-restore-groups";
 const ELEVATED_CREDENTIAL_WORKER_ARTIFACT: &[u8] =
     b"bangbang-elevated-credential-worker-v1-credential-drop-BBC1-BBG1-restore-groups";
+const ELEVATED_RUNTIME_DROP_MODE: &[u8] = b"runtime-drop";
+const ELEVATED_RUNTIME_RETAIN_MODE: &[u8] = b"runtime-retain-root";
+const ELEVATED_RUNTIME_UNMAPPED_MODE: &[u8] = b"runtime-unmapped";
+const ELEVATED_RUNTIME_STATUS: &[u8] = b"status: elevated runtime";
+const ELEVATED_CONTINUATION_RECORD: &[u8] = b"BBA1";
+const ELEVATED_RUNTIME_GRANT_CASE: &[u8] = b"target-runtime";
+const ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES: &[u8] = b"bangbang-elevated-runtime-launcher-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
+const ELEVATED_RUNTIME_WORKER_BOUNDARIES: &[u8] = b"bangbang-elevated-runtime-worker-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
 const ELEVATED_PROBE_MARKER: &str = "elevated-bootstrap-probe.enabled";
+const ELEVATED_RUNTIME_MARKER: &str = "target-runtime-grant-probe.enabled";
 const GRANT_PROBE_OUTSIDE: &str = "bangbang-grant-probe-outside";
 const RESTORE_ROOT_ID: &str = "restore-root-1601";
 const RESTORE_VSOCK_ID: &str = "restore-vsock-1601";
@@ -13053,6 +13062,13 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             .exists(),
         "normal production bundle must not carry the elevated probe marker"
     );
+    assert!(
+        !worker_bundle(&bundle)
+            .join("Contents/Resources")
+            .join(ELEVATED_RUNTIME_MARKER)
+            .exists(),
+        "normal production bundle must not carry the target runtime marker"
+    );
     let launcher_bytes = fs::read(launcher(&bundle)).expect("normal launcher should read");
     let worker_bytes = fs::read(worker_executable(&bundle)).expect("normal worker should read");
     for artifact in [&launcher_bytes, &worker_bytes] {
@@ -13072,6 +13088,14 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             ELEVATED_CREDENTIAL_STEP,
             ELEVATED_CREDENTIAL_LAUNCHER_ARTIFACT,
             ELEVATED_CREDENTIAL_WORKER_ARTIFACT,
+            ELEVATED_RUNTIME_DROP_MODE,
+            ELEVATED_RUNTIME_RETAIN_MODE,
+            ELEVATED_RUNTIME_UNMAPPED_MODE,
+            ELEVATED_RUNTIME_STATUS,
+            ELEVATED_CONTINUATION_RECORD,
+            ELEVATED_RUNTIME_GRANT_CASE,
+            ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES,
+            ELEVATED_RUNTIME_WORKER_BOUNDARIES,
         ] {
             assert!(
                 !artifact
@@ -13082,7 +13106,7 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
         }
     }
 
-    for mode in ["drop", "credential-drop"] {
+    for mode in ["drop", "credential-drop", "runtime-drop"] {
         let output = run_launcher(
             &bundle,
             &[
@@ -13111,6 +13135,11 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             ELEVATED_CREDENTIAL_STEP,
             ELEVATED_CREDENTIAL_LAUNCHER_ARTIFACT,
             ELEVATED_CREDENTIAL_WORKER_ARTIFACT,
+            ELEVATED_RUNTIME_STATUS,
+            ELEVATED_CONTINUATION_RECORD,
+            ELEVATED_RUNTIME_GRANT_CASE,
+            ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES,
+            ELEVATED_RUNTIME_WORKER_BOUNDARIES,
         ] {
             assert!(
                 !diagnostics

--- a/crates/session/src/codec.rs
+++ b/crates/session/src/codec.rs
@@ -328,6 +328,15 @@ impl WorkerPolicy {
         self
     }
 
+    /// Retargets only the authenticated worker identity, preserving all other policy.
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    #[must_use]
+    pub const fn with_identity(mut self, uid: u32, gid: u32) -> Self {
+        self.uid = uid;
+        self.gid = gid;
+        self
+    }
+
     /// Returns the required real and effective user identity.
     #[must_use]
     pub const fn uid(self) -> u32 {

--- a/crates/session/src/elevated_credential.rs
+++ b/crates/session/src/elevated_credential.rs
@@ -66,6 +66,38 @@ pub fn transition_process(
     transition_with(&mut DarwinCredentialOps, mode, target_uid, target_gid)
 }
 
+/// Re-attests the exact local post-transition identity before runtime work.
+pub fn attest_current_process(
+    mode: ProbeMode,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<CredentialSelfState, ProbeErrorCategory> {
+    if !mode.continues_runtime() || !mode.accepts_target(target_uid, target_gid) {
+        return Err(ProbeErrorCategory::InvalidInput);
+    }
+    let mut ops = DarwinCredentialOps;
+    let identities = ops.ids();
+    let groups = ops.groups().map_err(ProbeErrorCategory::from_io_kind)?;
+    if mode.retains_root() {
+        if identities != (0, 0, 0, 0) {
+            return Err(ProbeErrorCategory::PermissionDenied);
+        }
+        return Ok(CredentialSelfState::new(
+            CredentialIdentityClass::InitialAndTarget,
+            CredentialGroupClass::Initial,
+        ));
+    }
+    if identities != (target_uid, target_uid, target_gid, target_gid)
+        || groups.as_slice() != [target_gid]
+    {
+        return Err(ProbeErrorCategory::PermissionDenied);
+    }
+    Ok(CredentialSelfState::new(
+        CredentialIdentityClass::Target,
+        CredentialGroupClass::EffectiveOnly,
+    ))
+}
+
 /// Captures the initial connected stream/datagram peer observation.
 pub fn observe_initial_peer(
     stream: RawFd,
@@ -201,8 +233,11 @@ fn transition_with<O: CredentialOps>(
     target_gid: u32,
 ) -> Result<CredentialTransition, CredentialFailureValue> {
     let retains_root = match mode {
-        ProbeMode::CredentialRetainRoot => true,
-        ProbeMode::CredentialDrop | ProbeMode::CredentialUnmapped => false,
+        ProbeMode::CredentialRetainRoot | ProbeMode::RuntimeRetainRoot => true,
+        ProbeMode::CredentialDrop
+        | ProbeMode::CredentialUnmapped
+        | ProbeMode::RuntimeDrop
+        | ProbeMode::RuntimeUnmapped => false,
         ProbeMode::CredentialControl => target_uid == 0 && target_gid == 0,
         _ => {
             return Err(CredentialFailureValue::new(

--- a/crates/session/src/elevated_probe.rs
+++ b/crates/session/src/elevated_probe.rs
@@ -20,6 +20,10 @@ pub const RESULT_RECORD_BYTES: usize = 48;
 pub const CREDENTIAL_RECORD_BYTES: usize = 80;
 /// Encoded credential datagram-possession record length.
 pub const CREDENTIAL_DATAGRAM_BYTES: usize = 48;
+/// Encoded credential-to-lifecycle continuation acknowledgment length.
+pub const CONTINUATION_ACK_BYTES: usize = 48;
+/// Private worker exit used to report the measured target namespace denial.
+pub const RUNTIME_NAMESPACE_PERMISSION_EXIT_CODE: u8 = 3;
 
 const VERSION: u16 = 2;
 const BOOTSTRAP_MAGIC: [u8; 4] = *b"BBE2";
@@ -27,6 +31,7 @@ const RESULT_MAGIC: [u8; 4] = *b"BBR2";
 const CREDENTIAL_VERSION: u16 = 1;
 const CREDENTIAL_MAGIC: [u8; 4] = *b"BBC1";
 const CREDENTIAL_DATAGRAM_MAGIC: [u8; 4] = *b"BBG1";
+const CONTINUATION_ACK_MAGIC: [u8; 4] = *b"BBA1";
 
 /// Exact evidence mode selected by the explicit root wrapper.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -52,6 +57,12 @@ pub enum ProbeMode {
     CredentialUnmapped = 9,
     /// Run the same no-chroot credential primitive in the unsandboxed launcher.
     CredentialControl = 10,
+    /// Drop both endpoints, then continue into the target-owned runtime.
+    RuntimeDrop = 11,
+    /// Retain exact root on both endpoints, then continue into the root-owned runtime.
+    RuntimeRetainRoot = 12,
+    /// Use the SDK-maximum unmapped identity, then attempt the explicit runtime.
+    RuntimeUnmapped = 13,
 }
 
 impl ProbeMode {
@@ -68,6 +79,9 @@ impl ProbeMode {
             "credential-retain-root" => Self::CredentialRetainRoot,
             "credential-unmapped" => Self::CredentialUnmapped,
             "credential-control" => Self::CredentialControl,
+            "runtime-drop" => Self::RuntimeDrop,
+            "runtime-retain-root" => Self::RuntimeRetainRoot,
+            "runtime-unmapped" => Self::RuntimeUnmapped,
             _ => return None,
         };
         mode.accepts_target(uid, gid).then_some(mode)
@@ -87,6 +101,9 @@ impl ProbeMode {
             Self::CredentialRetainRoot => "credential-retain-root",
             Self::CredentialUnmapped => "credential-unmapped",
             Self::CredentialControl => "credential-control",
+            Self::RuntimeDrop => "runtime-drop",
+            Self::RuntimeRetainRoot => "runtime-retain-root",
+            Self::RuntimeUnmapped => "runtime-unmapped",
         }
     }
 
@@ -94,12 +111,16 @@ impl ProbeMode {
     #[must_use]
     pub const fn accepts_target(self, uid: u32, gid: u32) -> bool {
         match self {
-            Self::Drop | Self::UnmappedSyscall | Self::CredentialDrop => uid != 0 && gid != 0,
-            Self::CredentialUnmapped => uid == 2_147_483_647 && gid == 2_147_483_647,
+            Self::Drop | Self::UnmappedSyscall | Self::CredentialDrop | Self::RuntimeDrop => {
+                uid != 0 && gid != 0
+            }
+            Self::CredentialUnmapped | Self::RuntimeUnmapped => {
+                uid == 2_147_483_647 && gid == 2_147_483_647
+            }
             Self::RetainRoot | Self::Control | Self::HvfControl | Self::InheritedRoot => {
                 uid == 0 && gid == 0
             }
-            Self::CredentialRetainRoot => uid == 0 && gid == 0,
+            Self::CredentialRetainRoot | Self::RuntimeRetainRoot => uid == 0 && gid == 0,
             Self::CredentialControl => (uid == 0) == (gid == 0),
         }
     }
@@ -109,14 +130,28 @@ impl ProbeMode {
     pub const fn is_credential_pair(self) -> bool {
         matches!(
             self,
-            Self::CredentialDrop | Self::CredentialRetainRoot | Self::CredentialUnmapped
+            Self::CredentialDrop
+                | Self::CredentialRetainRoot
+                | Self::CredentialUnmapped
+                | Self::RuntimeDrop
+                | Self::RuntimeRetainRoot
+                | Self::RuntimeUnmapped
+        )
+    }
+
+    /// Returns whether the credential exchange must hand the same transports to lifecycle v6.
+    #[must_use]
+    pub const fn continues_runtime(self) -> bool {
+        matches!(
+            self,
+            Self::RuntimeDrop | Self::RuntimeRetainRoot | Self::RuntimeUnmapped
         )
     }
 
     /// Returns whether this mode retains exact root without credential mutation.
     #[must_use]
     pub const fn retains_root(self) -> bool {
-        matches!(self, Self::CredentialRetainRoot)
+        matches!(self, Self::CredentialRetainRoot | Self::RuntimeRetainRoot)
     }
 
     fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
@@ -131,6 +166,9 @@ impl ProbeMode {
             8 => Ok(Self::CredentialRetainRoot),
             9 => Ok(Self::CredentialUnmapped),
             10 => Ok(Self::CredentialControl),
+            11 => Ok(Self::RuntimeDrop),
+            12 => Ok(Self::RuntimeRetainRoot),
+            13 => Ok(Self::RuntimeUnmapped),
             _ => Err(ProbeProtocolError),
         }
     }
@@ -174,6 +212,22 @@ pub enum ProbeStage {
     HvfDestroy = 16,
     /// Observe the first authenticated application record from the spawned worker.
     WorkerBootstrap = 17,
+    /// Complete the exact credential-to-lifecycle acknowledgment.
+    ContinuationAck = 18,
+    /// Observe the ordinary lifecycle Hello on the reused stream.
+    LifecycleHello = 19,
+    /// Create or validate the explicit target-owned runtime namespace.
+    RuntimeNamespace = 20,
+    /// Transfer the exact committed representative grant batch.
+    GrantTransfer = 21,
+    /// Consume and validate the committed representative grants.
+    GrantAccepted = 22,
+    /// Cross the ordinary lifecycle Proceed boundary.
+    LifecycleProceed = 23,
+    /// Observe and validate the ordinary lifecycle terminal record.
+    LifecycleTerminal = 24,
+    /// Reap and clean every exact owned runtime object.
+    RuntimeCleanup = 25,
 }
 
 impl ProbeStage {
@@ -198,6 +252,14 @@ impl ProbeStage {
             Self::HvfCreate => "hvf-create",
             Self::HvfDestroy => "hvf-destroy",
             Self::WorkerBootstrap => "worker-bootstrap",
+            Self::ContinuationAck => "continuation-ack",
+            Self::LifecycleHello => "lifecycle-hello",
+            Self::RuntimeNamespace => "runtime-namespace",
+            Self::GrantTransfer => "grant-transfer",
+            Self::GrantAccepted => "grant-accepted",
+            Self::LifecycleProceed => "lifecycle-proceed",
+            Self::LifecycleTerminal => "lifecycle-terminal",
+            Self::RuntimeCleanup => "runtime-cleanup",
         }
     }
 
@@ -220,7 +282,114 @@ impl ProbeStage {
             15 => Ok(Self::HvfCreate),
             16 => Ok(Self::HvfDestroy),
             17 => Ok(Self::WorkerBootstrap),
+            18 => Ok(Self::ContinuationAck),
+            19 => Ok(Self::LifecycleHello),
+            20 => Ok(Self::RuntimeNamespace),
+            21 => Ok(Self::GrantTransfer),
+            22 => Ok(Self::GrantAccepted),
+            23 => Ok(Self::LifecycleProceed),
+            24 => Ok(Self::LifecycleTerminal),
+            25 => Ok(Self::RuntimeCleanup),
             _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+/// Feature-only deterministic stop boundary for runtime-continuation evidence.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RuntimeFault {
+    /// Do not inject a fault.
+    #[default]
+    None = 0,
+    /// Stop immediately before the continuation acknowledgment.
+    PreAck = 1,
+    /// Stop after the acknowledgment and before lifecycle Hello.
+    PostAck = 2,
+    /// Stop at target-owned namespace creation.
+    Namespace = 3,
+    /// Stop while transferring the committed grant batch.
+    GrantTransfer = 4,
+    /// Stop at the ordinary Proceed boundary.
+    Proceed = 5,
+    /// Stop at terminal ownership validation.
+    Terminal = 6,
+}
+
+impl RuntimeFault {
+    /// Parses the closed wrapper spelling.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "none" => Some(Self::None),
+            "pre-ack" => Some(Self::PreAck),
+            "post-ack" => Some(Self::PostAck),
+            "namespace" => Some(Self::Namespace),
+            "grant-transfer" => Some(Self::GrantTransfer),
+            "proceed" => Some(Self::Proceed),
+            "terminal" => Some(Self::Terminal),
+            _ => None,
+        }
+    }
+
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            0 => Ok(Self::None),
+            1 => Ok(Self::PreAck),
+            2 => Ok(Self::PostAck),
+            3 => Ok(Self::Namespace),
+            4 => Ok(Self::GrantTransfer),
+            5 => Ok(Self::Proceed),
+            6 => Ok(Self::Terminal),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free fault spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::PreAck => "pre-ack",
+            Self::PostAck => "post-ack",
+            Self::Namespace => "namespace",
+            Self::GrantTransfer => "grant-transfer",
+            Self::Proceed => "proceed",
+            Self::Terminal => "terminal",
+        }
+    }
+}
+
+/// Value-free capable-host result class for one runtime continuation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RuntimeResultClass {
+    /// Target/no-drop execution completed the full foreground lifecycle.
+    Complete,
+    /// The exact credential-to-lifecycle continuation could not be completed.
+    ContinuationBoundary,
+    /// Live target/no-drop process or code identity could not be revalidated.
+    IdentityBoundary,
+    /// The explicit root could not be acquired or validated.
+    ExplicitRootBoundary,
+    /// Namespace creation, locking, validation, or recovery stopped progress.
+    NamespaceBoundary,
+    /// Grant transfer, commitment, or target-side consumption stopped progress.
+    GrantBoundary,
+    /// The ordinary lifecycle stopped after committed grants.
+    LifecycleBoundary,
+}
+
+impl RuntimeResultClass {
+    /// Returns the stable value-free result spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::ContinuationBoundary => "continuation-boundary",
+            Self::IdentityBoundary => "identity-boundary",
+            Self::ExplicitRootBoundary => "explicit-root-boundary",
+            Self::NamespaceBoundary => "namespace-boundary",
+            Self::GrantBoundary => "grant-boundary",
+            Self::LifecycleBoundary => "lifecycle-boundary",
         }
     }
 }
@@ -454,6 +623,90 @@ impl CredentialDatagramProof {
 impl fmt::Debug for CredentialDatagramProof {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("CredentialDatagramProof(<redacted>)")
+    }
+}
+
+/// Exact single-use handoff from the credential exchange to lifecycle v6.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ContinuationAck {
+    mode: ProbeMode,
+    role: CredentialRole,
+    nonce: SessionId,
+}
+
+impl ContinuationAck {
+    /// Constructs the launcher's acknowledgment for one runtime continuation.
+    pub fn launcher(mode: ProbeMode, nonce: SessionId) -> Result<Self, ProbeProtocolError> {
+        if !mode.continues_runtime() || nonce.is_pre_session() {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            mode,
+            role: CredentialRole::Launcher,
+            nonce,
+        })
+    }
+
+    /// Returns the selected runtime mode.
+    #[must_use]
+    pub const fn mode(self) -> ProbeMode {
+        self.mode
+    }
+
+    /// Returns the fixed acknowledging role.
+    #[must_use]
+    pub const fn role(self) -> CredentialRole {
+        self.role
+    }
+
+    /// Returns the exact command nonce.
+    #[must_use]
+    pub const fn nonce(self) -> SessionId {
+        self.nonce
+    }
+
+    /// Returns whether this is the exact acknowledgment for an exchange.
+    #[must_use]
+    pub fn matches_expected(self, mode: ProbeMode, nonce: SessionId) -> bool {
+        self.mode == mode && self.role == CredentialRole::Launcher && self.nonce == nonce
+    }
+
+    /// Encodes the fixed acknowledgment record.
+    #[must_use]
+    pub fn encode(self) -> [u8; CONTINUATION_ACK_BYTES] {
+        let mut bytes = [0_u8; CONTINUATION_ACK_BYTES];
+        bytes[0..4].copy_from_slice(&CONTINUATION_ACK_MAGIC);
+        bytes[4..6].copy_from_slice(&CREDENTIAL_VERSION.to_be_bytes());
+        bytes[6] = self.mode as u8;
+        bytes[7] = self.role as u8;
+        bytes[16..48].copy_from_slice(self.nonce.as_bytes());
+        bytes
+    }
+
+    /// Decodes and canonically validates one acknowledgment record.
+    pub fn decode(bytes: &[u8; CONTINUATION_ACK_BYTES]) -> Result<Self, ProbeProtocolError> {
+        if bytes[0..4] != CONTINUATION_ACK_MAGIC
+            || bytes[4..6] != CREDENTIAL_VERSION.to_be_bytes()
+            || bytes[8..16] != [0; 8]
+        {
+            return Err(ProbeProtocolError);
+        }
+        let ack = Self::launcher(
+            ProbeMode::from_byte(bytes[6])?,
+            SessionId::from_bytes(array(bytes, 16)?),
+        )?;
+        if CredentialRole::from_byte(bytes[7])? != CredentialRole::Launcher
+            || ack.encode() != *bytes
+        {
+            return Err(ProbeProtocolError);
+        }
+        Ok(ack)
+    }
+}
+
+impl fmt::Debug for ContinuationAck {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ContinuationAck(<redacted>)")
     }
 }
 
@@ -1290,6 +1543,7 @@ impl fmt::Debug for CredentialRecord {
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ProbeBootstrap {
     mode: ProbeMode,
+    fault: RuntimeFault,
     target_uid: u32,
     target_gid: u32,
     root: ObjectIdentity,
@@ -1305,8 +1559,28 @@ impl ProbeBootstrap {
         root: ObjectIdentity,
         nonce: SessionId,
     ) -> Result<Self, ProbeProtocolError> {
+        Self::new_with_fault(
+            mode,
+            RuntimeFault::None,
+            target_uid,
+            target_gid,
+            root,
+            nonce,
+        )
+    }
+
+    /// Constructs a complete worker command with a new-mode-only deterministic fault.
+    pub fn new_with_fault(
+        mode: ProbeMode,
+        fault: RuntimeFault,
+        target_uid: u32,
+        target_gid: u32,
+        root: ObjectIdentity,
+        nonce: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
         if matches!(mode, ProbeMode::Control | ProbeMode::CredentialControl)
             || !mode.accepts_target(target_uid, target_gid)
+            || (!mode.continues_runtime() && fault != RuntimeFault::None)
             || root.device == 0
             || root.inode == 0
             || nonce.is_pre_session()
@@ -1315,6 +1589,7 @@ impl ProbeBootstrap {
         }
         Ok(Self {
             mode,
+            fault,
             target_uid,
             target_gid,
             root,
@@ -1326,6 +1601,12 @@ impl ProbeBootstrap {
     #[must_use]
     pub const fn mode(self) -> ProbeMode {
         self.mode
+    }
+
+    /// Returns the feature-only deterministic fault boundary.
+    #[must_use]
+    pub const fn fault(self) -> RuntimeFault {
+        self.fault
     }
 
     /// Returns the exact target user ID.
@@ -1359,6 +1640,7 @@ impl ProbeBootstrap {
         bytes[0..4].copy_from_slice(&BOOTSTRAP_MAGIC);
         bytes[4..6].copy_from_slice(&VERSION.to_be_bytes());
         bytes[6] = self.mode as u8;
+        bytes[7] = self.fault as u8;
         bytes[8..12].copy_from_slice(&self.target_uid.to_be_bytes());
         bytes[12..16].copy_from_slice(&self.target_gid.to_be_bytes());
         bytes[16..24].copy_from_slice(&self.root.device.to_be_bytes());
@@ -1369,10 +1651,11 @@ impl ProbeBootstrap {
 
     /// Decodes one exact fixed-size record.
     pub fn decode(bytes: &[u8; BOOTSTRAP_RECORD_BYTES]) -> Result<Self, ProbeProtocolError> {
-        if bytes[0..4] != BOOTSTRAP_MAGIC || bytes[4..6] != VERSION.to_be_bytes() || bytes[7] != 0 {
+        if bytes[0..4] != BOOTSTRAP_MAGIC || bytes[4..6] != VERSION.to_be_bytes() {
             return Err(ProbeProtocolError);
         }
         let mode = ProbeMode::from_byte(bytes[6])?;
+        let fault = RuntimeFault::from_byte(bytes[7])?;
         let target_uid = u32::from_be_bytes(array(bytes, 8)?);
         let target_gid = u32::from_be_bytes(array(bytes, 12)?);
         let root = ObjectIdentity {
@@ -1380,7 +1663,7 @@ impl ProbeBootstrap {
             inode: u64::from_be_bytes(array(bytes, 24)?),
         };
         let nonce = SessionId::from_bytes(array(bytes, 32)?);
-        Self::new(mode, target_uid, target_gid, root, nonce)
+        Self::new_with_fault(mode, fault, target_uid, target_gid, root, nonce)
     }
 }
 
@@ -1576,6 +1859,36 @@ mod tests {
             )
             .is_err()
         );
+
+        let runtime = ProbeBootstrap::new_with_fault(
+            ProbeMode::RuntimeDrop,
+            RuntimeFault::PostAck,
+            501,
+            20,
+            ObjectIdentity {
+                device: 1,
+                inode: 1,
+            },
+            SessionId::from_bytes([2; 32]),
+        )
+        .expect("runtime faults are explicit in new modes");
+        assert_eq!(runtime.fault(), RuntimeFault::PostAck);
+        assert_eq!(ProbeBootstrap::decode(&runtime.encode()), Ok(runtime));
+        assert!(
+            ProbeBootstrap::new_with_fault(
+                ProbeMode::CredentialDrop,
+                RuntimeFault::PostAck,
+                501,
+                20,
+                ObjectIdentity {
+                    device: 1,
+                    inode: 1,
+                },
+                SessionId::from_bytes([2; 32]),
+            )
+            .is_err(),
+            "historical mode bytes must retain a zero reserved byte"
+        );
         let mut version_one = encoded;
         version_one[4..6].copy_from_slice(&1_u16.to_be_bytes());
         assert_eq!(
@@ -1698,6 +2011,19 @@ mod tests {
             Some(ProbeMode::CredentialControl)
         );
         assert_eq!(ProbeMode::parse("credential-control", 501, 0), None);
+        assert_eq!(
+            ProbeMode::parse("runtime-drop", 501, 20),
+            Some(ProbeMode::RuntimeDrop)
+        );
+        assert_eq!(ProbeMode::parse("runtime-drop", 0, 0), None);
+        assert_eq!(
+            ProbeMode::parse("runtime-retain-root", 0, 0),
+            Some(ProbeMode::RuntimeRetainRoot)
+        );
+        assert_eq!(
+            ProbeMode::parse("runtime-unmapped", 2_147_483_647, 2_147_483_647),
+            Some(ProbeMode::RuntimeUnmapped)
+        );
         assert_eq!(ProbeMode::parse("unknown", 501, 20), None);
     }
 
@@ -1722,6 +2048,14 @@ mod tests {
             ProbeStage::HvfCreate,
             ProbeStage::HvfDestroy,
             ProbeStage::WorkerBootstrap,
+            ProbeStage::ContinuationAck,
+            ProbeStage::LifecycleHello,
+            ProbeStage::RuntimeNamespace,
+            ProbeStage::GrantTransfer,
+            ProbeStage::GrantAccepted,
+            ProbeStage::LifecycleProceed,
+            ProbeStage::LifecycleTerminal,
+            ProbeStage::RuntimeCleanup,
         ] {
             let result = ProbeResult::failure(
                 ProbeMode::InheritedRoot,
@@ -1746,6 +2080,9 @@ mod tests {
             (ProbeMode::CredentialDrop, 501, 20),
             (ProbeMode::CredentialRetainRoot, 0, 0),
             (ProbeMode::CredentialUnmapped, 2_147_483_647, 2_147_483_647),
+            (ProbeMode::RuntimeDrop, 501, 20),
+            (ProbeMode::RuntimeRetainRoot, 0, 0),
+            (ProbeMode::RuntimeUnmapped, 2_147_483_647, 2_147_483_647),
         ] {
             let bootstrap = ProbeBootstrap::new(
                 mode,
@@ -1770,6 +2107,83 @@ mod tests {
                 assert_eq!(ProbeResult::decode(&result.encode()), Ok(result));
             }
         }
+    }
+
+    #[test]
+    fn runtime_fault_and_result_vocabularies_are_closed_and_exhaustive() {
+        for (fault, byte, name) in [
+            (RuntimeFault::None, 0, "none"),
+            (RuntimeFault::PreAck, 1, "pre-ack"),
+            (RuntimeFault::PostAck, 2, "post-ack"),
+            (RuntimeFault::Namespace, 3, "namespace"),
+            (RuntimeFault::GrantTransfer, 4, "grant-transfer"),
+            (RuntimeFault::Proceed, 5, "proceed"),
+            (RuntimeFault::Terminal, 6, "terminal"),
+        ] {
+            assert_eq!(RuntimeFault::parse(name), Some(fault));
+            assert_eq!(RuntimeFault::from_byte(byte), Ok(fault));
+            assert_eq!(fault.name(), name);
+        }
+        assert_eq!(RuntimeFault::parse("unknown"), None);
+        assert_eq!(RuntimeFault::from_byte(7), Err(ProbeProtocolError));
+
+        for (result, name) in [
+            (RuntimeResultClass::Complete, "complete"),
+            (
+                RuntimeResultClass::ContinuationBoundary,
+                "continuation-boundary",
+            ),
+            (RuntimeResultClass::IdentityBoundary, "identity-boundary"),
+            (
+                RuntimeResultClass::ExplicitRootBoundary,
+                "explicit-root-boundary",
+            ),
+            (RuntimeResultClass::NamespaceBoundary, "namespace-boundary"),
+            (RuntimeResultClass::GrantBoundary, "grant-boundary"),
+            (RuntimeResultClass::LifecycleBoundary, "lifecycle-boundary"),
+        ] {
+            assert_eq!(result.name(), name);
+        }
+    }
+
+    #[test]
+    fn continuation_ack_is_closed_nonce_bound_and_new_mode_only() {
+        let nonce = SessionId::from_bytes([0x71; 32]);
+        for mode in [
+            ProbeMode::RuntimeDrop,
+            ProbeMode::RuntimeRetainRoot,
+            ProbeMode::RuntimeUnmapped,
+        ] {
+            let ack = ContinuationAck::launcher(mode, nonce).expect("new mode should acknowledge");
+            let encoded = ack.encode();
+            assert_eq!(encoded.len(), CONTINUATION_ACK_BYTES);
+            assert_eq!(ContinuationAck::decode(&encoded), Ok(ack));
+            assert!(ack.matches_expected(mode, nonce));
+            assert_eq!(format!("{ack:?}"), "ContinuationAck(<redacted>)");
+            for index in [0, 4, 7] {
+                let mut malformed = encoded;
+                malformed[index] ^= 0xff;
+                assert_eq!(ContinuationAck::decode(&malformed), Err(ProbeProtocolError));
+            }
+            for index in 8..16 {
+                let mut malformed = encoded;
+                malformed[index] = 1;
+                assert_eq!(ContinuationAck::decode(&malformed), Err(ProbeProtocolError));
+            }
+            let other_mode = if mode == ProbeMode::RuntimeDrop {
+                ProbeMode::RuntimeRetainRoot
+            } else {
+                ProbeMode::RuntimeDrop
+            };
+            let cross_mode = ContinuationAck::launcher(other_mode, nonce)
+                .expect("another runtime acknowledgment should construct");
+            assert!(!cross_mode.matches_expected(mode, nonce));
+            assert!(!ack.matches_expected(mode, SessionId::from_bytes([0x72; 32])));
+        }
+        assert!(ContinuationAck::launcher(ProbeMode::CredentialDrop, nonce).is_err());
+        assert!(
+            ContinuationAck::launcher(ProbeMode::RuntimeDrop, SessionId::pre_session()).is_err()
+        );
     }
 
     fn observation(identity: CredentialIdentityClass, token: PeerTokenClass) -> PeerObservation {

--- a/crates/session/src/macos/runtime.rs
+++ b/crates/session/src/macos/runtime.rs
@@ -2,7 +2,7 @@ use std::ffi::{CStr, CString, OsStr, OsString};
 use std::fmt;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
@@ -330,6 +330,8 @@ impl fmt::Debug for NamespaceIdentity {
 pub enum RuntimeError {
     /// A filesystem operation failed.
     Filesystem(io::ErrorKind),
+    /// Creating the exact random session directory failed.
+    NamespaceCreate(io::ErrorKind),
     /// The expected fixed container/root contract was not satisfied.
     InvalidRoot,
     /// A session entry failed owner, mode, type, identity, lock, or emptiness checks.
@@ -346,12 +348,107 @@ impl fmt::Display for RuntimeError {
 
 impl std::error::Error for RuntimeError {}
 
+#[derive(Clone, Copy)]
+struct DirectoryOwner {
+    uid: libc::uid_t,
+    gid: Option<libc::gid_t>,
+}
+
+impl DirectoryOwner {
+    fn current_user() -> Self {
+        // SAFETY: The identity getter has no pointer or ownership contract.
+        let uid = unsafe { libc::geteuid() };
+        Self { uid, gid: None }
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    const fn exact(uid: libc::uid_t, gid: libc::gid_t) -> Self {
+        Self {
+            uid,
+            gid: Some(gid),
+        }
+    }
+}
+
+/// Independently opened, descriptor-rooted authority for evidence-only runtimes.
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub struct ExplicitRuntimeRoot {
+    directory: OwnedFd,
+    identity: NamespaceIdentity,
+    owner: DirectoryOwner,
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl fmt::Debug for ExplicitRuntimeRoot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ExplicitRuntimeRoot(<redacted>)")
+    }
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl ExplicitRuntimeRoot {
+    /// Adopts and validates one already-opened exact target-owned runtime root.
+    pub fn from_owned_fd(
+        directory: OwnedFd,
+        expected: ObjectIdentity,
+        uid: libc::uid_t,
+        gid: libc::gid_t,
+        require_empty: bool,
+    ) -> Result<Self, RuntimeError> {
+        let owner = DirectoryOwner::exact(uid, gid);
+        let stat = directory_stat(directory.as_raw_fd())?;
+        let linked = stat.st_nlink >= 2;
+        let identity = validate_directory_stat(stat, owner)?;
+        if !linked
+            || identity.device != expected.device
+            || identity.inode != expected.inode
+            || (require_empty && !directory_is_empty(directory.as_raw_fd())?)
+        {
+            return Err(RuntimeError::InvalidRoot);
+        }
+        Ok(Self {
+            directory,
+            identity,
+            owner,
+        })
+    }
+
+    /// Reopens the same directory with an independent file description.
+    pub fn try_reopen(&self, require_empty: bool) -> Result<Self, RuntimeError> {
+        let directory = openat_directory(self.directory.as_raw_fd(), c".")?;
+        let identity = validate_directory_owned(directory.as_raw_fd(), self.owner)?;
+        if identity != self.identity
+            || (require_empty && !directory_is_empty(directory.as_raw_fd())?)
+        {
+            return Err(RuntimeError::InvalidRoot);
+        }
+        Ok(Self {
+            directory,
+            identity,
+            owner: self.owner,
+        })
+    }
+
+    /// Returns the retained root descriptor without transferring ownership.
+    #[must_use]
+    pub fn as_raw_fd(&self) -> RawFd {
+        self.directory.as_raw_fd()
+    }
+
+    /// Returns the validated root identity without revealing its path.
+    #[must_use]
+    pub const fn identity(&self) -> NamespaceIdentity {
+        self.identity
+    }
+}
+
 /// Worker-owned locked namespace inside its App Sandbox container.
 pub struct WorkerNamespace {
     root: OwnedFd,
     directory: OwnedFd,
     name: CString,
     identity: NamespaceIdentity,
+    owner: DirectoryOwner,
     cleaned: bool,
 }
 
@@ -370,8 +467,26 @@ impl WorkerNamespace {
     pub fn create(session: SessionId) -> Result<Self, RuntimeError> {
         let root_path = worker_runtime_root()?;
         let root = ensure_runtime_root(&root_path)?;
+        Self::create_in_root(root, DirectoryOwner::current_user(), session)
+    }
+
+    /// Creates the exact session beneath an already-opened target-owned root.
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    pub fn create_from_explicit_root(
+        root: ExplicitRuntimeRoot,
+        session: SessionId,
+    ) -> Result<Self, RuntimeError> {
+        Self::create_in_root(root.directory, root.owner, session)
+    }
+
+    fn create_in_root(
+        root: OwnedFd,
+        owner: DirectoryOwner,
+        session: SessionId,
+    ) -> Result<Self, RuntimeError> {
+        validate_directory_owned(root.as_raw_fd(), owner)?;
         let root_lock = RootLock::acquire(root.as_raw_fd())?;
-        recover_stale_entries(root.as_raw_fd())?;
+        recover_stale_entries(root.as_raw_fd(), owner)?;
         let name = session_name(session)?;
         // SAFETY: `root` is a live directory fd, `name` is NUL-terminated, and
         // no pointer is retained.
@@ -380,7 +495,7 @@ impl WorkerNamespace {
             return if error.kind() == io::ErrorKind::AlreadyExists {
                 Err(RuntimeError::Collision)
             } else {
-                Err(RuntimeError::Filesystem(error.kind()))
+                Err(RuntimeError::NamespaceCreate(error.kind()))
             };
         }
 
@@ -388,7 +503,7 @@ impl WorkerNamespace {
         // stale recovery. Blind rollback could remove a same-user replacement
         // installed between `mkdirat` and the failing operation.
         let directory = openat_directory(root.as_raw_fd(), &name)?;
-        let identity = validate_directory(directory.as_raw_fd())?;
+        let identity = validate_directory_owned(directory.as_raw_fd(), owner)?;
         lock_exclusive(directory.as_raw_fd())?;
         drop(root_lock);
         Ok(Self {
@@ -396,6 +511,7 @@ impl WorkerNamespace {
             directory,
             name,
             identity,
+            owner,
             cleaned: false,
         })
     }
@@ -425,8 +541,7 @@ impl WorkerNamespace {
 
     /// Rechecks that the process working directory is the retained namespace.
     pub fn verify_current_directory(&self) -> Result<(), RuntimeError> {
-        let current = open_directory(Path::new("."))?;
-        if validate_directory(current.as_raw_fd())? == self.identity {
+        if current_directory_identity(self.owner)? == self.identity {
             Ok(())
         } else {
             Err(RuntimeError::InvalidEntry)
@@ -443,6 +558,7 @@ impl WorkerNamespace {
             self.directory.as_raw_fd(),
             &self.name,
             self.identity,
+            self.owner,
         )?;
         self.cleaned = true;
         Ok(())
@@ -486,6 +602,7 @@ pub struct LauncherNamespace {
     directory: OwnedFd,
     name: CString,
     identity: NamespaceIdentity,
+    owner: DirectoryOwner,
     cleaned: bool,
 }
 
@@ -504,10 +621,29 @@ impl LauncherNamespace {
     pub fn validate(session: SessionId, expected: NamespaceIdentity) -> Result<Self, RuntimeError> {
         let root_path = launcher_runtime_root()?;
         let root = open_directory(&root_path)?;
-        validate_directory(root.as_raw_fd())?;
+        Self::validate_in_root(root, DirectoryOwner::current_user(), session, expected)
+    }
+
+    /// Validates a worker-created namespace beneath an explicit target-owned root.
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    pub fn validate_from_explicit_root(
+        root: ExplicitRuntimeRoot,
+        session: SessionId,
+        expected: NamespaceIdentity,
+    ) -> Result<Self, RuntimeError> {
+        Self::validate_in_root(root.directory, root.owner, session, expected)
+    }
+
+    fn validate_in_root(
+        root: OwnedFd,
+        owner: DirectoryOwner,
+        session: SessionId,
+        expected: NamespaceIdentity,
+    ) -> Result<Self, RuntimeError> {
+        validate_directory_owned(root.as_raw_fd(), owner)?;
         let name = session_name(session)?;
         let directory = openat_directory(root.as_raw_fd(), &name)?;
-        let actual = validate_directory(directory.as_raw_fd())?;
+        let actual = validate_directory_owned(directory.as_raw_fd(), owner)?;
         if actual != expected || !directory_is_empty(directory.as_raw_fd())? {
             return Err(RuntimeError::InvalidEntry);
         }
@@ -522,6 +658,7 @@ impl LauncherNamespace {
             directory,
             name,
             identity: actual,
+            owner,
             cleaned: false,
         })
     }
@@ -538,14 +675,31 @@ impl LauncherNamespace {
             Err(RuntimeError::Filesystem(io::ErrorKind::NotFound)) => return Ok(None),
             Err(error) => return Err(error),
         };
-        validate_directory(root.as_raw_fd())?;
+        Self::recover_in_root(root, DirectoryOwner::current_user(), session)
+    }
+
+    /// Recovers an exact namespace after worker exit beneath an explicit root.
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    pub fn recover_after_worker_exit_from_explicit_root(
+        root: ExplicitRuntimeRoot,
+        session: SessionId,
+    ) -> Result<Option<Self>, RuntimeError> {
+        Self::recover_in_root(root.directory, root.owner, session)
+    }
+
+    fn recover_in_root(
+        root: OwnedFd,
+        owner: DirectoryOwner,
+        session: SessionId,
+    ) -> Result<Option<Self>, RuntimeError> {
+        validate_directory_owned(root.as_raw_fd(), owner)?;
         let name = session_name(session)?;
         let directory = match openat_directory(root.as_raw_fd(), &name) {
             Ok(directory) => directory,
             Err(RuntimeError::Filesystem(io::ErrorKind::NotFound)) => return Ok(None),
             Err(error) => return Err(error),
         };
-        let identity = validate_directory(directory.as_raw_fd())?;
+        let identity = validate_directory_owned(directory.as_raw_fd(), owner)?;
         if !try_lock_exclusive(directory.as_raw_fd())? {
             return Err(RuntimeError::InvalidEntry);
         }
@@ -557,6 +711,7 @@ impl LauncherNamespace {
             directory,
             name,
             identity,
+            owner,
             cleaned: false,
         }))
     }
@@ -578,6 +733,7 @@ impl LauncherNamespace {
             self.directory.as_raw_fd(),
             &self.name,
             self.identity,
+            self.owner,
         )?;
         self.cleaned = true;
         Ok(())
@@ -1148,18 +1304,53 @@ fn unlink_staged_socket(
 }
 
 fn validate_directory(fd: RawFd) -> Result<NamespaceIdentity, RuntimeError> {
+    validate_directory_owned(fd, DirectoryOwner::current_user())
+}
+
+fn validate_directory_owned(
+    fd: RawFd,
+    owner: DirectoryOwner,
+) -> Result<NamespaceIdentity, RuntimeError> {
+    validate_directory_stat(directory_stat(fd)?, owner)
+}
+
+fn directory_stat(fd: RawFd) -> Result<libc::stat, RuntimeError> {
     let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
     // SAFETY: `stat` is writable for one result and `fd` remains owned by caller.
     if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
         return Err(RuntimeError::Filesystem(io::Error::last_os_error().kind()));
     }
     // SAFETY: Successful `fstat` initialized the result.
-    let stat = unsafe { stat.assume_init() };
-    // SAFETY: Identity call has no pointer or ownership contract.
-    let uid = unsafe { libc::geteuid() };
+    Ok(unsafe { stat.assume_init() })
+}
+
+fn current_directory_identity(owner: DirectoryOwner) -> Result<NamespaceIdentity, RuntimeError> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: The fixed dot component is NUL-terminated, `AT_FDCWD` names the
+    // process cwd, and `stat` is writable for one result.
+    if unsafe {
+        libc::fstatat(
+            libc::AT_FDCWD,
+            c".".as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(RuntimeError::Filesystem(io::Error::last_os_error().kind()));
+    }
+    // SAFETY: Successful `fstatat` initialized the result.
+    validate_directory_stat(unsafe { stat.assume_init() }, owner)
+}
+
+fn validate_directory_stat(
+    stat: libc::stat,
+    owner: DirectoryOwner,
+) -> Result<NamespaceIdentity, RuntimeError> {
     if stat.st_mode & libc::S_IFMT != libc::S_IFDIR
         || stat.st_mode & 0o7777 != 0o700
-        || stat.st_uid != uid
+        || stat.st_uid != owner.uid
+        || owner.gid.is_some_and(|gid| stat.st_gid != gid)
     {
         return Err(RuntimeError::InvalidEntry);
     }
@@ -1184,7 +1375,7 @@ fn valid_session_name(name: &OsStr) -> bool {
         && suffix.iter().all(|byte| !byte.is_ascii_uppercase())
 }
 
-fn recover_stale_entries(root: RawFd) -> Result<(), RuntimeError> {
+fn recover_stale_entries(root: RawFd, owner: DirectoryOwner) -> Result<(), RuntimeError> {
     for entry in directory_entries(root, MAX_RECOVERY_ENTRIES)? {
         if !valid_session_name(&entry) {
             continue;
@@ -1195,7 +1386,7 @@ fn recover_stale_entries(root: RawFd) -> Result<(), RuntimeError> {
         let Ok(directory) = openat_directory(root, &name) else {
             continue;
         };
-        let Ok(identity) = validate_directory(directory.as_raw_fd()) else {
+        let Ok(identity) = validate_directory_owned(directory.as_raw_fd(), owner) else {
             continue;
         };
         if !try_lock_exclusive(directory.as_raw_fd())? {
@@ -1204,7 +1395,7 @@ fn recover_stale_entries(root: RawFd) -> Result<(), RuntimeError> {
         if !directory_is_empty(directory.as_raw_fd())? {
             continue;
         }
-        let _ = cleanup_exact(root, directory.as_raw_fd(), &name, identity);
+        let _ = cleanup_exact(root, directory.as_raw_fd(), &name, identity, owner);
     }
     Ok(())
 }
@@ -1213,18 +1404,11 @@ fn directory_entries(fd: RawFd, limit: usize) -> Result<Vec<OsString>, RuntimeEr
     if limit == 0 {
         return Ok(Vec::new());
     }
-    // SAFETY: `fd` is a live directory and the fixed relative path opens the
-    // same directory with an independent file description and directory cursor.
-    let independent = unsafe {
-        libc::openat(
-            fd,
-            c".".as_ptr(),
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-        )
-    };
-    if independent < 0 {
-        return Err(RuntimeError::Filesystem(io::Error::last_os_error().kind()));
-    }
+    // Reopening an inherited directory through `openat(fd, ".")` performs a
+    // fresh path lookup that App Sandbox can deny even though the process owns
+    // the exact validated descriptor. Duplicate that authority instead and
+    // explicitly rewind its shared directory cursor before consuming it.
+    let independent = duplicate_fd(fd)?.into_raw_fd();
     // SAFETY: `independent` is a fresh descriptor; `fdopendir` takes ownership on success.
     let directory = unsafe { libc::fdopendir(independent) };
     if directory.is_null() {
@@ -1232,6 +1416,8 @@ fn directory_entries(fd: RawFd, limit: usize) -> Result<Vec<OsString>, RuntimeEr
         let _ = unsafe { libc::close(independent) };
         return Err(RuntimeError::Filesystem(io::Error::last_os_error().kind()));
     }
+    // SAFETY: `directory` is live and uniquely consumed by this bounded scan.
+    unsafe { libc::rewinddir(directory) };
     let mut entries = Vec::new();
     loop {
         // SAFETY: Darwin's thread-local errno pointer is writable for this call sequence.
@@ -1301,8 +1487,9 @@ fn cleanup_exact(
     directory: RawFd,
     name: &CStr,
     expected: NamespaceIdentity,
+    owner: DirectoryOwner,
 ) -> Result<(), RuntimeError> {
-    if validate_directory(directory)? != expected || !directory_is_empty(directory)? {
+    if validate_directory_owned(directory, owner)? != expected || !directory_is_empty(directory)? {
         return Err(RuntimeError::InvalidEntry);
     }
     match identity_at(root, name)? {
@@ -1462,6 +1649,82 @@ mod tests {
         assert_eq!(
             validate_directory(directory.as_raw_fd()),
             Err(RuntimeError::InvalidEntry)
+        );
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    #[test]
+    fn explicit_roots_require_exact_owner_and_independent_session_locks() {
+        let root = TestRoot::new();
+        let metadata = fs::symlink_metadata(root.path()).expect("root metadata should read");
+        let expected = ObjectIdentity {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        };
+        let uid = metadata.uid();
+        let gid = metadata.gid();
+
+        assert_eq!(
+            ExplicitRuntimeRoot::from_owned_fd(
+                open_directory(root.path()).expect("root should open"),
+                expected,
+                uid,
+                gid.wrapping_add(1),
+                true,
+            )
+            .expect_err("wrong gid must be rejected"),
+            RuntimeError::InvalidEntry
+        );
+
+        let unexpected = root.path().join("unexpected");
+        fs::write(&unexpected, b"occupied").expect("unexpected root entry should write");
+        assert_eq!(
+            ExplicitRuntimeRoot::from_owned_fd(
+                open_directory(root.path()).expect("root should open"),
+                expected,
+                uid,
+                gid,
+                true,
+            )
+            .expect_err("an explicit runtime root must be empty before handoff"),
+            RuntimeError::InvalidRoot
+        );
+        fs::remove_file(unexpected).expect("unexpected root entry should clean");
+
+        let root_authority = ExplicitRuntimeRoot::from_owned_fd(
+            open_directory(root.path()).expect("root should open"),
+            expected,
+            uid,
+            gid,
+            true,
+        )
+        .expect("exact root should validate");
+        let worker_root = root_authority
+            .try_reopen(true)
+            .expect("worker root should independently reopen");
+        let launcher_root = root_authority
+            .try_reopen(true)
+            .expect("launcher root should independently reopen");
+        drop(root_authority);
+
+        let session = SessionId::from_bytes([0x91; 32]);
+        let worker = WorkerNamespace::create_from_explicit_root(worker_root, session)
+            .expect("target-owned session should create and lock");
+        let identity = worker.identity();
+        let mut launcher =
+            LauncherNamespace::validate_from_explicit_root(launcher_root, session, identity)
+                .expect("independent launcher description should observe the worker lock");
+        drop(worker);
+        launcher
+            .cleanup()
+            .expect("launcher cleanup should accept worker removal");
+        assert!(
+            directory_is_empty(
+                open_directory(root.path())
+                    .expect("root should reopen")
+                    .as_raw_fd()
+            )
+            .expect("root should inspect")
         );
     }
 
@@ -1756,7 +2019,8 @@ mod tests {
         )
         .expect("populated marker should be written");
 
-        recover_stale_entries(directory.as_raw_fd()).expect("recovery should succeed");
+        recover_stale_entries(directory.as_raw_fd(), DirectoryOwner::current_user())
+            .expect("recovery should succeed");
 
         assert!(
             !root
@@ -1795,6 +2059,7 @@ mod tests {
             directory: original,
             name,
             identity,
+            owner: DirectoryOwner::current_user(),
             cleaned: false,
         };
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -59,8 +59,11 @@ read-only/read-write backing grants; logger, metrics, and serial adopt exact
 singleton write-only sink grants; vhost-user endpoints require repeatable
 connect-only directory grants and launcher-returned streams. Public product
 uid/gid transition, configurable chroot ownership, and complete
-distribution-signing policy remain absent; a disabled evidence bundle has
-measured credential bootstrap only. The
+distribution-signing policy remain absent. A disabled evidence bundle has
+measured credential bootstrap plus same-process continuation into ordinary
+`Hello`/`Start`; the current App Sandbox profile denies creation of the random
+session beneath an exact target-owned root, and the representative grants and
+later lifecycle remain unreached. The
 exact seccomp, cgroup, network-namespace, and PID-namespace mechanisms are now
 certified public-macOS exclusions rather than unresolved or silently accepted
 inputs.
@@ -80,6 +83,17 @@ block, pmem, logger, metrics, serial, snapshot input/output/root, API-socket,
 and vsock-socket consumers use granted identities or exact retained anchors
 without reopening their tagged path strings. General dynamic post-Ready
 delivery and hard revocation still need dedicated designs.
+
+The elevated evidence result is intentionally narrower than product support.
+For mapped and retained-root identities, the signed launcher and worker retain
+the same PIDs, lifecycle stream, and grant datagram through a canonical
+nonce-bound acknowledgment and ordinary `Hello`/`Start`. The worker then
+receives an already-opened validated target-owned root, but its exact session
+`mkdirat` returns permission denied under App Sandbox. The high unmapped case
+stops earlier at live code-identity revalidation. No hidden launcher-created
+session fallback is used: changing that authority ordering requires a separate
+Challenge. This evidence does not establish grants, `Proceed`, terminal
+ownership, API/guest execution, daemon recovery, or post-transition HVF.
 
 ## Certified Linux Runtime Isolation Exclusions
 
@@ -239,7 +253,7 @@ Use this checklist when reviewing Firecracker-facing host isolation changes:
 
 | Area | Current status | Review expectation |
 | --- | --- | --- |
-| Linux jailer, seccomp, namespaces, cgroups, chroot, and privilege dropping | Direct mechanisms unsupported; fixed-code/current-user/private-root/rlimit/daemon observable subset implemented; no-chroot credential bootstrap measured only in a disabled evidence bundle | Preserve the exact macOS launch-policy contract and reject unsupported Linux controls. Do not equate measured bootstrap with target-owned runtime/resource continuation or a private cwd with chroot. |
+| Linux jailer, seccomp, namespaces, cgroups, chroot, and privilege dropping | Direct mechanisms unsupported; fixed-code/current-user/private-root/rlimit/daemon observable subset implemented; disabled evidence reaches credential continuation and mapped/retained-root `Hello`/`Start`, then stops at App Sandbox target-session creation | Preserve the exact macOS launch-policy contract and reject unsupported Linux controls. Do not equate the measured namespace boundary with grants, lifecycle completion, product uid/gid support, or chroot. |
 | API socket ownership | Implemented subset | Keep owner-only socket permissions, final-path ownership checks, and owner-only cleanup tests current when API socket behavior changes. |
 | Host path policy | Operator-owned with per-resource validation | Redact sensitive path details in errors, avoid opening paths during pre-boot storage unless the resource explicitly requires it, and test cleanup for owned resources. |
 | HVF entitlement and code signing | Implemented direct, App Sandbox, and production nested-worker validation paths | Keep real HVF tests in signed targets, inspect entitlement separation and nested signatures, and keep unsupported CI hosts on explicit compile/sign-only validation, not silent skips. |
@@ -500,7 +514,7 @@ Use the following boundaries when designing or reviewing macOS isolation work:
 | HVF entitlement and code signing | The production worker alone receives the Hypervisor entitlement; the outer launcher cannot enter HVF. Both code objects use Hardened Runtime and are separately inspectable. | Developer ID possession, team policy, launch constraints, and notarization still require deployment evidence. |
 | macOS App Sandbox | The production worker is sandboxed; the ordinary direct CLI and outer launcher are not. Container/sealed resources plus granted config, metadata, kernel, initrd, block, pmem, logger, metrics, serial, snapshot, API-socket, vsock-socket, and connect-only vhost-user-socket authority form the current contained mode. Lifecycle v5 binds vmnet policy to exact networkless or caller-approved vmnet signature profiles. | The real restricted-entitlement credential and connectivity evidence remain operator-owned gates; general dynamic delivery still requires explicit design. |
 | Launcher or resource broker | The production launcher validates fixed/live nested code, starts one closed-environment/default-close worker, authenticates lifecycle v5 credential/resource-limit/vmnet policy, applies worker-local limits before `Prepared`, owns cancellation/status, coordinates and enters the private namespace, atomically transfers a bounded typed startup batch, supports adopted file/directory/block-special consumers, offers signed daemon detach, and exposes separate fixed vsock, vhost-user, and retained-descriptor block-control facets. | Keep each private protocol fixed and redacted; separately challenge any broader dynamic broker and never infer hard revocation from closing a duplicate descriptor. |
-| Firecracker Linux jailer model | Direct port unsupported; exact fixed executable/current-user/rlimit/version/daemon outcomes implemented through the versioned macOS policy envelope; public credential syscalls measured only in the disabled bootstrap harness. | Keep product uid/gid pending target-owned runtime/resource/lifecycle continuation, and keep configurable chroot, seccomp, namespaces, cgroups, and parent-cgroup controls rejected until separately challenged macOS outcomes exist. |
+| Firecracker Linux jailer model | Direct port unsupported; exact fixed executable/current-user/rlimit/version/daemon outcomes implemented through the versioned macOS policy envelope; the disabled bootstrap harness reaches mapped/retained-root credential continuation and ordinary `Hello`/`Start`, then records App Sandbox denial at exact target-session creation. | Keep product uid/gid pending a separately challenged session-authority direction and dynamic grants/lifecycle/guest evidence; keep configurable chroot, seccomp, namespaces, cgroups, and parent-cgroup controls rejected until separately challenged macOS outcomes exist. |
 
 This document intentionally does not define a sandbox profile, broker protocol,
 privilege-dropping flow, or new public API. PRs that add host resource types
@@ -3472,12 +3486,27 @@ datagram-possession barrier. Stream `getpeereid` and `LOCAL_PEERCRED` retained
 their documented connection-time root snapshot; connected-datagram
 `LOCAL_PEERCRED` was unsupported; opaque `LOCAL_PEERTOKEN` changed for a real
 transition and remained unchanged for retained-root; live stream/datagram PIDs
-remained exact. Repeated and concurrent runs left no exact process, private
-root, workspace, or named-socket residue. This proves bootstrap syscalls and
-observation classes only, not target-owned runtime/resources, typed grants,
-lifecycle/API, daemon/crash behavior, guest/HVF after transition, public policy,
-or an implemented uid/gid disposition. The complete boundary, alternatives,
-exact cleanup rules, reproduction command, and future-OS nonclaim are in the checked
+remained exact.
+
+#1889 continued the same launcher and worker PIDs over those exact transports.
+One canonical nonce-bound `BBA1` acknowledgment closes the credential transcript
+and rejects buffered/replayed bytes before lifecycle reuse. Mapped ordinary and
+retained-root no-drop cases then completed ordinary `Hello`/`Start`, but the
+worker's exact `mkdirat` for a random session beneath the already-opened
+target-owned root returned permission denied under App Sandbox. The
+SDK-maximum unmapped case completed the acknowledgment but stopped earlier at
+live code-identity revalidation. Repeated and concurrent runs left no exact
+process, private root, root-owned workspace ancestry, target-owned fixture, or
+named-socket residue.
+
+The representative typed grant and later production lifecycle code are
+feature-isolated and statically checked, but the natural namespace denial means
+grant commitment/consumption, `Proceed`/`Starting`/terminal, API/guest,
+daemon/crash behavior, and post-transition HVF were not dynamically reached.
+A launcher-precreated session changes authority ordering and is a separately
+challenged follow-up, not an implicit fallback. The complete boundary,
+alternatives, exact cleanup rules, reproduction command, and future-OS nonclaim
+are in the checked
 [elevated bootstrap evidence](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
 
 The six rows remain audit outcomes until #1371 challenges the controlled result

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2098,8 +2098,8 @@ merged-main OID are checked and recorded by the pull-request workflow.
 
 ## Explicit Elevated Bootstrap Evidence
 
-The #1373 direct-worker, #1884 inherited-root, and #1885 no-chroot credential
-proofs are deliberately
+The #1373 direct-worker, #1884 inherited-root, #1885 no-chroot credential, and
+#1889 target-owned runtime-continuation proofs are deliberately
 separate from `scripts/run-integration-tests.sh`. Normal validation never
 invokes `sudo`, prompts for a password, or treats missing root/HVF support as a
 passing skip.
@@ -2113,11 +2113,12 @@ scripts/build-elevated-bootstrap-probe.sh \
 
 The build compiles normal launcher and worker artifacts first and verifies that
 the V2 probe status, worker activation, Ready, inherited-root, HVF, credential
-mode, credential phase, and restoration-step markers are absent. It then builds
-both ends with the same disabled-by-default feature, checks role-specific
-credential markers, adds a visible test-only resource marker, and uses the
-normal production packager, signature split, entitlements, Hardened Runtime,
-and inspections.
+and runtime modes, credential phases and restoration steps, `BBA1`
+acknowledgment, representative grant activation, and complete boundary
+vocabulary are absent. It then builds both ends with disabled-by-default
+evidence features, checks role-specific credential/runtime markers, adds three
+visible test-only resource markers, and uses the normal production packager,
+signature split, entitlements, Hardened Runtime, and inspections.
 
 On a capable Apple Silicon host, calculate the explicit numeric target before
 elevation and invoke the wrapper yourself:
@@ -2140,7 +2141,7 @@ input with `/dev/null`, so elevation input cannot flow into the launcher or
 signed worker.
 
 The inherited branch stages exactly the complete signed evidence bundle and
-current `/usr/lib/dyld` in a root-owned private root. A 20-entry private ledger
+current `/usr/lib/dyld` in a root-owned private root. A 22-entry private ledger
 binds every device/inode/owner/group/type/mode; preactivation negatives cover a
 writable, missing, symlinked, and inode-replaced loader, a missing nested
 worker, and an unexpected entry. The wrapper retains the #1373 direct denial,
@@ -2159,14 +2160,34 @@ group restoration. Ordinary and retained-root cases repeat, and two ordinary
 pairs run concurrently against distinct private roots. Final independent scans
 must find no launcher, worker, root, workspace, or named-socket residue.
 
+The runtime-continuation branch reuses the exact stream, grant datagram, and
+launcher/worker PIDs after the credential transcript. It requires one canonical
+nonce-bound `BBA1` acknowledgment, empty live transports, fresh parent and
+target/no-drop attestations, and ordinary lifecycle `Hello`/`Start`. Each case
+receives an already-opened exact target-owned root plus a separately ledgered
+workspace whose root-owned traversal-only ancestry contains the exact
+target-owned read-only, write-only, and create-children fixtures. Mapped and
+retained-root cases repeat three times, mapped cases run concurrently, and the
+high unmapped numeric case remains separate. Pre/post-acknowledgment fault cases
+prove the closed handoff; later fault hooks are expected to remain masked when a
+natural earlier boundary is observed. Runtime cleanup validates and removes only
+the exact owned root and workspace objects, followed by independent residue
+scans.
+
 It reports OS/SDK/architecture and only value-free terminal classes. The
 inherited result remains `worker-bootstrap` / `other`: in-root `posix_spawn`
 returned success but the worker exited before its earliest application record.
 The no-chroot credential result completed mapped ordinary, retained-root
-no-drop, and SDK-maximum unmapped transitions. Stream credentials remained
+no-drop, and SDK-maximum unmapped transitions. The mapped and retained-root
+runtime cases then completed acknowledgment plus ordinary `Hello`/`Start`, but
+App Sandbox denied exact target-owned session `mkdirat`; the high unmapped case
+stopped earlier at live code-identity revalidation. Grants, `Proceed`,
+`Starting`, terminal ownership, API/guest, daemon/crash, and post-transition HVF
+were therefore unreached or unmeasured. Stream credentials remained
 connection-time snapshots, datagram credentials were unsupported, opaque
 datagram tokens changed only for credential transitions, and live peer PIDs
-remained exact. Its supported conclusion and nonclaims are in the
+remained exact. The exact result line, supported conclusion, and nonclaims are
+in the
 [elevated bootstrap evidence
 contract](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
 

--- a/scripts/build-elevated-bootstrap-probe.sh
+++ b/scripts/build-elevated-bootstrap-probe.sh
@@ -88,6 +88,15 @@ credential_datagram="BBG1"
 credential_step="restore-groups"
 credential_launcher_artifact="bangbang-elevated-credential-launcher-v1-credential-drop-BBC1-BBG1-restore-groups"
 credential_worker_artifact="bangbang-elevated-credential-worker-v1-credential-drop-BBC1-BBG1-restore-groups"
+runtime_drop_mode="runtime-drop"
+runtime_retain_mode="runtime-retain-root"
+runtime_unmapped_mode="runtime-unmapped"
+runtime_status="status: elevated runtime"
+continuation_record="BBA1"
+grant_activation="--bangbang-internal-grant-probe-v1"
+grant_runtime_case="target-runtime"
+runtime_launcher_boundary_artifact="bangbang-elevated-runtime-launcher-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary"
+runtime_worker_boundary_artifact="bangbang-elevated-runtime-worker-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary"
 
 cargo build \
   -p bangbang \
@@ -115,6 +124,15 @@ probe_markers=(
   "$credential_step"
   "$credential_launcher_artifact"
   "$credential_worker_artifact"
+  "$runtime_drop_mode"
+  "$runtime_retain_mode"
+  "$runtime_unmapped_mode"
+  "$runtime_status"
+  "$continuation_record"
+  "$grant_activation"
+  "$grant_runtime_case"
+  "$runtime_launcher_boundary_artifact"
+  "$runtime_worker_boundary_artifact"
 )
 for artifact in "$launcher_bin" "$worker_bin"; do
   for marker_value in "${probe_markers[@]}"; do
@@ -132,7 +150,7 @@ cargo build \
   --bin bangbang-launcher \
   --release \
   --no-default-features \
-  --features elevated-bootstrap-probe \
+  --features bangbang/elevated-bootstrap-probe,bangbang/grant-integration-probe,bangbang-launcher/elevated-bootstrap-probe \
   --locked \
   --target "$target_triple"
 
@@ -156,6 +174,18 @@ for marker_value in \
   fi
 done
 for marker_value in \
+  "$runtime_drop_mode" \
+  "$runtime_retain_mode" \
+  "$runtime_unmapped_mode" \
+  "$runtime_status" \
+  "$continuation_record" \
+  "$runtime_launcher_boundary_artifact"; do
+  if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$launcher_bin"; then
+    echo "evidence launcher is missing the runtime continuation boundary" >&2
+    exit 1
+  fi
+done
+for marker_value in \
   "$ready_activation" \
   "$credential_drop_mode" \
   "$credential_record" \
@@ -164,6 +194,19 @@ for marker_value in \
   "$credential_worker_artifact"; do
   if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$worker_bin"; then
     echo "evidence artifact is missing the elevated probe boundary" >&2
+    exit 1
+  fi
+done
+for marker_value in \
+  "$runtime_drop_mode" \
+  "$runtime_retain_mode" \
+  "$runtime_unmapped_mode" \
+  "$continuation_record" \
+  "$grant_activation" \
+  "$grant_runtime_case" \
+  "$runtime_worker_boundary_artifact"; do
+  if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$worker_bin"; then
+    echo "evidence worker is missing the runtime continuation boundary" >&2
     exit 1
   fi
 done
@@ -176,11 +219,19 @@ cargo build \
 
 resources="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/bangbang-elevated-resources.XXXXXXXX")"
 marker="$resources/elevated-bootstrap-probe.enabled"
+grant_marker="$resources/grant-integration-probe.enabled"
+runtime_marker="$resources/target-runtime-grant-probe.enabled"
 cleanup_resources() {
   local prior_status=$?
   trap - EXIT
   if [[ -f "$marker" && ! -L "$marker" ]]; then
     /bin/unlink "$marker" || exit 1
+  fi
+  if [[ -f "$grant_marker" && ! -L "$grant_marker" ]]; then
+    /bin/unlink "$grant_marker" || exit 1
+  fi
+  if [[ -f "$runtime_marker" && ! -L "$runtime_marker" ]]; then
+    /bin/unlink "$runtime_marker" || exit 1
   fi
   if [[ -d "$resources" && ! -L "$resources" ]]; then
     /bin/rmdir "$resources" || exit 1
@@ -191,6 +242,10 @@ trap cleanup_resources EXIT
 
 /usr/bin/printf 'test-only\n' > "$marker"
 /bin/chmod 0600 "$marker"
+/usr/bin/printf 'test-only\n' > "$grant_marker"
+/bin/chmod 0600 "$grant_marker"
+/usr/bin/printf 'test-only\n' > "$runtime_marker"
+/bin/chmod 0600 "$runtime_marker"
 
 "$repo_root/target/release/bangbang-bundle" build \
   --launcher "$launcher_bin" \

--- a/scripts/run-elevated-bootstrap-probe.sh
+++ b/scripts/run-elevated-bootstrap-probe.sh
@@ -129,7 +129,9 @@ launcher="$bundle/Contents/MacOS/bangbang"
 worker_bundle="$bundle/Contents/Helpers/BangbangWorker.app"
 worker="$worker_bundle/Contents/MacOS/bangbang-worker"
 marker="$worker_bundle/Contents/Resources/elevated-bootstrap-probe.enabled"
-for entry in "$launcher" "$worker" "$marker"; do
+grant_marker="$worker_bundle/Contents/Resources/grant-integration-probe.enabled"
+runtime_marker="$worker_bundle/Contents/Resources/target-runtime-grant-probe.enabled"
+for entry in "$launcher" "$worker" "$marker" "$grant_marker" "$runtime_marker"; do
   if [[ ! -f "$entry" || -L "$entry" ]]; then
     echo "invalid evidence bundle" >&2
     exit 1
@@ -195,6 +197,36 @@ concurrent_root_a=""
 concurrent_root_a_identity=""
 concurrent_root_b=""
 concurrent_root_b_identity=""
+runtime_root=""
+runtime_root_identity=""
+runtime_retain_root=""
+runtime_retain_root_identity=""
+runtime_unmapped_root=""
+runtime_unmapped_root_identity=""
+runtime_concurrent_root_a=""
+runtime_concurrent_root_a_identity=""
+runtime_concurrent_root_b=""
+runtime_concurrent_root_b_identity=""
+runtime_workspace=""
+runtime_workspace_identity=""
+runtime_ledger=""
+runtime_ledger_identity=""
+runtime_retain_workspace=""
+runtime_retain_workspace_identity=""
+runtime_retain_ledger=""
+runtime_retain_ledger_identity=""
+runtime_unmapped_workspace=""
+runtime_unmapped_workspace_identity=""
+runtime_unmapped_ledger=""
+runtime_unmapped_ledger_identity=""
+runtime_concurrent_workspace_a=""
+runtime_concurrent_workspace_a_identity=""
+runtime_concurrent_ledger_a=""
+runtime_concurrent_ledger_a_identity=""
+runtime_concurrent_workspace_b=""
+runtime_concurrent_workspace_b_identity=""
+runtime_concurrent_ledger_b=""
+runtime_concurrent_ledger_b_identity=""
 workspace=""
 workspace_identity=""
 symlink_root=""
@@ -205,6 +237,7 @@ replacement_root=""
 replacement_root_identity=""
 replacement_candidate=""
 replacement_candidate_identity=""
+unmapped_runtime_result="unmeasured"
 cleanup_return=false
 
 bundle_directories=(
@@ -224,6 +257,8 @@ bundle_files=(
   "Contents/Helpers/BangbangWorker.app/Contents/_CodeSignature/CodeResources"
   "Contents/Helpers/BangbangWorker.app/Contents/MacOS/bangbang-worker"
   "Contents/Helpers/BangbangWorker.app/Contents/Resources/elevated-bootstrap-probe.enabled"
+  "Contents/Helpers/BangbangWorker.app/Contents/Resources/grant-integration-probe.enabled"
+  "Contents/Helpers/BangbangWorker.app/Contents/Resources/target-runtime-grant-probe.enabled"
   "Contents/Helpers/BangbangWorker.app/Contents/Info.plist"
   "Contents/Info.plist"
 )
@@ -245,6 +280,8 @@ is_staged_relative() {
       | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/MacOS/bangbang-worker" \
       | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/Resources" \
       | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/Resources/elevated-bootstrap-probe.enabled" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/Resources/grant-integration-probe.enabled" \
+      | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/Resources/target-runtime-grant-probe.enabled" \
       | "Bangbang.app/Contents/Helpers/BangbangWorker.app/Contents/Info.plist" \
       | "Bangbang.app/Contents/Info.plist" \
       | "usr" \
@@ -334,7 +371,9 @@ stage_inherited_root() {
         | "Contents/Helpers/BangbangWorker.app/Contents/MacOS/bangbang-worker")
         mode=0755
         ;;
-      "Contents/Helpers/BangbangWorker.app/Contents/Resources/elevated-bootstrap-probe.enabled")
+      "Contents/Helpers/BangbangWorker.app/Contents/Resources/elevated-bootstrap-probe.enabled" \
+        | "Contents/Helpers/BangbangWorker.app/Contents/Resources/grant-integration-probe.enabled" \
+        | "Contents/Helpers/BangbangWorker.app/Contents/Resources/target-runtime-grant-probe.enabled")
         mode=0600
         ;;
     esac
@@ -383,7 +422,7 @@ validate_staged_root() {
     seen="${seen}${relative}|"
     lines+=("$relative"$'\t'"$identity"$'\t'"$kind")
   done < "$ledger"
-  if [[ "${#lines[@]}" -ne 20 ]]; then
+  if [[ "${#lines[@]}" -ne 22 ]]; then
     return 1
   fi
 
@@ -410,7 +449,7 @@ validate_staged_root() {
 
   local count
   count="$(/usr/bin/find -x "$root" -mindepth 1 -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
-  if [[ "$count" != "20" ]] \
+  if [[ "$count" != "22" ]] \
     || ! validate_source_bundle_shape \
     || ! /usr/bin/cmp -s /usr/lib/dyld "$root/usr/lib/dyld" \
     || ! /usr/bin/codesign --verify --strict "$root/usr/lib/dyld" >/dev/null 2>&1 \
@@ -469,6 +508,212 @@ create_private_directory() {
   trap 'exit 130' INT
   trap 'exit 143' TERM
   trap 'exit 129' HUP
+}
+
+create_owned_directory() {
+  local pattern="$1"
+  local uid="$2"
+  local gid="$3"
+  local path_variable="$4"
+  local identity_variable="$5"
+  local path
+  trap '' INT TERM HUP
+  path="$(/usr/bin/mktemp -d "$pattern")"
+  /bin/chmod 0700 "$path"
+  /usr/sbin/chown "$uid:$gid" "$path"
+  printf -v "$path_variable" '%s' "$path"
+  printf -v "$identity_variable" '%s' "$(/usr/bin/stat -f '%d:%i' "$path")"
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  trap 'exit 129' HUP
+}
+
+is_runtime_relative() {
+  case "$1" in
+    read.input | write.output | authorized-directory | bangbang-grant-probe-outside \
+      | grant-manifest.json)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+record_runtime_entry() {
+  local root="$1"
+  local ledger="$2"
+  local relative="$3"
+  local kind="$4"
+  if ! is_runtime_relative "$relative"; then
+    return 1
+  fi
+  local identity
+  identity="$(/usr/bin/stat -f '%d:%i:%u:%g:%Lp' "$root/$relative")"
+  /usr/bin/printf '%s\t%s\t%s\n' "$relative" "$identity" "$kind" >> "$ledger"
+}
+
+create_runtime_workspace() {
+  local uid="$1"
+  local gid="$2"
+  local path_variable="$3"
+  local identity_variable="$4"
+  local ledger_variable="$5"
+  local ledger_identity_variable="$6"
+  local path
+  local ledger
+  create_private_directory \
+    "/private/tmp/bangbang-elevated-runtime.XXXXXXXX" \
+    "$path_variable" \
+    "$identity_variable"
+  path="${!path_variable}"
+  ledger="$workspace/${path_variable}-ledger"
+  /usr/bin/touch "$ledger"
+  /usr/sbin/chown 0:0 "$ledger"
+  /bin/chmod 0600 "$ledger"
+  printf -v "$ledger_variable" '%s' "$ledger"
+  printf -v "$ledger_identity_variable" '%s' "$(/usr/bin/stat -f '%d:%i' "$ledger")"
+
+  /usr/bin/printf 'bangbang-grant-read-target-runtime\n' > "$path/read.input"
+  /usr/bin/printf '%36s\n' '' | /usr/bin/tr ' ' '?' > "$path/write.output"
+  /bin/mkdir "$path/authorized-directory"
+  /usr/bin/printf 'outside-authority\n' > "$path/bangbang-grant-probe-outside"
+  /usr/bin/printf \
+    '{"version":1,"grants":[{"id":"probe-read-target-runtime","role":"kernel-image","access":"read-only","source":"%s"},{"id":"probe-write-target-runtime","role":"logger-sink","access":"write-only","source":"%s"},{"id":"probe-dir-target-runtime","role":"api-socket-directory","access":"create-children","source":"%s"}]}\n' \
+    "$path/read.input" \
+    "$path/write.output" \
+    "$path/authorized-directory" \
+    > "$path/grant-manifest.json"
+  /usr/sbin/chown "$uid:$gid" \
+    "$path/read.input" \
+    "$path/write.output" \
+    "$path/authorized-directory" \
+    "$path/bangbang-grant-probe-outside" \
+    "$path/grant-manifest.json"
+  /bin/chmod 0600 \
+    "$path/read.input" \
+    "$path/write.output" \
+    "$path/bangbang-grant-probe-outside" \
+    "$path/grant-manifest.json"
+  /bin/chmod 0700 "$path/authorized-directory"
+  record_runtime_entry "$path" "$ledger" read.input file
+  record_runtime_entry "$path" "$ledger" write.output file
+  record_runtime_entry "$path" "$ledger" authorized-directory directory
+  record_runtime_entry "$path" "$ledger" bangbang-grant-probe-outside file
+  record_runtime_entry "$path" "$ledger" grant-manifest.json file
+  # Publish only traversal through the complete, identity-ledgered fixture.
+  # The outer directory remains root-owned, so the target cannot rename or add
+  # fixed entries; authority comes solely from the exact target-owned children.
+  /bin/chmod 0711 "$path"
+}
+
+validate_runtime_workspace() {
+  local path="$1"
+  local identity="$2"
+  local ledger="$3"
+  local ledger_identity="$4"
+  local uid="$5"
+  local gid="$6"
+  if [[ -z "$path" || ! -d "$path" || -L "$path" \
+    || "$(/usr/bin/stat -f '%d:%i' "$path" 2>/dev/null || true)" != "$identity" \
+    || "$(/usr/bin/stat -f '%u:%g:%HT:%Lp' "$path" 2>/dev/null || true)" \
+      != "0:0:Directory:711" \
+    || ! -f "$ledger" || -L "$ledger" \
+    || "$(/usr/bin/stat -f '%d:%i:%u:%g:%HT:%Lp' "$ledger" 2>/dev/null || true)" \
+      != "$ledger_identity:0:0:Regular File:600" ]]; then
+    return 1
+  fi
+  local entries=0
+  local seen="|"
+  local relative
+  local entry_identity
+  local kind
+  local entry_path
+  while IFS=$'\t' read -r relative entry_identity kind; do
+    if ! is_runtime_relative "$relative" \
+      || [[ "$kind" != "file" && "$kind" != "directory" ]]; then
+      return 1
+    fi
+    case "$seen" in
+      *"|$relative|"*) return 1 ;;
+    esac
+    seen="${seen}${relative}|"
+    entry_path="$path/$relative"
+    if [[ -L "$entry_path" \
+      || "$(/usr/bin/stat -f '%d:%i:%u:%g:%Lp' "$entry_path" 2>/dev/null || true)" \
+        != "$entry_identity" ]]; then
+      return 1
+    fi
+    if [[ "$kind" == "file" && ! -f "$entry_path" ]] \
+      || [[ "$kind" == "directory" && ! -d "$entry_path" ]]; then
+      return 1
+    fi
+    entries="$((entries + 1))"
+  done < "$ledger"
+  if [[ "$entries" -ne 5 ]]; then
+    return 1
+  fi
+  local child="$path/authorized-directory/bangbang-grant-target-runtime.out"
+  local child_count=0
+  if [[ -e "$child" || -L "$child" ]]; then
+    if [[ ! -f "$child" || -L "$child" \
+      || "$(/usr/bin/stat -f '%u:%g:%Lp:%l' "$child" 2>/dev/null || true)" \
+        != "$uid:$gid:600:1" ]]; then
+      return 1
+    fi
+    child_count=1
+  fi
+  local count
+  count="$(/usr/bin/find -x "$path" -mindepth 1 -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+  [[ "$count" -eq "$((5 + child_count))" ]]
+}
+
+cleanup_owned_directory() {
+  local path="$1"
+  local identity="$2"
+  local uid="$3"
+  local gid="$4"
+  if [[ -z "$path" ]]; then
+    return 0
+  fi
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    return 0
+  fi
+  if [[ ! -d "$path" || -L "$path" \
+    || "$(/usr/bin/stat -f '%d:%i' "$path" 2>/dev/null || true)" != "$identity" \
+    || "$(/usr/bin/stat -f '%u:%g:%HT:%Lp' "$path" 2>/dev/null || true)" \
+      != "$uid:$gid:Directory:700" ]]; then
+    return 1
+  fi
+  /bin/rmdir "$path"
+}
+
+cleanup_runtime_workspace() {
+  local path="$1"
+  local identity="$2"
+  local ledger="$3"
+  local ledger_identity="$4"
+  local uid="$5"
+  local gid="$6"
+  if [[ -z "$path" ]]; then
+    return 0
+  fi
+  if ! validate_runtime_workspace \
+    "$path" "$identity" "$ledger" "$ledger_identity" "$uid" "$gid"; then
+    return 1
+  fi
+  local child="$path/authorized-directory/bangbang-grant-target-runtime.out"
+  if [[ -e "$child" ]]; then
+    /bin/unlink "$child" || return 1
+  fi
+  /bin/unlink "$path/read.input" || return 1
+  /bin/unlink "$path/write.output" || return 1
+  /bin/rmdir "$path/authorized-directory" || return 1
+  /bin/unlink "$path/bangbang-grant-probe-outside" || return 1
+  /bin/unlink "$path/grant-manifest.json" || return 1
+  /bin/unlink "$ledger" || return 1
+  /bin/chmod 0700 "$path" || return 1
+  cleanup_directory "$path" "$identity"
 }
 
 cleanup_directory() {
@@ -546,6 +791,8 @@ cleanup() {
       for output in \
         "$workspace/case-a" \
         "$workspace/case-b" \
+        "$workspace/runtime-case-a" \
+        "$workspace/runtime-case-b" \
         "$workspace/inherited-case-a" \
         "$workspace/inherited-case-b"; do
         if [[ -f "$output" && ! -L "$output" ]]; then
@@ -556,6 +803,46 @@ cleanup() {
       cleanup_status=1
     fi
   fi
+  cleanup_runtime_workspace \
+    "$runtime_workspace" \
+    "$runtime_workspace_identity" \
+    "$runtime_ledger" \
+    "$runtime_ledger_identity" \
+    "$target_uid" \
+    "$target_gid" \
+    || cleanup_status=1
+  cleanup_runtime_workspace \
+    "$runtime_retain_workspace" \
+    "$runtime_retain_workspace_identity" \
+    "$runtime_retain_ledger" \
+    "$runtime_retain_ledger_identity" \
+    0 \
+    0 \
+    || cleanup_status=1
+  cleanup_runtime_workspace \
+    "$runtime_unmapped_workspace" \
+    "$runtime_unmapped_workspace_identity" \
+    "$runtime_unmapped_ledger" \
+    "$runtime_unmapped_ledger_identity" \
+    2147483647 \
+    2147483647 \
+    || cleanup_status=1
+  cleanup_runtime_workspace \
+    "$runtime_concurrent_workspace_a" \
+    "$runtime_concurrent_workspace_a_identity" \
+    "$runtime_concurrent_ledger_a" \
+    "$runtime_concurrent_ledger_a_identity" \
+    "$target_uid" \
+    "$target_gid" \
+    || cleanup_status=1
+  cleanup_runtime_workspace \
+    "$runtime_concurrent_workspace_b" \
+    "$runtime_concurrent_workspace_b_identity" \
+    "$runtime_concurrent_ledger_b" \
+    "$runtime_concurrent_ledger_b_identity" \
+    "$target_uid" \
+    "$target_gid" \
+    || cleanup_status=1
   cleanup_staged_root \
     "$inherited_root" \
     "$inherited_root_identity" \
@@ -579,6 +866,27 @@ cleanup() {
   cleanup_directory "$replacement_candidate" "$replacement_candidate_identity" || cleanup_status=1
   cleanup_directory "$replacement_root" "$replacement_root_identity" || cleanup_status=1
   cleanup_directory "$probe_root" "$probe_root_identity" || cleanup_status=1
+  cleanup_owned_directory \
+    "$runtime_root" "$runtime_root_identity" "$target_uid" "$target_gid" \
+    || cleanup_status=1
+  cleanup_owned_directory \
+    "$runtime_retain_root" "$runtime_retain_root_identity" 0 0 \
+    || cleanup_status=1
+  cleanup_owned_directory \
+    "$runtime_unmapped_root" "$runtime_unmapped_root_identity" 2147483647 2147483647 \
+    || cleanup_status=1
+  cleanup_owned_directory \
+    "$runtime_concurrent_root_a" \
+    "$runtime_concurrent_root_a_identity" \
+    "$target_uid" \
+    "$target_gid" \
+    || cleanup_status=1
+  cleanup_owned_directory \
+    "$runtime_concurrent_root_b" \
+    "$runtime_concurrent_root_b_identity" \
+    "$target_uid" \
+    "$target_gid" \
+    || cleanup_status=1
   cleanup_directory "$workspace" "$workspace_identity" || cleanup_status=1
   if [[ "$cleanup_status" -ne 0 ]]; then
     echo "bangbang elevated bootstrap proof: exact cleanup failed" >&2
@@ -612,6 +920,242 @@ invoke() {
     --target-gid "$gid" \
     --mode "$mode" \
     --
+}
+
+invoke_runtime() {
+  local root="$1"
+  local uid="$2"
+  local gid="$3"
+  local mode="$4"
+  local runtime_workspace_path="$5"
+  local fault="${6:-}"
+  local elevated_args=(
+    --bangbang-internal-elevated-bootstrap-probe-v2
+    --root "$root"
+    --target-uid "$uid"
+    --target-gid "$gid"
+    --mode "$mode"
+  )
+  if [[ -n "$fault" ]]; then
+    elevated_args+=(--fault "$fault")
+  fi
+  /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
+    "$launcher" \
+    "${elevated_args[@]}" \
+    -- \
+    --bangbang-grant-manifest "$runtime_workspace_path/grant-manifest.json" \
+    -- \
+    --bangbang-internal-grant-probe-v1 target-runtime
+}
+
+validate_empty_runtime_root() {
+  local root="$1"
+  local identity="$2"
+  local uid="$3"
+  local gid="$4"
+  if [[ ! -d "$root" || -L "$root" \
+    || "$(/usr/bin/stat -f '%d:%i:%u:%g:%HT:%Lp' "$root" 2>/dev/null || true)" \
+      != "$identity:$uid:$gid:Directory:700" ]]; then
+    return 1
+  fi
+  local count
+  count="$(/usr/bin/find -x "$root" -mindepth 1 -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+  [[ "$count" -eq 0 ]]
+}
+
+assert_runtime_objects() {
+  local root="$1"
+  local root_identity="$2"
+  local runtime_workspace_path="$3"
+  local runtime_workspace_object="$4"
+  local ledger="$5"
+  local ledger_identity="$6"
+  local uid="$7"
+  local gid="$8"
+  local write_state="$9"
+  if ! validate_empty_runtime_root "$root" "$root_identity" "$uid" "$gid" \
+    || ! validate_runtime_workspace \
+      "$runtime_workspace_path" \
+      "$runtime_workspace_object" \
+      "$ledger" \
+      "$ledger_identity" \
+      "$uid" \
+      "$gid" \
+    || [[ "$(<"$runtime_workspace_path/read.input")" \
+      != "bangbang-grant-read-target-runtime" ]] \
+    || [[ "$(<"$runtime_workspace_path/bangbang-grant-probe-outside")" \
+      != "outside-authority" ]] \
+    || [[ -e "$runtime_workspace_path/authorized-directory/bangbang-grant-target-runtime.out" \
+      || -L "$runtime_workspace_path/authorized-directory/bangbang-grant-target-runtime.out" ]]; then
+    echo "bangbang elevated bootstrap proof: runtime object validation failed" >&2
+    exit 1
+  fi
+  local actual_write
+  actual_write="$(<"$runtime_workspace_path/write.output")"
+  case "$write_state" in
+    initial)
+      if [[ "$actual_write" != "????????????????????????????????????" ]]; then
+        echo "bangbang elevated bootstrap proof: runtime output changed before grant use" >&2
+        exit 1
+      fi
+      ;;
+    complete)
+      if [[ "$actual_write" != "bangbang-grant-write-target-runtime" ]]; then
+        echo "bangbang elevated bootstrap proof: runtime output was not committed" >&2
+        exit 1
+      fi
+      ;;
+    either)
+      if [[ "$actual_write" != "????????????????????????????????????" \
+        && "$actual_write" != "bangbang-grant-write-target-runtime" ]]; then
+        echo "bangbang elevated bootstrap proof: runtime output is invalid" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+assert_runtime_output_redacted() {
+  local output="$1"
+  local root="$2"
+  local runtime_workspace_path="$3"
+  local sensitive
+  for sensitive in \
+    "$root" \
+    "$runtime_workspace_path" \
+    probe-read-target-runtime \
+    probe-write-target-runtime \
+    probe-dir-target-runtime \
+    bangbang-grant-read-target-runtime \
+    bangbang-grant-write-target-runtime; do
+    if [[ "$output" == *"$sensitive"* ]]; then
+      echo "bangbang elevated bootstrap proof: runtime diagnostics leaked fixture data" >&2
+      exit 1
+    fi
+  done
+}
+
+output_has_exact_line() {
+  local output="$1"
+  local expected="$2"
+  [[ $'\n'"$output"$'\n' == *$'\n'"$expected"$'\n'* ]]
+}
+
+assert_runtime_case() {
+  local root="$1"
+  local root_identity="$2"
+  local runtime_workspace_path="$3"
+  local runtime_workspace_object="$4"
+  local ledger="$5"
+  local ledger_identity="$6"
+  local uid="$7"
+  local gid="$8"
+  local mode="$9"
+  local expected_status="${10}"
+  local expected_line="${11}"
+  local write_state="${12}"
+  local fault="${13:-}"
+  local output
+  local status
+  set +e
+  output="$(invoke_runtime \
+    "$root" \
+    "$uid" \
+    "$gid" \
+    "$mode" \
+    "$runtime_workspace_path" \
+    "$fault" \
+    2>&1)"
+  status=$?
+  set -e
+  assert_runtime_output_redacted "$output" "$root" "$runtime_workspace_path"
+  if [[ "$status" -ne "$expected_status" ]]; then
+    /usr/bin/printf \
+      'bangbang elevated bootstrap proof: runtime case failed mode=%s fault=%s status=%s\n' \
+      "$mode" "${fault:-none}" "$status" >&2
+    /usr/bin/printf '%s\n' "$output" >&2
+    local write_observation="invalid"
+    if [[ "$(<"$runtime_workspace_path/write.output")" \
+      == "????????????????????????????????????" ]]; then
+      write_observation="initial"
+    elif [[ "$(<"$runtime_workspace_path/write.output")" \
+      == "bangbang-grant-write-target-runtime" ]]; then
+      write_observation="complete"
+    fi
+    local child_observation="absent"
+    if [[ -e "$runtime_workspace_path/authorized-directory/bangbang-grant-target-runtime.out" \
+      || -L "$runtime_workspace_path/authorized-directory/bangbang-grant-target-runtime.out" ]]; then
+      child_observation="present"
+    fi
+    /usr/bin/printf \
+      'runtime-objects: write=%s child=%s\n' \
+      "$write_observation" "$child_observation" >&2
+    exit 1
+  fi
+  if [[ "$expected_status" -eq 0 ]]; then
+    if [[ "$output" != "$expected_line" ]]; then
+      /usr/bin/printf \
+        'bangbang elevated bootstrap proof: runtime success output mismatch mode=%s\n' \
+        "$mode" >&2
+      exit 1
+    fi
+  elif ! output_has_exact_line "$output" "$expected_line"; then
+    /usr/bin/printf \
+      'bangbang elevated bootstrap proof: runtime failure output mismatch mode=%s fault=%s\n' \
+      "$mode" "${fault:-none}" >&2
+    exit 1
+  fi
+  assert_runtime_objects \
+    "$root" \
+    "$root_identity" \
+    "$runtime_workspace_path" \
+    "$runtime_workspace_object" \
+    "$ledger" \
+    "$ledger_identity" \
+    "$uid" \
+    "$gid" \
+    "$write_state"
+}
+
+assert_unmapped_runtime_case() {
+  local expected_boundary="$1"
+  local output
+  local status
+  set +e
+  output="$(invoke_runtime \
+    "$runtime_unmapped_root" \
+    2147483647 \
+    2147483647 \
+    runtime-unmapped \
+    "$runtime_unmapped_workspace" \
+    2>&1)"
+  status=$?
+  set -e
+  assert_runtime_output_redacted \
+    "$output" "$runtime_unmapped_root" "$runtime_unmapped_workspace"
+  if [[ "$status" -eq 3 ]] \
+    && output_has_exact_line "$output" "$expected_boundary"; then
+    unmapped_runtime_result="identity-boundary"
+    assert_runtime_objects \
+      "$runtime_unmapped_root" \
+      "$runtime_unmapped_root_identity" \
+      "$runtime_unmapped_workspace" \
+      "$runtime_unmapped_workspace_identity" \
+      "$runtime_unmapped_ledger" \
+      "$runtime_unmapped_ledger_identity" \
+      2147483647 \
+      2147483647 \
+      initial
+    return 0
+  fi
+  /usr/bin/printf \
+    'bangbang elevated bootstrap proof: unmapped runtime result was not an allowed exact boundary status=%s\n' \
+    "$status" >&2
+  /usr/bin/printf '%s\n' "$output" >&2
+  exit 1
 }
 
 invoke_inherited() {
@@ -701,6 +1245,112 @@ for _ in 1 2 3; do
 done
 assert_case "$probe_root" 2147483647 2147483647 credential-unmapped 0 \
   "$expected_credential_unmapped"
+
+runtime_drop_semantics="stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed datagram-pid=exact"
+runtime_retain_semantics="stream-eid=stable-root stream-cred=stable-root stream-pid=exact datagram-cred=unsupported datagram-token=unchanged datagram-pid=exact"
+expected_runtime_drop_boundary="status: elevated runtime runtime-drop blocked stage=runtime-namespace error=permission-denied result=namespace-boundary $runtime_drop_semantics"
+expected_runtime_retain_boundary="status: elevated runtime runtime-retain-root blocked stage=runtime-namespace error=permission-denied result=namespace-boundary $runtime_retain_semantics"
+expected_runtime_unmapped_boundary="status: elevated runtime runtime-unmapped blocked stage=live-identity error=other result=identity-boundary $runtime_drop_semantics"
+
+create_owned_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  "$target_uid" "$target_gid" runtime_root runtime_root_identity
+create_runtime_workspace \
+  "$target_uid" \
+  "$target_gid" \
+  runtime_workspace \
+  runtime_workspace_identity \
+  runtime_ledger \
+  runtime_ledger_identity
+for _ in 1 2 3; do
+  assert_runtime_case \
+    "$runtime_root" \
+    "$runtime_root_identity" \
+    "$runtime_workspace" \
+    "$runtime_workspace_identity" \
+    "$runtime_ledger" \
+    "$runtime_ledger_identity" \
+    "$target_uid" \
+    "$target_gid" \
+    runtime-drop \
+    3 \
+    "$expected_runtime_drop_boundary" \
+    initial
+done
+
+create_owned_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  0 0 runtime_retain_root runtime_retain_root_identity
+create_runtime_workspace \
+  0 \
+  0 \
+  runtime_retain_workspace \
+  runtime_retain_workspace_identity \
+  runtime_retain_ledger \
+  runtime_retain_ledger_identity
+for _ in 1 2 3; do
+  assert_runtime_case \
+    "$runtime_retain_root" \
+    "$runtime_retain_root_identity" \
+    "$runtime_retain_workspace" \
+    "$runtime_retain_workspace_identity" \
+    "$runtime_retain_ledger" \
+    "$runtime_retain_ledger_identity" \
+    0 \
+    0 \
+    runtime-retain-root \
+    3 \
+    "$expected_runtime_retain_boundary" \
+    initial
+done
+
+for fault_case in \
+  "pre-ack:continuation-ack:continuation-boundary:initial" \
+  "post-ack:lifecycle-hello:lifecycle-boundary:initial" \
+  "namespace:runtime-namespace:namespace-boundary:initial"; do
+  IFS=: read -r fault stage result_class write_state <<< "$fault_case"
+  expected_fault="status: elevated runtime runtime-drop blocked stage=$stage error=other result=$result_class $runtime_drop_semantics"
+  assert_runtime_case \
+    "$runtime_root" \
+    "$runtime_root_identity" \
+    "$runtime_workspace" \
+    "$runtime_workspace_identity" \
+    "$runtime_ledger" \
+    "$runtime_ledger_identity" \
+    "$target_uid" \
+    "$target_gid" \
+    runtime-drop \
+    3 \
+    "$expected_fault" \
+    "$write_state" \
+    "$fault"
+done
+
+for fault in grant-transfer proceed terminal; do
+  assert_runtime_case \
+    "$runtime_root" \
+    "$runtime_root_identity" \
+    "$runtime_workspace" \
+    "$runtime_workspace_identity" \
+    "$runtime_ledger" \
+    "$runtime_ledger_identity" \
+    "$target_uid" \
+    "$target_gid" \
+    runtime-drop \
+    3 \
+    "$expected_runtime_drop_boundary" \
+    initial \
+    "$fault"
+done
+
+create_owned_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  2147483647 2147483647 runtime_unmapped_root runtime_unmapped_root_identity
+create_runtime_workspace \
+  2147483647 \
+  2147483647 \
+  runtime_unmapped_workspace \
+  runtime_unmapped_workspace_identity \
+  runtime_unmapped_ledger \
+  runtime_unmapped_ledger_identity
+assert_unmapped_runtime_case "$expected_runtime_unmapped_boundary"
 
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
   inherited_root inherited_root_identity
@@ -918,6 +1568,87 @@ fi
 /bin/unlink "$workspace/case-a"
 /bin/unlink "$workspace/case-b"
 
+create_owned_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  "$target_uid" \
+  "$target_gid" \
+  runtime_concurrent_root_a \
+  runtime_concurrent_root_a_identity
+create_owned_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
+  "$target_uid" \
+  "$target_gid" \
+  runtime_concurrent_root_b \
+  runtime_concurrent_root_b_identity
+create_runtime_workspace \
+  "$target_uid" \
+  "$target_gid" \
+  runtime_concurrent_workspace_a \
+  runtime_concurrent_workspace_a_identity \
+  runtime_concurrent_ledger_a \
+  runtime_concurrent_ledger_a_identity
+create_runtime_workspace \
+  "$target_uid" \
+  "$target_gid" \
+  runtime_concurrent_workspace_b \
+  runtime_concurrent_workspace_b_identity \
+  runtime_concurrent_ledger_b \
+  runtime_concurrent_ledger_b_identity
+set +e
+invoke_runtime \
+  "$runtime_concurrent_root_a" \
+  "$target_uid" \
+  "$target_gid" \
+  runtime-drop \
+  "$runtime_concurrent_workspace_a" \
+  > "$workspace/runtime-case-a" 2>&1 &
+runtime_pid_a=$!
+invoke_runtime \
+  "$runtime_concurrent_root_b" \
+  "$target_uid" \
+  "$target_gid" \
+  runtime-drop \
+  "$runtime_concurrent_workspace_b" \
+  > "$workspace/runtime-case-b" 2>&1 &
+runtime_pid_b=$!
+wait "$runtime_pid_a"
+runtime_status_a=$?
+wait "$runtime_pid_b"
+runtime_status_b=$?
+set -e
+runtime_output_a="$(<"$workspace/runtime-case-a")"
+runtime_output_b="$(<"$workspace/runtime-case-b")"
+assert_runtime_output_redacted \
+  "$runtime_output_a" "$runtime_concurrent_root_a" "$runtime_concurrent_workspace_a"
+assert_runtime_output_redacted \
+  "$runtime_output_b" "$runtime_concurrent_root_b" "$runtime_concurrent_workspace_b"
+if [[ "$runtime_status_a" -ne 3 || "$runtime_status_b" -ne 3 ]] \
+  || ! output_has_exact_line "$runtime_output_a" "$expected_runtime_drop_boundary" \
+  || ! output_has_exact_line "$runtime_output_b" "$expected_runtime_drop_boundary"; then
+  echo "bangbang elevated bootstrap proof: runtime concurrency case failed" >&2
+  exit 1
+fi
+assert_runtime_objects \
+  "$runtime_concurrent_root_a" \
+  "$runtime_concurrent_root_a_identity" \
+  "$runtime_concurrent_workspace_a" \
+  "$runtime_concurrent_workspace_a_identity" \
+  "$runtime_concurrent_ledger_a" \
+  "$runtime_concurrent_ledger_a_identity" \
+  "$target_uid" \
+  "$target_gid" \
+  initial
+assert_runtime_objects \
+  "$runtime_concurrent_root_b" \
+  "$runtime_concurrent_root_b_identity" \
+  "$runtime_concurrent_workspace_b" \
+  "$runtime_concurrent_workspace_b_identity" \
+  "$runtime_concurrent_ledger_b" \
+  "$runtime_concurrent_ledger_b_identity" \
+  "$target_uid" \
+  "$target_gid" \
+  initial
+/bin/unlink "$workspace/runtime-case-a"
+/bin/unlink "$workspace/runtime-case-b"
+
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
   inherited_root_a inherited_root_a_identity
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
@@ -972,6 +1703,16 @@ for path in \
   "$inherited_root_b" \
   "$concurrent_root_a" \
   "$concurrent_root_b" \
+  "$runtime_root" \
+  "$runtime_retain_root" \
+  "$runtime_unmapped_root" \
+  "$runtime_concurrent_root_a" \
+  "$runtime_concurrent_root_b" \
+  "$runtime_workspace" \
+  "$runtime_retain_workspace" \
+  "$runtime_unmapped_workspace" \
+  "$runtime_concurrent_workspace_a" \
+  "$runtime_concurrent_workspace_b" \
   "$replacement_root" \
   "$workspace"; do
   if [[ -d "$path" && ! -L "$path" ]]; then
@@ -985,17 +1726,21 @@ cleanup
 root_residue="$(/usr/bin/find /private/var/root -maxdepth 1 \
   \( -name 'bangbang-elevated-probe.*' -o -name 'bangbang-elevated-work.*' \) \
   -print 2>/dev/null | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+runtime_workspace_residue="$(/usr/bin/find /private/tmp -maxdepth 1 \
+  -name 'bangbang-elevated-runtime.*' \
+  -print 2>/dev/null | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
 launcher_residue="$({ /usr/bin/pgrep -x bangbang-launcher 2>/dev/null || true; } \
   | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
 worker_residue="$({ /usr/bin/pgrep -x bangbang 2>/dev/null || true; } \
   | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
 if [[ "$socket_residue" -ne 0 || "$root_residue" -ne 0 \
+  || "$runtime_workspace_residue" -ne 0 \
   || "$launcher_residue" -ne 0 || "$worker_residue" -ne 0 ]]; then
   echo "bangbang elevated bootstrap proof: final residue scan failed" >&2
   exit 1
 fi
 
-echo "result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete controls=complete cleanup=exact"
+echo "result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete runtime-mapped=namespace-boundary runtime-retained-root=namespace-boundary runtime-unmapped=$unmapped_runtime_result grants=unreached lifecycle=hello-start controls=complete cleanup=exact"
 echo "observations: stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed-or-unchanged datagram-pid=exact"
 echo "residue: roots=zero workspaces=zero sockets=zero launchers=zero workers=zero"
-echo "nonclaims: target-runtime=unmeasured target-resources=unmeasured grants=unmeasured lifecycle-api=unmeasured daemon-crash=unmeasured guest-hvf=unmeasured public-policy=unchanged uid-gid=nonterminal chroot=unresolved aggregate-jailer=nonterminal"
+echo "nonclaims: target-session=unreached grants=unreached proceed-starting-terminal=unreached api-no-api-real-guest=unmeasured daemon-crash=unmeasured post-drop-guest-hvf=unmeasured public-policy=unchanged chroot=unresolved aggregate-jailer=nonterminal"


### PR DESCRIPTION
## Summary

- continue the exact signed launcher and App Sandbox worker from the proven credential exchange into the ordinary lifecycle on the same PIDs, stream, and grant datagram
- add closed runtime-continuation modes, nonce/mode/role-bound acknowledgment, feature-only live identity witnesses, and descriptor-rooted session APIs that reuse the production locking/recovery/cleanup implementation
- compose the representative grant probe and extend the signed exact-root matrix, deterministic controls, cleanup ledger, compatibility evidence, and security/testing documentation

## Capable-host result

On macOS 26.5.2 / SDK 26.5 / arm64 with HVF supported, mapped and retained-root workers completed the credential continuation and ordinary `Hello` -> `Start` lifecycle, then reached the exact App Sandbox `mkdirat` namespace boundary. The maximum-unmapped worker completed the credential protocol and acknowledgment, then reached the live code-identity boundary. Repeats, concurrency, historical modes, fault controls, and replacement checks were stable with zero runtime-root, workspace, socket, launcher, or worker residue.

This is the result-gated outcome required by #1889. Target session creation and grants remain unreached; `Proceed`/`Starting`/terminal ownership, API/no-API real guests, post-drop guest HVF, and daemon/crash work remain unmeasured. A root-precreated session was not used as a hidden fallback and requires a fresh challenge on parent #1888.

## Scope exclusions

- no public uid/gid, CLI, API, lifecycle-version, capability-disposition, entitlement, or ordinary peer-verification change
- no privileged service/helper, public product policy, Linux chroot equivalence, or aggregate jailer completion claim
- no claim that the target consumed grants or ran a real guest after the measured namespace/identity boundaries

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `bash -n scripts/build-elevated-bootstrap-probe.sh scripts/run-elevated-bootstrap-probe.sh`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker /Users/liangyou/github/firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/build-elevated-bootstrap-probe.sh --output /private/tmp/bangbang-issue-1889-final.Syb6QOor/Bangbang.app`
- `codesign --verify --strict --verbose=2 /private/tmp/bangbang-issue-1889-final.Syb6QOor/Bangbang.app`
- `scripts/run-integration-tests.sh`
- exact-root `scripts/run-elevated-bootstrap-probe.sh` against the final signed bundle for target UID/GID 501/20

Closes #1889

Parent context: #1888
