### PR TITLE
test: prove post-drop launcher-created session authority

### DIFF
--- a/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
+++ b/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
@@ -1,8 +1,8 @@
 # Elevated macOS Bootstrap Evidence
 
 This contract records the #1373 direct-worker result, the #1884 inherited-root
-follow-up, the #1885 no-chroot credential-transition result, and the #1889
-target-owned runtime continuation result beneath #1371. Together they test
+follow-up, the #1885 no-chroot credential-transition result, and the #1889 / #1891
+target-owned runtime continuation results beneath #1371. Together they test
 public chroot orderings, numeric credential bootstrap, and same-process
 continuation into the ordinary production lifecycle against Bangbang's
 mandatory worker boundary. They do not add a public root mode, accept jailer
@@ -23,7 +23,7 @@ The evidence bundle keeps the production layout and identity split:
   grant consumer additionally requires `grant-integration-probe`. A normal
   `--no-default-features` build is checked for absence of launcher-owned worker
   activation, ready/status records, credential and runtime modes/phases/steps,
-  the `BBA1` continuation, grant activation, boundary vocabulary, and all
+  the `BBA1` continuation, `BBN1` session authority, grant activation, boundary vocabulary, and all
   evidence marker resources. The normal signed bundle dynamically rejects the
   historical, credential, runtime, and grant-probe internal argv.
 
@@ -32,8 +32,14 @@ uid/gid zero, accepts explicit numeric target uid/gid values, runs with a
 closed environment and fixed absolute tools, replaces inherited standard input
 with `/dev/null`, and refuses missing root or HVF support rather than skipping.
 Caller-provided elevation input therefore cannot be inherited by the launcher
-or worker. The wrapper creates only root-owned mode-0700 children beneath the
-fixed non-writable `/private/var/root` ancestry. The launcher walks that
+or worker.
+The wrapper is a manual capable-host certification artifact, not an ordinary
+PR or CI gate. CI builds and inspects the isolated bundle and verifies its
+fail-closed non-root boundary; deterministic tests cover the authority,
+session, fault, and recovery contracts without elevation.
+Historical roots remain root-owned mode-0700 children beneath the
+fixed non-writable `/private/var/root` ancestry; runtime-continuation roots are
+instead created with the exact selected target/no-drop ownership. The launcher walks that
 ancestry with no-follow directory descriptors, binds the leaf device and inode
 into a random nonce record, and transfers only the retained root descriptor as
 new filesystem authority, at fixed worker fd 8. The existing fixed production
@@ -72,16 +78,26 @@ The three runtime-continuation modes perform that same credential exchange but
 do not respawn either endpoint. The launcher sends one fixed, canonical,
 nonce-bound `BBA1` acknowledgment only after the credential transcript is
 complete and both the lifecycle stream and grant datagram are live and empty.
-The same launcher and worker PIDs then continue over those same transports. The
-worker reattests the exact parent and target/no-drop identity, emits ordinary
-lifecycle `Hello`, receives the ordinary `Start` policy, and attempts to create
-the random locked session beneath the already-opened exact target-owned root.
-If that succeeds, the unchanged production supervisor is prepared to validate
-the namespace, transfer and commit the representative read-only, write-only,
-and create-children grant batch, cross `Proceed`, validate terminal ownership,
-and perform exact recovery. Feature-only closed fault points cover pre/post
-acknowledgment and the later namespace/grant/lifecycle boundaries without
-changing normal bundle behavior.
+The same launcher and worker PIDs then continue over those same transports.
+After exact target/no-drop and live-worker reattestation, the permanently
+transitioned launcher generates the lifecycle session, creates its random
+mode-0700 child beneath the exact target-owned root, and opens three independent
+session descriptions. It sends one fixed canonical `BBN1` record plus exactly
+one transfer descriptor and consumes the sender alias. `BBN1` binds the
+bootstrap mode, nonce, target, root identity, nonzero lifecycle session, and
+session identity; all flags and reserved bytes are closed.
+
+The worker receives, validates, adopts, and exclusively locks that descriptor
+before it emits ordinary lifecycle `Hello`. The later `Start` must carry the
+same session before policy installation and descriptor-relative entry;
+`Prepared` must report the same inode, and the launcher must observe the live
+lock through a separately opened description before grants begin. The existing
+read-only, write-only, and create-children grant batch then commits atomically,
+the target performs the complete allowed/denied workload, and ordinary
+`Proceed`/`Starting`/terminal supervision and reap-before-cleanup complete.
+Feature-only closed fault points cover acknowledgment, session creation/open,
+authority send/receive/validation, lock, enter, `Prepared`, grant, proceed, and
+terminal boundaries without changing lifecycle v5 or normal bundle behavior.
 
 Each runtime case uses a mode-0700 root and a separate bounded workspace with a
 root-owned traversal-only ancestry and exact target-owned fixtures. A root-owned
@@ -97,8 +113,9 @@ groups are cleared, so the checked postcondition is `effective-only`, not a
 literal zero-length list. Real/effective ids must equal the target, and attempts
 to restore uid zero, gid zero, or a root group must all return permission denied
 before any later work. Retained-root performs no credential mutation and is
-reported as no-drop. The SDK-maximum unmapped numeric class is measured only at
-the syscall/postcondition boundary.
+reported as no-drop. The SDK-maximum unmapped numeric class uses no account or
+home lookup and is measured by the same numeric postconditions and runtime
+gates as the mapped class.
 
 Stream `getpeereid` and `LOCAL_PEERCRED`, live `LOCAL_PEERPID`, datagram
 `LOCAL_PEERCRED`, and opaque `LOCAL_PEERTOKEN` comparison remain separate
@@ -128,10 +145,10 @@ root authority. The complete matrix produced these results:
 | same fixed pair | uid/gid-zero retained-root, repeated three times | both endpoints retained exact root without claiming privilege separation |
 | same fixed pair | SDK-maximum unmapped numeric target | both endpoint syscalls, postconditions, and restoration denials completed independently of account-backed runtime feasibility |
 | two concurrent fixed credential pairs | distinct exact roots/workspaces | both ordinary-target transitions completed with byte-identical bounded results |
-| same fixed pair continued in place | mapped ordinary target, repeated three times | credential exchange and `BBA1` acknowledgment completed; ordinary `Hello`/`Start` completed; App Sandbox denied `mkdirat` for the target-owned session (`runtime-namespace` / `permission-denied` / `namespace-boundary`) |
-| same fixed pair continued in place | uid/gid-zero retained-root, repeated three times | no-drop credential exchange, acknowledgment, and ordinary `Hello`/`Start` completed; the same target-owned session creation was denied |
-| same fixed pair continued in place | SDK-maximum unmapped numeric target | credential exchange and acknowledgment completed; live code-identity revalidation stopped before lifecycle `Hello` (`live-identity` / `other` / `identity-boundary`) |
-| two concurrent runtime-continuation pairs | distinct exact roots and workspaces | both mapped-target pairs returned the same namespace boundary with byte-identical bounded result lines |
+| same fixed pair continued in place | mapped ordinary target, repeated three times | credential exchange and `BBA1` completed; the launcher created and published the target-owned session through `BBN1`; worker adoption, independent lock proof, exact grants, terminal lifecycle, and cleanup completed |
+| same fixed pair continued in place | uid/gid-zero retained-root, repeated three times | the identical authority/grant/lifecycle/cleanup path completed with explicit no-drop semantics |
+| same fixed pair continued in place | SDK-maximum unmapped numeric target, repeated three times | both live code/profile revalidations and the complete authority/grant/lifecycle/cleanup path completed without an account lookup or identity-check bypass |
+| two concurrent runtime-continuation pairs | distinct exact roots and workspaces | both mapped-target pairs completed with distinct sessions and byte-identical bounded result lines |
 
 Focused negative cases reject a group-writable root and a symlink root. The
 staged manifest also rejects a writable, missing, symlinked, or inode-replaced
@@ -155,13 +172,12 @@ result: the same exact unchrooted signed worker completed real HVF
 create/destroy in the same wrapper run. The inherited branch nevertheless
 never reached application entry, root attestation, the direct-chroot sandbox
 control, or HVF. The runtime continuation separately reached both signed
-application endpoints, completed the exact acknowledgment, and reached ordinary
-`Hello`/`Start` for mapped and retained-root modes. It then stopped at the exact
-target-owned session-directory creation call. The representative typed grants,
-`Prepared`/grant commitment, `Proceed`/`Starting`/terminal sequence, API, guest,
-daemon/crash recovery, and post-transition HVF therefore remained unreached or
-unmeasured. The high unmapped runtime case stopped earlier at live code-identity
-revalidation, so it makes no lifecycle claim.
+application endpoints, completed the exact acknowledgment, and reached the
+private pre-`Hello` `BBN1` adoption gate for all three runtime identity classes.
+Each class then completed exact `Start`/`Prepared` binding, representative typed
+grant commitment and consumption, `Proceed`/`Starting`/terminal ownership, and
+exact session recovery/cleanup. API/no-API real guests, daemon/crash
+convergence, and post-transition guest HVF remain unmeasured.
 
 After those results were established, the checked harness remained at the
 evidence boundary: it contains no credential-changing product path. If a
@@ -170,12 +186,12 @@ future platform permits the direct sandboxed `chroot`, that branch reports
 entry, it must pass exact root, sandbox-denial, and HVF checks before success.
 Either changed result forces fresh implementation research and Challenge. The
 harness leaves the normal peer verifier and public launch policy unchanged.
-Pre/post-acknowledgment fault cases reached their exact closed boundaries; the
-natural namespace denial masks grant-transfer, `Proceed`, and terminal fault
-points on this host, so those later hooks are only feature-isolation and unit/
-artifact validated here. A launcher-precreated session would change the
-authority ordering and remains a separately challenged follow-up rather than a
-hidden fallback in this result. #1885 and #1889 are evidence results; product
+All enabled runtime fault cases reached their exact closed boundary, including
+the launcher-create/open and authority-send paths, worker receive/validate/
+lock/enter/`Prepared` exits, and the grant/proceed/terminal paths. Exact object
+state and the final residue scan remained clean. #1891 is the separately
+challenged launcher-created-session authority result; it is not a hidden
+fallback in #1889. #1885, #1889, and #1891 are evidence results; product
 uid/gid behavior still requires the parent-selected continuation.
 
 ## Supported conclusion and nonclaims
@@ -208,15 +224,14 @@ The measured public credential primitives are available in the exact signed
 no-chroot process shape: mapped ordinary and SDK-maximum unmapped transitions
 both completed, while zero remained an explicit no-drop class. This is not yet
 a Firecracker uid/gid implementation. Same-process continuation is viable
-through exact acknowledgment and ordinary `Hello`/`Start` for mapped and
-retained-root identities, but the measured App Sandbox profile denies creation
-of a session beneath the target-owned root even when the process owns the
-validated descriptor and numeric identity. It therefore does not establish a
-target-owned session, grant commitment or consumption, lifecycle completion,
-API, daemon/crash cleanup, real guest/HVF work after transition, public policy,
-or aggregate jailer behavior. It also does not prove that a separately
-challenged launcher-precreated session, a larger fixed in-root Darwin dependency
-set, or a materially different security model cannot work; nor does it claim
+through exact acknowledgment, launcher-created session authority, worker
+adoption, the representative grant workload, and ordinary terminal cleanup for
+mapped, retained-root, and SDK-maximum unmapped numeric identities on the
+measured host. This establishes that narrow feature-only process/resource
+composition; it does not establish API/no-API real guests, daemon/crash
+convergence, real guest/HVF work after transition, public policy, or aggregate
+jailer behavior. It also does not prove that a larger fixed in-root Darwin
+dependency set or a materially different security model cannot work; nor does it claim
 Linux mount/PID/user namespace parity, notarized distribution, or behavior
 beyond the recorded OS/SDK. A changed platform result requires rerunning the
 wrapper and a fresh ID-by-ID Challenge.
@@ -230,24 +245,21 @@ scripts/build-elevated-bootstrap-probe.sh \
   --output /absolute/absent/path/Bangbang.app
 ```
 
-Capture target values before elevation, then explicitly run the root wrapper:
+Capture target values before elevation, then explicitly run the root wrapper
+through the native administrator authorization dialog (substitute the captured
+numeric values and absolute paths):
 
 ```sh
-target_uid="$(id -u)"
-target_gid="$(id -g)"
-sudo /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
-  /bin/bash "$PWD/scripts/run-elevated-bootstrap-probe.sh" \
-  --bundle /absolute/absent/path/Bangbang.app \
-  --target-uid "$target_uid" \
-  --target-gid "$target_gid"
+/usr/bin/osascript -e \
+  'do shell script "/bin/bash /absolute/repo/scripts/run-elevated-bootstrap-probe.sh --bundle /absolute/absent/path/Bangbang.app --target-uid 501 --target-gid 20" with administrator privileges'
 ```
 
 The required terminal summary remains value-free and includes credential and
 runtime results, observations, residue, and nonclaim classes:
 
 ```text
-result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete runtime-mapped=namespace-boundary runtime-retained-root=namespace-boundary runtime-unmapped=identity-boundary grants=unreached lifecycle=hello-start controls=complete cleanup=exact
+result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete runtime-mapped=complete runtime-retained-root=complete-no-drop runtime-unmapped=complete authority=consumed lock=independent grants=committed lifecycle=terminal controls=complete cleanup=exact
 observations: stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed-or-unchanged datagram-pid=exact
 residue: roots=zero workspaces=zero sockets=zero launchers=zero workers=zero
-nonclaims: target-session=unreached grants=unreached proceed-starting-terminal=unreached api-no-api-real-guest=unmeasured daemon-crash=unmeasured post-drop-guest-hvf=unmeasured public-policy=unchanged chroot=unresolved aggregate-jailer=nonterminal
+nonclaims: api-no-api-real-guest=unmeasured daemon-crash=unmeasured post-drop-guest-hvf=unmeasured public-policy=unchanged chroot=unresolved aggregate-jailer=nonterminal
 ```

--- a/crates/bangbang/src/contained_session.rs
+++ b/crates/bangbang/src/contained_session.rs
@@ -330,11 +330,9 @@ mod platform {
         GrantedFile, StagedGrantBatch,
     };
     use bangbang_session::macos::grant_transport::receive_grant;
-    #[cfg(feature = "elevated-bootstrap-probe")]
-    use bangbang_session::macos::runtime::RuntimeError;
     use bangbang_session::macos::runtime::{
-        SnapshotStagingKind, SnapshotStagingName, SnapshotStagingOwnershipRecord, WorkerNamespace,
-        WorkerSocketNamespace,
+        RuntimeError, SnapshotStagingKind, SnapshotStagingName, SnapshotStagingOwnershipRecord,
+        WorkerNamespace, WorkerSocketNamespace,
     };
     use bangbang_session::macos::vhost_user_broker::{
         VhostUserBrokerError, VhostUserBrokerMessage, receive_vhost_user_broker_message,
@@ -368,18 +366,16 @@ mod platform {
     pub(crate) enum ContainedBootstrapError {
         Session,
         #[cfg(feature = "elevated-bootstrap-probe")]
-        RuntimeNamespace(RuntimeError),
+        RuntimeWorker(bangbang_session::elevated_probe::RuntimeWorkerFailure),
     }
 
     #[cfg(feature = "elevated-bootstrap-probe")]
     impl ContainedBootstrapError {
-        pub(crate) const fn is_runtime_namespace_permission_denied(self) -> bool {
-            matches!(
-                self,
-                Self::RuntimeNamespace(RuntimeError::NamespaceCreate(
-                    io::ErrorKind::PermissionDenied
-                ))
-            )
+        pub(crate) fn runtime_worker_exit_code(self) -> Option<u8> {
+            match self {
+                Self::RuntimeWorker(failure) => Some(failure.exit_code()),
+                Self::Session => None,
+            }
         }
     }
 
@@ -396,6 +392,32 @@ mod platform {
     }
 
     impl std::error::Error for ContainedBootstrapError {}
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    fn runtime_worker_failure(
+        stage: bangbang_session::elevated_probe::ProbeStage,
+        category: bangbang_session::elevated_probe::ProbeErrorCategory,
+    ) -> ContainedBootstrapError {
+        bangbang_session::elevated_probe::RuntimeWorkerFailure::new(stage, category).map_or(
+            ContainedBootstrapError::Session,
+            ContainedBootstrapError::RuntimeWorker,
+        )
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum RuntimeBootstrapStage {
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        AuthorityValidate,
+        SessionEnter,
+        Prepared,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum RuntimeBootstrapCategory {
+        InvalidInput,
+        Other,
+        Namespace(RuntimeError),
+    }
 
     #[cfg(feature = "grant-integration-probe")]
     fn grant_delay_requested() -> bool {
@@ -3535,7 +3557,8 @@ mod platform {
         Ordinary,
         #[cfg(feature = "elevated-bootstrap-probe")]
         Elevated {
-            root: Option<bangbang_session::macos::runtime::ExplicitRuntimeRoot>,
+            namespace: Option<WorkerNamespace>,
+            expected_session: SessionId,
             bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
             parent: libc::pid_t,
         },
@@ -3586,7 +3609,25 @@ mod platform {
             }
         }
 
-        fn create_namespace(
+        fn validate_start_session(
+            &self,
+            _session: SessionId,
+        ) -> Result<(), ContainedBootstrapError> {
+            match self {
+                Self::Ordinary => Ok(()),
+                #[cfg(feature = "elevated-bootstrap-probe")]
+                Self::Elevated {
+                    expected_session, ..
+                } if *expected_session == _session => Ok(()),
+                #[cfg(feature = "elevated-bootstrap-probe")]
+                Self::Elevated { .. } => Err(self.runtime_failure(
+                    RuntimeBootstrapStage::AuthorityValidate,
+                    RuntimeBootstrapCategory::InvalidInput,
+                )),
+            }
+        }
+
+        fn take_namespace(
             &mut self,
             session: SessionId,
         ) -> Result<WorkerNamespace, ContainedBootstrapError> {
@@ -3596,20 +3637,53 @@ mod platform {
                 }
                 #[cfg(feature = "elevated-bootstrap-probe")]
                 Self::Elevated {
-                    root, bootstrap, ..
+                    namespace,
+                    bootstrap,
+                    ..
                 } => {
                     if bootstrap.fault()
                         == bangbang_session::elevated_probe::RuntimeFault::Namespace
                     {
                         return Err(ContainedBootstrapError::Session);
                     }
-                    WorkerNamespace::create_from_explicit_root(
-                        root.take().ok_or(ContainedBootstrapError::Session)?,
-                        session,
-                    )
-                    .map_err(ContainedBootstrapError::RuntimeNamespace)
+                    namespace.take().ok_or(ContainedBootstrapError::Session)
                 }
             }
+        }
+
+        fn runtime_failure(
+            &self,
+            stage: RuntimeBootstrapStage,
+            category: RuntimeBootstrapCategory,
+        ) -> ContainedBootstrapError {
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            if matches!(self, Self::Elevated { .. }) {
+                use bangbang_session::elevated_probe::{ProbeErrorCategory, ProbeStage};
+
+                let stage = match stage {
+                    #[cfg(feature = "elevated-bootstrap-probe")]
+                    RuntimeBootstrapStage::AuthorityValidate => {
+                        ProbeStage::RuntimeAuthorityValidate
+                    }
+                    RuntimeBootstrapStage::SessionEnter => ProbeStage::RuntimeSessionEnter,
+                    RuntimeBootstrapStage::Prepared => ProbeStage::LifecyclePrepared,
+                };
+                let category = match category {
+                    RuntimeBootstrapCategory::InvalidInput => ProbeErrorCategory::InvalidInput,
+                    RuntimeBootstrapCategory::Other => ProbeErrorCategory::Other,
+                    RuntimeBootstrapCategory::Namespace(
+                        RuntimeError::Filesystem(kind) | RuntimeError::NamespaceCreate(kind),
+                    ) => ProbeErrorCategory::from_io_kind(kind),
+                    RuntimeBootstrapCategory::Namespace(
+                        RuntimeError::InvalidRoot
+                        | RuntimeError::InvalidEntry
+                        | RuntimeError::Collision,
+                    ) => ProbeErrorCategory::InvalidInput,
+                };
+                return runtime_worker_failure(stage, category);
+            }
+            let _ = (stage, category);
+            ContainedBootstrapError::Session
         }
 
         #[cfg(feature = "elevated-bootstrap-probe")]
@@ -3735,7 +3809,8 @@ mod platform {
                     .map_err(|_| ContainedSessionError)?;
             }
             let source = BootstrapSource::Elevated {
-                root: Some(continuation.root),
+                namespace: Some(continuation.namespace),
+                expected_session: continuation.expected_session,
                 bootstrap: continuation.bootstrap,
                 parent: continuation.parent,
             };
@@ -3781,20 +3856,51 @@ mod platform {
                 Message::Start(policy) => policy,
                 _ => return Err(ContainedSessionError.into()),
             };
-            install_worker_policy(policy, parent)?;
             let session = lifecycle.session().ok_or(ContainedSessionError)?;
-            let namespace = source.create_namespace(session)?;
-            namespace.enter().map_err(|_| ContainedSessionError)?;
+            source.validate_start_session(session)?;
+            install_worker_policy(policy, parent)?;
+            let namespace = source.take_namespace(session)?;
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            if source.has_fault(bangbang_session::elevated_probe::RuntimeFault::SessionEnter) {
+                return Err(source.runtime_failure(
+                    RuntimeBootstrapStage::SessionEnter,
+                    RuntimeBootstrapCategory::Other,
+                ));
+            }
+            namespace.enter().map_err(|error| {
+                source.runtime_failure(
+                    RuntimeBootstrapStage::SessionEnter,
+                    RuntimeBootstrapCategory::Namespace(error),
+                )
+            })?;
             let identity = namespace.identity();
-            let socket_namespace = Rc::new(
-                namespace
-                    .socket_namespace()
-                    .map_err(|_| ContainedSessionError)?,
-            );
+            let socket_namespace = Rc::new(namespace.socket_namespace().map_err(|error| {
+                source.runtime_failure(
+                    RuntimeBootstrapStage::Prepared,
+                    RuntimeBootstrapCategory::Namespace(error),
+                )
+            })?);
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            if source.has_fault(bangbang_session::elevated_probe::RuntimeFault::Prepared) {
+                return Err(source.runtime_failure(
+                    RuntimeBootstrapStage::Prepared,
+                    RuntimeBootstrapCategory::Other,
+                ));
+            }
             let prepared = lifecycle
                 .prepared(identity.device, identity.inode)
-                .map_err(|_| ContainedSessionError)?;
-            write_frame(&mut stream, prepared)?;
+                .map_err(|_| {
+                    source.runtime_failure(
+                        RuntimeBootstrapStage::Prepared,
+                        RuntimeBootstrapCategory::InvalidInput,
+                    )
+                })?;
+            write_frame(&mut stream, prepared).map_err(|_| {
+                source.runtime_failure(
+                    RuntimeBootstrapStage::Prepared,
+                    RuntimeBootstrapCategory::Other,
+                )
+            })?;
 
             #[cfg(feature = "elevated-bootstrap-probe")]
             if source.has_fault(bangbang_session::elevated_probe::RuntimeFault::GrantTransfer) {
@@ -4552,26 +4658,24 @@ mod platform {
 
         #[cfg(feature = "elevated-bootstrap-probe")]
         #[test]
-        fn runtime_permission_boundary_is_exactly_namespace_creation() {
-            use bangbang_session::macos::runtime::RuntimeError;
+        fn runtime_worker_failure_preserves_the_closed_exit_mapping() {
+            use bangbang_session::elevated_probe::{
+                ProbeErrorCategory, ProbeStage, RuntimeWorkerFailure,
+            };
 
-            assert!(
-                super::ContainedBootstrapError::RuntimeNamespace(RuntimeError::NamespaceCreate(
-                    io::ErrorKind::PermissionDenied
-                ))
-                .is_runtime_namespace_permission_denied()
+            let failure = RuntimeWorkerFailure::new(
+                ProbeStage::RuntimeSessionEnter,
+                ProbeErrorCategory::PermissionDenied,
+            )
+            .expect("worker stage should be supported");
+            assert_eq!(
+                super::ContainedBootstrapError::RuntimeWorker(failure).runtime_worker_exit_code(),
+                Some(failure.exit_code())
             );
-            for error in [
-                super::ContainedBootstrapError::Session,
-                super::ContainedBootstrapError::RuntimeNamespace(RuntimeError::Filesystem(
-                    io::ErrorKind::PermissionDenied,
-                )),
-                super::ContainedBootstrapError::RuntimeNamespace(RuntimeError::NamespaceCreate(
-                    io::ErrorKind::Other,
-                )),
-            ] {
-                assert!(!error.is_runtime_namespace_permission_denied());
-            }
+            assert_eq!(
+                super::ContainedBootstrapError::Session.runtime_worker_exit_code(),
+                None
+            );
         }
 
         pub(crate) struct TestDirectory(PathBuf);

--- a/crates/bangbang/src/elevated_bootstrap_probe.rs
+++ b/crates/bangbang/src/elevated_bootstrap_probe.rs
@@ -15,17 +15,21 @@ use bangbang_session::elevated_probe::{
     CredentialFailureValue, CredentialGroupClass, CredentialIdentityClass, CredentialPrefix,
     CredentialRecord, CredentialRecordKind, CredentialRole, CredentialSelfState, CredentialStep,
     PeerObservation, ProbeBootstrap, ProbeErrorCategory, ProbeResult, ProbeStage, READY_RECORD,
-    RESULT_RECORD_BYTES, ROOT_FD, RuntimeFault, WORKER_ACTIVATION,
+    RESULT_RECORD_BYTES, ROOT_FD, RuntimeFault, RuntimeWorkerFailure, WORKER_ACTIVATION,
 };
 use bangbang_session::{GRANT_FD, ObjectIdentity, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD};
 
-use bangbang_session::macos::runtime::ExplicitRuntimeRoot;
+use bangbang_session::macos::grant_transport::GrantTransportError;
+use bangbang_session::macos::runtime::{
+    ExplicitRuntimeRoot, RuntimeError, ValidatedWorkerNamespace, WorkerNamespace,
+};
+use bangbang_session::macos::runtime_authority::receive_runtime_session_authority;
 
 const CREDENTIAL_TIMEOUT: Duration = Duration::from_secs(5);
 const CREDENTIAL_WORKER_ARTIFACT: &str =
     "bangbang-elevated-credential-worker-v1-credential-drop-BBC1-BBG1-restore-groups";
-const RUNTIME_WORKER_ARTIFACT: &str = "bangbang-elevated-runtime-worker-v1-runtime-drop-runtime-retain-root-runtime-unmapped-BBA1---bangbang-internal-grant-probe-v1-target-runtime";
-const RUNTIME_WORKER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-runtime-worker-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
+const RUNTIME_WORKER_ARTIFACT: &str = "bangbang-elevated-runtime-worker-v2-runtime-drop-runtime-retain-root-runtime-unmapped-BBA1-BBN1-adopted-session---bangbang-internal-grant-probe-v1-target-runtime";
+const RUNTIME_WORKER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-runtime-worker-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ProbeError {
@@ -45,7 +49,8 @@ pub(crate) enum ProbeEntry {
 pub(crate) struct RuntimeContinuation {
     pub(crate) stream: UnixStream,
     pub(crate) grants: UnixDatagram,
-    pub(crate) root: ExplicitRuntimeRoot,
+    pub(crate) namespace: WorkerNamespace,
+    pub(crate) expected_session: bangbang_session::SessionId,
     pub(crate) bootstrap: ProbeBootstrap,
     pub(crate) parent: libc::pid_t,
     worker_args: Option<Vec<OsString>>,
@@ -63,23 +68,7 @@ impl RuntimeContinuation {
     }
 
     pub(crate) fn verify_witness(&self) -> Result<(), ()> {
-        // SAFETY: `getppid` has no pointer or ownership contract.
-        let live_parent = unsafe { libc::getppid() };
-        if live_parent != self.parent
-            || bangbang_session::macos::verify_peer_pid(self.stream.as_raw_fd(), self.parent)
-                .is_err()
-            || bangbang_session::macos::verify_peer_pid(self.grants.as_raw_fd(), self.parent)
-                .is_err()
-            || bangbang_session::elevated_credential::attest_current_process(
-                self.bootstrap.mode(),
-                self.bootstrap.target_uid(),
-                self.bootstrap.target_gid(),
-            )
-            .is_err()
-        {
-            return Err(());
-        }
-        Ok(())
+        verify_runtime_witness(&self.stream, &self.grants, self.bootstrap, self.parent)
     }
 }
 
@@ -490,23 +479,99 @@ fn run_credential_pair(
         || grants.set_read_timeout(None).is_err()
         || grants.set_write_timeout(None).is_err()
         || !transport_is_empty(stream.as_raw_fd())
-        || !transport_is_empty(grants.as_raw_fd())
     {
         return terminal(ExitCode::FAILURE);
     }
     if bootstrap.fault() == RuntimeFault::PostAck {
         return terminal(ExitCode::FAILURE);
     }
+    if verify_runtime_witness(&stream, &grants, bootstrap, parent).is_err() {
+        return terminal_runtime_failure(
+            ProbeStage::RuntimeAuthorityReceive,
+            ProbeErrorCategory::PermissionDenied,
+        );
+    }
+    if grants.set_read_timeout(Some(CREDENTIAL_TIMEOUT)).is_err() {
+        return terminal_runtime_failure(
+            ProbeStage::RuntimeAuthorityReceive,
+            ProbeErrorCategory::Other,
+        );
+    }
+    let received = match receive_runtime_session_authority(&grants) {
+        Ok(received) => received,
+        Err(error) => {
+            return terminal_runtime_failure(
+                ProbeStage::RuntimeAuthorityReceive,
+                runtime_transport_category(error),
+            );
+        }
+    };
+    if bootstrap.fault() == RuntimeFault::AuthorityReceive {
+        return terminal_runtime_failure(
+            ProbeStage::RuntimeAuthorityReceive,
+            ProbeErrorCategory::Other,
+        );
+    }
+    if bootstrap.fault() == RuntimeFault::AuthorityValidate {
+        return terminal_runtime_failure(
+            ProbeStage::RuntimeAuthorityValidate,
+            ProbeErrorCategory::Other,
+        );
+    }
+    let authority = received.authority;
+    let expected_session = authority.session();
+    if !authority.matches_expected(bootstrap, expected_session, authority.session_identity()) {
+        return terminal_runtime_failure(
+            ProbeStage::RuntimeAuthorityValidate,
+            ProbeErrorCategory::InvalidInput,
+        );
+    }
+    let validated = match ValidatedWorkerNamespace::from_explicit_root(
+        root,
+        received.descriptor,
+        expected_session,
+        authority.session_identity(),
+    ) {
+        Ok(validated) => validated,
+        Err(error) => {
+            return terminal_runtime_failure(
+                ProbeStage::RuntimeAuthorityValidate,
+                runtime_namespace_category(error),
+            );
+        }
+    };
+    if bootstrap.fault() == RuntimeFault::SessionLock {
+        return terminal_runtime_failure(ProbeStage::RuntimeSessionLock, ProbeErrorCategory::Other);
+    }
+    let namespace = match validated.lock() {
+        Ok(namespace) => namespace,
+        Err(error) => {
+            return terminal_runtime_failure(
+                ProbeStage::RuntimeSessionLock,
+                runtime_namespace_category(error),
+            );
+        }
+    };
+    if grants.set_read_timeout(None).is_err() || !transport_is_empty(grants.as_raw_fd()) {
+        return terminal_runtime_failure(
+            ProbeStage::RuntimeAuthorityValidate,
+            ProbeErrorCategory::InvalidInput,
+        );
+    }
     let continuation = RuntimeContinuation {
         stream,
         grants,
-        root,
+        namespace,
+        expected_session,
         bootstrap,
         parent,
         worker_args: Some(worker_args),
     };
     if continuation.verify_witness().is_err() {
-        terminal(ExitCode::FAILURE)
+        terminal_runtime_failure(
+            ProbeStage::RuntimeAuthorityValidate,
+            ProbeErrorCategory::PermissionDenied,
+        )
     } else {
         ProbeEntry::Continue(continuation)
     }
@@ -514,6 +579,54 @@ fn run_credential_pair(
 
 const fn terminal(code: ExitCode) -> ProbeEntry {
     ProbeEntry::Terminal(code)
+}
+
+fn terminal_runtime_failure(stage: ProbeStage, category: ProbeErrorCategory) -> ProbeEntry {
+    let code = RuntimeWorkerFailure::new(stage, category).map_or(ExitCode::FAILURE, |failure| {
+        ExitCode::from(failure.exit_code())
+    });
+    terminal(code)
+}
+
+fn runtime_transport_category(error: GrantTransportError) -> ProbeErrorCategory {
+    match error {
+        GrantTransportError::Io(kind) => ProbeErrorCategory::from_io_kind(kind),
+        GrantTransportError::Invalid => ProbeErrorCategory::InvalidInput,
+    }
+}
+
+fn runtime_namespace_category(error: RuntimeError) -> ProbeErrorCategory {
+    match error {
+        RuntimeError::Filesystem(kind) | RuntimeError::NamespaceCreate(kind) => {
+            ProbeErrorCategory::from_io_kind(kind)
+        }
+        RuntimeError::InvalidRoot | RuntimeError::InvalidEntry | RuntimeError::Collision => {
+            ProbeErrorCategory::InvalidInput
+        }
+    }
+}
+
+fn verify_runtime_witness(
+    stream: &UnixStream,
+    grants: &UnixDatagram,
+    bootstrap: ProbeBootstrap,
+    parent: libc::pid_t,
+) -> Result<(), ()> {
+    // SAFETY: `getppid` has no pointer or ownership contract.
+    let live_parent = unsafe { libc::getppid() };
+    if live_parent != parent
+        || bangbang_session::macos::verify_peer_pid(stream.as_raw_fd(), parent).is_err()
+        || bangbang_session::macos::verify_peer_pid(grants.as_raw_fd(), parent).is_err()
+        || bangbang_session::elevated_credential::attest_current_process(
+            bootstrap.mode(),
+            bootstrap.target_uid(),
+            bootstrap.target_gid(),
+        )
+        .is_err()
+    {
+        return Err(());
+    }
+    Ok(())
 }
 
 fn take_credential_root(bootstrap: ProbeBootstrap) -> Result<Option<OwnedFd>, ProbeError> {

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -188,10 +188,8 @@ fn run_process_lifecycle(
         Ok(contained) => contained,
         Err(err) => {
             #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
-            if err.is_runtime_namespace_permission_denied() {
-                return ExitCode::from(
-                    bangbang_session::elevated_probe::RUNTIME_NAMESPACE_PERMISSION_EXIT_CODE,
-                );
+            if let Some(exit_code) = err.runtime_worker_exit_code() {
+                return ExitCode::from(exit_code);
             }
             eprintln!("bangbang: {err}");
             return ProcessExitCode::ProcessFailure.into_exit_code();

--- a/crates/launcher/src/macos/supervise.rs
+++ b/crates/launcher/src/macos/supervise.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 
 use bangbang_session::macos::grant_transport::{GrantTransportError, send_grant};
 #[cfg(feature = "elevated-bootstrap-probe")]
-use bangbang_session::macos::runtime::ExplicitRuntimeRoot;
+use bangbang_session::macos::runtime::LauncherSessionHandles;
 use bangbang_session::macos::runtime::{
     LauncherNamespace, NamespaceIdentity, RuntimeError, SnapshotStagingOwnershipRecord,
     SocketOwnershipRecord,
@@ -188,42 +188,30 @@ pub(crate) fn wait_session(
 }
 
 #[cfg(feature = "elevated-bootstrap-probe")]
-pub(crate) struct ExplicitSessionStart {
-    root: ExplicitRuntimeRoot,
+pub(crate) struct PreopenedSessionStart {
+    handles: LauncherSessionHandles,
     frame: Frame,
 }
 
 #[cfg(feature = "elevated-bootstrap-probe")]
-impl ExplicitSessionStart {
-    pub(crate) const fn new(root: ExplicitRuntimeRoot, frame: Frame) -> Self {
-        Self { root, frame }
+impl PreopenedSessionStart {
+    pub(crate) const fn new(handles: LauncherSessionHandles, frame: Frame) -> Self {
+        Self { handles, frame }
     }
 }
 
 #[cfg(feature = "elevated-bootstrap-probe")]
-pub(crate) fn wait_session_with_explicit_root(
+pub(crate) fn wait_session_with_preopened_namespace(
     worker: &mut OwnedWorker,
     session: &mut UnixStream,
     auxiliary: AuxiliaryChannels<'_>,
     lifecycle: LauncherLifecycle,
     wakeups: SignalWakeups,
     grants: &PreparedGrantBatch,
-    start: ExplicitSessionStart,
+    start: PreopenedSessionStart,
 ) -> Result<ExitStatus, LauncherError> {
-    let ExplicitSessionStart { root, frame } = start;
-    // Establish both independent namespace authorities before the worker can
-    // observe Start and publish a session. No failure after this point can
-    // strand a namespace solely because its recovery handle was unavailable.
-    let validation = root
-        .try_reopen(false)
-        .map_err(|_| LauncherError::RuntimeNamespace)?;
-    let recovery = root
-        .try_reopen(false)
-        .map_err(|_| LauncherError::RuntimeNamespace)?;
-    let mut roots = NamespaceRoots::Explicit {
-        validation: Some(validation),
-        recovery: Some(recovery),
-    };
+    let PreopenedSessionStart { handles, frame } = start;
+    let mut roots = NamespaceRoots::Preopened(handles);
     if let Err(error) = write_frame(session, frame) {
         terminate_session(worker, session, &auxiliary);
         roots
@@ -333,10 +321,7 @@ struct SessionOptions<'a> {
 enum NamespaceRoots {
     Ordinary,
     #[cfg(feature = "elevated-bootstrap-probe")]
-    Explicit {
-        validation: Option<ExplicitRuntimeRoot>,
-        recovery: Option<ExplicitRuntimeRoot>,
-    },
+    Preopened(LauncherSessionHandles),
 }
 
 impl NamespaceRoots {
@@ -348,11 +333,7 @@ impl NamespaceRoots {
         match self {
             Self::Ordinary => LauncherNamespace::validate(session, expected),
             #[cfg(feature = "elevated-bootstrap-probe")]
-            Self::Explicit { validation, .. } => LauncherNamespace::validate_from_explicit_root(
-                validation.take().ok_or(RuntimeError::InvalidRoot)?,
-                session,
-                expected,
-            ),
+            Self::Preopened(handles) => handles.validate_live(session, expected),
         }
     }
 
@@ -363,12 +344,7 @@ impl NamespaceRoots {
         match self {
             Self::Ordinary => LauncherNamespace::recover_after_worker_exit(session),
             #[cfg(feature = "elevated-bootstrap-probe")]
-            Self::Explicit { recovery, .. } => {
-                LauncherNamespace::recover_after_worker_exit_from_explicit_root(
-                    recovery.take().ok_or(RuntimeError::InvalidRoot)?,
-                    session,
-                )
-            }
+            Self::Preopened(handles) => handles.recover_after_worker_exit(session),
         }
     }
 }

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -870,15 +870,18 @@ fn continue_runtime_session(
     bootstrap: bangbang_session::elevated_probe::ProbeBootstrap,
     semantics: CredentialSemantics,
 ) -> Result<LauncherExit, LauncherError> {
-    const RUNTIME_LAUNCHER_ARTIFACT: &str = "bangbang-elevated-runtime-launcher-v1-runtime-drop-runtime-retain-root-runtime-unmapped-status: elevated runtime-BBA1";
-    const RUNTIME_LAUNCHER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-runtime-launcher-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
+    const RUNTIME_LAUNCHER_ARTIFACT: &str = "bangbang-elevated-runtime-launcher-v2-runtime-drop-runtime-retain-root-runtime-unmapped-status: elevated runtime-BBA1-BBN1-launcher-created-session";
+    const RUNTIME_LAUNCHER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-runtime-launcher-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
 
     use std::io::Write;
     use std::os::fd::AsRawFd;
 
     use bangbang_session::elevated_probe::{
-        ContinuationAck, ProbeErrorCategory, ProbeStage, RuntimeFault,
+        ContinuationAck, ProbeErrorCategory, ProbeStage, RuntimeFault, RuntimeSessionAuthority,
+        RuntimeWorkerFailure,
     };
+    use bangbang_session::macos::runtime::{PreparedLauncherSession, RuntimeError};
+    use bangbang_session::macos::runtime_authority::send_runtime_session_authority;
     use bangbang_session::{LauncherLifecycle, SessionId};
 
     std::hint::black_box(RUNTIME_LAUNCHER_ARTIFACT);
@@ -935,9 +938,106 @@ fn continue_runtime_session(
     };
     let session_id = SessionId::generate().map_err(|_| LauncherError::SessionProtocol)?;
     let mut lifecycle = LauncherLifecycle::new(session_id);
+    if bootstrap.fault() == RuntimeFault::SessionCreate {
+        spawned.worker.terminate_and_reap();
+        return blocked(ProbeStage::RuntimeSessionCreate, ProbeErrorCategory::Other);
+    }
+    let prepared = match PreparedLauncherSession::create(runtime.root, session_id) {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            let stage = match error {
+                RuntimeError::NamespaceCreate(_) | RuntimeError::Collision => {
+                    ProbeStage::RuntimeSessionCreate
+                }
+                RuntimeError::Filesystem(_)
+                | RuntimeError::InvalidRoot
+                | RuntimeError::InvalidEntry => ProbeStage::RuntimeSessionOpen,
+            };
+            return blocked(stage, runtime_namespace_error_category(error));
+        }
+    };
+    if bootstrap.fault() == RuntimeFault::SessionOpen {
+        if prepared.cleanup_unpublished().is_err() {
+            spawned.worker.terminate_and_reap();
+            return blocked(ProbeStage::RuntimeCleanup, ProbeErrorCategory::Other);
+        }
+        spawned.worker.terminate_and_reap();
+        return blocked(ProbeStage::RuntimeSessionOpen, ProbeErrorCategory::Other);
+    }
+    let authority = match RuntimeSessionAuthority::launcher(
+        bootstrap.mode(),
+        bootstrap.target_uid(),
+        bootstrap.target_gid(),
+        bootstrap.root(),
+        prepared.identity().object_identity(),
+        bootstrap.nonce(),
+        session_id,
+    ) {
+        Ok(authority) => authority,
+        Err(_) => {
+            if prepared.cleanup_unpublished().is_err() {
+                spawned.worker.terminate_and_reap();
+                return blocked(ProbeStage::RuntimeCleanup, ProbeErrorCategory::Other);
+            }
+            spawned.worker.terminate_and_reap();
+            return blocked(
+                ProbeStage::RuntimeAuthoritySend,
+                ProbeErrorCategory::InvalidInput,
+            );
+        }
+    };
+    if bootstrap.fault() == RuntimeFault::AuthoritySend {
+        if prepared.cleanup_unpublished().is_err() {
+            spawned.worker.terminate_and_reap();
+            return blocked(ProbeStage::RuntimeCleanup, ProbeErrorCategory::Other);
+        }
+        spawned.worker.terminate_and_reap();
+        return blocked(ProbeStage::RuntimeAuthoritySend, ProbeErrorCategory::Other);
+    }
+    let (transfer, handles) = prepared.into_publication();
+    if let Err(error) = send_runtime_session_authority(&spawned.grants, authority, transfer) {
+        if finish_published_runtime_session(&mut spawned, handles).is_err() {
+            return blocked(ProbeStage::RuntimeCleanup, ProbeErrorCategory::Other);
+        }
+        return blocked(
+            ProbeStage::RuntimeAuthoritySend,
+            runtime_transport_error_category(error),
+        );
+    }
+    let mut handles = Some(handles);
     if crate::macos::supervise::read_bootstrap_hello(&mut spawned.session, &mut lifecycle).is_err()
     {
-        return blocked(ProbeStage::LifecycleHello, ProbeErrorCategory::Other);
+        let outcome = finish_published_runtime_session(
+            &mut spawned,
+            handles.take().ok_or(LauncherError::RuntimeNamespace)?,
+        );
+        return match outcome {
+            Ok(Some(failure)) => blocked(failure.stage(), failure.category()),
+            Ok(None) => {
+                let stage = match bootstrap.fault() {
+                    RuntimeFault::AuthorityReceive => ProbeStage::RuntimeAuthorityReceive,
+                    RuntimeFault::AuthorityValidate => ProbeStage::RuntimeAuthorityValidate,
+                    RuntimeFault::SessionLock => ProbeStage::RuntimeSessionLock,
+                    _ => ProbeStage::LifecycleHello,
+                };
+                blocked(stage, ProbeErrorCategory::Other)
+            }
+            Err(_) => blocked(ProbeStage::RuntimeCleanup, ProbeErrorCategory::Other),
+        };
+    }
+    if !runtime_transport_is_empty(spawned.grants.as_raw_fd()) {
+        if finish_published_runtime_session(
+            &mut spawned,
+            handles.take().ok_or(LauncherError::RuntimeNamespace)?,
+        )
+        .is_err()
+        {
+            return blocked(ProbeStage::RuntimeCleanup, ProbeErrorCategory::Other);
+        }
+        return blocked(
+            ProbeStage::RuntimeAuthorityValidate,
+            ProbeErrorCategory::InvalidInput,
+        );
     }
     if bangbang_session::macos::verify_peer_pid(spawned.session.as_raw_fd(), spawned.worker.pid())
         .is_err()
@@ -948,18 +1048,45 @@ fn continue_runtime_session(
         )
         .is_err()
     {
+        if finish_published_runtime_session(
+            &mut spawned,
+            handles.take().ok_or(LauncherError::RuntimeNamespace)?,
+        )
+        .is_err()
+        {
+            return blocked(ProbeStage::RuntimeCleanup, ProbeErrorCategory::Other);
+        }
         return blocked(
             ProbeStage::LiveIdentity,
             ProbeErrorCategory::PermissionDenied,
         );
     }
     if let Err(category) = validate_runtime_worker(spawned.worker.pid(), &launch.worker_profile) {
+        if finish_published_runtime_session(
+            &mut spawned,
+            handles.take().ok_or(LauncherError::RuntimeNamespace)?,
+        )
+        .is_err()
+        {
+            return blocked(ProbeStage::RuntimeCleanup, ProbeErrorCategory::Other);
+        }
         return blocked(ProbeStage::LiveIdentity, category);
     }
-    let start = lifecycle
-        .start(launch.worker_policy)
-        .map_err(|_| LauncherError::SessionProtocol)?;
-    let status = match crate::macos::supervise::wait_session_with_explicit_root(
+    let start = match lifecycle.start(launch.worker_policy) {
+        Ok(start) => start,
+        Err(_) => {
+            if finish_published_runtime_session(
+                &mut spawned,
+                handles.take().ok_or(LauncherError::RuntimeNamespace)?,
+            )
+            .is_err()
+            {
+                return blocked(ProbeStage::RuntimeCleanup, ProbeErrorCategory::Other);
+            }
+            return blocked(ProbeStage::LifecycleHello, ProbeErrorCategory::InvalidInput);
+        }
+    };
+    let status = match crate::macos::supervise::wait_session_with_preopened_namespace(
         &mut spawned.worker,
         &mut spawned.session,
         crate::macos::supervise::AuxiliaryChannels::new(
@@ -971,7 +1098,10 @@ fn continue_runtime_session(
         lifecycle,
         wakeups,
         &launch.grants,
-        crate::macos::supervise::ExplicitSessionStart::new(runtime.root, start),
+        crate::macos::supervise::PreopenedSessionStart::new(
+            handles.take().ok_or(LauncherError::RuntimeNamespace)?,
+            start,
+        ),
     ) {
         Ok(status) => status,
         Err(error) => {
@@ -980,6 +1110,14 @@ fn continue_runtime_session(
                 RuntimeFault::GrantTransfer => ProbeStage::GrantTransfer,
                 RuntimeFault::Proceed => ProbeStage::LifecycleProceed,
                 RuntimeFault::Terminal => ProbeStage::LifecycleTerminal,
+                RuntimeFault::SessionEnter => ProbeStage::RuntimeSessionEnter,
+                RuntimeFault::Prepared => ProbeStage::LifecyclePrepared,
+                RuntimeFault::SessionCreate => ProbeStage::RuntimeSessionCreate,
+                RuntimeFault::SessionOpen => ProbeStage::RuntimeSessionOpen,
+                RuntimeFault::AuthoritySend => ProbeStage::RuntimeAuthoritySend,
+                RuntimeFault::AuthorityReceive => ProbeStage::RuntimeAuthorityReceive,
+                RuntimeFault::AuthorityValidate => ProbeStage::RuntimeAuthorityValidate,
+                RuntimeFault::SessionLock => ProbeStage::RuntimeSessionLock,
                 RuntimeFault::None | RuntimeFault::PreAck | RuntimeFault::PostAck => match error {
                     LauncherError::RuntimeNamespace => ProbeStage::RuntimeNamespace,
                     LauncherError::GrantProtocol | LauncherError::GrantPreparation => {
@@ -992,6 +1130,9 @@ fn continue_runtime_session(
         }
     };
     let exit = map_exit_status(status)?;
+    if let Ok(failure) = RuntimeWorkerFailure::from_exit_code(exit.code()) {
+        return blocked(failure.stage(), failure.category());
+    }
     if exit.code() == bangbang_session::elevated_probe::RUNTIME_NAMESPACE_PERMISSION_EXIT_CODE {
         return blocked(
             ProbeStage::RuntimeNamespace,
@@ -1004,6 +1145,14 @@ fn continue_runtime_session(
             RuntimeFault::GrantTransfer => ProbeStage::GrantTransfer,
             RuntimeFault::Proceed => ProbeStage::LifecycleProceed,
             RuntimeFault::Terminal => ProbeStage::LifecycleTerminal,
+            RuntimeFault::SessionCreate => ProbeStage::RuntimeSessionCreate,
+            RuntimeFault::SessionOpen => ProbeStage::RuntimeSessionOpen,
+            RuntimeFault::AuthoritySend => ProbeStage::RuntimeAuthoritySend,
+            RuntimeFault::AuthorityReceive => ProbeStage::RuntimeAuthorityReceive,
+            RuntimeFault::AuthorityValidate => ProbeStage::RuntimeAuthorityValidate,
+            RuntimeFault::SessionLock => ProbeStage::RuntimeSessionLock,
+            RuntimeFault::SessionEnter => ProbeStage::RuntimeSessionEnter,
+            RuntimeFault::Prepared => ProbeStage::LifecyclePrepared,
             RuntimeFault::None | RuntimeFault::PreAck | RuntimeFault::PostAck => {
                 ProbeStage::LifecycleTerminal
             }
@@ -1011,7 +1160,7 @@ fn continue_runtime_session(
         return blocked(stage, ProbeErrorCategory::Other);
     }
     println!(
-        "status: elevated runtime {} complete result={} stream-eid={} stream-cred={} stream-pid=exact datagram-cred={} datagram-token={} datagram-pid={} namespace=target-owned grants=committed lifecycle=terminal cleanup=complete",
+        "status: elevated runtime {} complete result={} stream-eid={} stream-cred={} stream-pid=exact datagram-cred={} datagram-token={} datagram-pid={} namespace=launcher-created-target-owned authority=consumed lock=independent grants=committed lifecycle=terminal cleanup=complete",
         bootstrap.mode().name(),
         bangbang_session::elevated_probe::RuntimeResultClass::Complete.name(),
         semantics.stream_eid,
@@ -1021,6 +1170,86 @@ fn continue_runtime_session(
         semantics.datagram_pid
     );
     Ok(exit)
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn finish_published_runtime_session(
+    spawned: &mut crate::macos::spawn::SuspendedWorker,
+    mut handles: bangbang_session::macos::runtime::LauncherSessionHandles,
+) -> Result<Option<bangbang_session::elevated_probe::RuntimeWorkerFailure>, LauncherError> {
+    let status = match spawned.worker.try_wait()? {
+        Some(status) => status,
+        None => {
+            spawned
+                .worker
+                .signal(libc::SIGKILL)
+                .map_err(LauncherError::SignalForward)?;
+            spawned.worker.wait()?
+        }
+    };
+    let session = handles.session();
+    if let Some(mut namespace) = handles
+        .recover_after_worker_exit(session)
+        .map_err(|_| LauncherError::RuntimeNamespace)?
+    {
+        namespace
+            .cleanup()
+            .map_err(|_| LauncherError::RuntimeNamespace)?;
+    }
+    let exit = map_exit_status(status)?;
+    Ok(bangbang_session::elevated_probe::RuntimeWorkerFailure::from_exit_code(exit.code()).ok())
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+const fn runtime_namespace_error_category(
+    error: bangbang_session::macos::runtime::RuntimeError,
+) -> bangbang_session::elevated_probe::ProbeErrorCategory {
+    use bangbang_session::elevated_probe::ProbeErrorCategory;
+    use bangbang_session::macos::runtime::RuntimeError;
+
+    match error {
+        RuntimeError::Filesystem(kind) | RuntimeError::NamespaceCreate(kind) => {
+            ProbeErrorCategory::from_io_kind(kind)
+        }
+        RuntimeError::InvalidRoot | RuntimeError::InvalidEntry | RuntimeError::Collision => {
+            ProbeErrorCategory::InvalidInput
+        }
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+const fn runtime_transport_error_category(
+    error: bangbang_session::macos::grant_transport::GrantTransportError,
+) -> bangbang_session::elevated_probe::ProbeErrorCategory {
+    use bangbang_session::elevated_probe::ProbeErrorCategory;
+    use bangbang_session::macos::grant_transport::GrantTransportError;
+
+    match error {
+        GrantTransportError::Io(kind) => ProbeErrorCategory::from_io_kind(kind),
+        GrantTransportError::Invalid => ProbeErrorCategory::InvalidInput,
+    }
+}
+
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+fn runtime_transport_is_empty(fd: libc::c_int) -> bool {
+    let mut byte = 0_u8;
+    // SAFETY: `byte` is writable for one non-consuming byte probe and `fd` is
+    // the live connected evidence datagram endpoint.
+    let result = unsafe {
+        libc::recv(
+            fd,
+            (&raw mut byte).cast(),
+            1,
+            libc::MSG_PEEK | libc::MSG_DONTWAIT,
+        )
+    };
+    if result < 0 {
+        let error = std::io::Error::last_os_error();
+        return error
+            .raw_os_error()
+            .is_some_and(|code| code == libc::EAGAIN || code == libc::EWOULDBLOCK);
+    }
+    false
 }
 
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
@@ -1296,7 +1525,15 @@ fn elevated_runtime_blocked(
 
     let result = match stage {
         ProbeStage::ContinuationAck => RuntimeResultClass::ContinuationBoundary,
-        ProbeStage::RuntimeNamespace => RuntimeResultClass::NamespaceBoundary,
+        ProbeStage::RuntimeNamespace
+        | ProbeStage::RuntimeSessionCreate
+        | ProbeStage::RuntimeSessionOpen
+        | ProbeStage::RuntimeAuthoritySend
+        | ProbeStage::RuntimeAuthorityReceive
+        | ProbeStage::RuntimeAuthorityValidate
+        | ProbeStage::RuntimeSessionLock
+        | ProbeStage::RuntimeSessionEnter
+        | ProbeStage::LifecyclePrepared => RuntimeResultClass::NamespaceBoundary,
         ProbeStage::GrantTransfer | ProbeStage::GrantAccepted => RuntimeResultClass::GrantBoundary,
         ProbeStage::LifecycleHello
         | ProbeStage::LifecycleProceed

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -105,9 +105,10 @@ const ELEVATED_RUNTIME_RETAIN_MODE: &[u8] = b"runtime-retain-root";
 const ELEVATED_RUNTIME_UNMAPPED_MODE: &[u8] = b"runtime-unmapped";
 const ELEVATED_RUNTIME_STATUS: &[u8] = b"status: elevated runtime";
 const ELEVATED_CONTINUATION_RECORD: &[u8] = b"BBA1";
+const ELEVATED_RUNTIME_AUTHORITY_RECORD: &[u8] = b"BBN1";
 const ELEVATED_RUNTIME_GRANT_CASE: &[u8] = b"target-runtime";
-const ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES: &[u8] = b"bangbang-elevated-runtime-launcher-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
-const ELEVATED_RUNTIME_WORKER_BOUNDARIES: &[u8] = b"bangbang-elevated-runtime-worker-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
+const ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES: &[u8] = b"bangbang-elevated-runtime-launcher-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
+const ELEVATED_RUNTIME_WORKER_BOUNDARIES: &[u8] = b"bangbang-elevated-runtime-worker-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
 const ELEVATED_PROBE_MARKER: &str = "elevated-bootstrap-probe.enabled";
 const ELEVATED_RUNTIME_MARKER: &str = "target-runtime-grant-probe.enabled";
 const GRANT_PROBE_OUTSIDE: &str = "bangbang-grant-probe-outside";
@@ -13093,6 +13094,7 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             ELEVATED_RUNTIME_UNMAPPED_MODE,
             ELEVATED_RUNTIME_STATUS,
             ELEVATED_CONTINUATION_RECORD,
+            ELEVATED_RUNTIME_AUTHORITY_RECORD,
             ELEVATED_RUNTIME_GRANT_CASE,
             ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES,
             ELEVATED_RUNTIME_WORKER_BOUNDARIES,
@@ -13137,6 +13139,7 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             ELEVATED_CREDENTIAL_WORKER_ARTIFACT,
             ELEVATED_RUNTIME_STATUS,
             ELEVATED_CONTINUATION_RECORD,
+            ELEVATED_RUNTIME_AUTHORITY_RECORD,
             ELEVATED_RUNTIME_GRANT_CASE,
             ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES,
             ELEVATED_RUNTIME_WORKER_BOUNDARIES,

--- a/crates/session/src/elevated_probe.rs
+++ b/crates/session/src/elevated_probe.rs
@@ -22,6 +22,8 @@ pub const CREDENTIAL_RECORD_BYTES: usize = 80;
 pub const CREDENTIAL_DATAGRAM_BYTES: usize = 48;
 /// Encoded credential-to-lifecycle continuation acknowledgment length.
 pub const CONTINUATION_ACK_BYTES: usize = 48;
+/// Encoded launcher-created runtime-session authority length.
+pub const RUNTIME_SESSION_AUTHORITY_BYTES: usize = 120;
 /// Private worker exit used to report the measured target namespace denial.
 pub const RUNTIME_NAMESPACE_PERMISSION_EXIT_CODE: u8 = 3;
 
@@ -32,6 +34,9 @@ const CREDENTIAL_VERSION: u16 = 1;
 const CREDENTIAL_MAGIC: [u8; 4] = *b"BBC1";
 const CREDENTIAL_DATAGRAM_MAGIC: [u8; 4] = *b"BBG1";
 const CONTINUATION_ACK_MAGIC: [u8; 4] = *b"BBA1";
+const RUNTIME_SESSION_AUTHORITY_MAGIC: [u8; 4] = *b"BBN1";
+const RUNTIME_SESSION_AUTHORITY_VERSION: u16 = 1;
+const RUNTIME_WORKER_FAILURE_EXIT_BASE: u8 = 64;
 
 /// Exact evidence mode selected by the explicit root wrapper.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -228,6 +233,22 @@ pub enum ProbeStage {
     LifecycleTerminal = 24,
     /// Reap and clean every exact owned runtime object.
     RuntimeCleanup = 25,
+    /// Create the canonical session as the permanently transitioned launcher.
+    RuntimeSessionCreate = 26,
+    /// Open and validate independent session descriptions before publication.
+    RuntimeSessionOpen = 27,
+    /// Publish the canonical session authority and exact descriptor.
+    RuntimeAuthoritySend = 28,
+    /// Receive the exact session-authority datagram in the worker.
+    RuntimeAuthorityReceive = 29,
+    /// Validate the authority record, descriptor, and parent association.
+    RuntimeAuthorityValidate = 30,
+    /// Acquire and revalidate the worker-owned session lock.
+    RuntimeSessionLock = 31,
+    /// Enter and revalidate the adopted session after Start.
+    RuntimeSessionEnter = 32,
+    /// Publish and independently validate Prepared for the adopted session.
+    LifecyclePrepared = 33,
 }
 
 impl ProbeStage {
@@ -260,6 +281,14 @@ impl ProbeStage {
             Self::LifecycleProceed => "lifecycle-proceed",
             Self::LifecycleTerminal => "lifecycle-terminal",
             Self::RuntimeCleanup => "runtime-cleanup",
+            Self::RuntimeSessionCreate => "runtime-session-create",
+            Self::RuntimeSessionOpen => "runtime-session-open",
+            Self::RuntimeAuthoritySend => "runtime-authority-send",
+            Self::RuntimeAuthorityReceive => "runtime-authority-receive",
+            Self::RuntimeAuthorityValidate => "runtime-authority-validate",
+            Self::RuntimeSessionLock => "runtime-session-lock",
+            Self::RuntimeSessionEnter => "runtime-session-enter",
+            Self::LifecyclePrepared => "lifecycle-prepared",
         }
     }
 
@@ -290,6 +319,14 @@ impl ProbeStage {
             23 => Ok(Self::LifecycleProceed),
             24 => Ok(Self::LifecycleTerminal),
             25 => Ok(Self::RuntimeCleanup),
+            26 => Ok(Self::RuntimeSessionCreate),
+            27 => Ok(Self::RuntimeSessionOpen),
+            28 => Ok(Self::RuntimeAuthoritySend),
+            29 => Ok(Self::RuntimeAuthorityReceive),
+            30 => Ok(Self::RuntimeAuthorityValidate),
+            31 => Ok(Self::RuntimeSessionLock),
+            32 => Ok(Self::RuntimeSessionEnter),
+            33 => Ok(Self::LifecyclePrepared),
             _ => Err(ProbeProtocolError),
         }
     }
@@ -314,6 +351,22 @@ pub enum RuntimeFault {
     Proceed = 5,
     /// Stop at terminal ownership validation.
     Terminal = 6,
+    /// Stop while the launcher creates the canonical target session.
+    SessionCreate = 7,
+    /// Stop while the launcher opens independent session descriptions.
+    SessionOpen = 8,
+    /// Stop before the launcher publishes session authority.
+    AuthoritySend = 9,
+    /// Stop before the worker receives session authority.
+    AuthorityReceive = 10,
+    /// Stop before the worker validates received session authority.
+    AuthorityValidate = 11,
+    /// Stop before the worker locks the adopted session.
+    SessionLock = 12,
+    /// Stop before the worker enters the adopted session.
+    SessionEnter = 13,
+    /// Stop before the worker publishes Prepared for the adopted session.
+    Prepared = 14,
 }
 
 impl RuntimeFault {
@@ -327,6 +380,14 @@ impl RuntimeFault {
             "grant-transfer" => Some(Self::GrantTransfer),
             "proceed" => Some(Self::Proceed),
             "terminal" => Some(Self::Terminal),
+            "session-create" => Some(Self::SessionCreate),
+            "session-open" => Some(Self::SessionOpen),
+            "authority-send" => Some(Self::AuthoritySend),
+            "authority-receive" => Some(Self::AuthorityReceive),
+            "authority-validate" => Some(Self::AuthorityValidate),
+            "session-lock" => Some(Self::SessionLock),
+            "session-enter" => Some(Self::SessionEnter),
+            "prepared" => Some(Self::Prepared),
             _ => None,
         }
     }
@@ -340,6 +401,14 @@ impl RuntimeFault {
             4 => Ok(Self::GrantTransfer),
             5 => Ok(Self::Proceed),
             6 => Ok(Self::Terminal),
+            7 => Ok(Self::SessionCreate),
+            8 => Ok(Self::SessionOpen),
+            9 => Ok(Self::AuthoritySend),
+            10 => Ok(Self::AuthorityReceive),
+            11 => Ok(Self::AuthorityValidate),
+            12 => Ok(Self::SessionLock),
+            13 => Ok(Self::SessionEnter),
+            14 => Ok(Self::Prepared),
             _ => Err(ProbeProtocolError),
         }
     }
@@ -355,6 +424,14 @@ impl RuntimeFault {
             Self::GrantTransfer => "grant-transfer",
             Self::Proceed => "proceed",
             Self::Terminal => "terminal",
+            Self::SessionCreate => "session-create",
+            Self::SessionOpen => "session-open",
+            Self::AuthoritySend => "authority-send",
+            Self::AuthorityReceive => "authority-receive",
+            Self::AuthorityValidate => "authority-validate",
+            Self::SessionLock => "session-lock",
+            Self::SessionEnter => "session-enter",
+            Self::Prepared => "prepared",
         }
     }
 }
@@ -436,6 +513,77 @@ impl ProbeErrorCategory {
             3 => Ok(Self::Other),
             _ => Err(ProbeProtocolError),
         }
+    }
+}
+
+/// Closed private worker exit used before a lifecycle failure can be framed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RuntimeWorkerFailure {
+    stage: ProbeStage,
+    category: ProbeErrorCategory,
+}
+
+impl RuntimeWorkerFailure {
+    /// Constructs one worker-owned runtime failure.
+    pub fn new(
+        stage: ProbeStage,
+        category: ProbeErrorCategory,
+    ) -> Result<Self, ProbeProtocolError> {
+        if runtime_worker_stage_index(stage).is_none() {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self { stage, category })
+    }
+
+    /// Returns the exact value-free stage.
+    #[must_use]
+    pub const fn stage(self) -> ProbeStage {
+        self.stage
+    }
+
+    /// Returns the exact value-free category.
+    #[must_use]
+    pub const fn category(self) -> ProbeErrorCategory {
+        self.category
+    }
+
+    /// Encodes the failure into the reserved feature-only worker exit range.
+    #[must_use]
+    pub fn exit_code(self) -> u8 {
+        let stage = runtime_worker_stage_index(self.stage).unwrap_or(0);
+        RUNTIME_WORKER_FAILURE_EXIT_BASE + stage * 3 + self.category as u8 - 1
+    }
+
+    /// Decodes one exact feature-only worker exit.
+    pub fn from_exit_code(exit_code: u8) -> Result<Self, ProbeProtocolError> {
+        let offset = exit_code
+            .checked_sub(RUNTIME_WORKER_FAILURE_EXIT_BASE)
+            .ok_or(ProbeProtocolError)?;
+        let stage = runtime_worker_stage(offset / 3).ok_or(ProbeProtocolError)?;
+        let category = ProbeErrorCategory::from_byte(offset % 3 + 1)?;
+        Self::new(stage, category)
+    }
+}
+
+const fn runtime_worker_stage_index(stage: ProbeStage) -> Option<u8> {
+    match stage {
+        ProbeStage::RuntimeAuthorityReceive => Some(0),
+        ProbeStage::RuntimeAuthorityValidate => Some(1),
+        ProbeStage::RuntimeSessionLock => Some(2),
+        ProbeStage::RuntimeSessionEnter => Some(3),
+        ProbeStage::LifecyclePrepared => Some(4),
+        _ => None,
+    }
+}
+
+const fn runtime_worker_stage(index: u8) -> Option<ProbeStage> {
+    match index {
+        0 => Some(ProbeStage::RuntimeAuthorityReceive),
+        1 => Some(ProbeStage::RuntimeAuthorityValidate),
+        2 => Some(ProbeStage::RuntimeSessionLock),
+        3 => Some(ProbeStage::RuntimeSessionEnter),
+        4 => Some(ProbeStage::LifecyclePrepared),
+        _ => None,
     }
 }
 
@@ -707,6 +855,180 @@ impl ContinuationAck {
 impl fmt::Debug for ContinuationAck {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("ContinuationAck(<redacted>)")
+    }
+}
+
+/// Canonical one-descriptor authority for a launcher-created runtime session.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeSessionAuthority {
+    mode: ProbeMode,
+    role: CredentialRole,
+    target_uid: u32,
+    target_gid: u32,
+    root: ObjectIdentity,
+    session_identity: ObjectIdentity,
+    nonce: SessionId,
+    session: SessionId,
+}
+
+impl RuntimeSessionAuthority {
+    /// Constructs the launcher's exact authority for one adopted session.
+    pub fn launcher(
+        mode: ProbeMode,
+        target_uid: u32,
+        target_gid: u32,
+        root: ObjectIdentity,
+        session_identity: ObjectIdentity,
+        nonce: SessionId,
+        session: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
+        if !mode.continues_runtime()
+            || !mode.accepts_target(target_uid, target_gid)
+            || root.device == 0
+            || root.inode == 0
+            || session_identity.device == 0
+            || session_identity.inode == 0
+            || nonce.is_pre_session()
+            || session.is_pre_session()
+        {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            mode,
+            role: CredentialRole::Launcher,
+            target_uid,
+            target_gid,
+            root,
+            session_identity,
+            nonce,
+            session,
+        })
+    }
+
+    /// Returns the selected runtime mode.
+    #[must_use]
+    pub const fn mode(self) -> ProbeMode {
+        self.mode
+    }
+
+    /// Returns the fixed sending role.
+    #[must_use]
+    pub const fn role(self) -> CredentialRole {
+        self.role
+    }
+
+    /// Returns the exact target uid.
+    #[must_use]
+    pub const fn target_uid(self) -> u32 {
+        self.target_uid
+    }
+
+    /// Returns the exact target gid.
+    #[must_use]
+    pub const fn target_gid(self) -> u32 {
+        self.target_gid
+    }
+
+    /// Returns the exact inherited runtime-root identity.
+    #[must_use]
+    pub const fn root(self) -> ObjectIdentity {
+        self.root
+    }
+
+    /// Returns the exact launcher-created session identity.
+    #[must_use]
+    pub const fn session_identity(self) -> ObjectIdentity {
+        self.session_identity
+    }
+
+    /// Returns the credential/bootstrap nonce.
+    #[must_use]
+    pub const fn nonce(self) -> SessionId {
+        self.nonce
+    }
+
+    /// Returns the lifecycle session bound to the authority.
+    #[must_use]
+    pub const fn session(self) -> SessionId {
+        self.session
+    }
+
+    /// Returns whether every bootstrap, session, and object field is exact.
+    #[must_use]
+    pub fn matches_expected(
+        self,
+        bootstrap: ProbeBootstrap,
+        session: SessionId,
+        session_identity: ObjectIdentity,
+    ) -> bool {
+        self.mode == bootstrap.mode()
+            && self.role == CredentialRole::Launcher
+            && self.target_uid == bootstrap.target_uid()
+            && self.target_gid == bootstrap.target_gid()
+            && self.root == bootstrap.root()
+            && self.session_identity == session_identity
+            && self.nonce == bootstrap.nonce()
+            && self.session == session
+    }
+
+    /// Encodes the fixed canonical authority record.
+    #[must_use]
+    pub fn encode(self) -> [u8; RUNTIME_SESSION_AUTHORITY_BYTES] {
+        let mut bytes = [0_u8; RUNTIME_SESSION_AUTHORITY_BYTES];
+        bytes[0..4].copy_from_slice(&RUNTIME_SESSION_AUTHORITY_MAGIC);
+        bytes[4..6].copy_from_slice(&RUNTIME_SESSION_AUTHORITY_VERSION.to_be_bytes());
+        bytes[6] = self.mode as u8;
+        bytes[7] = self.role as u8;
+        bytes[8] = 1;
+        bytes[16..20].copy_from_slice(&self.target_uid.to_be_bytes());
+        bytes[20..24].copy_from_slice(&self.target_gid.to_be_bytes());
+        bytes[24..32].copy_from_slice(&self.root.device.to_be_bytes());
+        bytes[32..40].copy_from_slice(&self.root.inode.to_be_bytes());
+        bytes[40..48].copy_from_slice(&self.session_identity.device.to_be_bytes());
+        bytes[48..56].copy_from_slice(&self.session_identity.inode.to_be_bytes());
+        bytes[56..88].copy_from_slice(self.nonce.as_bytes());
+        bytes[88..120].copy_from_slice(self.session.as_bytes());
+        bytes
+    }
+
+    /// Decodes and validates one exact authority record.
+    pub fn decode(
+        bytes: &[u8; RUNTIME_SESSION_AUTHORITY_BYTES],
+    ) -> Result<Self, ProbeProtocolError> {
+        if bytes[0..4] != RUNTIME_SESSION_AUTHORITY_MAGIC
+            || bytes[4..6] != RUNTIME_SESSION_AUTHORITY_VERSION.to_be_bytes()
+            || bytes[8] != 1
+            || bytes[9..16] != [0; 7]
+        {
+            return Err(ProbeProtocolError);
+        }
+        let authority = Self::launcher(
+            ProbeMode::from_byte(bytes[6])?,
+            u32::from_be_bytes(array(bytes, 16)?),
+            u32::from_be_bytes(array(bytes, 20)?),
+            ObjectIdentity {
+                device: u64::from_be_bytes(array(bytes, 24)?),
+                inode: u64::from_be_bytes(array(bytes, 32)?),
+            },
+            ObjectIdentity {
+                device: u64::from_be_bytes(array(bytes, 40)?),
+                inode: u64::from_be_bytes(array(bytes, 48)?),
+            },
+            SessionId::from_bytes(array(bytes, 56)?),
+            SessionId::from_bytes(array(bytes, 88)?),
+        )?;
+        if CredentialRole::from_byte(bytes[7])? != CredentialRole::Launcher
+            || authority.encode() != *bytes
+        {
+            return Err(ProbeProtocolError);
+        }
+        Ok(authority)
+    }
+}
+
+impl fmt::Debug for RuntimeSessionAuthority {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("RuntimeSessionAuthority(<redacted>)")
     }
 }
 
@@ -2056,6 +2378,14 @@ mod tests {
             ProbeStage::LifecycleProceed,
             ProbeStage::LifecycleTerminal,
             ProbeStage::RuntimeCleanup,
+            ProbeStage::RuntimeSessionCreate,
+            ProbeStage::RuntimeSessionOpen,
+            ProbeStage::RuntimeAuthoritySend,
+            ProbeStage::RuntimeAuthorityReceive,
+            ProbeStage::RuntimeAuthorityValidate,
+            ProbeStage::RuntimeSessionLock,
+            ProbeStage::RuntimeSessionEnter,
+            ProbeStage::LifecyclePrepared,
         ] {
             let result = ProbeResult::failure(
                 ProbeMode::InheritedRoot,
@@ -2119,13 +2449,21 @@ mod tests {
             (RuntimeFault::GrantTransfer, 4, "grant-transfer"),
             (RuntimeFault::Proceed, 5, "proceed"),
             (RuntimeFault::Terminal, 6, "terminal"),
+            (RuntimeFault::SessionCreate, 7, "session-create"),
+            (RuntimeFault::SessionOpen, 8, "session-open"),
+            (RuntimeFault::AuthoritySend, 9, "authority-send"),
+            (RuntimeFault::AuthorityReceive, 10, "authority-receive"),
+            (RuntimeFault::AuthorityValidate, 11, "authority-validate"),
+            (RuntimeFault::SessionLock, 12, "session-lock"),
+            (RuntimeFault::SessionEnter, 13, "session-enter"),
+            (RuntimeFault::Prepared, 14, "prepared"),
         ] {
             assert_eq!(RuntimeFault::parse(name), Some(fault));
             assert_eq!(RuntimeFault::from_byte(byte), Ok(fault));
             assert_eq!(fault.name(), name);
         }
         assert_eq!(RuntimeFault::parse("unknown"), None);
-        assert_eq!(RuntimeFault::from_byte(7), Err(ProbeProtocolError));
+        assert_eq!(RuntimeFault::from_byte(15), Err(ProbeProtocolError));
 
         for (result, name) in [
             (RuntimeResultClass::Complete, "complete"),
@@ -2144,6 +2482,230 @@ mod tests {
         ] {
             assert_eq!(result.name(), name);
         }
+    }
+
+    #[test]
+    fn runtime_session_authority_is_canonical_bound_and_redacted() {
+        let bootstrap = ProbeBootstrap::new(
+            ProbeMode::RuntimeDrop,
+            501,
+            20,
+            ObjectIdentity {
+                device: 101,
+                inode: 103,
+            },
+            SessionId::from_bytes([0x81; 32]),
+        )
+        .expect("runtime bootstrap should construct");
+        let session = SessionId::from_bytes([0x82; 32]);
+        let identity = ObjectIdentity {
+            device: 107,
+            inode: 109,
+        };
+        let authority = RuntimeSessionAuthority::launcher(
+            bootstrap.mode(),
+            bootstrap.target_uid(),
+            bootstrap.target_gid(),
+            bootstrap.root(),
+            identity,
+            bootstrap.nonce(),
+            session,
+        )
+        .expect("authority should construct");
+        let encoded = authority.encode();
+        assert_eq!(encoded.len(), RUNTIME_SESSION_AUTHORITY_BYTES);
+        assert_eq!(RuntimeSessionAuthority::decode(&encoded), Ok(authority));
+        assert!(authority.matches_expected(bootstrap, session, identity));
+        assert_eq!(authority.mode(), bootstrap.mode());
+        assert_eq!(authority.role(), CredentialRole::Launcher);
+        assert_eq!(authority.target_uid(), bootstrap.target_uid());
+        assert_eq!(authority.target_gid(), bootstrap.target_gid());
+        assert_eq!(authority.root(), bootstrap.root());
+        assert_eq!(authority.session_identity(), identity);
+        assert_eq!(authority.nonce(), bootstrap.nonce());
+        assert_eq!(authority.session(), session);
+        assert_eq!(
+            format!("{authority:?}"),
+            "RuntimeSessionAuthority(<redacted>)"
+        );
+
+        for index in [0, 4, 6, 7, 8, 9] {
+            let mut malformed = encoded;
+            malformed[index] ^= 0xff;
+            assert_eq!(
+                RuntimeSessionAuthority::decode(&malformed),
+                Err(ProbeProtocolError),
+                "byte {index} must be canonical"
+            );
+        }
+        for index in 9..16 {
+            let mut malformed = encoded;
+            malformed[index] = 1;
+            assert_eq!(
+                RuntimeSessionAuthority::decode(&malformed),
+                Err(ProbeProtocolError)
+            );
+        }
+        for range in [
+            16..20,
+            20..24,
+            24..32,
+            32..40,
+            40..48,
+            48..56,
+            56..88,
+            88..120,
+        ] {
+            let mut malformed = encoded;
+            malformed[range].fill(0);
+            assert_eq!(
+                RuntimeSessionAuthority::decode(&malformed),
+                Err(ProbeProtocolError)
+            );
+        }
+        for index in 0..encoded.len() {
+            let mut hostile = encoded;
+            hostile[index] ^= 1;
+            if let Ok(decoded) = RuntimeSessionAuthority::decode(&hostile) {
+                assert!(
+                    !decoded.matches_expected(bootstrap, session, identity),
+                    "mutated byte {index} must not retain the original authority"
+                );
+            }
+        }
+
+        let other_session = SessionId::from_bytes([0x83; 32]);
+        let other_identity = ObjectIdentity {
+            device: 107,
+            inode: 113,
+        };
+        assert!(!authority.matches_expected(bootstrap, other_session, identity));
+        assert!(!authority.matches_expected(bootstrap, session, other_identity));
+        let other_bootstrap = ProbeBootstrap::new(
+            ProbeMode::RuntimeDrop,
+            502,
+            20,
+            bootstrap.root(),
+            bootstrap.nonce(),
+        )
+        .expect("other bootstrap should construct");
+        assert!(!authority.matches_expected(other_bootstrap, session, identity));
+        let other_root = ProbeBootstrap::new(
+            ProbeMode::RuntimeDrop,
+            501,
+            20,
+            ObjectIdentity {
+                device: 101,
+                inode: 127,
+            },
+            bootstrap.nonce(),
+        )
+        .expect("other-root bootstrap should construct");
+        assert!(!authority.matches_expected(other_root, session, identity));
+        let other_nonce = ProbeBootstrap::new(
+            ProbeMode::RuntimeDrop,
+            501,
+            20,
+            bootstrap.root(),
+            SessionId::from_bytes([0x84; 32]),
+        )
+        .expect("other-nonce bootstrap should construct");
+        assert!(!authority.matches_expected(other_nonce, session, identity));
+        let other_mode = ProbeBootstrap::new(
+            ProbeMode::RuntimeUnmapped,
+            2_147_483_647,
+            2_147_483_647,
+            bootstrap.root(),
+            bootstrap.nonce(),
+        )
+        .expect("other-mode bootstrap should construct");
+        assert!(!authority.matches_expected(other_mode, session, identity));
+        assert!(
+            RuntimeSessionAuthority::launcher(
+                ProbeMode::CredentialDrop,
+                501,
+                20,
+                bootstrap.root(),
+                identity,
+                bootstrap.nonce(),
+                session,
+            )
+            .is_err()
+        );
+        assert!(
+            RuntimeSessionAuthority::launcher(
+                ProbeMode::RuntimeDrop,
+                501,
+                20,
+                ObjectIdentity {
+                    device: 0,
+                    inode: 1,
+                },
+                identity,
+                bootstrap.nonce(),
+                session,
+            )
+            .is_err()
+        );
+        assert!(
+            RuntimeSessionAuthority::launcher(
+                ProbeMode::RuntimeDrop,
+                501,
+                20,
+                bootstrap.root(),
+                identity,
+                bootstrap.nonce(),
+                SessionId::pre_session(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn runtime_worker_failure_exit_range_is_closed_and_exact() {
+        let stages = [
+            ProbeStage::RuntimeAuthorityReceive,
+            ProbeStage::RuntimeAuthorityValidate,
+            ProbeStage::RuntimeSessionLock,
+            ProbeStage::RuntimeSessionEnter,
+            ProbeStage::LifecyclePrepared,
+        ];
+        let categories = [
+            ProbeErrorCategory::PermissionDenied,
+            ProbeErrorCategory::InvalidInput,
+            ProbeErrorCategory::Other,
+        ];
+        for (stage_index, stage) in stages.into_iter().enumerate() {
+            for category in categories {
+                let failure = RuntimeWorkerFailure::new(stage, category)
+                    .expect("worker failure should construct");
+                assert_eq!(
+                    failure.exit_code(),
+                    RUNTIME_WORKER_FAILURE_EXIT_BASE
+                        + u8::try_from(stage_index).expect("small stage index") * 3
+                        + category as u8
+                        - 1
+                );
+                assert_eq!(
+                    RuntimeWorkerFailure::from_exit_code(failure.exit_code()),
+                    Ok(failure)
+                );
+                assert_eq!(failure.stage(), stage);
+                assert_eq!(failure.category(), category);
+            }
+        }
+        assert!(
+            RuntimeWorkerFailure::new(ProbeStage::RuntimeSessionCreate, ProbeErrorCategory::Other)
+                .is_err()
+        );
+        assert_eq!(
+            RuntimeWorkerFailure::from_exit_code(RUNTIME_WORKER_FAILURE_EXIT_BASE - 1),
+            Err(ProbeProtocolError)
+        );
+        assert_eq!(
+            RuntimeWorkerFailure::from_exit_code(RUNTIME_WORKER_FAILURE_EXIT_BASE + 15),
+            Err(ProbeProtocolError)
+        );
     }
 
     #[test]

--- a/crates/session/src/macos.rs
+++ b/crates/session/src/macos.rs
@@ -8,6 +8,8 @@ pub mod bookmark;
 pub mod grant_registry;
 pub mod grant_transport;
 pub mod runtime;
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub mod runtime_authority;
 pub mod socket_broker;
 pub mod vhost_user_broker;
 

--- a/crates/session/src/macos/runtime.rs
+++ b/crates/session/src/macos/runtime.rs
@@ -319,6 +319,17 @@ pub struct NamespaceIdentity {
     pub inode: u64,
 }
 
+impl NamespaceIdentity {
+    /// Returns the equivalent protocol object identity.
+    #[must_use]
+    pub const fn object_identity(self) -> ObjectIdentity {
+        ObjectIdentity {
+            device: self.device,
+            inode: self.inode,
+        }
+    }
+}
+
 impl fmt::Debug for NamespaceIdentity {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("NamespaceIdentity(<redacted>)")
@@ -442,6 +453,405 @@ impl ExplicitRuntimeRoot {
     }
 }
 
+/// Unpublished launcher-created session with three independent descriptions.
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub struct PreparedLauncherSession {
+    transfer: OwnedFd,
+    handles: LauncherSessionHandles,
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl fmt::Debug for PreparedLauncherSession {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PreparedLauncherSession(<redacted>)")
+    }
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl PreparedLauncherSession {
+    /// Creates one target-owned session and preopens every later authority.
+    pub fn create(root: ExplicitRuntimeRoot, session: SessionId) -> Result<Self, RuntimeError> {
+        let validation_root = root.try_reopen(true)?;
+        let recovery_root = root.try_reopen(true)?;
+        let ExplicitRuntimeRoot {
+            directory: root,
+            identity: root_identity,
+            owner,
+        } = root;
+        if validate_directory_owned(root.as_raw_fd(), owner)? != root_identity
+            || !directory_is_empty(root.as_raw_fd())?
+        {
+            return Err(RuntimeError::InvalidRoot);
+        }
+        let root_lock = RootLock::acquire(root.as_raw_fd())?;
+        recover_stale_entries(root.as_raw_fd(), owner)?;
+        let name = session_name(session)?;
+        // SAFETY: `root` is a live exact directory, `name` is NUL-terminated,
+        // and the permanently transitioned launcher owns the new child.
+        if unsafe { libc::mkdirat(root.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
+            let error = io::Error::last_os_error();
+            return if error.kind() == io::ErrorKind::AlreadyExists {
+                Err(RuntimeError::Collision)
+            } else {
+                Err(RuntimeError::NamespaceCreate(error.kind()))
+            };
+        }
+
+        let transfer = match openat_directory(root.as_raw_fd(), &name) {
+            Ok(transfer) => transfer,
+            Err(error) => {
+                return Err(cleanup_created_session_after_error(
+                    root.as_raw_fd(),
+                    &name,
+                    owner,
+                    error,
+                ));
+            }
+        };
+        let identity = match validate_linked_directory_owned(transfer.as_raw_fd(), owner) {
+            Ok(identity) => identity,
+            Err(error) => {
+                return Err(cleanup_open_session_after_error(
+                    root.as_raw_fd(),
+                    transfer.as_raw_fd(),
+                    &name,
+                    owner,
+                    error,
+                ));
+            }
+        };
+        let session_is_exact = match directory_is_empty(transfer.as_raw_fd()).and_then(|empty| {
+            identity_at(root.as_raw_fd(), &name).map(|linked| empty && linked == Some(identity))
+        }) {
+            Ok(exact) => exact,
+            Err(error) => {
+                return Err(cleanup_open_session_after_error(
+                    root.as_raw_fd(),
+                    transfer.as_raw_fd(),
+                    &name,
+                    owner,
+                    error,
+                ));
+            }
+        };
+        if !session_is_exact {
+            return Err(cleanup_open_session_after_error(
+                root.as_raw_fd(),
+                transfer.as_raw_fd(),
+                &name,
+                owner,
+                RuntimeError::InvalidEntry,
+            ));
+        }
+
+        let validation =
+            openat_directory(validation_root.directory.as_raw_fd(), &name).and_then(|directory| {
+                PreopenedLauncherNamespace::new(
+                    validation_root.directory,
+                    directory,
+                    name.clone(),
+                    identity,
+                    owner,
+                )
+            });
+        let validation = match validation {
+            Ok(validation) => validation,
+            Err(error) => {
+                return Err(cleanup_open_session_after_error(
+                    root.as_raw_fd(),
+                    transfer.as_raw_fd(),
+                    &name,
+                    owner,
+                    error,
+                ));
+            }
+        };
+        let recovery =
+            openat_directory(recovery_root.directory.as_raw_fd(), &name).and_then(|directory| {
+                PreopenedLauncherNamespace::new(
+                    recovery_root.directory,
+                    directory,
+                    name.clone(),
+                    identity,
+                    owner,
+                )
+            });
+        let recovery = match recovery {
+            Ok(recovery) => recovery,
+            Err(error) => {
+                return Err(cleanup_open_session_after_error(
+                    root.as_raw_fd(),
+                    transfer.as_raw_fd(),
+                    &name,
+                    owner,
+                    error,
+                ));
+            }
+        };
+        drop(root_lock);
+        drop(root);
+        Ok(Self {
+            transfer,
+            handles: LauncherSessionHandles {
+                validation: Some(validation),
+                recovery: Some(recovery),
+                session,
+                identity,
+            },
+        })
+    }
+
+    /// Returns the exact created session identity.
+    #[must_use]
+    pub const fn identity(&self) -> NamespaceIdentity {
+        self.handles.identity
+    }
+
+    /// Separates the single-use transfer descriptor from later launcher state.
+    #[must_use]
+    pub fn into_publication(self) -> (OwnedFd, LauncherSessionHandles) {
+        (self.transfer, self.handles)
+    }
+
+    /// Removes an exact session that was never published to the worker.
+    pub fn cleanup_unpublished(self) -> Result<(), RuntimeError> {
+        let Self {
+            transfer,
+            mut handles,
+        } = self;
+        drop(transfer);
+        handles.discard_validation();
+        let session = handles.session();
+        handles
+            .recover_after_worker_exit(session)?
+            .map_or(Ok(()), |mut namespace| namespace.cleanup())
+    }
+}
+
+/// Preopened independent validation and recovery state after publication.
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub struct LauncherSessionHandles {
+    validation: Option<PreopenedLauncherNamespace>,
+    recovery: Option<PreopenedLauncherNamespace>,
+    session: SessionId,
+    identity: NamespaceIdentity,
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl fmt::Debug for LauncherSessionHandles {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("LauncherSessionHandles(<redacted>)")
+    }
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl LauncherSessionHandles {
+    /// Returns the exact created session identity.
+    #[must_use]
+    pub const fn identity(&self) -> NamespaceIdentity {
+        self.identity
+    }
+
+    /// Returns the lifecycle session bound to the canonical directory name.
+    #[must_use]
+    pub const fn session(&self) -> SessionId {
+        self.session
+    }
+
+    /// Consumes the independent live-validation description after Prepared.
+    pub fn validate_live(
+        &mut self,
+        session: SessionId,
+        expected: NamespaceIdentity,
+    ) -> Result<LauncherNamespace, RuntimeError> {
+        if session != self.session || expected != self.identity {
+            return Err(RuntimeError::InvalidEntry);
+        }
+        self.validation
+            .take()
+            .ok_or(RuntimeError::InvalidEntry)?
+            .validate_live(expected)
+    }
+
+    /// Consumes the independent recovery description after the worker is reaped.
+    pub fn recover_after_worker_exit(
+        &mut self,
+        session: SessionId,
+    ) -> Result<Option<LauncherNamespace>, RuntimeError> {
+        if session != self.session {
+            return Err(RuntimeError::InvalidEntry);
+        }
+        self.recovery
+            .take()
+            .ok_or(RuntimeError::InvalidEntry)?
+            .recover_after_worker_exit()
+    }
+
+    fn discard_validation(&mut self) {
+        drop(self.validation.take());
+    }
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+struct PreopenedLauncherNamespace {
+    root: OwnedFd,
+    directory: OwnedFd,
+    name: CString,
+    identity: NamespaceIdentity,
+    owner: DirectoryOwner,
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl PreopenedLauncherNamespace {
+    fn new(
+        root: OwnedFd,
+        directory: OwnedFd,
+        name: CString,
+        identity: NamespaceIdentity,
+        owner: DirectoryOwner,
+    ) -> Result<Self, RuntimeError> {
+        validate_preopened_namespace(
+            root.as_raw_fd(),
+            directory.as_raw_fd(),
+            &name,
+            identity,
+            owner,
+            true,
+        )?;
+        Ok(Self {
+            root,
+            directory,
+            name,
+            identity,
+            owner,
+        })
+    }
+
+    fn validate_live(self, expected: NamespaceIdentity) -> Result<LauncherNamespace, RuntimeError> {
+        validate_preopened_namespace(
+            self.root.as_raw_fd(),
+            self.directory.as_raw_fd(),
+            &self.name,
+            expected,
+            self.owner,
+            true,
+        )?;
+        if expected != self.identity {
+            return Err(RuntimeError::InvalidEntry);
+        }
+        if try_lock_exclusive(self.directory.as_raw_fd())? {
+            unlock(self.directory.as_raw_fd());
+            return Err(RuntimeError::InvalidEntry);
+        }
+        Ok(LauncherNamespace {
+            root: self.root,
+            directory: self.directory,
+            name: self.name,
+            identity: self.identity,
+            owner: self.owner,
+            cleaned: false,
+        })
+    }
+
+    fn recover_after_worker_exit(self) -> Result<Option<LauncherNamespace>, RuntimeError> {
+        validate_directory_owned(self.root.as_raw_fd(), self.owner)?;
+        if identity_at(self.root.as_raw_fd(), &self.name)?.is_none() {
+            return Ok(None);
+        }
+        validate_preopened_namespace(
+            self.root.as_raw_fd(),
+            self.directory.as_raw_fd(),
+            &self.name,
+            self.identity,
+            self.owner,
+            false,
+        )?;
+        if !try_lock_exclusive(self.directory.as_raw_fd())?
+            || !directory_contains_only_ownership_records(self.directory.as_raw_fd())?
+        {
+            return Err(RuntimeError::InvalidEntry);
+        }
+        Ok(Some(LauncherNamespace {
+            root: self.root,
+            directory: self.directory,
+            name: self.name,
+            identity: self.identity,
+            owner: self.owner,
+            cleaned: false,
+        }))
+    }
+}
+
+/// Validated but not yet locked worker adoption state.
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub struct ValidatedWorkerNamespace {
+    root: OwnedFd,
+    directory: OwnedFd,
+    name: CString,
+    identity: NamespaceIdentity,
+    owner: DirectoryOwner,
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl fmt::Debug for ValidatedWorkerNamespace {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ValidatedWorkerNamespace(<redacted>)")
+    }
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+impl ValidatedWorkerNamespace {
+    /// Validates one launcher-created session without acquiring its live lock.
+    pub fn from_explicit_root(
+        root: ExplicitRuntimeRoot,
+        directory: OwnedFd,
+        session: SessionId,
+        expected: ObjectIdentity,
+    ) -> Result<Self, RuntimeError> {
+        let name = session_name(session)?;
+        let identity = NamespaceIdentity {
+            device: expected.device,
+            inode: expected.inode,
+        };
+        validate_preopened_namespace(
+            root.directory.as_raw_fd(),
+            directory.as_raw_fd(),
+            &name,
+            identity,
+            root.owner,
+            true,
+        )?;
+        Ok(Self {
+            root: root.directory,
+            directory,
+            name,
+            identity,
+            owner: root.owner,
+        })
+    }
+
+    /// Acquires the worker lock and repeats every identity/emptiness check.
+    pub fn lock(self) -> Result<WorkerNamespace, RuntimeError> {
+        lock_exclusive(self.directory.as_raw_fd())?;
+        validate_preopened_namespace(
+            self.root.as_raw_fd(),
+            self.directory.as_raw_fd(),
+            &self.name,
+            self.identity,
+            self.owner,
+            true,
+        )?;
+        Ok(WorkerNamespace {
+            root: self.root,
+            directory: self.directory,
+            name: self.name,
+            identity: self.identity,
+            owner: self.owner,
+            cleaned: false,
+        })
+    }
+}
+
 /// Worker-owned locked namespace inside its App Sandbox container.
 pub struct WorkerNamespace {
     root: OwnedFd,
@@ -477,6 +887,17 @@ impl WorkerNamespace {
         session: SessionId,
     ) -> Result<Self, RuntimeError> {
         Self::create_in_root(root.directory, root.owner, session)
+    }
+
+    /// Validates, locks, and adopts one launcher-created target session.
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    pub fn adopt_from_explicit_root(
+        root: ExplicitRuntimeRoot,
+        directory: OwnedFd,
+        session: SessionId,
+        expected: ObjectIdentity,
+    ) -> Result<Self, RuntimeError> {
+        ValidatedWorkerNamespace::from_explicit_root(root, directory, session, expected)?.lock()
     }
 
     fn create_in_root(
@@ -1314,6 +1735,68 @@ fn validate_directory_owned(
     validate_directory_stat(directory_stat(fd)?, owner)
 }
 
+#[cfg(feature = "elevated-bootstrap-probe")]
+fn validate_linked_directory_owned(
+    fd: RawFd,
+    owner: DirectoryOwner,
+) -> Result<NamespaceIdentity, RuntimeError> {
+    let stat = directory_stat(fd)?;
+    if stat.st_nlink < 2 {
+        return Err(RuntimeError::InvalidEntry);
+    }
+    validate_directory_stat(stat, owner)
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+fn validate_preopened_namespace(
+    root: RawFd,
+    directory: RawFd,
+    name: &CStr,
+    expected: NamespaceIdentity,
+    owner: DirectoryOwner,
+    require_empty: bool,
+) -> Result<(), RuntimeError> {
+    validate_linked_directory_owned(root, owner)?;
+    if validate_linked_directory_owned(directory, owner)? != expected
+        || identity_at(root, name)? != Some(expected)
+        || (require_empty && !directory_is_empty(directory)?)
+    {
+        return Err(RuntimeError::InvalidEntry);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+fn cleanup_created_session_after_error(
+    root: RawFd,
+    name: &CStr,
+    owner: DirectoryOwner,
+    error: RuntimeError,
+) -> RuntimeError {
+    match openat_directory(root, name) {
+        Ok(directory) => {
+            cleanup_open_session_after_error(root, directory.as_raw_fd(), name, owner, error)
+        }
+        Err(cleanup_error) => cleanup_error,
+    }
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+fn cleanup_open_session_after_error(
+    root: RawFd,
+    directory: RawFd,
+    name: &CStr,
+    owner: DirectoryOwner,
+    error: RuntimeError,
+) -> RuntimeError {
+    match validate_linked_directory_owned(directory, owner)
+        .and_then(|identity| cleanup_exact(root, directory, name, identity, owner))
+    {
+        Ok(()) => error,
+        Err(cleanup_error) => cleanup_error,
+    }
+}
+
 fn directory_stat(fd: RawFd) -> Result<libc::stat, RuntimeError> {
     let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
     // SAFETY: `stat` is writable for one result and `fd` remains owned by caller.
@@ -1609,6 +2092,22 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    fn explicit_test_root(root: &TestRoot) -> ExplicitRuntimeRoot {
+        let metadata = fs::symlink_metadata(root.path()).expect("root metadata should read");
+        ExplicitRuntimeRoot::from_owned_fd(
+            open_directory(root.path()).expect("root should open"),
+            ObjectIdentity {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+            },
+            metadata.uid(),
+            metadata.gid(),
+            true,
+        )
+        .expect("explicit root should validate")
+    }
+
     impl Drop for TestRoot {
         fn drop(&mut self) {
             fs::remove_dir_all(&self.0).expect("test root should be removed");
@@ -1725,6 +2224,222 @@ mod tests {
                     .as_raw_fd()
             )
             .expect("root should inspect")
+        );
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    #[test]
+    fn launcher_created_session_is_adopted_locked_validated_and_cleaned() {
+        let root = TestRoot::new();
+        let worker_root = explicit_test_root(&root);
+        let session = SessionId::from_bytes([0x92; 32]);
+        let prepared = PreparedLauncherSession::create(explicit_test_root(&root), session)
+            .expect("launcher session should prepare");
+        let identity = prepared.identity();
+        assert_eq!(
+            format!("{prepared:?}"),
+            "PreparedLauncherSession(<redacted>)"
+        );
+        let (transfer, mut handles) = prepared.into_publication();
+        assert_eq!(handles.session(), session);
+        assert_eq!(handles.identity(), identity);
+        assert_eq!(format!("{handles:?}"), "LauncherSessionHandles(<redacted>)");
+
+        let validated = ValidatedWorkerNamespace::from_explicit_root(
+            worker_root,
+            transfer,
+            session,
+            identity.object_identity(),
+        )
+        .expect("transferred session should validate");
+        assert_eq!(
+            format!("{validated:?}"),
+            "ValidatedWorkerNamespace(<redacted>)"
+        );
+        let mut worker = validated.lock().expect("worker should acquire its lock");
+        let mut launcher = handles
+            .validate_live(session, identity)
+            .expect("independent launcher description should observe the lock");
+
+        // Model an abrupt worker exit: close its descriptions without running
+        // the worker-owned best-effort removal, then let the launcher clean.
+        worker.cleaned = true;
+        drop(worker);
+        launcher
+            .cleanup()
+            .expect("launcher should remove the exact unlocked session");
+        drop(handles);
+        assert!(
+            directory_is_empty(
+                open_directory(root.path())
+                    .expect("root should reopen")
+                    .as_raw_fd()
+            )
+            .expect("root should inspect")
+        );
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    #[test]
+    fn unpublished_and_post_exit_recovery_use_only_preopened_handles() {
+        let root = TestRoot::new();
+        let unpublished_session = SessionId::from_bytes([0x93; 32]);
+        PreparedLauncherSession::create(explicit_test_root(&root), unpublished_session)
+            .expect("unpublished session should prepare")
+            .cleanup_unpublished()
+            .expect("unpublished session should clean");
+
+        let session = SessionId::from_bytes([0x94; 32]);
+        let worker_root = explicit_test_root(&root);
+        let prepared = PreparedLauncherSession::create(explicit_test_root(&root), session)
+            .expect("published session should prepare");
+        let identity = prepared.identity();
+        let (transfer, mut handles) = prepared.into_publication();
+        let mut worker = WorkerNamespace::adopt_from_explicit_root(
+            worker_root,
+            transfer,
+            session,
+            identity.object_identity(),
+        )
+        .expect("worker should adopt the exact session");
+        worker.cleaned = true;
+        drop(worker);
+        handles.discard_validation();
+        let mut recovered = handles
+            .recover_after_worker_exit(session)
+            .expect("recovery should validate")
+            .expect("session should remain after abrupt exit");
+        recovered
+            .cleanup()
+            .expect("recovery handle should remove exact session");
+        assert!(
+            directory_is_empty(
+                open_directory(root.path())
+                    .expect("root should reopen")
+                    .as_raw_fd()
+            )
+            .expect("root should inspect")
+        );
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    #[test]
+    fn adopted_session_rejects_wrong_identity_content_and_replacement() {
+        let wrong_root = TestRoot::new();
+        let session = SessionId::from_bytes([0x95; 32]);
+        let wrong_worker_root = explicit_test_root(&wrong_root);
+        let prepared = PreparedLauncherSession::create(explicit_test_root(&wrong_root), session)
+            .expect("session should prepare");
+        let identity = prepared.identity();
+        let (transfer, _handles) = prepared.into_publication();
+        assert_eq!(
+            ValidatedWorkerNamespace::from_explicit_root(
+                wrong_worker_root,
+                transfer,
+                session,
+                ObjectIdentity {
+                    device: identity.device,
+                    inode: identity.inode.wrapping_add(1),
+                },
+            )
+            .expect_err("wrong identity must fail"),
+            RuntimeError::InvalidEntry
+        );
+
+        let wrong_session_root = TestRoot::new();
+        let correct_session = SessionId::from_bytes([0x98; 32]);
+        let wrong_session = SessionId::from_bytes([0x99; 32]);
+        let wrong_session_worker_root = explicit_test_root(&wrong_session_root);
+        let prepared = PreparedLauncherSession::create(
+            explicit_test_root(&wrong_session_root),
+            correct_session,
+        )
+        .expect("wrong-session fixture should prepare");
+        let identity = prepared.identity();
+        let (transfer, _handles) = prepared.into_publication();
+        assert_eq!(
+            ValidatedWorkerNamespace::from_explicit_root(
+                wrong_session_worker_root,
+                transfer,
+                wrong_session,
+                identity.object_identity(),
+            )
+            .expect_err("wrong session name must fail"),
+            RuntimeError::InvalidEntry
+        );
+
+        let source_root = TestRoot::new();
+        let foreign_root = TestRoot::new();
+        let cross_root_session = SessionId::from_bytes([0x9a; 32]);
+        let prepared =
+            PreparedLauncherSession::create(explicit_test_root(&source_root), cross_root_session)
+                .expect("cross-root fixture should prepare");
+        let identity = prepared.identity();
+        let (transfer, _handles) = prepared.into_publication();
+        assert_eq!(
+            ValidatedWorkerNamespace::from_explicit_root(
+                explicit_test_root(&foreign_root),
+                transfer,
+                cross_root_session,
+                identity.object_identity(),
+            )
+            .expect_err("cross-root descriptor must fail"),
+            RuntimeError::InvalidEntry
+        );
+
+        let populated_root = TestRoot::new();
+        let populated_session = SessionId::from_bytes([0x96; 32]);
+        let populated_worker_root = explicit_test_root(&populated_root);
+        let populated =
+            PreparedLauncherSession::create(explicit_test_root(&populated_root), populated_session)
+                .expect("populated session should prepare");
+        let populated_identity = populated.identity();
+        let populated_name = session_name(populated_session).expect("name should derive");
+        fs::write(
+            populated_root
+                .path()
+                .join(OsStr::from_bytes(populated_name.as_bytes()))
+                .join("unexpected"),
+            b"occupied",
+        )
+        .expect("unexpected entry should write");
+        let (populated_transfer, _populated_handles) = populated.into_publication();
+        assert_eq!(
+            ValidatedWorkerNamespace::from_explicit_root(
+                populated_worker_root,
+                populated_transfer,
+                populated_session,
+                populated_identity.object_identity(),
+            )
+            .expect_err("nonempty session must fail"),
+            RuntimeError::InvalidEntry
+        );
+
+        let replacement_root = TestRoot::new();
+        let replacement_session = SessionId::from_bytes([0x97; 32]);
+        let replacement = PreparedLauncherSession::create(
+            explicit_test_root(&replacement_root),
+            replacement_session,
+        )
+        .expect("replacement session should prepare");
+        let replacement_name = session_name(replacement_session).expect("name should derive");
+        let named_path = replacement_root
+            .path()
+            .join(OsStr::from_bytes(replacement_name.as_bytes()));
+        let moved_path = replacement_root.path().join("moved-launcher-session");
+        fs::rename(&named_path, &moved_path).expect("original session should move");
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&named_path)
+            .expect("replacement should create");
+        assert_eq!(
+            replacement.cleanup_unpublished(),
+            Err(RuntimeError::InvalidEntry)
+        );
+        assert!(named_path.is_dir(), "replacement must be preserved");
+        assert!(
+            moved_path.is_dir(),
+            "original descriptor target must be preserved"
         );
     }
 

--- a/crates/session/src/macos/runtime_authority.rs
+++ b/crates/session/src/macos/runtime_authority.rs
@@ -1,0 +1,256 @@
+//! Strict one-shot transport for launcher-created runtime-session authority.
+
+use std::fmt;
+use std::io;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::unix::net::UnixDatagram;
+
+use crate::elevated_probe::{RUNTIME_SESSION_AUTHORITY_BYTES, RuntimeSessionAuthority};
+
+use super::grant_transport::{GrantTransportError, receive_raw, send_raw};
+
+/// One canonical authority record and its exact session descriptor.
+pub struct ReceivedRuntimeSessionAuthority {
+    /// Bootstrap- and lifecycle-bound authority record.
+    pub authority: RuntimeSessionAuthority,
+    /// Exact launcher-created session directory.
+    pub descriptor: OwnedFd,
+}
+
+impl fmt::Debug for ReceivedRuntimeSessionAuthority {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ReceivedRuntimeSessionAuthority(<redacted>)")
+    }
+}
+
+/// Sends one canonical authority and consumes the launcher's descriptor alias.
+pub fn send_runtime_session_authority(
+    socket: &UnixDatagram,
+    authority: RuntimeSessionAuthority,
+    descriptor: OwnedFd,
+) -> Result<(), GrantTransportError> {
+    let encoded = authority.encode();
+    let raw = descriptor.as_raw_fd();
+    let result = send_raw(socket.as_raw_fd(), &encoded, &[raw]);
+    drop(descriptor);
+    result
+}
+
+/// Receives exactly one canonical authority and one close-on-exec descriptor.
+pub fn receive_runtime_session_authority(
+    socket: &UnixDatagram,
+) -> Result<ReceivedRuntimeSessionAuthority, GrantTransportError> {
+    let mut payload = [0_u8; RUNTIME_SESSION_AUTHORITY_BYTES];
+    let (length, descriptors) = receive_raw(socket, &mut payload)?;
+    if length != payload.len() || descriptors.len() != 1 {
+        return Err(GrantTransportError::Invalid);
+    }
+    let authority =
+        RuntimeSessionAuthority::decode(&payload).map_err(|_| GrantTransportError::Invalid)?;
+    let mut descriptors = descriptors.into_iter();
+    let descriptor = descriptors.next().ok_or(GrantTransportError::Invalid)?;
+    if descriptors.next().is_some() {
+        return Err(GrantTransportError::Invalid);
+    }
+    if !transport_is_empty(socket.as_raw_fd()) {
+        return Err(GrantTransportError::Invalid);
+    }
+    Ok(ReceivedRuntimeSessionAuthority {
+        authority,
+        descriptor,
+    })
+}
+
+fn transport_is_empty(fd: libc::c_int) -> bool {
+    let mut byte = 0_u8;
+    // SAFETY: `byte` is writable for one non-consuming byte probe and `fd` is
+    // the live connected authority datagram endpoint.
+    let result = unsafe {
+        libc::recv(
+            fd,
+            (&raw mut byte).cast(),
+            1,
+            libc::MSG_PEEK | libc::MSG_DONTWAIT,
+        )
+    };
+    if result < 0 {
+        let error = io::Error::last_os_error();
+        return error
+            .raw_os_error()
+            .is_some_and(|code| code == libc::EAGAIN || code == libc::EWOULDBLOCK);
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::time::Duration;
+
+    use crate::elevated_probe::{ProbeMode, RuntimeSessionAuthority};
+    use crate::{ObjectIdentity, SessionId};
+
+    use super::*;
+
+    fn authority() -> RuntimeSessionAuthority {
+        RuntimeSessionAuthority::launcher(
+            ProbeMode::RuntimeDrop,
+            501,
+            20,
+            ObjectIdentity {
+                device: 11,
+                inode: 12,
+            },
+            ObjectIdentity {
+                device: 13,
+                inode: 14,
+            },
+            SessionId::from_bytes([1; 32]),
+            SessionId::from_bytes([2; 32]),
+        )
+        .expect("authority should construct")
+    }
+
+    fn duplicate(file: &File) -> OwnedFd {
+        // SAFETY: `file` remains live and success returns one new owned descriptor.
+        let descriptor = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+        assert!(descriptor >= 0, "descriptor duplication should succeed");
+        // SAFETY: The successful fresh descriptor transfers into this owner once.
+        unsafe { OwnedFd::from_raw_fd(descriptor) }
+    }
+
+    #[test]
+    fn authority_round_trips_and_consumes_sender_alias() {
+        let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should create");
+        let file = File::open("/dev/null").expect("fixture should open");
+        let descriptor = duplicate(&file);
+        let raw = descriptor.as_raw_fd();
+        send_runtime_session_authority(&sender, authority(), descriptor)
+            .expect("authority should send");
+        // SAFETY: The sender function consumed the exact descriptor number.
+        assert_eq!(unsafe { libc::fcntl(raw, libc::F_GETFD) }, -1);
+
+        let received =
+            receive_runtime_session_authority(&receiver).expect("authority should receive");
+        assert_eq!(received.authority, authority());
+        // SAFETY: The received descriptor is live and queried without mutation.
+        let flags = unsafe { libc::fcntl(received.descriptor.as_raw_fd(), libc::F_GETFD) };
+        assert!(flags >= 0 && flags & libc::FD_CLOEXEC != 0);
+        assert_eq!(
+            format!("{received:?}"),
+            "ReceivedRuntimeSessionAuthority(<redacted>)"
+        );
+    }
+
+    #[test]
+    fn authority_rejects_missing_and_extra_descriptors() {
+        let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should create");
+        let encoded = authority().encode();
+        send_raw(sender.as_raw_fd(), &encoded, &[]).expect("missing-rights record should send");
+        assert!(matches!(
+            receive_runtime_session_authority(&receiver),
+            Err(GrantTransportError::Invalid)
+        ));
+
+        let first = File::open("/dev/null").expect("first fixture should open");
+        let second = File::open("/dev/null").expect("second fixture should open");
+        let third = File::open("/dev/null").expect("third fixture should open");
+        send_raw(
+            sender.as_raw_fd(),
+            &encoded,
+            &[first.as_raw_fd(), second.as_raw_fd(), third.as_raw_fd()],
+        )
+        .expect("control-truncating record should send");
+        assert!(matches!(
+            receive_runtime_session_authority(&receiver),
+            Err(GrantTransportError::Invalid)
+        ));
+
+        send_raw(
+            sender.as_raw_fd(),
+            &encoded,
+            &[first.as_raw_fd(), second.as_raw_fd()],
+        )
+        .expect("extra-rights record should send");
+        assert!(matches!(
+            receive_runtime_session_authority(&receiver),
+            Err(GrantTransportError::Invalid)
+        ));
+    }
+
+    #[test]
+    fn authority_rejects_wrong_payload_shape() {
+        let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should create");
+        let file = File::open("/dev/null").expect("fixture should open");
+        send_raw(sender.as_raw_fd(), b"short", &[file.as_raw_fd()])
+            .expect("short record should send");
+        assert!(matches!(
+            receive_runtime_session_authority(&receiver),
+            Err(GrantTransportError::Invalid)
+        ));
+
+        let mut malformed = authority().encode();
+        malformed[9] = 1;
+        send_raw(sender.as_raw_fd(), &malformed, &[file.as_raw_fd()])
+            .expect("malformed record should send");
+        assert!(matches!(
+            receive_runtime_session_authority(&receiver),
+            Err(GrantTransportError::Invalid)
+        ));
+
+        let oversized = [0_u8; RUNTIME_SESSION_AUTHORITY_BYTES + 1];
+        send_raw(sender.as_raw_fd(), &oversized, &[file.as_raw_fd()])
+            .expect("oversized record should send at the raw boundary");
+        assert!(matches!(
+            receive_runtime_session_authority(&receiver),
+            Err(GrantTransportError::Invalid)
+        ));
+    }
+
+    #[test]
+    fn authority_rejects_an_already_queued_replay() {
+        let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should create");
+        let first = File::open("/dev/null").expect("first fixture should open");
+        let second = File::open("/dev/null").expect("second fixture should open");
+        let encoded = authority().encode();
+        send_raw(sender.as_raw_fd(), &encoded, &[first.as_raw_fd()])
+            .expect("first authority should queue");
+        send_raw(sender.as_raw_fd(), &encoded, &[second.as_raw_fd()])
+            .expect("replayed authority should queue");
+        assert!(matches!(
+            receive_runtime_session_authority(&receiver),
+            Err(GrantTransportError::Invalid)
+        ));
+    }
+
+    #[test]
+    fn failed_send_still_consumes_the_sender_alias() {
+        let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should create");
+        drop(receiver);
+        let file = File::open("/dev/null").expect("fixture should open");
+        let descriptor = duplicate(&file);
+        let raw = descriptor.as_raw_fd();
+        assert!(send_runtime_session_authority(&sender, authority(), descriptor).is_err());
+        // SAFETY: The send function consumes its exact descriptor on failure.
+        assert_eq!(unsafe { libc::fcntl(raw, libc::F_GETFD) }, -1);
+    }
+
+    #[test]
+    fn authority_receive_fails_closed_on_timeout_and_peer_close() {
+        let (_sender, receiver) = UnixDatagram::pair().expect("datagram pair should create");
+        receiver
+            .set_read_timeout(Some(Duration::from_millis(10)))
+            .expect("receive timeout should install");
+        assert!(matches!(
+            receive_runtime_session_authority(&receiver),
+            Err(GrantTransportError::Io(
+                io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+            ))
+        ));
+
+        let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should create");
+        drop(sender);
+        assert!(receive_runtime_session_authority(&receiver).is_err());
+    }
+}

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -1231,18 +1231,27 @@ SIGINT/SIGTERM to that PID follows normal reap and cleanup. Signed evidence also
 covers two simultaneous daemon supervisors and peer survival after one stops.
 
 The disabled-by-default elevated evidence bundle additionally proves a
-no-chroot credential bootstrap boundary on Apple Silicon macOS 26.5.2 / SDK
-26.5. With explicit operator root, both fixed signed endpoints complete
+no-chroot credential and target-runtime boundary on Apple Silicon macOS 26.5.2
+/ SDK 26.5. With explicit operator root, both fixed signed endpoints complete
 worker-first then launcher-second mapped ordinary and SDK-maximum unmapped
 credential transitions. Public `setgroups`/`setgid`/`setuid` order, the Darwin
 `effective-only` access-group postcondition, exact real/effective target ids,
 and failed root restoration are checked; zero is retained-root/no-drop. Stream
 credentials remain connection-time snapshots, datagram peer credentials are
 unsupported, opaque datagram tokens distinguish changed from retained-root,
-and live PIDs remain exact. This is evidence for #1371, not a public launch
-policy or capability disposition: target-owned runtime/resources, typed grants,
-lifecycle/API, daemon/crash, guest/HVF continuation, and final uid/gid semantics
-remain unmeasured.
+and live PIDs remain exact.
+
+After the credential transcript, the transitioned launcher creates one random
+target-owned session, opens three independent descriptions, and transfers one
+canonical bootstrap/lifecycle-bound `BBN1` record plus exactly one descriptor.
+The worker validates, adopts, and locks it before ordinary `Hello`; later
+`Start`/`Prepared` bind the same session and inode before the existing typed
+grant transaction. Mapped, retained-root, and SDK-maximum unmapped cases each
+completed three times, including the unchanged live-code checks, representative
+grant workload, `Proceed`/`Starting`/terminal ownership, and exact cleanup. This
+is evidence for #1371, not a public launch policy or capability disposition:
+API/no-API real guests, daemon/crash convergence, post-transition guest HVF,
+and final uid/gid semantics remain unmeasured.
 
 This is macOS containment, not direct Linux jailer/seccomp equivalence. The
 session namespace itself grants no host resource. The bounded startup channel

--- a/docs/security.md
+++ b/docs/security.md
@@ -60,10 +60,11 @@ singleton write-only sink grants; vhost-user endpoints require repeatable
 connect-only directory grants and launcher-returned streams. Public product
 uid/gid transition, configurable chroot ownership, and complete
 distribution-signing policy remain absent. A disabled evidence bundle has
-measured credential bootstrap plus same-process continuation into ordinary
-`Hello`/`Start`; the current App Sandbox profile denies creation of the random
-session beneath an exact target-owned root, and the representative grants and
-later lifecycle remain unreached. The
+measured credential bootstrap plus same-process continuation through a
+launcher-created target-owned session. The worker consumes one exact
+session-bound descriptor authority before `Hello`; mapped, retained-root, and
+SDK-maximum unmapped cases then complete the representative grants and terminal
+lifecycle. The
 exact seccomp, cgroup, network-namespace, and PID-namespace mechanisms are now
 certified public-macOS exclusions rather than unresolved or silently accepted
 inputs.
@@ -85,15 +86,18 @@ without reopening their tagged path strings. General dynamic post-Ready
 delivery and hard revocation still need dedicated designs.
 
 The elevated evidence result is intentionally narrower than product support.
-For mapped and retained-root identities, the signed launcher and worker retain
-the same PIDs, lifecycle stream, and grant datagram through a canonical
-nonce-bound acknowledgment and ordinary `Hello`/`Start`. The worker then
-receives an already-opened validated target-owned root, but its exact session
-`mkdirat` returns permission denied under App Sandbox. The high unmapped case
-stops earlier at live code-identity revalidation. No hidden launcher-created
-session fallback is used: changing that authority ordering requires a separate
-Challenge. This evidence does not establish grants, `Proceed`, terminal
-ownership, API/guest execution, daemon recovery, or post-transition HVF.
+For mapped, retained-root, and SDK-maximum unmapped identities, the signed
+launcher and worker retain the same PIDs, lifecycle stream, and grant datagram
+through a canonical nonce-bound acknowledgment. After the unchanged live-code
+checks, the permanently transitioned launcher creates the exact target-owned
+session and sends one canonical `BBN1` record plus one descriptor. The worker
+validates, adopts, and locks it before ordinary `Hello`; `Start` and `Prepared`
+bind the same session/inode, and the launcher proves the lock through an
+independent description before committing grants. The representative grant
+workload, `Proceed`/`Starting`/terminal ownership, reap, and exact cleanup all
+complete. This separately challenged test-only authority path does not establish
+public uid/gid policy, API/guest execution, daemon/crash convergence, or
+post-transition guest HVF.
 
 ## Certified Linux Runtime Isolation Exclusions
 
@@ -253,7 +257,7 @@ Use this checklist when reviewing Firecracker-facing host isolation changes:
 
 | Area | Current status | Review expectation |
 | --- | --- | --- |
-| Linux jailer, seccomp, namespaces, cgroups, chroot, and privilege dropping | Direct mechanisms unsupported; fixed-code/current-user/private-root/rlimit/daemon observable subset implemented; disabled evidence reaches credential continuation and mapped/retained-root `Hello`/`Start`, then stops at App Sandbox target-session creation | Preserve the exact macOS launch-policy contract and reject unsupported Linux controls. Do not equate the measured namespace boundary with grants, lifecycle completion, product uid/gid support, or chroot. |
+| Linux jailer, seccomp, namespaces, cgroups, chroot, and privilege dropping | Direct mechanisms unsupported; fixed-code/current-user/private-root/rlimit/daemon observable subset implemented; disabled evidence completes numeric credential continuation, launcher-created target-session adoption, representative grants, and terminal cleanup for mapped, retained-root, and SDK-maximum unmapped classes | Preserve the exact macOS launch-policy contract and reject unsupported Linux controls. Do not equate the feature-only evidence with product uid/gid support, configurable chroot, or Linux isolation parity. |
 | API socket ownership | Implemented subset | Keep owner-only socket permissions, final-path ownership checks, and owner-only cleanup tests current when API socket behavior changes. |
 | Host path policy | Operator-owned with per-resource validation | Redact sensitive path details in errors, avoid opening paths during pre-boot storage unless the resource explicitly requires it, and test cleanup for owned resources. |
 | HVF entitlement and code signing | Implemented direct, App Sandbox, and production nested-worker validation paths | Keep real HVF tests in signed targets, inspect entitlement separation and nested signatures, and keep unsupported CI hosts on explicit compile/sign-only validation, not silent skips. |
@@ -514,7 +518,7 @@ Use the following boundaries when designing or reviewing macOS isolation work:
 | HVF entitlement and code signing | The production worker alone receives the Hypervisor entitlement; the outer launcher cannot enter HVF. Both code objects use Hardened Runtime and are separately inspectable. | Developer ID possession, team policy, launch constraints, and notarization still require deployment evidence. |
 | macOS App Sandbox | The production worker is sandboxed; the ordinary direct CLI and outer launcher are not. Container/sealed resources plus granted config, metadata, kernel, initrd, block, pmem, logger, metrics, serial, snapshot, API-socket, vsock-socket, and connect-only vhost-user-socket authority form the current contained mode. Lifecycle v5 binds vmnet policy to exact networkless or caller-approved vmnet signature profiles. | The real restricted-entitlement credential and connectivity evidence remain operator-owned gates; general dynamic delivery still requires explicit design. |
 | Launcher or resource broker | The production launcher validates fixed/live nested code, starts one closed-environment/default-close worker, authenticates lifecycle v5 credential/resource-limit/vmnet policy, applies worker-local limits before `Prepared`, owns cancellation/status, coordinates and enters the private namespace, atomically transfers a bounded typed startup batch, supports adopted file/directory/block-special consumers, offers signed daemon detach, and exposes separate fixed vsock, vhost-user, and retained-descriptor block-control facets. | Keep each private protocol fixed and redacted; separately challenge any broader dynamic broker and never infer hard revocation from closing a duplicate descriptor. |
-| Firecracker Linux jailer model | Direct port unsupported; exact fixed executable/current-user/rlimit/version/daemon outcomes implemented through the versioned macOS policy envelope; the disabled bootstrap harness reaches mapped/retained-root credential continuation and ordinary `Hello`/`Start`, then records App Sandbox denial at exact target-session creation. | Keep product uid/gid pending a separately challenged session-authority direction and dynamic grants/lifecycle/guest evidence; keep configurable chroot, seccomp, namespaces, cgroups, and parent-cgroup controls rejected until separately challenged macOS outcomes exist. |
+| Firecracker Linux jailer model | Direct port unsupported; exact fixed executable/current-user/rlimit/version/daemon outcomes implemented through the versioned macOS policy envelope; the disabled bootstrap harness completes credential continuation, launcher-created target-session adoption, representative grants, and terminal cleanup for mapped, retained-root, and SDK-maximum unmapped classes. | Keep product uid/gid pending the remaining real-guest and daemon/resilience evidence; keep configurable chroot, seccomp, namespaces, cgroups, and parent-cgroup controls rejected until separately challenged macOS outcomes exist. |
 
 This document intentionally does not define a sandbox profile, broker protocol,
 privilege-dropping flow, or new public API. PRs that add host resource types
@@ -3490,23 +3494,34 @@ remained exact.
 
 #1889 continued the same launcher and worker PIDs over those exact transports.
 One canonical nonce-bound `BBA1` acknowledgment closes the credential transcript
-and rejects buffered/replayed bytes before lifecycle reuse. Mapped ordinary and
-retained-root no-drop cases then completed ordinary `Hello`/`Start`, but the
-worker's exact `mkdirat` for a random session beneath the already-opened
-target-owned root returned permission denied under App Sandbox. The
-SDK-maximum unmapped case completed the acknowledgment but stopped earlier at
-live code-identity revalidation. Repeated and concurrent runs left no exact
-process, private root, root-owned workspace ancestry, target-owned fixture, or
-named-socket residue.
+and rejects buffered/replayed bytes before lifecycle reuse. It measured the
+App Sandbox worker's exact target-session `mkdirat` denial for mapped and
+retained-root classes and an earlier live-code boundary for SDK-maximum
+unmapped.
 
-The representative typed grant and later production lifecycle code are
-feature-isolated and statically checked, but the natural namespace denial means
-grant commitment/consumption, `Proceed`/`Starting`/terminal, API/guest,
-daemon/crash behavior, and post-transition HVF were not dynamically reached.
-A launcher-precreated session changes authority ordering and is a separately
-challenged follow-up, not an implicit fallback. The complete boundary,
-alternatives, exact cleanup rules, reproduction command, and future-OS nonclaim
-are in the checked
+#1891 separately challenged and changed only the session-creation authority.
+After the same prepublication live-code and target/no-drop checks, the
+permanently transitioned launcher creates the random target-owned session,
+opens independent worker/validation/recovery descriptions, and sends one fixed
+bootstrap- and lifecycle-bound `BBN1` record plus exactly one descriptor. The
+worker validates the record, root association, metadata, emptiness, and inode,
+then acquires and revalidates the exclusive lock before `Hello`. A later exact
+`Start` match precedes policy and descriptor entry; `Prepared` reports the same
+inode, and an independent launcher description must observe the live lock
+before the existing grant transaction begins. No account lookup, ownership
+change, credential restoration, ambient path fallback, or lifecycle-v5 change
+is introduced.
+
+On the capable host, mapped, retained-root no-drop, and SDK-maximum unmapped
+cases each completed three times, including both unchanged dynamic worker-code
+checks. Two mapped sessions also completed concurrently. Every class reached
+representative grant commitment and target-side allow/deny checks,
+`Proceed`/`Starting`/terminal ownership, reap, and exact session/workspace
+cleanup; final process, root, workspace, and socket scans were zero. The earlier
+unmapped identity boundary is superseded by this same-check witness, not by a
+bypass. API/no-API real guests, daemon/crash convergence, and post-transition
+guest HVF remain unmeasured. The complete boundary, alternatives, exact cleanup
+rules, reproduction command, and future-OS nonclaim are in the checked
 [elevated bootstrap evidence](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
 
 The six rows remain audit outcomes until #1371 challenges the controlled result

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2099,10 +2099,15 @@ merged-main OID are checked and recorded by the pull-request workflow.
 ## Explicit Elevated Bootstrap Evidence
 
 The #1373 direct-worker, #1884 inherited-root, #1885 no-chroot credential, and
-#1889 target-owned runtime-continuation proofs are deliberately
+#1889 / #1891 target-owned runtime-continuation proofs are deliberately
 separate from `scripts/run-integration-tests.sh`. Normal validation never
 invokes `sudo`, prompts for a password, or treats missing root/HVF support as a
 passing skip.
+The capable-host wrapper is a manual certification artifact, not an ordinary
+PR or CI gate. CI builds the statically isolated bundle and verifies its
+fail-closed non-root boundary; deterministic unit and process tests cover the
+authority codec and transport, session validation and locking, fault stages,
+and exact recovery without elevation.
 First build the test-only bundle as an ordinary user at an absent absolute
 destination:
 
@@ -2114,23 +2119,19 @@ scripts/build-elevated-bootstrap-probe.sh \
 The build compiles normal launcher and worker artifacts first and verifies that
 the V2 probe status, worker activation, Ready, inherited-root, HVF, credential
 and runtime modes, credential phases and restoration steps, `BBA1`
-acknowledgment, representative grant activation, and complete boundary
+acknowledgment, `BBN1` session authority, representative grant activation, and complete boundary
 vocabulary are absent. It then builds both ends with disabled-by-default
 evidence features, checks role-specific credential/runtime markers, adds three
 visible test-only resource markers, and uses the normal production packager,
 signature split, entitlements, Hardened Runtime, and inspections.
 
 On a capable Apple Silicon host, calculate the explicit numeric target before
-elevation and invoke the wrapper yourself:
+elevation and invoke the wrapper through the native administrator authorization
+dialog (substitute the captured numeric values and absolute paths):
 
 ```sh
-target_uid="$(id -u)"
-target_gid="$(id -g)"
-sudo /usr/bin/env -i HOME=/var/root PATH=/usr/bin:/bin \
-  /bin/bash "$PWD/scripts/run-elevated-bootstrap-probe.sh" \
-  --bundle /absolute/absent/path/Bangbang.app \
-  --target-uid "$target_uid" \
-  --target-gid "$target_gid"
+/usr/bin/osascript -e \
+  'do shell script "/bin/bash /absolute/repo/scripts/run-elevated-bootstrap-probe.sh --bundle /absolute/absent/path/Bangbang.app --target-uid 501 --target-gid 20" with administrator privileges'
 ```
 
 Do not use `--allow-unsupported` for this proof. Missing exact root, Apple
@@ -2162,28 +2163,38 @@ must find no launcher, worker, root, workspace, or named-socket residue.
 
 The runtime-continuation branch reuses the exact stream, grant datagram, and
 launcher/worker PIDs after the credential transcript. It requires one canonical
-nonce-bound `BBA1` acknowledgment, empty live transports, fresh parent and
-target/no-drop attestations, and ordinary lifecycle `Hello`/`Start`. Each case
-receives an already-opened exact target-owned root plus a separately ledgered
-workspace whose root-owned traversal-only ancestry contains the exact
-target-owned read-only, write-only, and create-children fixtures. Mapped and
-retained-root cases repeat three times, mapped cases run concurrently, and the
-high unmapped numeric case remains separate. Pre/post-acknowledgment fault cases
-prove the closed handoff; later fault hooks are expected to remain masked when a
-natural earlier boundary is observed. Runtime cleanup validates and removes only
-the exact owned root and workspace objects, followed by independent residue
-scans.
+nonce-bound `BBA1` acknowledgment, empty live transports, and fresh parent,
+target/no-drop, and live-code attestations. The transitioned launcher then
+creates the random session beneath the exact target-owned root, opens separate
+worker-transfer, live-validation, and recovery descriptions, and sends one
+fixed `BBN1` record with exactly one descriptor. The worker must consume,
+validate, and lock that authority before ordinary `Hello`; later `Start` and
+`Prepared` must bind the same session and inode before the launcher commits
+grants. Each case also receives a separately ledgered workspace whose
+root-owned traversal-only ancestry contains the exact target-owned read-only,
+write-only, and create-children fixtures.
+
+Mapped, retained-root, and high-unmapped cases each repeat three times, and two
+mapped cases run concurrently. Closed faults exercise acknowledgment,
+launcher create/open, authority send/receive/validate, worker lock/enter,
+`Prepared`, grant transfer, `Proceed`, and terminal boundaries. Runtime cleanup
+validates and removes only the exact owned session, root, and workspace objects,
+followed by independent residue scans. Unit tests additionally cover malformed,
+truncated, missing/extra-descriptor and queued authority records, sender-alias
+closure, wrong identity/nonempty/replaced sessions, independent lock
+descriptions, and recovery after worker release.
 
 It reports OS/SDK/architecture and only value-free terminal classes. The
 inherited result remains `worker-bootstrap` / `other`: in-root `posix_spawn`
 returned success but the worker exited before its earliest application record.
 The no-chroot credential result completed mapped ordinary, retained-root
-no-drop, and SDK-maximum unmapped transitions. The mapped and retained-root
-runtime cases then completed acknowledgment plus ordinary `Hello`/`Start`, but
-App Sandbox denied exact target-owned session `mkdirat`; the high unmapped case
-stopped earlier at live code-identity revalidation. Grants, `Proceed`,
-`Starting`, terminal ownership, API/guest, daemon/crash, and post-transition HVF
-were therefore unreached or unmeasured. Stream credentials remained
+no-drop, and SDK-maximum unmapped transitions. All three runtime classes then
+completed acknowledgment, launcher-created session authority, worker adoption,
+the representative grant workload, `Proceed`/`Starting`/terminal ownership,
+and exact cleanup. The SDK-maximum result retained both live-code checks and is
+therefore a changed same-check witness, not a bypass. API/no-API real guests,
+daemon/crash convergence, and post-transition guest HVF remain unmeasured.
+Stream credentials remained
 connection-time snapshots, datagram credentials were unsupported, opaque
 datagram tokens changed only for credential transitions, and live peer PIDs
 remained exact. The exact result line, supported conclusion, and nonclaims are

--- a/scripts/build-elevated-bootstrap-probe.sh
+++ b/scripts/build-elevated-bootstrap-probe.sh
@@ -93,10 +93,11 @@ runtime_retain_mode="runtime-retain-root"
 runtime_unmapped_mode="runtime-unmapped"
 runtime_status="status: elevated runtime"
 continuation_record="BBA1"
+runtime_authority_record="BBN1"
 grant_activation="--bangbang-internal-grant-probe-v1"
 grant_runtime_case="target-runtime"
-runtime_launcher_boundary_artifact="bangbang-elevated-runtime-launcher-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary"
-runtime_worker_boundary_artifact="bangbang-elevated-runtime-worker-boundaries-v1-pre-ack-post-ack-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary"
+runtime_launcher_boundary_artifact="bangbang-elevated-runtime-launcher-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary"
+runtime_worker_boundary_artifact="bangbang-elevated-runtime-worker-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary"
 
 cargo build \
   -p bangbang \
@@ -129,6 +130,7 @@ probe_markers=(
   "$runtime_unmapped_mode"
   "$runtime_status"
   "$continuation_record"
+  "$runtime_authority_record"
   "$grant_activation"
   "$grant_runtime_case"
   "$runtime_launcher_boundary_artifact"
@@ -179,6 +181,7 @@ for marker_value in \
   "$runtime_unmapped_mode" \
   "$runtime_status" \
   "$continuation_record" \
+  "$runtime_authority_record" \
   "$runtime_launcher_boundary_artifact"; do
   if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$launcher_bin"; then
     echo "evidence launcher is missing the runtime continuation boundary" >&2
@@ -202,6 +205,7 @@ for marker_value in \
   "$runtime_retain_mode" \
   "$runtime_unmapped_mode" \
   "$continuation_record" \
+  "$runtime_authority_record" \
   "$grant_activation" \
   "$grant_runtime_case" \
   "$runtime_worker_boundary_artifact"; do

--- a/scripts/run-elevated-bootstrap-probe.sh
+++ b/scripts/run-elevated-bootstrap-probe.sh
@@ -4,9 +4,9 @@ LC_ALL=C
 export LC_ALL
 umask 077
 
-# The caller may supply an elevation credential on standard input. Sudo starts
-# this wrapper only after consuming it, so replace that descriptor before any
-# validation tool, launcher, or signed worker can inherit it.
+# The caller's elevation mechanism may use standard input. Replace that
+# descriptor before any validation tool, launcher, or signed worker can inherit
+# it. Ordinary tests and CI do not invoke this manual capable-host certifier.
 exec </dev/null
 
 usage() {
@@ -14,9 +14,10 @@ usage() {
 Usage: scripts/run-elevated-bootstrap-probe.sh --bundle /absolute/path/Bangbang.app
        --target-uid UID --target-gid GID
 
-Run the no-skip elevated bootstrap evidence matrix on a capable Apple Silicon
-host. This wrapper must already have exact real/effective uid/gid zero. It does
-not invoke sudo or infer authority from SUDO_*, HOME, PATH, or account names.
+Manually certify the no-skip elevated bootstrap evidence matrix on a capable
+Apple Silicon host. This wrapper is separate from ordinary tests and CI and
+must already have exact real/effective uid/gid zero. It does not elevate itself
+or infer authority from SUDO_*, HOME, PATH, or account names.
 EOF
 }
 
@@ -237,7 +238,6 @@ replacement_root=""
 replacement_root_identity=""
 replacement_candidate=""
 replacement_candidate_identity=""
-unmapped_runtime_result="unmeasured"
 cleanup_return=false
 
 bundle_directories=(
@@ -1038,6 +1038,27 @@ assert_runtime_output_redacted() {
   done
 }
 
+reset_runtime_write_fixture() {
+  local runtime_workspace_path="$1"
+  local runtime_workspace_object="$2"
+  local ledger="$3"
+  local ledger_identity="$4"
+  local uid="$5"
+  local gid="$6"
+  if ! validate_runtime_workspace \
+    "$runtime_workspace_path" \
+    "$runtime_workspace_object" \
+    "$ledger" \
+    "$ledger_identity" \
+    "$uid" \
+    "$gid"; then
+    echo "bangbang elevated bootstrap proof: runtime fixture reset validation failed" >&2
+    exit 1
+  fi
+  /usr/bin/printf '%36s\n' '' | /usr/bin/tr ' ' '?' \
+    > "$runtime_workspace_path/write.output"
+}
+
 output_has_exact_line() {
   local output="$1"
   local expected="$2"
@@ -1060,6 +1081,13 @@ assert_runtime_case() {
   local fault="${13:-}"
   local output
   local status
+  reset_runtime_write_fixture \
+    "$runtime_workspace_path" \
+    "$runtime_workspace_object" \
+    "$ledger" \
+    "$ledger_identity" \
+    "$uid" \
+    "$gid"
   set +e
   output="$(invoke_runtime \
     "$root" \
@@ -1106,6 +1134,7 @@ assert_runtime_case() {
     /usr/bin/printf \
       'bangbang elevated bootstrap proof: runtime failure output mismatch mode=%s fault=%s\n' \
       "$mode" "${fault:-none}" >&2
+    /usr/bin/printf '%s\n' "$output" >&2
     exit 1
   fi
   assert_runtime_objects \
@@ -1118,44 +1147,6 @@ assert_runtime_case() {
     "$uid" \
     "$gid" \
     "$write_state"
-}
-
-assert_unmapped_runtime_case() {
-  local expected_boundary="$1"
-  local output
-  local status
-  set +e
-  output="$(invoke_runtime \
-    "$runtime_unmapped_root" \
-    2147483647 \
-    2147483647 \
-    runtime-unmapped \
-    "$runtime_unmapped_workspace" \
-    2>&1)"
-  status=$?
-  set -e
-  assert_runtime_output_redacted \
-    "$output" "$runtime_unmapped_root" "$runtime_unmapped_workspace"
-  if [[ "$status" -eq 3 ]] \
-    && output_has_exact_line "$output" "$expected_boundary"; then
-    unmapped_runtime_result="identity-boundary"
-    assert_runtime_objects \
-      "$runtime_unmapped_root" \
-      "$runtime_unmapped_root_identity" \
-      "$runtime_unmapped_workspace" \
-      "$runtime_unmapped_workspace_identity" \
-      "$runtime_unmapped_ledger" \
-      "$runtime_unmapped_ledger_identity" \
-      2147483647 \
-      2147483647 \
-      initial
-    return 0
-  fi
-  /usr/bin/printf \
-    'bangbang elevated bootstrap proof: unmapped runtime result was not an allowed exact boundary status=%s\n' \
-    "$status" >&2
-  /usr/bin/printf '%s\n' "$output" >&2
-  exit 1
 }
 
 invoke_inherited() {
@@ -1248,9 +1239,9 @@ assert_case "$probe_root" 2147483647 2147483647 credential-unmapped 0 \
 
 runtime_drop_semantics="stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed datagram-pid=exact"
 runtime_retain_semantics="stream-eid=stable-root stream-cred=stable-root stream-pid=exact datagram-cred=unsupported datagram-token=unchanged datagram-pid=exact"
-expected_runtime_drop_boundary="status: elevated runtime runtime-drop blocked stage=runtime-namespace error=permission-denied result=namespace-boundary $runtime_drop_semantics"
-expected_runtime_retain_boundary="status: elevated runtime runtime-retain-root blocked stage=runtime-namespace error=permission-denied result=namespace-boundary $runtime_retain_semantics"
-expected_runtime_unmapped_boundary="status: elevated runtime runtime-unmapped blocked stage=live-identity error=other result=identity-boundary $runtime_drop_semantics"
+expected_runtime_drop_complete="status: elevated runtime runtime-drop complete result=complete $runtime_drop_semantics namespace=launcher-created-target-owned authority=consumed lock=independent grants=committed lifecycle=terminal cleanup=complete"
+expected_runtime_retain_complete="status: elevated runtime runtime-retain-root complete result=complete $runtime_retain_semantics namespace=launcher-created-target-owned authority=consumed lock=independent grants=committed lifecycle=terminal cleanup=complete"
+expected_runtime_unmapped_complete="status: elevated runtime runtime-unmapped complete result=complete $runtime_drop_semantics namespace=launcher-created-target-owned authority=consumed lock=independent grants=committed lifecycle=terminal cleanup=complete"
 
 create_owned_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
   "$target_uid" "$target_gid" runtime_root runtime_root_identity
@@ -1272,9 +1263,9 @@ for _ in 1 2 3; do
     "$target_uid" \
     "$target_gid" \
     runtime-drop \
-    3 \
-    "$expected_runtime_drop_boundary" \
-    initial
+    0 \
+    "$expected_runtime_drop_complete" \
+    complete
 done
 
 create_owned_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
@@ -1297,14 +1288,22 @@ for _ in 1 2 3; do
     0 \
     0 \
     runtime-retain-root \
-    3 \
-    "$expected_runtime_retain_boundary" \
-    initial
+    0 \
+    "$expected_runtime_retain_complete" \
+    complete
 done
 
 for fault_case in \
   "pre-ack:continuation-ack:continuation-boundary:initial" \
   "post-ack:lifecycle-hello:lifecycle-boundary:initial" \
+  "session-create:runtime-session-create:namespace-boundary:initial" \
+  "session-open:runtime-session-open:namespace-boundary:initial" \
+  "authority-send:runtime-authority-send:namespace-boundary:initial" \
+  "authority-receive:runtime-authority-receive:namespace-boundary:initial" \
+  "authority-validate:runtime-authority-validate:namespace-boundary:initial" \
+  "session-lock:runtime-session-lock:namespace-boundary:initial" \
+  "session-enter:runtime-session-enter:namespace-boundary:initial" \
+  "prepared:lifecycle-prepared:namespace-boundary:initial" \
   "namespace:runtime-namespace:namespace-boundary:initial"; do
   IFS=: read -r fault stage result_class write_state <<< "$fault_case"
   expected_fault="status: elevated runtime runtime-drop blocked stage=$stage error=other result=$result_class $runtime_drop_semantics"
@@ -1324,7 +1323,12 @@ for fault_case in \
     "$fault"
 done
 
-for fault in grant-transfer proceed terminal; do
+for fault_case in \
+  "grant-transfer:grant-transfer:grant-boundary:initial" \
+  "proceed:lifecycle-proceed:lifecycle-boundary:initial" \
+  "terminal:lifecycle-terminal:lifecycle-boundary:complete"; do
+  IFS=: read -r fault stage result_class write_state <<< "$fault_case"
+  expected_fault="status: elevated runtime runtime-drop blocked stage=$stage error=other result=$result_class $runtime_drop_semantics"
   assert_runtime_case \
     "$runtime_root" \
     "$runtime_root_identity" \
@@ -1336,8 +1340,8 @@ for fault in grant-transfer proceed terminal; do
     "$target_gid" \
     runtime-drop \
     3 \
-    "$expected_runtime_drop_boundary" \
-    initial \
+    "$expected_fault" \
+    "$write_state" \
     "$fault"
 done
 
@@ -1350,7 +1354,21 @@ create_runtime_workspace \
   runtime_unmapped_workspace_identity \
   runtime_unmapped_ledger \
   runtime_unmapped_ledger_identity
-assert_unmapped_runtime_case "$expected_runtime_unmapped_boundary"
+for _ in 1 2 3; do
+  assert_runtime_case \
+    "$runtime_unmapped_root" \
+    "$runtime_unmapped_root_identity" \
+    "$runtime_unmapped_workspace" \
+    "$runtime_unmapped_workspace_identity" \
+    "$runtime_unmapped_ledger" \
+    "$runtime_unmapped_ledger_identity" \
+    2147483647 \
+    2147483647 \
+    runtime-unmapped \
+    0 \
+    "$expected_runtime_unmapped_complete" \
+    complete
+done
 
 create_private_directory "/private/var/root/bangbang-elevated-probe.XXXXXXXX" \
   inherited_root inherited_root_identity
@@ -1620,9 +1638,9 @@ assert_runtime_output_redacted \
   "$runtime_output_a" "$runtime_concurrent_root_a" "$runtime_concurrent_workspace_a"
 assert_runtime_output_redacted \
   "$runtime_output_b" "$runtime_concurrent_root_b" "$runtime_concurrent_workspace_b"
-if [[ "$runtime_status_a" -ne 3 || "$runtime_status_b" -ne 3 ]] \
-  || ! output_has_exact_line "$runtime_output_a" "$expected_runtime_drop_boundary" \
-  || ! output_has_exact_line "$runtime_output_b" "$expected_runtime_drop_boundary"; then
+if [[ "$runtime_status_a" -ne 0 || "$runtime_status_b" -ne 0 \
+  || "$runtime_output_a" != "$expected_runtime_drop_complete" \
+  || "$runtime_output_b" != "$expected_runtime_drop_complete" ]]; then
   echo "bangbang elevated bootstrap proof: runtime concurrency case failed" >&2
   exit 1
 fi
@@ -1635,7 +1653,7 @@ assert_runtime_objects \
   "$runtime_concurrent_ledger_a_identity" \
   "$target_uid" \
   "$target_gid" \
-  initial
+  complete
 assert_runtime_objects \
   "$runtime_concurrent_root_b" \
   "$runtime_concurrent_root_b_identity" \
@@ -1645,7 +1663,7 @@ assert_runtime_objects \
   "$runtime_concurrent_ledger_b_identity" \
   "$target_uid" \
   "$target_gid" \
-  initial
+  complete
 /bin/unlink "$workspace/runtime-case-a"
 /bin/unlink "$workspace/runtime-case-b"
 
@@ -1740,7 +1758,7 @@ if [[ "$socket_residue" -ne 0 || "$root_residue" -ne 0 \
   exit 1
 fi
 
-echo "result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete runtime-mapped=namespace-boundary runtime-retained-root=namespace-boundary runtime-unmapped=$unmapped_runtime_result grants=unreached lifecycle=hello-start controls=complete cleanup=exact"
+echo "result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete runtime-mapped=complete runtime-retained-root=complete-no-drop runtime-unmapped=complete authority=consumed lock=independent grants=committed lifecycle=terminal controls=complete cleanup=exact"
 echo "observations: stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed-or-unchanged datagram-pid=exact"
 echo "residue: roots=zero workspaces=zero sockets=zero launchers=zero workers=zero"
-echo "nonclaims: target-session=unreached grants=unreached proceed-starting-terminal=unreached api-no-api-real-guest=unmeasured daemon-crash=unmeasured post-drop-guest-hvf=unmeasured public-policy=unchanged chroot=unresolved aggregate-jailer=nonterminal"
+echo "nonclaims: api-no-api-real-guest=unmeasured daemon-crash=unmeasured post-drop-guest-hvf=unmeasured public-policy=unchanged chroot=unresolved aggregate-jailer=nonterminal"


### PR DESCRIPTION
## Summary

- add a fixed canonical BBN1 runtime-session authority record and strict one-descriptor transport
- let the permanently transitioned launcher create and preopen the target-owned session, then require worker adoption and locking before `Hello`
- bind `Start` and `Prepared` to the same session/inode, preserve grant and terminal supervision, and make unpublished/published recovery replacement-safe
- extend closed fault coverage, normal-artifact isolation, capable-host evidence expectations, and security/testing documentation
- document the exact-root matrix as a manual capable-host certifier; ordinary PR and CI validation stays unprivileged

## Scope exclusions

Public uid/gid or chroot policy, sandbox/entitlement widening, guest execution after credential transition, and daemon/crash convergence remain outside this child.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple-target Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- Firecracker capability audit validation and exact sibling v1.16.0 comparison
- `scripts/run-integration-tests.sh`
- manual capable-host evidence during implementation: mapped, retained-root, and maximum-unmapped completed three times; two mapped sessions completed concurrently; residue was zero
- final unprivileged wrapper boundary returns explicit-root-required without prompting or elevating

Closes #1891

