### PR TITLE
test: certify launcher-created API listener boundary

### DIFF
--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -124,7 +124,7 @@ reviewed delta.
 | [Specification benchmark](specification-benchmark-contract.md) | Terminal three-row reference interpretation, strict signed collector/report/comparison, real FIFO loss/replay evidence, optional fixture boundary, and exact performance nonclaims |
 | [Wave 7 aggregate](observability-tools-specification-contract.md#wave-7-aggregate-certification) | Terminal 93-row parent distribution, exact design/device API/release/tool/MMIO ledgers, and explicit #1351/#1373/#1378/Wave 8 handoffs |
 | [Wave 8 platform-feasible certification](wave8-certification-contract.md) | Final seven-domain/21-pair interaction authority, four current platform-mechanism reviews, one exact successor transition, and its retained external outcomes |
-| [Elevated macOS bootstrap evidence](elevated-bootstrap-evidence.md) | Same-host signed evidence for the chroot boundary, three-class permanent credential/session/grant continuation, real no-API HVF completion, the contained API publication boundary, and exact cleanup |
+| [Elevated macOS bootstrap evidence](elevated-bootstrap-evidence.md) | Same-host signed evidence for the chroot boundary, three-class permanent credential/session/grant continuation, real no-API HVF completion, the historical contained API publication boundary, the launcher-created listener transfer and worker-adoption boundary, and exact cleanup |
 
 ## Dispositions
 

--- a/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
+++ b/compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md
@@ -3,7 +3,8 @@
 This contract records the #1373 direct-worker result, the #1884 inherited-root
 follow-up, the #1885 no-chroot credential-transition result, the #1889 / #1891
 target-owned runtime continuation results, and the #1893 post-transition guest
-result beneath #1371. Together they test public chroot orderings, numeric
+result plus the #1895 launcher-created API-listener result beneath #1371.
+Together they test public chroot orderings, numeric
 credential bootstrap, same-process continuation into the ordinary production
 lifecycle, and real guest execution against Bangbang's mandatory worker
 boundary. They do not add a public root mode, accept jailer uid/gid/chroot
@@ -27,7 +28,9 @@ The evidence bundle keeps the production layout and identity split:
   the `BBA1` continuation, `BBN1` session authority, guest evidence channel,
   grant activation, boundary vocabulary, and all evidence marker resources.
   The normal signed bundle dynamically rejects the historical, credential,
-  runtime, guest, and grant-probe internal argv.
+  runtime, guest, and grant-probe internal argv. The scan also excludes the
+  dedicated `BBL1` listener handoff and both role-specific listener evidence
+  markers from normal launcher and worker artifacts.
 
 The root wrapper never invokes `sudo`. It requires exact real/effective
 uid/gid zero, accepts explicit numeric target uid/gid values, runs with a
@@ -101,8 +104,9 @@ Feature-only closed fault points cover acknowledgment, session creation/open,
 authority send/receive/validation, lock, enter, `Prepared`, grant, proceed, and
 terminal boundaries without changing lifecycle v5 or normal bundle behavior.
 
-The six guest modes append API and no-API workloads for mapped, retained-root,
-and SDK-maximum unmapped identities without changing that prefix. The same
+The six #1893 guest modes append API and no-API workloads for mapped,
+retained-root, and SDK-maximum unmapped identities without changing that
+prefix. The same
 authenticated grant datagram carries two closed late reattestation barriers
 before the first guest resource claim and before HVF creation, followed by
 value-free HVF-created and guest-shutdown reports. Immutable kernel, initrd,
@@ -112,12 +116,20 @@ by exact identity under root. The root wrapper never downloads, repairs, or
 builds guest inputs.
 
 No-API consumes the canonical config and boot/output grants through the normal
-startup path. API uses the normal contained API directory grant and signed
-descriptor-relative binder, while the transitioned launcher owns the bounded
-HTTP state machine. Guest success requires the exact serial oracle, guest
-poweroff, ordered logger evidence, bounded metrics, lifecycle terminal,
-replacement-safe authority cleanup, and zero residue; launcher output alone is
-not sufficient.
+startup path. #1893 API uses the normal contained API directory grant and
+signed descriptor-relative binder, while the transitioned launcher owns the
+bounded HTTP state machine. #1895 preserves that historical result and replaces
+only the feature-only listener producer: after the worker consumes the exact
+claim, it sends a canonical zero-right `BBL1` request; the transitioned launcher
+enters the retained exact anchor, binds fixed final `evidence-api.sock`, and
+sends one canonical acknowledgment plus exactly one listener descriptor. A
+complete send releases the launcher descriptor alias while retaining exact
+post-reap cleanup metadata. The worker must validate and adopt the listener,
+sync the existing socket ownership record, and install its exact cleanup guard
+before API readiness. Guest success requires the exact HTTP responses, serial
+oracle, guest poweroff, ordered logger evidence, bounded metrics, lifecycle
+terminal, replacement-safe authority cleanup, and zero residue; launcher
+output alone is not sufficient.
 
 Each runtime case uses a mode-0700 root and a separate bounded workspace with a
 root-owned traversal-only ancestry and exact target-owned fixtures. A root-owned
@@ -171,9 +183,11 @@ root authority. The complete matrix produced these results:
 | two concurrent runtime-continuation pairs | distinct exact roots and workspaces | both mapped-target pairs completed with distinct sessions and byte-identical bounded result lines |
 | same fixed pair, real no-API guest | mapped ordinary target, retained-root no-drop, and SDK-maximum unmapped target, each repeated three times | both late reattestations, exact boot/output grants, real HVF creation, the fixed guest oracle, guest-requested poweroff, ordinary terminal ownership, and cleanup completed |
 | two concurrent real no-API guests | distinct mapped-target roots, sessions, artifacts, outputs, launchers, and workers | both completed independently with no API socket publication |
-| same fixed pair, contained API guest | mapped ordinary and SDK-maximum unmapped targets, each repeated three times | stopped at `api-socket-publication` / `other`: App Sandbox reinitialization rejected the post-transition binder before application entry |
-| same fixed pair, contained API guest | uid/gid-zero retained-root, repeated three times | stopped at the same value-free API boundary: the reinitialized App Sandbox denied creation of the descriptor-rooted staging socket |
-| two concurrent contained API attempts | distinct mapped-target roots, sessions, and API authorities | both returned the same `api-socket-publication` boundary and cleaned exactly |
+| #1893 ordinary-binder contained API guest | mapped ordinary and SDK-maximum unmapped targets, each repeated three times | stopped at `api-socket-publication` / `other`: App Sandbox reinitialization rejected the post-transition binder before application entry |
+| #1893 ordinary-binder contained API guest | uid/gid-zero retained-root, repeated three times | stopped at the same value-free API boundary: the reinitialized App Sandbox denied creation of the descriptor-rooted staging socket |
+| two concurrent #1893 ordinary-binder API attempts | distinct mapped-target roots, sessions, and API authorities | both returned the same `api-socket-publication` boundary and cleaned exactly |
+| #1895 launcher-created final listener | mapped ordinary, uid/gid-zero retained-root, and SDK-maximum unmapped targets, each repeated three times | the request, direct final bind, exactly-one-descriptor transfer, and launcher alias release completed; the signed worker then stopped in the closed receive/adoption interval reported as `api-listener-adoption` / `other` before readiness |
+| two concurrent #1895 launcher-created-listener attempts | distinct mapped-target roots, sessions, anchors, sockets, outputs, launchers, and workers | both returned the same `api-listener-adoption` boundary and cleaned exactly |
 
 Focused negative cases reject a group-writable root and a symlink root. The
 staged manifest also rejects a writable, missing, symlinked, or inode-replaced
@@ -211,7 +225,16 @@ three API classes stopped earlier at `api-socket-publication`: mapped and
 unmapped binder images failed during App Sandbox container initialization,
 while retained-root reached the binder but App Sandbox denied creation of its
 descriptor-rooted staging socket. No API configuration request or API-started
-guest ran after that boundary. Daemon/crash convergence remains unmeasured.
+guest ran after that boundary. #1895 then removed only that binder/publication
+step from the evidence shape. In every identity class the transitioned launcher
+accepted the fixed request, directly bound the final target-owned listener,
+sent its one descriptor, and released its alias. The already-running signed App
+Sandbox worker stopped in the closed receive/adoption interval reported as
+`api-listener-adoption` / `other` before durable ownership, readiness, HTTP
+configuration, or HVF. Two concurrent mapped attempts returned the same
+boundary. This result establishes the producer and transfer prefix, but does
+not identify the exact failing operation or kernel/sandbox sub-cause inside
+that closed interval. Daemon/crash convergence remains unmeasured.
 
 After those results were established, the checked harness remained at the
 evidence boundary: it contains no credential-changing product path. If a
@@ -224,11 +247,12 @@ All reachable runtime and no-API guest fault cases reached their exact closed
 boundary, including the launcher-create/open and authority-send paths, worker
 receive/validate/lock/enter/`Prepared` exits, grant/proceed/terminal paths, late
 reattestation, HVF creation, guest execution/oracle/poweroff, endpoint death,
-and cleanup. API configuration faults after publication are ineligible because
-the measured platform boundary occurs first. Exact object state and the final
-residue scan remained clean. #1891 is the separately
+and cleanup. #1895 additionally reaches deterministic listener request, bind,
+transfer, and adoption faults; API configuration and later faults remain
+ineligible because the measured adoption boundary occurs first. Exact object
+state and the final residue scan remained clean. #1891 is the separately
 challenged launcher-created-session authority result; it is not a hidden
-fallback in #1889. #1885, #1889, #1891, and #1893 are evidence results; product
+fallback in #1889. #1885, #1889, #1891, #1893, and #1895 are evidence results; product
 uid/gid behavior still requires the parent-selected continuation.
 
 ## Supported conclusion and nonclaims
@@ -266,12 +290,16 @@ adoption, the representative grant workload, and ordinary terminal cleanup for
 mapped, retained-root, and SDK-maximum unmapped numeric identities on the
 measured host. This establishes that narrow feature-only process/resource
 composition. It now also establishes real no-API guest/HVF execution after the
-transition for all three identities. The contained API path is independently
-blocked before socket publication by App Sandbox reinitialization and write
-policy, so it establishes neither API configuration nor an API-started guest.
-Avoiding that boundary would require a separately challenged signing/helper or
-sandbox-authority model; this evidence does not weaken App Sandbox, use a
-private extension API, or treat a different topology as equivalent. Daemon/
+transition for all three identities. #1893 records the ordinary contained API
+binder block before publication. #1895 proves that the already-transitioned
+launcher can instead bind the fixed final listener and transfer exactly one
+descriptor, but the same worker then stops in the closed receive/adoption
+interval before durable ownership or readiness. It therefore establishes
+neither API configuration nor an API-started guest and does not establish the
+exact cause within that interval. Any next producer, helper, signing, sandbox,
+or topology alternative requires a fresh parent Challenge; this evidence does
+not weaken App Sandbox, use a private extension API, or treat a different
+topology as equivalent. Daemon/
 crash convergence, public policy, and aggregate jailer behavior remain
 unmeasured. It also does not prove that a larger fixed in-root Darwin dependency
 set or a materially different security model cannot work; nor does it claim
@@ -305,7 +333,7 @@ runtime results, observations, residue, and nonclaim classes:
 
 ```text
 result: inherited-root-worker=blocked stage=worker-bootstrap error=other credential-ordinary=complete credential-retained-root=complete-no-drop credential-unmapped=complete runtime-mapped=complete runtime-retained-root=complete-no-drop runtime-unmapped=complete authority=consumed lock=independent grants=committed lifecycle=terminal controls=complete cleanup=exact
-guest-matrix: api-mapped=blocked-api-publication api-retained-root=blocked-api-publication-no-drop api-unmapped=blocked-api-publication no-api-mapped=complete no-api-retained-root=complete-no-drop no-api-unmapped=complete repeats=three concurrency=no-api-isolated-api-blocked faults=no-api-reachable-complete-api-later-ineligible deaths=worker-first-launcher-first tamper=rejected adoption-replacement=no-api-preopened-api-ineligible cleanup=exact
+guest-matrix: api-mapped=blocked-listener-adoption api-retained-root=blocked-listener-adoption-no-drop api-unmapped=blocked-listener-adoption no-api-mapped=complete no-api-retained-root=complete-no-drop no-api-unmapped=complete repeats=three concurrency=no-api-complete-api-isolated-blocked faults=no-api-reachable-api-through-adoption deaths=no-api-worker-first-launcher-first tamper=rejected-both-workloads adoption-replacement=no-api-preopened-api-rejected-at-grant cleanup=exact
 observations: stream-eid=snapshot stream-cred=snapshot stream-pid=exact datagram-cred=unsupported datagram-token=changed-or-unchanged datagram-pid=exact
 residue: roots=zero workspaces=zero sockets=zero launchers=zero workers=zero
 nonclaims: daemon-crash=unmeasured public-policy=unchanged chroot=unresolved aggregate-jailer=nonterminal

--- a/crates/bangbang/src/anchored_socket.rs
+++ b/crates/bangbang/src/anchored_socket.rs
@@ -12,6 +12,8 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use bangbang_runtime::vsock::VsockGuestConnector;
+#[cfg(feature = "elevated-bootstrap-probe")]
+use bangbang_session::macos::api_listener::ReceivedApiListener;
 use bangbang_session::macos::runtime::{
     SocketOwnershipRecord, WorkerSocketNamespace, socket_staging_name,
 };
@@ -250,6 +252,7 @@ pub(crate) struct AnchoredSocketGuard {
     namespace: WorkerSocketNamespace,
     claim: ClaimedSocketDirectory,
     record: SocketOwnershipRecord,
+    expected_owner: Option<(u32, u32)>,
 }
 
 impl fmt::Debug for AnchoredSocketGuard {
@@ -265,7 +268,12 @@ impl fmt::Debug for AnchoredSocketGuard {
 
 impl Drop for AnchoredSocketGuard {
     fn drop(&mut self) {
-        cleanup_published_record(&self.namespace, &self.claim, &self.record);
+        cleanup_published_record(
+            &self.namespace,
+            &self.claim,
+            &self.record,
+            self.expected_owner,
+        );
     }
 }
 
@@ -349,6 +357,103 @@ pub(crate) fn bind(
         broker.map(SocketBrokerClaim::Committed),
         || false,
     )
+}
+
+/// Adopts the fixed final API listener created by the elevated launcher.
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub(crate) fn adopt_elevated_api_listener(
+    namespace: WorkerSocketNamespace,
+    claim: ClaimedSocketDirectory,
+    received: ReceivedApiListener,
+) -> Result<BoundAnchoredSocket, AnchoredSocketError> {
+    use bangbang_session::elevated_probe::{GUEST_API_DIRECTORY_GRANT_ID, GUEST_API_SOCKET_CHILD};
+
+    let expected_grant = bangbang_session::GrantId::parse(GUEST_API_DIRECTORY_GRANT_ID)
+        .map_err(|_| AnchoredSocketError::Invalid)?;
+    let expected_child =
+        SocketChild::parse(GUEST_API_SOCKET_CHILD).map_err(|_| AnchoredSocketError::Invalid)?;
+    if claim.grant_id != expected_grant || claim.child != expected_child {
+        return Err(AnchoredSocketError::Invalid);
+    }
+    // SAFETY: Effective identity calls have no pointer or ownership contract.
+    let expected_owner = unsafe { (libc::geteuid(), libc::getegid()) };
+    let path_identity = received
+        .record
+        .path_identity()
+        .ok_or(AnchoredSocketError::Invalid)?;
+    if path_identity.device != claim.directory.identity().device {
+        return Err(AnchoredSocketError::Invalid);
+    }
+    let child = child_cstring(&claim.child)?;
+    let current = relative_socket_identity_with_owner(
+        claim.directory.anchor_fd(),
+        &child,
+        Some(expected_owner),
+    )?;
+    if current != path_identity {
+        return Err(AnchoredSocketError::PathChanged);
+    }
+    let record = SocketOwnershipRecord::new(
+        ResourceRole::ApiSocketDirectory,
+        claim.child.clone(),
+        path_identity,
+    )
+    .map_err(|_| AnchoredSocketError::Invalid)?;
+    let listener = UnixListener::from(received.listener);
+    let mut record_written = false;
+    let adopted = (|| {
+        validate_elevated_listener_descriptor(listener.as_raw_fd(), &child)?;
+        if relative_socket_identity_with_owner(
+            claim.directory.anchor_fd(),
+            &child,
+            Some(expected_owner),
+        )? != path_identity
+        {
+            return Err(AnchoredSocketError::PathChanged);
+        }
+        namespace
+            .write_socket_record(&record)
+            .map_err(|_| AnchoredSocketError::Invalid)?;
+        record_written = true;
+        if relative_socket_identity_with_owner(
+            claim.directory.anchor_fd(),
+            &child,
+            Some(expected_owner),
+        )? != path_identity
+        {
+            return Err(AnchoredSocketError::PathChanged);
+        }
+        validate_elevated_listener_descriptor(listener.as_raw_fd(), &child)
+    })();
+    if let Err(error) = adopted {
+        let cleanup = checked_cleanup(unlink_socket_if_owned_with_owner(
+            claim.directory.anchor_fd(),
+            &claim.child,
+            path_identity,
+            Some(expected_owner),
+        ));
+        let clear = if record_written {
+            namespace
+                .clear_socket_record(&record)
+                .map_err(|_| AnchoredSocketError::Cleanup)
+        } else {
+            Ok(())
+        };
+        if cleanup.is_err() || clear.is_err() {
+            return Err(AnchoredSocketError::Cleanup);
+        }
+        return Err(error);
+    }
+    Ok(BoundAnchoredSocket {
+        listener,
+        guard: AnchoredSocketGuard {
+            namespace,
+            claim,
+            record,
+            expected_owner: Some(expected_owner),
+        },
+        connector: None,
+    })
 }
 
 /// Binds a restore vsock while retaining reusable authority until activation.
@@ -553,7 +658,7 @@ fn bind_inner(
         match spawn_connector(&claim, endpoint) {
             Ok(connector) => (claim, Some(connector)),
             Err(_) => {
-                cleanup_published_record(&namespace, &claim, &record);
+                cleanup_published_record(&namespace, &claim, &record, None);
                 return Err(AnchoredSocketError::Broker);
             }
         }
@@ -567,6 +672,7 @@ fn bind_inner(
             namespace,
             claim,
             record,
+            expected_owner: None,
         },
         connector,
     })
@@ -1083,6 +1189,14 @@ fn validate_listener_descriptor(
     descriptor: RawFd,
     role: ResourceRole,
 ) -> Result<(), AnchoredSocketError> {
+    let staging = socket_staging_name(role).map_err(|_| AnchoredSocketError::Invalid)?;
+    validate_listener_descriptor_for_name(descriptor, staging)
+}
+
+fn validate_listener_descriptor_for_name(
+    descriptor: RawFd,
+    expected_name: &std::ffi::CStr,
+) -> Result<(), AnchoredSocketError> {
     let mut socket_type = 0;
     let mut socket_type_len = libc::socklen_t::try_from(size_of::<libc::c_int>())
         .map_err(|_| AnchoredSocketError::Invalid)?;
@@ -1102,7 +1216,6 @@ fn validate_listener_descriptor(
         return Err(AnchoredSocketError::Invalid);
     }
     validate_accepting_listener(descriptor)?;
-    let staging = socket_staging_name(role).map_err(|_| AnchoredSocketError::Invalid)?;
     let mut address = MaybeUninit::<libc::sockaddr_un>::zeroed();
     let mut address_len = libc::socklen_t::try_from(size_of::<libc::sockaddr_un>())
         .map_err(|_| AnchoredSocketError::Invalid)?;
@@ -1129,7 +1242,7 @@ fn validate_listener_descriptor(
     let path_len = returned
         .checked_sub(path_offset)
         .ok_or(AnchoredSocketError::Invalid)?;
-    let expected = staging.to_bytes_with_nul();
+    let expected = expected_name.to_bytes_with_nul();
     if path_len != expected.len() {
         return Err(AnchoredSocketError::Invalid);
     }
@@ -1140,6 +1253,26 @@ fn validate_listener_descriptor(
         return Err(AnchoredSocketError::Invalid);
     }
     Ok(())
+}
+
+#[cfg(feature = "elevated-bootstrap-probe")]
+fn validate_elevated_listener_descriptor(
+    descriptor: RawFd,
+    expected_name: &std::ffi::CStr,
+) -> Result<(), AnchoredSocketError> {
+    // SAFETY: F_GETFD and F_GETFL inspect the live received descriptor.
+    let descriptor_flags = unsafe { libc::fcntl(descriptor, libc::F_GETFD) };
+    // SAFETY: F_GETFL inspects the same live received descriptor.
+    let status_flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    if descriptor_flags < 0
+        || status_flags < 0
+        || descriptor_flags & libc::FD_CLOEXEC == 0
+        || status_flags & libc::O_NONBLOCK == 0
+        || socket_int_option(descriptor, libc::SO_ERROR)? != 0
+    {
+        return Err(AnchoredSocketError::Invalid);
+    }
+    validate_listener_descriptor_for_name(descriptor, expected_name)
 }
 
 fn validate_accepting_listener(descriptor: RawFd) -> Result<(), AnchoredSocketError> {
@@ -1323,6 +1456,14 @@ fn relative_socket_identity(
     directory: RawFd,
     name: &std::ffi::CStr,
 ) -> Result<ObjectIdentity, AnchoredSocketError> {
+    relative_socket_identity_with_owner(directory, name, None)
+}
+
+fn relative_socket_identity_with_owner(
+    directory: RawFd,
+    name: &std::ffi::CStr,
+    expected_owner: Option<(u32, u32)>,
+) -> Result<ObjectIdentity, AnchoredSocketError> {
     let mut stat = MaybeUninit::<libc::stat>::uninit();
     // SAFETY: `stat` is writable, the directory is live, and the C string is fixed/live.
     if unsafe {
@@ -1344,8 +1485,11 @@ fn relative_socket_identity(
     {
         return Err(AnchoredSocketError::Invalid);
     }
-    // SAFETY: `geteuid` has no pointer or ownership contract.
-    if stat.st_uid != unsafe { libc::geteuid() } {
+    // SAFETY: Effective identity calls have no pointer or ownership contract.
+    let default_uid = unsafe { libc::geteuid() };
+    if stat.st_uid != expected_owner.map_or(default_uid, |(uid, _)| uid)
+        || expected_owner.is_some_and(|(_, gid)| stat.st_gid != gid)
+    {
         return Err(AnchoredSocketError::Invalid);
     }
     Ok(ObjectIdentity {
@@ -1384,8 +1528,17 @@ fn unlink_socket_if_owned(
     child: &SocketChild,
     identity: ObjectIdentity,
 ) -> Result<(), AnchoredSocketError> {
+    unlink_socket_if_owned_with_owner(directory, child, identity, None)
+}
+
+fn unlink_socket_if_owned_with_owner(
+    directory: RawFd,
+    child: &SocketChild,
+    identity: ObjectIdentity,
+    expected_owner: Option<(u32, u32)>,
+) -> Result<(), AnchoredSocketError> {
     let child = child_cstring(child)?;
-    unlink_relative_if_socket_at(directory, &child, Some(identity))
+    unlink_relative_if_socket_at_with_owner(directory, &child, Some(identity), expected_owner)
 }
 
 fn cleanup_staged_socket_checked(
@@ -1415,9 +1568,14 @@ fn cleanup_published_record(
     namespace: &WorkerSocketNamespace,
     claim: &ClaimedSocketDirectory,
     record: &SocketOwnershipRecord,
+    expected_owner: Option<(u32, u32)>,
 ) {
-    let cleanup =
-        unlink_socket_if_owned(claim.directory.anchor_fd(), &claim.child, record.identity());
+    let cleanup = unlink_socket_if_owned_with_owner(
+        claim.directory.anchor_fd(),
+        &claim.child,
+        record.identity(),
+        expected_owner,
+    );
     if matches!(
         cleanup,
         Ok(()) | Err(AnchoredSocketError::Invalid | AnchoredSocketError::PathChanged)
@@ -1463,7 +1621,16 @@ fn unlink_relative_if_socket_at(
     name: &std::ffi::CStr,
     identity: Option<ObjectIdentity>,
 ) -> Result<(), AnchoredSocketError> {
-    let current = match relative_socket_identity(directory, name) {
+    unlink_relative_if_socket_at_with_owner(directory, name, identity, None)
+}
+
+fn unlink_relative_if_socket_at_with_owner(
+    directory: RawFd,
+    name: &std::ffi::CStr,
+    identity: Option<ObjectIdentity>,
+    expected_owner: Option<(u32, u32)>,
+) -> Result<(), AnchoredSocketError> {
+    let current = match relative_socket_identity_with_owner(directory, name, expected_owner) {
         Ok(current) => current,
         Err(AnchoredSocketError::Io(io::ErrorKind::NotFound)) => return Ok(()),
         Err(error) => return Err(error),
@@ -1838,7 +2005,11 @@ fn cvt_spawn(result: libc::c_int) -> Result<(), AnchoredSocketError> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::io::{Read as _, Write as _};
+    use std::os::unix::fs::{FileTypeExt as _, PermissionsExt as _};
+    use std::os::unix::process::CommandExt as _;
+    use std::process::{Command, Stdio};
     use std::rc::Rc;
 
     use bangbang_session::SessionId;
@@ -1849,6 +2020,305 @@ mod tests {
     #[ignore = "private binder subprocess entry point"]
     fn binder_process_entry() {
         assert!(run_binder());
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    const ELEVATED_LISTENER_TEST_FD: RawFd = 9;
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    #[test]
+    #[ignore = "private elevated-listener subprocess entry point"]
+    fn elevated_listener_process_entry() {
+        use bangbang_session::elevated_probe::GUEST_API_SOCKET_CHILD;
+
+        set_cloexec(ELEVATED_LISTENER_TEST_FD)
+            .expect("inherited test transport should become close-on-exec");
+        // SAFETY: The test spawn contract transfers fd 9 exactly once here.
+        let transport =
+            UnixStream::from(unsafe { OwnedFd::from_raw_fd(ELEVATED_LISTENER_TEST_FD) });
+        let listener = UnixListener::bind(GUEST_API_SOCKET_CHILD)
+            .expect("relative elevated listener should bind");
+        fs::set_permissions(GUEST_API_SOCKET_CHILD, fs::Permissions::from_mode(0o600))
+            .expect("elevated listener mode should install");
+        listener
+            .set_nonblocking(true)
+            .expect("elevated listener should become nonblocking");
+        let child = CString::new(GUEST_API_SOCKET_CHILD).expect("fixed child should encode");
+        let identity = relative_socket_identity(libc::AT_FDCWD, &child)
+            .expect("relative listener identity should validate");
+        send_listener(
+            &transport,
+            ResourceRole::ApiSocketDirectory,
+            identity,
+            listener.as_raw_fd(),
+        )
+        .expect("elevated listener should transfer");
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    fn receive_relative_elevated_listener(directory: &Path) -> (UnixListener, ObjectIdentity) {
+        let (parent, child) = UnixStream::pair().expect("test transport should create");
+        parent
+            .set_read_timeout(Some(BINDER_TIMEOUT))
+            .expect("test transport should be bounded");
+        let child_descriptor = child.as_raw_fd();
+        let mut command = Command::new(env::current_exe().expect("test executable should resolve"));
+        command
+            .args([
+                "--ignored",
+                "--exact",
+                "anchored_socket::tests::elevated_listener_process_entry",
+                "--test-threads=1",
+            ])
+            .current_dir(directory)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        // SAFETY: The child hook performs only async-signal-safe descriptor operations.
+        unsafe {
+            command.pre_exec(move || {
+                if child_descriptor == ELEVATED_LISTENER_TEST_FD {
+                    let flags = libc::fcntl(child_descriptor, libc::F_GETFD);
+                    if flags < 0
+                        || libc::fcntl(child_descriptor, libc::F_SETFD, flags & !libc::FD_CLOEXEC)
+                            < 0
+                    {
+                        return Err(io::Error::last_os_error());
+                    }
+                } else if libc::dup2(child_descriptor, ELEVATED_LISTENER_TEST_FD) < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut process = command
+            .spawn()
+            .expect("relative listener child should spawn");
+        drop(child);
+        let (listener, role, identity) =
+            receive_listener(&parent).expect("relative listener child should return one listener");
+        assert_eq!(role, ResourceRole::ApiSocketDirectory);
+        assert!(
+            process
+                .wait()
+                .expect("relative listener child should reap")
+                .success()
+        );
+        (listener, identity)
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    fn prepare_elevated_test_directory(path: &Path) {
+        let directory = fs::File::open(path).expect("test directory should open");
+        // SAFETY: The descriptor is live and effective identity calls have no pointer contract.
+        let status =
+            unsafe { libc::fchown(directory.as_raw_fd(), libc::geteuid(), libc::getegid()) };
+        assert_eq!(status, 0, "test directory owner and group should install");
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .expect("test directory mode should install");
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    fn elevated_api_adoption_fixture() -> (
+        WorkerSocketNamespace,
+        ClaimedSocketDirectory,
+        crate::contained_session::TestVhostDirectory,
+        crate::contained_session::TestVhostDirectory,
+        ReceivedApiListener,
+    ) {
+        use crate::contained_session::{TestVhostDirectory, api_directory_authority_for_test};
+        use bangbang_session::elevated_probe::{
+            ApiListenerRecord, GUEST_API_SOCKET_REFERENCE, ProbeMode,
+        };
+
+        let (authority, api_directory) = api_directory_authority_for_test();
+        prepare_elevated_test_directory(api_directory.path());
+        let claim = authority
+            .claim_socket_directory(
+                Path::new(GUEST_API_SOCKET_REFERENCE),
+                ResourceRole::ApiSocketDirectory,
+            )
+            .expect("API directory claim should validate")
+            .expect("fixed API reference should claim");
+        let namespace_directory = TestVhostDirectory::new();
+        prepare_elevated_test_directory(namespace_directory.path());
+        let namespace = WorkerSocketNamespace::from_directory_for_test(namespace_directory.path())
+            .expect("test namespace should validate");
+        let (listener, identity) = receive_relative_elevated_listener(api_directory.path());
+        let child = CString::new(bangbang_session::elevated_probe::GUEST_API_SOCKET_CHILD)
+            .expect("fixed child should encode");
+        // SAFETY: Effective identity calls have no pointer or ownership contract.
+        let expected_owner = unsafe { (libc::geteuid(), libc::getegid()) };
+        assert_eq!(
+            relative_socket_identity_with_owner(
+                claim.directory.anchor_fd(),
+                &child,
+                Some(expected_owner),
+            ),
+            Ok(identity),
+            "fixture path metadata must satisfy elevated adoption"
+        );
+        assert_eq!(
+            validate_elevated_listener_descriptor(listener.as_raw_fd(), &child),
+            Ok(()),
+            "fixture descriptor must satisfy elevated adoption"
+        );
+        let record = ApiListenerRecord::launcher_ack(
+            ProbeMode::GuestApiDrop,
+            SessionId::from_bytes([73; 32]),
+            SessionId::from_bytes([74; 32]),
+            identity,
+        )
+        .expect("listener acknowledgment should construct");
+        (
+            namespace,
+            claim,
+            namespace_directory,
+            api_directory,
+            ReceivedApiListener {
+                record,
+                listener: listener.into(),
+            },
+        )
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    #[test]
+    fn elevated_listener_adoption_installs_live_authority_and_cleans_exactly() {
+        use bangbang_session::elevated_probe::GUEST_API_SOCKET_CHILD;
+
+        let (namespace, claim, namespace_directory, api_directory, received) =
+            elevated_api_adoption_fixture();
+        let path = api_directory.path().join(GUEST_API_SOCKET_CHILD);
+        let bound = adopt_elevated_api_listener(namespace, claim, received)
+            .expect("exact elevated listener should adopt");
+        assert!(
+            fs::symlink_metadata(&path)
+                .expect("published listener should exist")
+                .file_type()
+                .is_socket()
+        );
+        assert_eq!(
+            fs::read_dir(namespace_directory.path())
+                .expect("namespace should read")
+                .count(),
+            1,
+            "durable ownership must precede readiness"
+        );
+        let client = UnixStream::connect(&path).expect("adopted listener should accept clients");
+        let (listener, guard) = bound.into_parts();
+        let (server, _) = listener.accept().expect("queued client should accept");
+        drop((client, server, listener));
+        drop(guard);
+        assert_eq!(
+            fs::symlink_metadata(&path)
+                .expect_err("guard should remove the exact listener")
+                .kind(),
+            io::ErrorKind::NotFound
+        );
+        assert_eq!(
+            fs::read_dir(namespace_directory.path())
+                .expect("namespace should read")
+                .count(),
+            0
+        );
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    #[test]
+    fn elevated_listener_adoption_rejects_flags_substitution_and_queued_clients() {
+        use bangbang_session::elevated_probe::GUEST_API_SOCKET_CHILD;
+
+        let (namespace, claim, namespace_directory, api_directory, received) =
+            elevated_api_adoption_fixture();
+        let path = api_directory.path().join(GUEST_API_SOCKET_CHILD);
+        // SAFETY: F_GETFL and F_SETFL inspect and update the owned test descriptor.
+        let flags = unsafe { libc::fcntl(received.listener.as_raw_fd(), libc::F_GETFL) };
+        assert!(flags >= 0);
+        // SAFETY: The descriptor remains live and the new flags preserve every other bit.
+        let status = unsafe {
+            libc::fcntl(
+                received.listener.as_raw_fd(),
+                libc::F_SETFL,
+                flags & !libc::O_NONBLOCK,
+            )
+        };
+        assert_eq!(status, 0);
+        assert_eq!(
+            adopt_elevated_api_listener(namespace, claim, received)
+                .expect_err("blocking listener should reject"),
+            AnchoredSocketError::Invalid
+        );
+        assert!(!path.exists());
+        assert_eq!(
+            fs::read_dir(namespace_directory.path())
+                .expect("namespace should read")
+                .count(),
+            0
+        );
+
+        let (namespace, claim, _namespace_directory, api_directory, mut received) =
+            elevated_api_adoption_fixture();
+        let path = api_directory.path().join(GUEST_API_SOCKET_CHILD);
+        let (bogus, bogus_peer) = UnixStream::pair().expect("substitute stream should create");
+        bogus
+            .set_nonblocking(true)
+            .expect("substitute should become nonblocking");
+        let retained_listener = std::mem::replace(&mut received.listener, bogus.into());
+        assert_eq!(
+            adopt_elevated_api_listener(namespace, claim, received)
+                .expect_err("connected descriptor substitution should reject"),
+            AnchoredSocketError::Invalid
+        );
+        drop((bogus_peer, retained_listener));
+        assert!(!path.exists());
+
+        let (namespace, claim, _namespace_directory, api_directory, received) =
+            elevated_api_adoption_fixture();
+        let path = api_directory.path().join(GUEST_API_SOCKET_CHILD);
+        let queued = UnixStream::connect(&path).expect("queued client should connect");
+        assert_eq!(
+            adopt_elevated_api_listener(namespace, claim, received)
+                .expect_err("queued client should reject"),
+            AnchoredSocketError::Invalid
+        );
+        drop(queued);
+        assert!(!path.exists());
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    #[test]
+    fn elevated_listener_cleanup_preserves_post_adoption_path_replacement() {
+        use bangbang_session::elevated_probe::GUEST_API_SOCKET_CHILD;
+
+        let (namespace, claim, namespace_directory, api_directory, received) =
+            elevated_api_adoption_fixture();
+        let path = api_directory.path().join(GUEST_API_SOCKET_CHILD);
+        let displaced = api_directory.path().join("displaced-evidence-api.sock");
+        let bound = adopt_elevated_api_listener(namespace, claim, received)
+            .expect("exact elevated listener should adopt");
+        fs::rename(&path, &displaced).expect("owned listener should displace");
+        fs::write(&path, b"replacement\n").expect("replacement should create");
+        let (listener, guard) = bound.into_parts();
+        drop(listener);
+        drop(guard);
+        assert_eq!(
+            fs::read(&path).expect("replacement should remain"),
+            b"replacement\n"
+        );
+        assert!(
+            fs::symlink_metadata(&displaced)
+                .expect("displaced listener should remain")
+                .file_type()
+                .is_socket()
+        );
+        assert_eq!(
+            fs::read_dir(namespace_directory.path())
+                .expect("namespace should read")
+                .count(),
+            0,
+            "replacement preservation must still clear the exact ownership record"
+        );
     }
 
     #[test]

--- a/crates/bangbang/src/contained_session.rs
+++ b/crates/bangbang/src/contained_session.rs
@@ -319,6 +319,10 @@ mod platform {
         SnapshotStagingTracker, SnapshotStagingTrackingError,
     };
     use bangbang_session::ConnectedUnixPeer;
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    use bangbang_session::macos::api_listener::{
+        ReceivedApiListener, receive_api_listener_ack, send_api_listener_request,
+    };
     use bangbang_session::macos::block_control::{
         BlockControlError, BlockControlMessage, BlockControlOperation, BlockControlTarget,
         receive_block_control_message, send_block_control_message,
@@ -3703,6 +3707,8 @@ mod platform {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     enum GuestEvidenceStep {
         ResourceClaim,
+        ApiListener,
+        ApiListenerReceived,
         HvfCreate,
         HvfCreated,
         GuestShutdown,
@@ -3795,11 +3801,22 @@ mod platform {
         pub(crate) fn before_first_guest_resource_claim(
             &self,
         ) -> Result<(), ContainedSessionError> {
+            let next_step = match self.workload()? {
+                bangbang_session::elevated_probe::RuntimeWorkload::GuestNoApi => {
+                    GuestEvidenceStep::HvfCreate
+                }
+                bangbang_session::elevated_probe::RuntimeWorkload::GuestApi => {
+                    GuestEvidenceStep::ApiListener
+                }
+                bangbang_session::elevated_probe::RuntimeWorkload::RepresentativeGrants => {
+                    return Err(ContainedSessionError);
+                }
+            };
             self.exchange(
                 GuestEvidenceStep::ResourceClaim,
                 bangbang_session::elevated_probe::GuestEvidencePhase::ResourceClaim,
                 bangbang_session::elevated_probe::RuntimeFault::GuestResourceWitness,
-                GuestEvidenceStep::HvfCreate,
+                next_step,
             )
         }
 
@@ -3809,13 +3826,121 @@ mod platform {
         ) -> Result<(), ContainedSessionError> {
             let mut locked = self.state.lock().map_err(|_| ContainedSessionError)?;
             let state = locked.as_mut().ok_or(ContainedSessionError)?;
-            if state.step != GuestEvidenceStep::HvfCreate
+            let expected_step = match expected_workload {
+                bangbang_session::elevated_probe::RuntimeWorkload::GuestNoApi => {
+                    GuestEvidenceStep::HvfCreate
+                }
+                bangbang_session::elevated_probe::RuntimeWorkload::GuestApi => {
+                    GuestEvidenceStep::ApiListener
+                }
+                bangbang_session::elevated_probe::RuntimeWorkload::RepresentativeGrants => {
+                    return Err(ContainedSessionError);
+                }
+            };
+            if state.step != expected_step
                 || state.mode.runtime_workload() != Some(expected_workload)
                 || state.directory_authority_consumed
             {
                 return Err(ContainedSessionError);
             }
             state.directory_authority_consumed = true;
+            Ok(())
+        }
+
+        fn receive_api_listener(&self) -> Result<ReceivedApiListener, ContainedSessionError> {
+            let mut locked = self.state.lock().map_err(|_| ContainedSessionError)?;
+            let Some(mut state) = locked.take() else {
+                return Err(ContainedSessionError);
+            };
+            let result = (|| {
+                if state.step != GuestEvidenceStep::ApiListener
+                    || state.mode.runtime_workload()
+                        != Some(bangbang_session::elevated_probe::RuntimeWorkload::GuestApi)
+                    || !state.directory_authority_consumed
+                    || state.fault
+                        == bangbang_session::elevated_probe::RuntimeFault::ApiListenerRequest
+                {
+                    return Err(ContainedSessionError);
+                }
+                validate_guest_evidence_worker(&state)?;
+                let request = bangbang_session::elevated_probe::ApiListenerRecord::worker_request(
+                    state.mode,
+                    state.nonce,
+                    state.session,
+                )
+                .map_err(|_| ContainedSessionError)?;
+                let send_deadline = Instant::now()
+                    .checked_add(GUEST_EVIDENCE_TIMEOUT)
+                    .ok_or(ContainedSessionError)?;
+                loop {
+                    set_remaining_write_timeout(&state.socket, send_deadline)?;
+                    match send_api_listener_request(&state.socket, request) {
+                        Ok(()) => break,
+                        Err(bangbang_session::macos::grant_transport::GrantTransportError::Io(
+                            io::ErrorKind::Interrupted,
+                        )) => {}
+                        Err(_) => return Err(ContainedSessionError),
+                    }
+                }
+                let receive_deadline = Instant::now()
+                    .checked_add(GUEST_EVIDENCE_TIMEOUT)
+                    .ok_or(ContainedSessionError)?;
+                let received = loop {
+                    set_remaining_read_timeout(&state.socket, receive_deadline)?;
+                    match receive_api_listener_ack(&state.socket) {
+                        Ok(received) => break received,
+                        Err(bangbang_session::macos::grant_transport::GrantTransportError::Io(
+                            io::ErrorKind::Interrupted,
+                        )) => {}
+                        Err(_) => return Err(ContainedSessionError),
+                    }
+                };
+                let identity = received
+                    .record
+                    .path_identity()
+                    .ok_or(ContainedSessionError)?;
+                if !received.record.matches_expected(
+                    state.mode,
+                    bangbang_session::elevated_probe::ApiListenerKind::Ack,
+                    state.nonce,
+                    state.session,
+                    Some(identity),
+                ) || !guest_evidence_transport_is_empty(&state.socket)
+                {
+                    return Err(ContainedSessionError);
+                }
+                validate_guest_evidence_worker(&state)?;
+                if state.fault
+                    == bangbang_session::elevated_probe::RuntimeFault::ApiListenerTransfer
+                    || state.fault
+                        == bangbang_session::elevated_probe::RuntimeFault::ApiListenerAdoption
+                {
+                    return Err(ContainedSessionError);
+                }
+                state.step = GuestEvidenceStep::ApiListenerReceived;
+                Ok(received)
+            })();
+            if result.is_ok() {
+                *locked = Some(state);
+            } else {
+                let _ = state.socket.shutdown(std::net::Shutdown::Both);
+            }
+            result
+        }
+
+        fn confirm_api_listener_adopted(&self) -> Result<(), ContainedSessionError> {
+            let mut locked = self.state.lock().map_err(|_| ContainedSessionError)?;
+            let state = locked.as_mut().ok_or(ContainedSessionError)?;
+            if state.step != GuestEvidenceStep::ApiListenerReceived
+                || state.mode.runtime_workload()
+                    != Some(bangbang_session::elevated_probe::RuntimeWorkload::GuestApi)
+                || !state.directory_authority_consumed
+                || !guest_evidence_transport_is_empty(&state.socket)
+            {
+                return Err(ContainedSessionError);
+            }
+            validate_guest_evidence_worker(state)?;
+            state.step = GuestEvidenceStep::HvfCreate;
             Ok(())
         }
 
@@ -4044,6 +4169,34 @@ mod platform {
                 let _ = state.socket.shutdown(std::net::Shutdown::Both);
             }
         }
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    fn set_remaining_write_timeout(
+        socket: &UnixDatagram,
+        deadline: Instant,
+    ) -> Result<(), ContainedSessionError> {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or(ContainedSessionError)?;
+        socket
+            .set_write_timeout(Some(remaining))
+            .map_err(|_| ContainedSessionError)
+    }
+
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    fn set_remaining_read_timeout(
+        socket: &UnixDatagram,
+        deadline: Instant,
+    ) -> Result<(), ContainedSessionError> {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or(ContainedSessionError)?;
+        socket
+            .set_read_timeout(Some(remaining))
+            .map_err(|_| ContainedSessionError)
     }
 
     #[cfg(feature = "elevated-bootstrap-probe")]
@@ -4721,6 +4874,26 @@ mod platform {
             )
         }
 
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        pub(crate) fn receive_elevated_api_listener(
+            &self,
+        ) -> Result<Option<ReceivedApiListener>, ContainedSessionError> {
+            self.guest_evidence
+                .as_ref()
+                .map(GuestEvidenceAuthority::receive_api_listener)
+                .transpose()
+        }
+
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        pub(crate) fn confirm_elevated_api_listener_adopted(
+            &self,
+        ) -> Result<(), ContainedSessionError> {
+            let Some(authority) = &self.guest_evidence else {
+                return Err(ContainedSessionError);
+            };
+            authority.confirm_api_listener_adopted()
+        }
+
         pub(crate) fn pager_grant_authority(&self) -> Option<PagerGrantAuthority> {
             self.started.then(|| self.pager_grants.clone())
         }
@@ -5269,11 +5442,12 @@ mod platform {
     #[cfg(test)]
     pub(crate) use tests::{
         TestContainedRestoreAuthority, TestDirectory as TestVhostDirectory,
-        contained_restore_authority_for_test, contained_restore_authority_with_grants_for_test,
-        empty_grant_authority_for_vhost_test, file_grant_authority_for_test,
-        root_file_grant_authority_for_test, snapshot_file_grant_authority_for_test,
-        snapshot_root_file_grant_authority_for_test, snapshot_storage_grant_authority_for_test,
-        vhost_directory_authority_for_test, vsock_directory_authority_for_test,
+        api_directory_authority_for_test, contained_restore_authority_for_test,
+        contained_restore_authority_with_grants_for_test, empty_grant_authority_for_vhost_test,
+        file_grant_authority_for_test, root_file_grant_authority_for_test,
+        snapshot_file_grant_authority_for_test, snapshot_root_file_grant_authority_for_test,
+        snapshot_storage_grant_authority_for_test, vhost_directory_authority_for_test,
+        vsock_directory_authority_for_test,
     };
 
     #[cfg(test)]
@@ -5366,7 +5540,7 @@ mod platform {
         pub(crate) struct TestDirectory(PathBuf);
 
         impl TestDirectory {
-            fn new() -> Self {
+            pub(crate) fn new() -> Self {
                 loop {
                     let id = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
                     let path =
@@ -6900,6 +7074,18 @@ mod platform {
             )
         }
 
+        pub(crate) fn api_directory_authority_for_test() -> (DirectoryGrantAuthority, TestDirectory)
+        {
+            let (mut registry, directory) = directory_registry(
+                bangbang_session::elevated_probe::GUEST_API_DIRECTORY_GRANT_ID,
+                ResourceRole::ApiSocketDirectory,
+            );
+            (
+                DirectoryGrantAuthority::new(registry.take_directory_registry()),
+                directory,
+            )
+        }
+
         #[test]
         fn file_authority_is_send_sync_and_claims_fail_closed_atomically() {
             fn assert_send_sync<T: Send + Sync>() {}
@@ -8233,9 +8419,10 @@ pub(crate) use platform::{
 #[cfg(all(test, target_os = "macos"))]
 pub(crate) use platform::{
     ContainedSnapshotRestoreDriveRequest, TestContainedRestoreAuthority, TestVhostDirectory,
-    contained_restore_authority_for_test, contained_restore_authority_with_grants_for_test,
-    empty_grant_authority_for_vhost_test, file_grant_authority_for_test,
-    root_file_grant_authority_for_test, snapshot_file_grant_authority_for_test,
-    snapshot_root_file_grant_authority_for_test, snapshot_storage_grant_authority_for_test,
-    vhost_directory_authority_for_test, vsock_directory_authority_for_test,
+    api_directory_authority_for_test, contained_restore_authority_for_test,
+    contained_restore_authority_with_grants_for_test, empty_grant_authority_for_vhost_test,
+    file_grant_authority_for_test, root_file_grant_authority_for_test,
+    snapshot_file_grant_authority_for_test, snapshot_root_file_grant_authority_for_test,
+    snapshot_storage_grant_authority_for_test, vhost_directory_authority_for_test,
+    vsock_directory_authority_for_test,
 };

--- a/crates/bangbang/src/elevated_bootstrap_probe.rs
+++ b/crates/bangbang/src/elevated_bootstrap_probe.rs
@@ -31,6 +31,8 @@ const CREDENTIAL_WORKER_ARTIFACT: &str =
 const RUNTIME_WORKER_ARTIFACT: &str = "bangbang-elevated-runtime-worker-v2-runtime-drop-runtime-retain-root-runtime-unmapped-BBA1-BBN1-adopted-session---bangbang-internal-grant-probe-v1-target-runtime";
 const RUNTIME_WORKER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-runtime-worker-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
 const GUEST_WORKER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-guest-worker-boundaries-v1-guest-no-api-drop-guest-no-api-retain-root-guest-no-api-unmapped-guest-api-drop-guest-api-retain-root-guest-api-unmapped-BBW1-guest-resource-witness-guest-grant-accepted-guest-transport-contamination-guest-hvf-witness-guest-terminal-evidence-bangbang-grant:evidence-guest-kernel-bangbang-grant:evidence-guest-serial";
+const API_LISTENER_WORKER_BOUNDARY_ARTIFACT: &str =
+    "bangbang-elevated-api-listener-worker-v1-BBL1-request-ack-adoption-record-readiness";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ProbeError {
@@ -163,6 +165,7 @@ fn run_credential_pair(
     std::hint::black_box(RUNTIME_WORKER_ARTIFACT);
     std::hint::black_box(RUNTIME_WORKER_BOUNDARY_ARTIFACT);
     std::hint::black_box(GUEST_WORKER_BOUNDARY_ARTIFACT);
+    std::hint::black_box(API_LISTENER_WORKER_BOUNDARY_ARTIFACT);
     if stream.set_read_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
         || stream.set_write_timeout(Some(CREDENTIAL_TIMEOUT)).is_err()
     {

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -40,6 +40,8 @@ mod vmm;
 #[cfg(target_os = "macos")]
 mod vsock_restore;
 
+#[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
+use anchored_socket::adopt_elevated_api_listener;
 #[cfg(target_os = "macos")]
 use anchored_socket::bind as bind_anchored_socket;
 use api_server::{ApiServer, ApiServerError, config_vmm_action_from_api_request};
@@ -502,6 +504,44 @@ fn run(
                                         .socket_namespace()
                                         .map_err(|_| ProcessError::ContainedSession)?
                                         .ok_or(ProcessError::ContainedSession)?;
+                                    #[cfg(feature = "elevated-bootstrap-probe")]
+                                    let elevated_listener = contained
+                                        .as_ref()
+                                        .map(ContainedSession::receive_elevated_api_listener)
+                                        .transpose()
+                                        .map_err(|_| ProcessError::ContainedSession)?
+                                        .flatten();
+                                    #[cfg(feature = "elevated-bootstrap-probe")]
+                                    let socket = if let Some(received) = elevated_listener {
+                                        let socket =
+                                            adopt_elevated_api_listener(namespace, claim, received)
+                                                .map_err(|error| {
+                                                    ProcessError::ApiServer(
+                                                        ApiServerError::Anchored(error),
+                                                    )
+                                                })?;
+                                        contained
+                                            .as_ref()
+                                            .ok_or(ProcessError::ContainedSession)?
+                                            .confirm_elevated_api_listener_adopted()
+                                            .map_err(|_| ProcessError::ContainedSession)?;
+                                        socket
+                                    } else {
+                                        bind_anchored_socket(
+                                            namespace,
+                                            claim,
+                                            ResourceRole::ApiSocketDirectory,
+                                            None,
+                                        )
+                                        .map_err(
+                                            |error| {
+                                                ProcessError::ApiServer(ApiServerError::Anchored(
+                                                    error,
+                                                ))
+                                            },
+                                        )?
+                                    };
+                                    #[cfg(not(feature = "elevated-bootstrap-probe"))]
                                     let socket = bind_anchored_socket(
                                         namespace,
                                         claim,

--- a/crates/launcher/src/macos/elevated_api_listener.rs
+++ b/crates/launcher/src/macos/elevated_api_listener.rs
@@ -1,0 +1,735 @@
+//! Feature-only launcher authority for the fixed final guest API listener.
+
+use std::ffi::CStr;
+use std::io;
+use std::mem::{MaybeUninit, size_of};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixListener;
+
+use bangbang_session::elevated_probe::{GUEST_API_SOCKET_CHILD, RuntimeWorkload};
+use bangbang_session::macos::runtime::SocketOwnershipRecord;
+use bangbang_session::macos::set_cloexec;
+use bangbang_session::{ObjectIdentity, ResourceRole, SocketChild};
+
+use crate::grant_manifest::{ElevatedGuestContract, SocketDirectoryAnchor};
+
+use super::scoped_cwd::{ScopedCwdOperationError, directory_descriptor_identity, with_scoped_cwd};
+
+const LISTEN_BACKLOG: libc::c_int = 128;
+const FINAL_CHILD: &CStr = c"evidence-api.sock";
+
+/// Redacted failure while creating or owning the fixed API listener.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ElevatedApiListenerError {
+    Io(io::ErrorKind),
+    Invalid,
+    PathExists,
+    PathChanged,
+    Cwd,
+}
+
+/// Strict post-reap policy for the one feature-owned final socket.
+#[derive(Clone, Copy)]
+pub(crate) struct ElevatedApiCleanupPolicy {
+    anchor_descriptor: RawFd,
+    anchor_identity: ObjectIdentity,
+    target_uid: u32,
+    target_gid: u32,
+    path_identity: ObjectIdentity,
+}
+
+impl std::fmt::Debug for ElevatedApiCleanupPolicy {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ElevatedApiCleanupPolicy(<redacted>)")
+    }
+}
+
+impl ElevatedApiCleanupPolicy {
+    pub(crate) const fn anchor_descriptor(self) -> RawFd {
+        self.anchor_descriptor
+    }
+
+    pub(crate) const fn anchor_identity(self) -> ObjectIdentity {
+        self.anchor_identity
+    }
+
+    pub(crate) const fn target_uid(self) -> u32 {
+        self.target_uid
+    }
+
+    pub(crate) const fn target_gid(self) -> u32 {
+        self.target_gid
+    }
+
+    pub(crate) const fn path_identity(self) -> ObjectIdentity {
+        self.path_identity
+    }
+}
+
+/// Listener alias, durable-record value, and exact retained pathname cleanup.
+pub(crate) struct ElevatedApiPublication {
+    listener: Option<UnixListener>,
+    record: SocketOwnershipRecord,
+    path_guard: ElevatedApiPathGuard,
+}
+
+impl std::fmt::Debug for ElevatedApiPublication {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ElevatedApiPublication(<redacted>)")
+    }
+}
+
+impl ElevatedApiPublication {
+    pub(crate) fn listener_fd(&self) -> Option<RawFd> {
+        self.listener.as_ref().map(AsRawFd::as_raw_fd)
+    }
+
+    pub(crate) fn release_listener_alias(&mut self) -> Result<(), ElevatedApiListenerError> {
+        self.listener
+            .take()
+            .map(drop)
+            .ok_or(ElevatedApiListenerError::Invalid)
+    }
+
+    pub(crate) const fn record(&self) -> &SocketOwnershipRecord {
+        &self.record
+    }
+
+    pub(crate) const fn path_identity(&self) -> ObjectIdentity {
+        self.path_guard.policy.path_identity
+    }
+
+    pub(crate) fn cleanup_policy(&self) -> ElevatedApiCleanupPolicy {
+        ElevatedApiCleanupPolicy {
+            path_identity: self.record().identity(),
+            ..self.path_guard.policy
+        }
+    }
+
+    pub(crate) fn validate_path(&self) -> Result<(), ElevatedApiListenerError> {
+        self.path_guard.validate()
+    }
+
+    pub(crate) fn cleanup(&mut self) -> Result<(), ElevatedApiListenerError> {
+        self.listener.take();
+        self.path_guard.cleanup()
+    }
+}
+
+/// Binds the one fixed API listener beneath the contract's retained API anchor.
+pub(crate) fn bind_elevated_api_listener(
+    contract: ElevatedGuestContract,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<ElevatedApiPublication, ElevatedApiListenerError> {
+    if contract.workload() != RuntimeWorkload::GuestApi {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+    let anchor = contract
+        .api_anchor()
+        .ok_or(ElevatedApiListenerError::Invalid)?;
+    bind_at_anchor(anchor, target_uid, target_gid)
+}
+
+fn bind_at_anchor(
+    anchor: SocketDirectoryAnchor,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<ElevatedApiPublication, ElevatedApiListenerError> {
+    if !credentials_match(target_uid, target_gid)
+        || directory_descriptor_identity(anchor.descriptor())
+            .map_err(|_| ElevatedApiListenerError::Invalid)?
+            != anchor.identity()
+    {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+    let publication = with_scoped_cwd(anchor.descriptor(), anchor.identity(), || {
+        bind_relative(anchor, target_uid, target_gid)
+    })
+    .map_err(map_scoped_cwd_error)?;
+    if !credentials_match(target_uid, target_gid)
+        || directory_descriptor_identity(anchor.descriptor())
+            .map_err(|_| ElevatedApiListenerError::Invalid)?
+            != anchor.identity()
+        || publication.validate_path().is_err()
+        || publication
+            .listener_fd()
+            .is_none_or(|descriptor| validate_listener_descriptor(descriptor).is_err())
+    {
+        return Err(ElevatedApiListenerError::PathChanged);
+    }
+    Ok(publication)
+}
+
+fn bind_relative(
+    anchor: SocketDirectoryAnchor,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<ElevatedApiPublication, ElevatedApiListenerError> {
+    ensure_child_absent()?;
+    // SAFETY: A successful descriptor is immediately wrapped for unique ownership.
+    let descriptor = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+    if descriptor < 0 {
+        return Err(ElevatedApiListenerError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    // SAFETY: The fresh descriptor has no other owner.
+    let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
+    set_cloexec(descriptor.as_raw_fd())
+        .map_err(|error| ElevatedApiListenerError::Io(error.kind()))?;
+    set_nonblocking(descriptor.as_raw_fd())?;
+    let (address, address_length) = fixed_relative_address()?;
+    // SAFETY: The descriptor and fully initialized bounded address remain live.
+    if unsafe {
+        libc::bind(
+            descriptor.as_raw_fd(),
+            (&raw const address).cast(),
+            address_length,
+        )
+    } != 0
+    {
+        let error = io::Error::last_os_error();
+        return if matches!(
+            error.kind(),
+            io::ErrorKind::AlreadyExists | io::ErrorKind::AddrInUse
+        ) {
+            Err(ElevatedApiListenerError::PathExists)
+        } else {
+            Err(ElevatedApiListenerError::Io(error.kind()))
+        };
+    }
+
+    let path_identity = relative_socket_identity(target_uid, target_gid, None)?;
+    let policy = ElevatedApiCleanupPolicy {
+        anchor_descriptor: anchor.descriptor(),
+        anchor_identity: anchor.identity(),
+        target_uid,
+        target_gid,
+        path_identity,
+    };
+    let mut path_guard = ElevatedApiPathGuard {
+        policy,
+        expected_mode: None,
+        armed: true,
+    };
+    // SAFETY: The fixed relative path names the identity-captured socket just bound.
+    if unsafe { libc::chmod(FINAL_CHILD.as_ptr(), 0o600) } != 0 {
+        return Err(ElevatedApiListenerError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    path_guard.expected_mode = Some(0o600);
+    if relative_socket_identity(target_uid, target_gid, Some(0o600))? != path_identity {
+        return Err(ElevatedApiListenerError::PathChanged);
+    }
+    // SAFETY: The live stream socket is ready to become a listener.
+    if unsafe { libc::listen(descriptor.as_raw_fd(), LISTEN_BACKLOG) } != 0 {
+        return Err(ElevatedApiListenerError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    validate_listener_descriptor(descriptor.as_raw_fd())?;
+    path_guard.validate()?;
+    let child = SocketChild::parse(GUEST_API_SOCKET_CHILD)
+        .map_err(|_| ElevatedApiListenerError::Invalid)?;
+    let record = SocketOwnershipRecord::new(ResourceRole::ApiSocketDirectory, child, path_identity)
+        .map_err(|_| ElevatedApiListenerError::Invalid)?;
+    Ok(ElevatedApiPublication {
+        listener: Some(UnixListener::from(descriptor)),
+        record,
+        path_guard,
+    })
+}
+
+struct ElevatedApiPathGuard {
+    policy: ElevatedApiCleanupPolicy,
+    expected_mode: Option<u32>,
+    armed: bool,
+}
+
+impl ElevatedApiPathGuard {
+    fn validate(&self) -> Result<(), ElevatedApiListenerError> {
+        if !self.armed
+            || directory_descriptor_identity(self.policy.anchor_descriptor)
+                .map_err(|_| ElevatedApiListenerError::Invalid)?
+                != self.policy.anchor_identity
+        {
+            return Err(ElevatedApiListenerError::PathChanged);
+        }
+        let identity = socket_identity_at(
+            self.policy.anchor_descriptor,
+            self.policy.target_uid,
+            self.policy.target_gid,
+            self.expected_mode,
+        )?;
+        if identity != self.policy.path_identity {
+            return Err(ElevatedApiListenerError::PathChanged);
+        }
+        Ok(())
+    }
+
+    fn cleanup(&mut self) -> Result<(), ElevatedApiListenerError> {
+        if !self.armed {
+            return Ok(());
+        }
+        self.armed = false;
+        if directory_descriptor_identity(self.policy.anchor_descriptor).ok()
+            != Some(self.policy.anchor_identity)
+        {
+            return Ok(());
+        }
+        let identity = match socket_identity_at(
+            self.policy.anchor_descriptor,
+            self.policy.target_uid,
+            self.policy.target_gid,
+            self.expected_mode,
+        ) {
+            Ok(identity) => identity,
+            Err(ElevatedApiListenerError::Io(io::ErrorKind::NotFound))
+            | Err(ElevatedApiListenerError::Invalid)
+            | Err(ElevatedApiListenerError::PathChanged) => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        if identity != self.policy.path_identity {
+            return Ok(());
+        }
+        // SAFETY: The retained anchor and fixed child name the exact validated socket.
+        if unsafe { libc::unlinkat(self.policy.anchor_descriptor, FINAL_CHILD.as_ptr(), 0) } == 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() == io::ErrorKind::NotFound {
+            Ok(())
+        } else {
+            Err(ElevatedApiListenerError::Io(error.kind()))
+        }
+    }
+}
+
+impl Drop for ElevatedApiPathGuard {
+    fn drop(&mut self) {
+        let _ = self.cleanup();
+    }
+}
+
+fn map_scoped_cwd_error(
+    error: ScopedCwdOperationError<ElevatedApiListenerError>,
+) -> ElevatedApiListenerError {
+    match error {
+        ScopedCwdOperationError::Boundary(_) => ElevatedApiListenerError::Cwd,
+        ScopedCwdOperationError::Operation(error) => error,
+    }
+}
+
+fn credentials_match(target_uid: u32, target_gid: u32) -> bool {
+    // SAFETY: Identity calls have no pointer or ownership contract.
+    unsafe {
+        libc::getuid() == target_uid
+            && libc::geteuid() == target_uid
+            && libc::getgid() == target_gid
+            && libc::getegid() == target_gid
+    }
+}
+
+fn ensure_child_absent() -> Result<(), ElevatedApiListenerError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: The fixed relative child and writable stat storage remain valid.
+    if unsafe {
+        libc::fstatat(
+            libc::AT_FDCWD,
+            FINAL_CHILD.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } == 0
+    {
+        return Err(ElevatedApiListenerError::PathExists);
+    }
+    let error = io::Error::last_os_error();
+    if error.kind() == io::ErrorKind::NotFound {
+        Ok(())
+    } else {
+        Err(ElevatedApiListenerError::Io(error.kind()))
+    }
+}
+
+fn relative_socket_identity(
+    expected_uid: u32,
+    expected_gid: u32,
+    expected_mode: Option<u32>,
+) -> Result<ObjectIdentity, ElevatedApiListenerError> {
+    socket_identity_at(libc::AT_FDCWD, expected_uid, expected_gid, expected_mode)
+}
+
+fn socket_identity_at(
+    directory: RawFd,
+    expected_uid: u32,
+    expected_gid: u32,
+    expected_mode: Option<u32>,
+) -> Result<ObjectIdentity, ElevatedApiListenerError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: The retained anchor, fixed child, and writable stat remain live.
+    if unsafe {
+        libc::fstatat(
+            directory,
+            FINAL_CHILD.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(ElevatedApiListenerError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    // SAFETY: Successful fstatat initialized the complete structure.
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFSOCK
+        || stat.st_uid != expected_uid
+        || stat.st_gid != expected_gid
+        || stat.st_nlink != 1
+        || expected_mode.is_some_and(|mode| u32::from(stat.st_mode & 0o7777) != mode)
+    {
+        return Err(ElevatedApiListenerError::PathChanged);
+    }
+    let identity = ObjectIdentity {
+        device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
+        inode: stat.st_ino,
+    };
+    if identity.device == 0 || identity.inode == 0 {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+    Ok(identity)
+}
+
+fn set_nonblocking(descriptor: RawFd) -> Result<(), ElevatedApiListenerError> {
+    // SAFETY: F_GETFL inspects the live descriptor.
+    let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(ElevatedApiListenerError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    // SAFETY: F_SETFL updates status flags on the same live descriptor.
+    if unsafe { libc::fcntl(descriptor, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(ElevatedApiListenerError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    Ok(())
+}
+
+fn fixed_relative_address() -> Result<(libc::sockaddr_un, libc::socklen_t), ElevatedApiListenerError>
+{
+    let bytes = FINAL_CHILD.to_bytes_with_nul();
+    let address = MaybeUninit::<libc::sockaddr_un>::zeroed();
+    // SAFETY: Zeroed sockaddr_un is valid before initialization below.
+    let mut address = unsafe { address.assume_init() };
+    if bytes.len() > address.sun_path.len() {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+    address.sun_family = libc::sa_family_t::try_from(libc::AF_UNIX)
+        .map_err(|_| ElevatedApiListenerError::Invalid)?;
+    address.sun_len = u8::try_from(
+        std::mem::offset_of!(libc::sockaddr_un, sun_path)
+            .checked_add(bytes.len())
+            .ok_or(ElevatedApiListenerError::Invalid)?,
+    )
+    .map_err(|_| ElevatedApiListenerError::Invalid)?;
+    // SAFETY: The bounded source including NUL fits the destination array.
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            address.sun_path.as_mut_ptr().cast::<u8>(),
+            bytes.len(),
+        );
+    }
+    Ok((address, libc::socklen_t::from(address.sun_len)))
+}
+
+fn validate_listener_descriptor(descriptor: RawFd) -> Result<(), ElevatedApiListenerError> {
+    // SAFETY: F_GETFD and F_GETFL inspect the live listener.
+    let descriptor_flags = unsafe { libc::fcntl(descriptor, libc::F_GETFD) };
+    // SAFETY: F_GETFL inspects the same live listener.
+    let status_flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    if descriptor_flags < 0
+        || status_flags < 0
+        || descriptor_flags & libc::FD_CLOEXEC == 0
+        || status_flags & libc::O_NONBLOCK == 0
+        || socket_int_option(descriptor, libc::SO_TYPE)? != libc::SOCK_STREAM
+    {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+
+    let mut address = MaybeUninit::<libc::sockaddr_un>::zeroed();
+    let mut address_length = libc::socklen_t::try_from(size_of::<libc::sockaddr_un>())
+        .map_err(|_| ElevatedApiListenerError::Invalid)?;
+    // SAFETY: Address storage and length are writable for the live listener.
+    if unsafe {
+        libc::getsockname(
+            descriptor,
+            address.as_mut_ptr().cast(),
+            &raw mut address_length,
+        )
+    } != 0
+    {
+        return Err(ElevatedApiListenerError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    // SAFETY: Successful getsockname initialized the returned address prefix.
+    let address = unsafe { address.assume_init() };
+    if address.sun_family
+        != libc::sa_family_t::try_from(libc::AF_UNIX)
+            .map_err(|_| ElevatedApiListenerError::Invalid)?
+    {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+    let path_length = usize::try_from(address_length)
+        .map_err(|_| ElevatedApiListenerError::Invalid)?
+        .checked_sub(std::mem::offset_of!(libc::sockaddr_un, sun_path))
+        .ok_or(ElevatedApiListenerError::Invalid)?;
+    if path_length != FINAL_CHILD.to_bytes_with_nul().len() || path_length > address.sun_path.len()
+    {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+    // SAFETY: Kernel-returned length bounds the path read within `address`.
+    let path =
+        unsafe { std::slice::from_raw_parts(address.sun_path.as_ptr().cast::<u8>(), path_length) };
+    if path != FINAL_CHILD.to_bytes_with_nul() {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+
+    // SAFETY: Null address arguments probe for an already queued client only.
+    let accepted = unsafe { libc::accept(descriptor, std::ptr::null_mut(), std::ptr::null_mut()) };
+    if accepted >= 0 {
+        // SAFETY: A successful accept returns a uniquely owned descriptor.
+        drop(unsafe { OwnedFd::from_raw_fd(accepted) });
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+    if io::Error::last_os_error().kind() != io::ErrorKind::WouldBlock {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+    Ok(())
+}
+
+fn socket_int_option(
+    descriptor: RawFd,
+    option: libc::c_int,
+) -> Result<libc::c_int, ElevatedApiListenerError> {
+    let mut value = 0;
+    let mut length = libc::socklen_t::try_from(size_of::<libc::c_int>())
+        .map_err(|_| ElevatedApiListenerError::Invalid)?;
+    // SAFETY: Option storage and length are writable for the live listener.
+    if unsafe {
+        libc::getsockopt(
+            descriptor,
+            libc::SOL_SOCKET,
+            option,
+            (&raw mut value).cast(),
+            &raw mut length,
+        )
+    } != 0
+    {
+        return Err(ElevatedApiListenerError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    if usize::try_from(length).ok() != Some(size_of::<libc::c_int>()) {
+        return Err(ElevatedApiListenerError::Invalid);
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::thread;
+
+    use super::*;
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn create() -> Self {
+            let id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bangbang-elevated-api-listener-{}-{id}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("test directory should create");
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+                .expect("test directory mode should set");
+            Self(path)
+        }
+
+        fn anchor(&self) -> (File, SocketDirectoryAnchor) {
+            let file = File::open(&self.0).expect("test directory should open");
+            let identity = directory_descriptor_identity(file.as_raw_fd())
+                .expect("anchor identity should inspect");
+            let anchor = SocketDirectoryAnchor::for_test(file.as_raw_fd(), identity);
+            (file, anchor)
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let child = self.0.join(GUEST_API_SOCKET_CHILD);
+            if let Ok(metadata) = fs::symlink_metadata(&child) {
+                if metadata.file_type().is_dir() {
+                    let _ = fs::remove_dir(&child);
+                } else {
+                    let _ = fs::remove_file(&child);
+                }
+            }
+            let _ = fs::remove_dir(&self.0);
+        }
+    }
+
+    fn current_ids() -> (u32, u32) {
+        // SAFETY: Effective identity calls have no pointer or ownership contract.
+        unsafe { (libc::geteuid(), libc::getegid()) }
+    }
+
+    #[test]
+    fn final_listener_is_exact_lives_past_alias_close_and_cleans() {
+        let directory = TestDir::create();
+        let (_file, anchor) = directory.anchor();
+        let (uid, gid) = current_ids();
+        let mut publication = bind_at_anchor(anchor, uid, gid).expect("fixed listener should bind");
+        assert!(publication.listener_fd().is_some());
+        assert_eq!(
+            publication.record().role(),
+            ResourceRole::ApiSocketDirectory
+        );
+        assert_eq!(
+            publication.record().child().as_bytes(),
+            GUEST_API_SOCKET_CHILD.as_bytes()
+        );
+        assert_eq!(publication.record().identity(), publication.path_identity());
+        publication.validate_path().expect("path should validate");
+        assert!(!directory.0.join(".api-socket.pending").exists());
+
+        publication
+            .release_listener_alias()
+            .expect("listener alias should release");
+        assert!(directory.0.join(GUEST_API_SOCKET_CHILD).exists());
+        publication.cleanup().expect("path should clean");
+        assert!(!directory.0.join(GUEST_API_SOCKET_CHILD).exists());
+    }
+
+    #[test]
+    fn collisions_and_wrong_anchor_identity_fail_without_replacement() {
+        let directory = TestDir::create();
+        let (_file, anchor) = directory.anchor();
+        let (uid, gid) = current_ids();
+        let child = directory.0.join(GUEST_API_SOCKET_CHILD);
+        File::create(&child).expect("collision file should create");
+        assert!(matches!(
+            bind_at_anchor(anchor, uid, gid),
+            Err(ElevatedApiListenerError::PathExists)
+        ));
+        assert!(child.is_file());
+        fs::remove_file(&child).expect("collision file should remove");
+        symlink("missing", &child).expect("collision symlink should create");
+        assert!(matches!(
+            bind_at_anchor(anchor, uid, gid),
+            Err(ElevatedApiListenerError::PathExists)
+        ));
+        assert!(
+            fs::symlink_metadata(&child)
+                .expect("symlink should inspect")
+                .file_type()
+                .is_symlink()
+        );
+        fs::remove_file(&child).expect("collision symlink should remove");
+
+        let wrong = SocketDirectoryAnchor::for_test(
+            anchor.descriptor(),
+            ObjectIdentity {
+                device: anchor.identity().device,
+                inode: anchor.identity().inode.saturating_add(1),
+            },
+        );
+        assert!(matches!(
+            bind_at_anchor(wrong, uid, gid),
+            Err(ElevatedApiListenerError::Invalid)
+        ));
+        assert!(!child.exists());
+    }
+
+    #[test]
+    fn cleanup_preserves_a_replaced_pathname() {
+        let directory = TestDir::create();
+        let (_file, anchor) = directory.anchor();
+        let (uid, gid) = current_ids();
+        let mut publication = bind_at_anchor(anchor, uid, gid).expect("fixed listener should bind");
+        publication
+            .release_listener_alias()
+            .expect("listener alias should release");
+        let child = directory.0.join(GUEST_API_SOCKET_CHILD);
+        fs::remove_file(&child).expect("owned socket should unlink for replacement");
+        File::create(&child).expect("replacement should create");
+        publication
+            .cleanup()
+            .expect("replacement should be preserved");
+        assert!(child.is_file());
+    }
+
+    #[test]
+    fn independent_anchors_bind_concurrently_under_the_shared_cwd_boundary() {
+        let directories = [TestDir::create(), TestDir::create()];
+        let (uid, gid) = current_ids();
+        thread::scope(|scope| {
+            for directory in &directories {
+                scope.spawn(move || {
+                    let (_file, anchor) = directory.anchor();
+                    let mut publication = bind_at_anchor(anchor, uid, gid)
+                        .expect("concurrent fixed listener should bind");
+                    publication.validate_path().expect("path should validate");
+                    publication.cleanup().expect("path should clean");
+                });
+            }
+        });
+        for directory in &directories {
+            assert!(!directory.0.join(GUEST_API_SOCKET_CHILD).exists());
+        }
+    }
+
+    #[test]
+    fn strict_metadata_validation_rejects_expected_owner_group_and_mode_changes() {
+        let directory = TestDir::create();
+        let (_file, anchor) = directory.anchor();
+        let (uid, gid) = current_ids();
+        let mut publication = bind_at_anchor(anchor, uid, gid).expect("fixed listener should bind");
+        let child = directory.0.join(GUEST_API_SOCKET_CHILD);
+        assert_eq!(
+            socket_identity_at(anchor.descriptor(), uid ^ 1, gid, Some(0o600)),
+            Err(ElevatedApiListenerError::PathChanged)
+        );
+        assert_eq!(
+            socket_identity_at(anchor.descriptor(), uid, gid ^ 1, Some(0o600)),
+            Err(ElevatedApiListenerError::PathChanged)
+        );
+        fs::set_permissions(&child, fs::Permissions::from_mode(0o666))
+            .expect("socket mode should mutate");
+        assert_eq!(
+            publication.validate_path(),
+            Err(ElevatedApiListenerError::PathChanged)
+        );
+        publication
+            .cleanup()
+            .expect("tampered mode should be preserved");
+        let metadata = fs::symlink_metadata(&child).expect("socket should remain");
+        assert_eq!(metadata.mode() & 0o7777, 0o666);
+        assert_eq!(metadata.uid(), uid);
+        assert_eq!(metadata.gid(), gid);
+    }
+}

--- a/crates/launcher/src/macos/elevated_guest.rs
+++ b/crates/launcher/src/macos/elevated_guest.rs
@@ -8,10 +8,12 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use bangbang_session::elevated_probe::{
-    CredentialRole, GuestEvidenceKind, GuestEvidencePhase, GuestEvidenceRecord,
-    GuestSerialTranscript, MAX_GUEST_SERIAL_TRANSCRIPT_BYTES, ProbeBootstrap, ProbeErrorCategory,
-    ProbeStage, RuntimeFault, RuntimeWorkload, classify_guest_serial_transcript,
+    ApiListenerKind, ApiListenerRecord, CredentialRole, GuestEvidenceKind, GuestEvidencePhase,
+    GuestEvidenceRecord, GuestSerialTranscript, MAX_GUEST_SERIAL_TRANSCRIPT_BYTES, ProbeBootstrap,
+    ProbeErrorCategory, ProbeStage, RuntimeFault, RuntimeWorkload,
+    classify_guest_serial_transcript,
 };
+use bangbang_session::macos::api_listener::{receive_api_listener_request, send_api_listener_ack};
 use bangbang_session::macos::grant_transport::GrantTransportError;
 use bangbang_session::macos::guest_evidence::{receive_guest_evidence, send_guest_evidence};
 use bangbang_session::macos::runtime::LauncherNamespace;
@@ -19,6 +21,10 @@ use bangbang_session::macos::verify_peer_pid;
 use bangbang_session::{Readiness, SessionId, TerminalCategory};
 
 use super::code_sign::{WorkerProfile, validate_launcher_process, validate_worker_process};
+use super::elevated_api_listener::{
+    ElevatedApiCleanupPolicy, ElevatedApiListenerError, ElevatedApiPublication,
+    bind_elevated_api_listener,
+};
 use super::local_socket::{
     LocalSocketConnectStart, PendingLocalSocket, anchored_child_is_absent, begin_connect_anchored,
     finish_connect_anchored, validate_anchored_child,
@@ -77,6 +83,9 @@ enum WitnessStep {
     AwaitingGrantAcceptance,
     AwaitingResourceRequest,
     SendingResourceAck,
+    AwaitingApiListenerRequest,
+    SendingApiListenerAck,
+    AwaitingApiListenerAdoption,
     AwaitingHvfRequest,
     SendingHvfAck,
     AwaitingHvfCreated,
@@ -490,6 +499,16 @@ fn api_socket_failure(stage: ProbeStage, error: ScopedConnectError) -> ApiDriver
     ApiDriverFailure { stage, category }
 }
 
+fn elevated_api_listener_category(error: ElevatedApiListenerError) -> ProbeErrorCategory {
+    match error {
+        ElevatedApiListenerError::Io(kind) => ProbeErrorCategory::from_io_kind(kind),
+        ElevatedApiListenerError::Cwd => ProbeErrorCategory::Other,
+        ElevatedApiListenerError::Invalid
+        | ElevatedApiListenerError::PathExists
+        | ElevatedApiListenerError::PathChanged => ProbeErrorCategory::InvalidInput,
+    }
+}
+
 fn api_deadline(stage: ProbeStage) -> Result<Instant, ApiDriverFailure> {
     Instant::now()
         .checked_add(API_REQUEST_TIMEOUT)
@@ -556,6 +575,8 @@ pub(crate) struct ElevatedGuestSupervisor {
     session: SessionId,
     step: WitnessStep,
     pending_ack: Option<GuestEvidenceRecord>,
+    pending_listener_ack: Option<ApiListenerRecord>,
+    publication: Option<ElevatedApiPublication>,
     deadline: Option<Instant>,
     transport_closed: bool,
     readiness: Option<Readiness>,
@@ -605,6 +626,8 @@ impl ElevatedGuestSupervisor {
                 session,
                 step: WitnessStep::AwaitingGrantAcceptance,
                 pending_ack: None,
+                pending_listener_ack: None,
+                publication: None,
                 deadline: None,
                 transport_closed: false,
                 readiness: None,
@@ -635,6 +658,8 @@ impl ElevatedGuestSupervisor {
         };
         if self.step != WitnessStep::AwaitingGrantAcceptance
             || self.pending_ack.is_some()
+            || self.pending_listener_ack.is_some()
+            || self.publication.is_some()
             || !matches!(transport_state(socket), TransportState::Empty)
             || !api_child_absent
         {
@@ -678,7 +703,11 @@ impl ElevatedGuestSupervisor {
                         Ok(())
                     } else {
                         self.fail(
-                            missing_serial_stage(self.contract.workload(), self.readiness),
+                            missing_serial_stage(
+                                self.contract.workload(),
+                                self.readiness,
+                                self.step,
+                            ),
                             ProbeErrorCategory::Other,
                         )
                     };
@@ -691,11 +720,21 @@ impl ElevatedGuestSupervisor {
                 }
                 TransportState::Data => {}
             }
+            if self.step == WitnessStep::AwaitingApiListenerRequest {
+                return self.accept_api_listener_request(
+                    socket,
+                    worker_pid,
+                    session_stream,
+                    namespace,
+                );
+            }
             if self.pending_ack.is_some()
+                || self.pending_listener_ack.is_some()
                 || matches!(
                     self.step,
                     WitnessStep::AwaitingGrantAcceptance
                         | WitnessStep::SendingResourceAck
+                        | WitnessStep::SendingApiListenerAck
                         | WitnessStep::SendingHvfAck
                         | WitnessStep::Complete
                 )
@@ -728,6 +767,92 @@ impl ElevatedGuestSupervisor {
         }
     }
 
+    fn accept_api_listener_request(
+        &mut self,
+        socket: &UnixDatagram,
+        worker_pid: libc::pid_t,
+        session_stream: &UnixStream,
+        namespace: Option<&LauncherNamespace>,
+    ) -> Result<(), LauncherError> {
+        if self.bootstrap.fault() == RuntimeFault::ApiListenerRequest {
+            return self.fail(ProbeStage::ApiListenerRequest, ProbeErrorCategory::Other);
+        }
+        let request = loop {
+            match receive_api_listener_request(socket) {
+                Ok(record) => break record,
+                Err(GrantTransportError::Io(io::ErrorKind::Interrupted)) => {}
+                Err(GrantTransportError::Io(io::ErrorKind::WouldBlock)) => return Ok(()),
+                Err(GrantTransportError::Io(kind)) => {
+                    return self.fail(
+                        ProbeStage::ApiListenerRequest,
+                        ProbeErrorCategory::from_io_kind(kind),
+                    );
+                }
+                Err(GrantTransportError::Invalid) => {
+                    return self.fail(
+                        ProbeStage::ApiListenerRequest,
+                        ProbeErrorCategory::InvalidInput,
+                    );
+                }
+            }
+        };
+        if !request.matches_expected(
+            self.bootstrap.mode(),
+            ApiListenerKind::Request,
+            self.bootstrap.nonce(),
+            self.session,
+            None,
+        ) || !matches!(transport_state(socket), TransportState::Empty)
+        {
+            return self.fail(
+                ProbeStage::ApiListenerRequest,
+                ProbeErrorCategory::InvalidInput,
+            );
+        }
+        self.revalidate(
+            ProbeStage::ApiListenerRequest,
+            socket,
+            worker_pid,
+            session_stream,
+            namespace,
+        )?;
+        if self.bootstrap.fault() == RuntimeFault::ApiListenerBind {
+            return self.fail(ProbeStage::ApiListenerBind, ProbeErrorCategory::Other);
+        }
+        let publication = match bind_elevated_api_listener(
+            self.contract,
+            self.bootstrap.target_uid(),
+            self.bootstrap.target_gid(),
+        ) {
+            Ok(publication) => publication,
+            Err(error) => {
+                return self.fail(
+                    ProbeStage::ApiListenerBind,
+                    elevated_api_listener_category(error),
+                );
+            }
+        };
+        let acknowledgment = match ApiListenerRecord::launcher_ack(
+            self.bootstrap.mode(),
+            self.bootstrap.nonce(),
+            self.session,
+            publication.path_identity(),
+        ) {
+            Ok(acknowledgment) => acknowledgment,
+            Err(_) => {
+                return self.fail(
+                    ProbeStage::ApiListenerTransfer,
+                    ProbeErrorCategory::InvalidInput,
+                );
+            }
+        };
+        self.publication = Some(publication);
+        self.pending_listener_ack = Some(acknowledgment);
+        self.step = WitnessStep::SendingApiListenerAck;
+        self.deadline = Some(deadline_after(WITNESS_TIMEOUT)?);
+        Ok(())
+    }
+
     fn accept_record(
         &mut self,
         record: GuestEvidenceRecord,
@@ -743,7 +868,7 @@ impl ElevatedGuestSupervisor {
                 ProbeStage::GuestResourceWitness,
                 WitnessStep::SendingResourceAck,
             ),
-            WitnessStep::AwaitingHvfRequest => (
+            WitnessStep::AwaitingHvfRequest | WitnessStep::AwaitingApiListenerAdoption => (
                 GuestEvidencePhase::HvfCreate,
                 GuestEvidenceKind::Request,
                 ProbeStage::GuestHvfWitness,
@@ -763,6 +888,8 @@ impl ElevatedGuestSupervisor {
             ),
             WitnessStep::AwaitingGrantAcceptance
             | WitnessStep::SendingResourceAck
+            | WitnessStep::AwaitingApiListenerRequest
+            | WitnessStep::SendingApiListenerAck
             | WitnessStep::SendingHvfAck
             | WitnessStep::Complete => {
                 return self.fail(self.expected_stage(), ProbeErrorCategory::InvalidInput);
@@ -778,6 +905,10 @@ impl ElevatedGuestSupervisor {
             }
             (RuntimeWorkload::GuestApi, GuestEvidencePhase::HvfCreate) => {
                 self.readiness == Some(Readiness::Api)
+                    && self.pending_listener_ack.is_none()
+                    && self.publication.as_ref().is_some_and(|publication| {
+                        publication.listener_fd().is_none() && publication.validate_path().is_ok()
+                    })
                     && self
                         .api
                         .as_ref()
@@ -821,7 +952,11 @@ impl ElevatedGuestSupervisor {
         ) {
             return self.fail(stage, ProbeErrorCategory::InvalidInput);
         }
-        self.revalidate(stage, socket, worker_pid, session_stream, namespace)?;
+        if guest_evidence_requires_live_sender(phase) {
+            self.revalidate(stage, socket, worker_pid, session_stream, namespace)?;
+        } else {
+            self.revalidate_terminal_receiver(stage)?;
+        }
         self.step = next;
         match kind {
             GuestEvidenceKind::Request => {
@@ -854,7 +989,86 @@ impl ElevatedGuestSupervisor {
         Ok(())
     }
 
-    pub(crate) fn pump_write(&mut self, socket: &UnixDatagram) -> Result<(), LauncherError> {
+    pub(crate) fn pump_write(
+        &mut self,
+        socket: &UnixDatagram,
+        worker_pid: libc::pid_t,
+        session_stream: &UnixStream,
+        namespace: Option<&LauncherNamespace>,
+    ) -> Result<(), LauncherError> {
+        if let Some(record) = self.pending_listener_ack {
+            if self.step != WitnessStep::SendingApiListenerAck {
+                return self.fail(
+                    ProbeStage::ApiListenerTransfer,
+                    ProbeErrorCategory::InvalidInput,
+                );
+            }
+            if self.bootstrap.fault() == RuntimeFault::ApiListenerTransfer {
+                return self.fail(ProbeStage::ApiListenerTransfer, ProbeErrorCategory::Other);
+            }
+            self.revalidate(
+                ProbeStage::ApiListenerTransfer,
+                socket,
+                worker_pid,
+                session_stream,
+                namespace,
+            )?;
+            let Some(listener) = self
+                .publication
+                .as_ref()
+                .filter(|publication| publication.validate_path().is_ok())
+                .and_then(ElevatedApiPublication::listener_fd)
+            else {
+                return self.fail(
+                    ProbeStage::ApiListenerTransfer,
+                    ProbeErrorCategory::InvalidInput,
+                );
+            };
+            return match send_api_listener_ack(socket, record, listener) {
+                Ok(()) => {
+                    self.pending_listener_ack = None;
+                    if !matches!(
+                        self.publication
+                            .as_mut()
+                            .map(ElevatedApiPublication::release_listener_alias),
+                        Some(Ok(()))
+                    ) {
+                        return self.fail(
+                            ProbeStage::ApiListenerTransfer,
+                            ProbeErrorCategory::InvalidInput,
+                        );
+                    }
+                    if !matches!(transport_state(socket), TransportState::Empty) {
+                        return self.fail(
+                            ProbeStage::ApiListenerTransfer,
+                            ProbeErrorCategory::InvalidInput,
+                        );
+                    }
+                    self.step = WitnessStep::AwaitingApiListenerAdoption;
+                    self.deadline = Some(deadline_after(WITNESS_TIMEOUT)?);
+                    self.revalidate_with_category(
+                        ProbeStage::ApiListenerAdoption,
+                        ProbeErrorCategory::Other,
+                        socket,
+                        worker_pid,
+                        session_stream,
+                        namespace,
+                    )?;
+                    Ok(())
+                }
+                Err(GrantTransportError::Io(
+                    io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock,
+                )) => Ok(()),
+                Err(GrantTransportError::Io(kind)) => self.fail(
+                    ProbeStage::ApiListenerTransfer,
+                    ProbeErrorCategory::from_io_kind(kind),
+                ),
+                Err(GrantTransportError::Invalid) => self.fail(
+                    ProbeStage::ApiListenerTransfer,
+                    ProbeErrorCategory::InvalidInput,
+                ),
+            };
+        }
         let Some(record) = self.pending_ack else {
             return Ok(());
         };
@@ -862,6 +1076,11 @@ impl ElevatedGuestSupervisor {
             Ok(()) => {
                 self.pending_ack = None;
                 self.step = match self.step {
+                    WitnessStep::SendingResourceAck
+                        if self.contract.workload() == RuntimeWorkload::GuestApi =>
+                    {
+                        WitnessStep::AwaitingApiListenerRequest
+                    }
                     WitnessStep::SendingResourceAck => WitnessStep::AwaitingHvfRequest,
                     WitnessStep::SendingHvfAck => WitnessStep::AwaitingHvfCreated,
                     _ => {
@@ -891,7 +1110,7 @@ impl ElevatedGuestSupervisor {
     }
 
     pub(crate) const fn requires_write_event(&self) -> bool {
-        self.pending_ack.is_some()
+        self.pending_ack.is_some() || self.pending_listener_ack.is_some()
     }
 
     pub(crate) fn deadline(&self) -> Option<Instant> {
@@ -940,6 +1159,19 @@ impl ElevatedGuestSupervisor {
                 }
             };
             return self.fail(stage, ProbeErrorCategory::InvalidInput);
+        }
+        if workload == RuntimeWorkload::GuestApi
+            && (self.step != WitnessStep::AwaitingApiListenerAdoption
+                || self.pending_listener_ack.is_some()
+                || self.publication.as_ref().is_none_or(|publication| {
+                    publication.listener_fd().is_some() || publication.validate_path().is_err()
+                })
+                || !matches!(transport_state(socket), TransportState::Empty))
+        {
+            return self.fail(
+                ProbeStage::ApiSocketPublication,
+                ProbeErrorCategory::InvalidInput,
+            );
         }
         if self.readiness.replace(readiness).is_some() || self.api.is_some() {
             return self.fail(
@@ -1016,7 +1248,7 @@ impl ElevatedGuestSupervisor {
 
     pub(crate) fn fail_endpoint_death(&mut self) -> Result<(), LauncherError> {
         self.fail(
-            missing_serial_stage(self.contract.workload(), self.readiness),
+            missing_serial_stage(self.contract.workload(), self.readiness, self.step),
             ProbeErrorCategory::Other,
         )
     }
@@ -1052,7 +1284,7 @@ impl ElevatedGuestSupervisor {
             }
             GuestSerialEvidence::Missing => {
                 return self.fail(
-                    missing_serial_stage(self.contract.workload(), self.readiness),
+                    missing_serial_stage(self.contract.workload(), self.readiness, self.step),
                     ProbeErrorCategory::Other,
                 );
             }
@@ -1071,6 +1303,12 @@ impl ElevatedGuestSupervisor {
             };
             if self.step != WitnessStep::Complete
                 || self.pending_ack.is_some()
+                || self.pending_listener_ack.is_some()
+                || (self.contract.workload() == RuntimeWorkload::GuestApi
+                    && self
+                        .publication
+                        .as_ref()
+                        .is_none_or(|publication| publication.listener_fd().is_some()))
                 || !workload_complete
             {
                 return self.fail(
@@ -1090,13 +1328,27 @@ impl ElevatedGuestSupervisor {
                     return self.fail(ProbeStage::GuestEndpointDeath, ProbeErrorCategory::Other);
                 }
             }
-        } else if self.step != WitnessStep::Complete || self.pending_ack.is_some() {
+        } else if self.step != WitnessStep::Complete
+            || self.pending_ack.is_some()
+            || self.pending_listener_ack.is_some()
+        {
             return self.fail(ProbeStage::GuestEndpointDeath, ProbeErrorCategory::Other);
         }
         Ok(())
     }
 
+    pub(crate) fn cleanup_policy(&self) -> Option<ElevatedApiCleanupPolicy> {
+        self.publication
+            .as_ref()
+            .map(ElevatedApiPublication::cleanup_policy)
+    }
+
     pub(crate) fn finish_cleanup(&mut self) -> Result<(), LauncherError> {
+        if let Some(publication) = self.publication.as_mut()
+            && publication.cleanup().is_err()
+        {
+            return self.fail(ProbeStage::GuestCleanup, ProbeErrorCategory::Other);
+        }
         if let Some(anchor) = self.contract.api_anchor()
             && anchored_child_is_absent(
                 anchor.descriptor(),
@@ -1115,6 +1367,50 @@ impl ElevatedGuestSupervisor {
     fn revalidate(
         &mut self,
         stage: ProbeStage,
+        socket: &UnixDatagram,
+        worker_pid: libc::pid_t,
+        session_stream: &UnixStream,
+        namespace: Option<&LauncherNamespace>,
+    ) -> Result<(), LauncherError> {
+        self.revalidate_with_category(
+            stage,
+            ProbeErrorCategory::PermissionDenied,
+            socket,
+            worker_pid,
+            session_stream,
+            namespace,
+        )
+    }
+
+    fn revalidate_terminal_receiver(&mut self, stage: ProbeStage) -> Result<(), LauncherError> {
+        // GuestShutdown is the final one-way record. Once its canonical bytes
+        // have been received from the connected, correlated evidence endpoint,
+        // the worker may legitimately send lifecycle Terminal and exit before
+        // the launcher is scheduled. Do not make that successful report depend
+        // on a later live-process or session-lock observation.
+        let valid = bangbang_session::elevated_credential::attest_current_process(
+            self.bootstrap.mode(),
+            self.bootstrap.target_uid(),
+            self.bootstrap.target_gid(),
+        )
+        .is_ok()
+            && self.contract.workload()
+                == self
+                    .bootstrap
+                    .mode()
+                    .runtime_workload()
+                    .unwrap_or(RuntimeWorkload::RepresentativeGrants);
+        if valid {
+            Ok(())
+        } else {
+            self.fail(stage, ProbeErrorCategory::PermissionDenied)
+        }
+    }
+
+    fn revalidate_with_category(
+        &mut self,
+        stage: ProbeStage,
+        category: ProbeErrorCategory,
         socket: &UnixDatagram,
         worker_pid: libc::pid_t,
         session_stream: &UnixStream,
@@ -1143,7 +1439,7 @@ impl ElevatedGuestSupervisor {
         if valid {
             Ok(())
         } else {
-            self.fail(stage, ProbeErrorCategory::PermissionDenied)
+            self.fail(stage, category)
         }
     }
 
@@ -1152,6 +1448,9 @@ impl ElevatedGuestSupervisor {
             WitnessStep::AwaitingGrantAcceptance
             | WitnessStep::AwaitingResourceRequest
             | WitnessStep::SendingResourceAck => ProbeStage::GuestResourceWitness,
+            WitnessStep::AwaitingApiListenerRequest => ProbeStage::ApiListenerRequest,
+            WitnessStep::SendingApiListenerAck => ProbeStage::ApiListenerTransfer,
+            WitnessStep::AwaitingApiListenerAdoption => ProbeStage::ApiListenerAdoption,
             WitnessStep::AwaitingHvfRequest | WitnessStep::SendingHvfAck => {
                 ProbeStage::GuestHvfWitness
             }
@@ -1192,12 +1491,22 @@ enum GuestSerialEvidence {
     Invalid,
 }
 
+const fn guest_evidence_requires_live_sender(phase: GuestEvidencePhase) -> bool {
+    !matches!(phase, GuestEvidencePhase::GuestShutdown)
+}
+
 const fn missing_serial_stage(
     workload: RuntimeWorkload,
     readiness: Option<Readiness>,
+    step: WitnessStep,
 ) -> ProbeStage {
     match (workload, readiness) {
-        (RuntimeWorkload::GuestApi, None) => ProbeStage::ApiSocketPublication,
+        (RuntimeWorkload::GuestApi, None) => match step {
+            WitnessStep::AwaitingApiListenerRequest => ProbeStage::ApiListenerRequest,
+            WitnessStep::SendingApiListenerAck => ProbeStage::ApiListenerTransfer,
+            WitnessStep::AwaitingApiListenerAdoption => ProbeStage::ApiListenerAdoption,
+            _ => ProbeStage::ApiSocketPublication,
+        },
         (RuntimeWorkload::GuestNoApi, None) => ProbeStage::NoApiStartup,
         _ => ProbeStage::GuestEndpointDeath,
     }
@@ -1367,6 +1676,22 @@ mod tests {
     use serde_json::Value;
 
     use super::*;
+
+    #[test]
+    fn only_the_final_one_way_guest_report_allows_sender_exit() {
+        assert!(guest_evidence_requires_live_sender(
+            GuestEvidencePhase::ResourceClaim
+        ));
+        assert!(guest_evidence_requires_live_sender(
+            GuestEvidencePhase::HvfCreate
+        ));
+        assert!(guest_evidence_requires_live_sender(
+            GuestEvidencePhase::HvfCreated
+        ));
+        assert!(!guest_evidence_requires_live_sender(
+            GuestEvidencePhase::GuestShutdown
+        ));
+    }
 
     #[test]
     fn api_requests_are_closed_ordered_and_use_only_guest_grant_references() {
@@ -1556,20 +1881,55 @@ mod tests {
     #[test]
     fn missing_serial_before_readiness_reports_the_workload_boundary() {
         assert_eq!(
-            missing_serial_stage(RuntimeWorkload::GuestApi, None),
+            missing_serial_stage(
+                RuntimeWorkload::GuestApi,
+                None,
+                WitnessStep::AwaitingResourceRequest,
+            ),
             ProbeStage::ApiSocketPublication
         );
         assert_eq!(
-            missing_serial_stage(RuntimeWorkload::GuestNoApi, None),
+            missing_serial_stage(
+                RuntimeWorkload::GuestNoApi,
+                None,
+                WitnessStep::AwaitingHvfRequest,
+            ),
             ProbeStage::NoApiStartup
         );
         assert_eq!(
-            missing_serial_stage(RuntimeWorkload::GuestApi, Some(Readiness::Api)),
+            missing_serial_stage(
+                RuntimeWorkload::GuestApi,
+                Some(Readiness::Api),
+                WitnessStep::AwaitingApiListenerAdoption,
+            ),
             ProbeStage::GuestEndpointDeath
         );
         assert_eq!(
-            missing_serial_stage(RuntimeWorkload::GuestNoApi, Some(Readiness::NoApi)),
+            missing_serial_stage(
+                RuntimeWorkload::GuestNoApi,
+                Some(Readiness::NoApi),
+                WitnessStep::AwaitingHvfRequest,
+            ),
             ProbeStage::GuestEndpointDeath
         );
+        for (step, stage) in [
+            (
+                WitnessStep::AwaitingApiListenerRequest,
+                ProbeStage::ApiListenerRequest,
+            ),
+            (
+                WitnessStep::SendingApiListenerAck,
+                ProbeStage::ApiListenerTransfer,
+            ),
+            (
+                WitnessStep::AwaitingApiListenerAdoption,
+                ProbeStage::ApiListenerAdoption,
+            ),
+        ] {
+            assert_eq!(
+                missing_serial_stage(RuntimeWorkload::GuestApi, None, step),
+                stage
+            );
+        }
     }
 }

--- a/crates/launcher/src/macos/mod.rs
+++ b/crates/launcher/src/macos/mod.rs
@@ -3,9 +3,12 @@ pub(crate) mod block_device;
 pub(crate) mod code_sign;
 pub(crate) mod daemon;
 #[cfg(feature = "elevated-bootstrap-probe")]
+pub(crate) mod elevated_api_listener;
+#[cfg(feature = "elevated-bootstrap-probe")]
 pub(crate) mod elevated_guest;
 pub(crate) mod local_socket;
 pub(crate) mod publish;
+pub(crate) mod scoped_cwd;
 pub(crate) mod socket_broker;
 pub(crate) mod spawn;
 pub(crate) mod supervise;

--- a/crates/launcher/src/macos/scoped_cwd.rs
+++ b/crates/launcher/src/macos/scoped_cwd.rs
@@ -1,0 +1,326 @@
+//! One process-wide boundary for Darwin Unix-socket operations by directory anchor.
+
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::sync::Mutex;
+
+use bangbang_session::ObjectIdentity;
+
+// Darwin has no descriptor-relative Unix-socket bind or connect. Every process
+// cwd switch in the launcher must share this one lock for the whole operation
+// and its verified restoration.
+static CWD_OPERATION_LOCK: Mutex<()> = Mutex::new(());
+
+/// Redacted failure at the shared process-cwd boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ScopedCwdError;
+
+/// Distinguishes the caller's operation error from the shared cwd boundary.
+pub(crate) enum ScopedCwdOperationError<E> {
+    /// Entering, validating, restoring, or locking the cwd boundary failed.
+    Boundary(ScopedCwdError),
+    /// The bounded operation returned its own error after entering the anchor.
+    Operation(E),
+}
+
+/// Runs one closure relative to an exact live directory anchor and restores cwd.
+///
+/// The one process-wide lock remains held until restoration has completed and
+/// been independently revalidated. A panic is resumed only after the same
+/// explicit restoration path succeeds; the process aborts if restoration also
+/// fails because unwinding into an unknown process-wide cwd is unsafe.
+pub(crate) fn with_scoped_cwd<T, E>(
+    anchor_descriptor: RawFd,
+    anchor_identity: ObjectIdentity,
+    operation: impl FnOnce() -> Result<T, E>,
+) -> Result<T, ScopedCwdOperationError<E>> {
+    let lock = CWD_OPERATION_LOCK
+        .lock()
+        .map_err(|_| ScopedCwdOperationError::Boundary(ScopedCwdError))?;
+    let mut guard = CwdGuard::enter(anchor_descriptor, anchor_identity)
+        .map_err(ScopedCwdOperationError::Boundary)?;
+    let outcome = catch_unwind(AssertUnwindSafe(operation));
+    let restored = guard.restore();
+    if restored.is_err() && guard.restore().is_err() {
+        // Continuing with an unknown process-wide cwd could redirect every
+        // later relative operation outside its validated anchor.
+        std::process::abort();
+    }
+    // Keep the global boundary locked through the independently validated
+    // recovery attempt after an explicit restoration failure.
+    drop(guard);
+    drop(lock);
+    match (outcome, restored) {
+        (Ok(Ok(value)), Ok(())) => Ok(value),
+        (Ok(Err(error)), Ok(())) => Err(ScopedCwdOperationError::Operation(error)),
+        (Ok(_), Err(error)) => Err(ScopedCwdOperationError::Boundary(error)),
+        (Err(payload), Ok(())) => resume_unwind(payload),
+        (Err(payload), Err(_)) => resume_unwind(payload),
+    }
+}
+
+struct CwdGuard {
+    saved: Option<OwnedFd>,
+    identity: ObjectIdentity,
+}
+
+impl CwdGuard {
+    fn enter(
+        anchor_descriptor: RawFd,
+        anchor_identity: ObjectIdentity,
+    ) -> Result<Self, ScopedCwdError> {
+        // SAFETY: The fixed relative directory path is NUL-terminated; success
+        // returns a fresh close-on-exec directory descriptor.
+        let saved = unsafe {
+            libc::open(
+                c".".as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if saved < 0 {
+            return Err(ScopedCwdError);
+        }
+        // SAFETY: `saved` is the fresh descriptor returned above.
+        let saved = unsafe { OwnedFd::from_raw_fd(saved) };
+        let identity = directory_descriptor_identity(saved.as_raw_fd())?;
+        if current_directory_identity()? != identity
+            || directory_descriptor_identity(anchor_descriptor)? != anchor_identity
+        {
+            return Err(ScopedCwdError);
+        }
+        let guard = Self {
+            saved: Some(saved),
+            identity,
+        };
+        // SAFETY: The independently validated retained descriptor is a live directory.
+        if unsafe { libc::fchdir(anchor_descriptor) } != 0
+            || current_directory_identity()? != anchor_identity
+        {
+            return Err(ScopedCwdError);
+        }
+        Ok(guard)
+    }
+
+    fn restore(&mut self) -> Result<(), ScopedCwdError> {
+        let saved = self.saved.as_ref().ok_or(ScopedCwdError)?;
+        if directory_descriptor_identity(saved.as_raw_fd())? != self.identity {
+            return Err(ScopedCwdError);
+        }
+        // SAFETY: `saved` remains a live descriptor for the original cwd.
+        if unsafe { libc::fchdir(saved.as_raw_fd()) } != 0
+            || current_directory_identity()? != self.identity
+        {
+            return Err(ScopedCwdError);
+        }
+        self.saved.take();
+        Ok(())
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        if let Some(saved) = self.saved.as_ref() {
+            // SAFETY: Best-effort restoration uses the still-owned original cwd.
+            let _ = unsafe { libc::fchdir(saved.as_raw_fd()) };
+        }
+    }
+}
+
+pub(crate) fn current_directory_identity() -> Result<ObjectIdentity, ScopedCwdError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: The fixed relative name is live and output storage is writable.
+    if unsafe {
+        libc::fstatat(
+            libc::AT_FDCWD,
+            c".".as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(ScopedCwdError);
+    }
+    // SAFETY: Successful fstatat initialized the complete structure.
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
+        return Err(ScopedCwdError);
+    }
+    Ok(stat_identity(&stat))
+}
+
+pub(crate) fn directory_descriptor_identity(
+    descriptor: RawFd,
+) -> Result<ObjectIdentity, ScopedCwdError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: The descriptor remains live and output storage is writable.
+    if unsafe { libc::fstat(descriptor, stat.as_mut_ptr()) } != 0 {
+        return Err(ScopedCwdError);
+    }
+    // SAFETY: Successful fstat initialized the complete structure.
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
+        return Err(ScopedCwdError);
+    }
+    Ok(stat_identity(&stat))
+}
+
+fn stat_identity(stat: &libc::stat) -> ObjectIdentity {
+    ObjectIdentity {
+        device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
+        inode: stat.st_ino,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+    use std::os::fd::AsRawFd;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+
+    const CHILD_ENV: &str = "BANGBANG_TEST_SCOPED_CWD_CHILD";
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn create(label: &str) -> Self {
+            let id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bangbang-scoped-cwd-{label}-{}-{id}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("test directory should create");
+            Self(path)
+        }
+
+        fn open(&self) -> File {
+            File::open(&self.0).expect("test directory should open")
+        }
+
+        fn identity(&self) -> ObjectIdentity {
+            let descriptor = self.open();
+            directory_descriptor_identity(descriptor.as_raw_fd()).expect("identity should inspect")
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir(&self.0);
+        }
+    }
+
+    #[test]
+    fn scoped_cwd_restores_success_error_panic_and_serializes_operations() {
+        if std::env::var_os(CHILD_ENV).is_none() {
+            let status =
+                Command::new(std::env::current_exe().expect("test executable should resolve"))
+                    .arg("scoped_cwd_restores_success_error_panic_and_serializes_operations")
+                    .current_dir("/")
+                    .env(CHILD_ENV, "1")
+                    .env("RUST_TEST_THREADS", "1")
+                    .status()
+                    .expect("isolated cwd test should launch");
+            assert!(status.success(), "isolated cwd test should pass: {status}");
+            return;
+        }
+
+        let original = std::env::current_dir().expect("original cwd should read");
+        let unrelated = TestDir::create("unrelated");
+        let first = TestDir::create("first");
+        let second = TestDir::create("second");
+        std::env::set_current_dir(&unrelated.0).expect("test cwd should change");
+        let unrelated_identity = current_directory_identity().expect("cwd should inspect");
+
+        let first_descriptor = first.open();
+        let value = with_scoped_cwd(
+            first_descriptor.as_raw_fd(),
+            first.identity(),
+            || -> Result<_, ()> {
+                assert_eq!(
+                    current_directory_identity().expect("entered cwd should inspect"),
+                    first.identity()
+                );
+                Ok(7)
+            },
+        )
+        .unwrap_or_else(|_| panic!("success operation should complete"));
+        assert_eq!(value, 7);
+        assert_eq!(
+            current_directory_identity().expect("restored cwd should inspect"),
+            unrelated_identity
+        );
+
+        assert!(matches!(
+            with_scoped_cwd(
+                first_descriptor.as_raw_fd(),
+                first.identity(),
+                || -> Result<(), u8> { Err(9) },
+            ),
+            Err(ScopedCwdOperationError::Operation(9))
+        ));
+        assert_eq!(
+            current_directory_identity().expect("error cwd should inspect"),
+            unrelated_identity
+        );
+
+        let panic_result = std::panic::catch_unwind(|| {
+            let _: Result<(), ScopedCwdOperationError<()>> = with_scoped_cwd(
+                first_descriptor.as_raw_fd(),
+                first.identity(),
+                || -> Result<(), ()> { panic!("deliberate scoped panic") },
+            );
+        });
+        assert!(panic_result.is_err());
+        assert_eq!(
+            current_directory_identity().expect("panic cwd should inspect"),
+            unrelated_identity
+        );
+
+        assert!(matches!(
+            with_scoped_cwd(
+                first_descriptor.as_raw_fd(),
+                second.identity(),
+                || -> Result<(), ()> { Ok(()) },
+            ),
+            Err(ScopedCwdOperationError::Boundary(_))
+        ));
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let mut threads = Vec::new();
+        for directory in [&first, &second] {
+            let descriptor = directory.open();
+            let identity = directory.identity();
+            let active = Arc::clone(&active);
+            let maximum = Arc::clone(&maximum);
+            threads.push(thread::spawn(move || {
+                with_scoped_cwd(descriptor.as_raw_fd(), identity, || -> Result<(), ()> {
+                    let count = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(count, Ordering::SeqCst);
+                    thread::sleep(Duration::from_millis(10));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok(())
+                })
+                .unwrap_or_else(|_| panic!("concurrent operation should complete"));
+            }));
+        }
+        for thread in threads {
+            thread.join().expect("scoped thread should join");
+        }
+        assert_eq!(maximum.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            current_directory_identity().expect("concurrent cwd should inspect"),
+            unrelated_identity
+        );
+
+        std::env::set_current_dir(original).expect("original cwd should restore");
+    }
+}

--- a/crates/launcher/src/macos/supervise.rs
+++ b/crates/launcher/src/macos/supervise.rs
@@ -235,7 +235,7 @@ pub(crate) fn wait_session_with_preopened_namespace(
             .recover_after_worker_exit(lifecycle.session())
             .and_then(|recovered| {
                 recovered.map_or(Ok(()), |mut namespace| {
-                    cleanup_namespace_after_worker(&mut namespace, grants)
+                    cleanup_namespace_after_worker(&mut namespace, grants, None)
                 })
             })
             .map_err(|_| LauncherError::RuntimeNamespace)?;
@@ -292,14 +292,28 @@ fn wait_session_with_roots(
         terminate_session(worker, session, &auxiliary);
     }
 
+    #[cfg(feature = "elevated-bootstrap-probe")]
+    let strict_api_cleanup = guest
+        .as_ref()
+        .and_then(ElevatedGuestSupervisor::cleanup_policy)
+        .map(|policy| StrictSocketCleanupPolicy {
+            anchor_descriptor: policy.anchor_descriptor(),
+            anchor_identity: policy.anchor_identity(),
+            target_uid: policy.target_uid(),
+            target_gid: policy.target_gid(),
+            path_identity: policy.path_identity(),
+        });
+    #[cfg(not(feature = "elevated-bootstrap-probe"))]
+    let strict_api_cleanup = None;
+
     let cleanup = if let Some(namespace) = observation.namespace.as_mut() {
-        cleanup_namespace_after_worker(namespace, grants)
+        cleanup_namespace_after_worker(namespace, grants, strict_api_cleanup)
     } else {
         roots
             .recover_after_worker_exit(session_id)
             .and_then(|recovered| {
                 recovered.map_or(Ok(()), |mut namespace| {
-                    cleanup_namespace_after_worker(&mut namespace, grants)
+                    cleanup_namespace_after_worker(&mut namespace, grants, strict_api_cleanup)
                 })
             })
     }
@@ -381,15 +395,42 @@ impl NamespaceRoots {
     }
 }
 
+#[derive(Clone, Copy)]
+struct StrictSocketCleanupPolicy {
+    anchor_descriptor: RawFd,
+    anchor_identity: bangbang_session::ObjectIdentity,
+    target_uid: u32,
+    target_gid: u32,
+    path_identity: bangbang_session::ObjectIdentity,
+}
+
 fn cleanup_namespace_after_worker(
     namespace: &mut LauncherNamespace,
     grants: &PreparedGrantBatch,
+    strict_api: Option<StrictSocketCleanupPolicy>,
 ) -> Result<(), RuntimeError> {
     for record in namespace.socket_ownership_records()? {
         let anchor = grants
             .socket_directory_anchor(record.role())
             .ok_or(RuntimeError::InvalidEntry)?;
-        unlink_owned_socket(anchor.descriptor(), &record)?;
+        let strict_owner = match (record.role(), strict_api) {
+            (bangbang_session::ResourceRole::ApiSocketDirectory, Some(policy)) => {
+                if anchor.descriptor() != policy.anchor_descriptor
+                    || anchor.identity() != policy.anchor_identity
+                    || record.identity() != policy.path_identity
+                {
+                    return Err(RuntimeError::InvalidEntry);
+                }
+                Some((policy.target_uid, policy.target_gid))
+            }
+            (_, Some(_)) => None,
+            (_, None) => None,
+        };
+        if let Some(owner) = strict_owner {
+            unlink_owned_socket_with_owner(anchor.descriptor(), &record, Some(owner))?;
+        } else {
+            unlink_owned_socket(anchor.descriptor(), &record)?;
+        }
         namespace.unlink_staged_socket(&record)?;
         namespace.clear_socket_record(&record)?;
     }
@@ -407,6 +448,14 @@ fn cleanup_namespace_after_worker(
 fn unlink_owned_socket(
     directory: RawFd,
     record: &SocketOwnershipRecord,
+) -> Result<(), RuntimeError> {
+    unlink_owned_socket_with_owner(directory, record, None)
+}
+
+fn unlink_owned_socket_with_owner(
+    directory: RawFd,
+    record: &SocketOwnershipRecord,
+    strict_owner: Option<(u32, u32)>,
 ) -> Result<(), RuntimeError> {
     let child = CString::new(record.child().as_bytes()).map_err(|_| RuntimeError::InvalidEntry)?;
     let mut stat = MaybeUninit::<libc::stat>::uninit();
@@ -429,15 +478,16 @@ fn unlink_owned_socket(
     }
     // SAFETY: Successful fstatat initialized the complete result.
     let stat = unsafe { stat.assume_init() };
-    // SAFETY: `geteuid` has no pointer or ownership contract.
-    let uid = unsafe { libc::geteuid() };
+    // SAFETY: Effective identity calls have no pointer or ownership contract.
+    let default_uid = unsafe { libc::geteuid() };
     let identity = bangbang_session::ObjectIdentity {
         device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
         inode: stat.st_ino,
     };
     if stat.st_mode & libc::S_IFMT != libc::S_IFSOCK
         || stat.st_mode & 0o7777 != 0o600
-        || stat.st_uid != uid
+        || stat.st_uid != strict_owner.map_or(default_uid, |(uid, _)| uid)
+        || strict_owner.is_some_and(|(_, gid)| stat.st_gid != gid)
         || stat.st_nlink != 1
         || identity != record.identity()
     {
@@ -969,7 +1019,12 @@ fn wait_session_inner(
             if !grant_send.requires_write_event()
                 && let Some(guest) = guest.as_mut()
             {
-                guest.pump_write(grant_socket)?;
+                guest.pump_write(
+                    grant_socket,
+                    worker.pid(),
+                    session,
+                    observation.namespace.as_ref(),
+                )?;
             }
             let grant_write_required = grant_send.requires_write_event();
             #[cfg(feature = "elevated-bootstrap-probe")]

--- a/crates/launcher/src/macos/vhost_user_broker.rs
+++ b/crates/launcher/src/macos/vhost_user_broker.rs
@@ -5,7 +5,6 @@ use std::io;
 use std::mem::{MaybeUninit, size_of};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::net::{UnixDatagram, UnixStream};
-use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use bangbang_session::macos::vhost_user_broker::{
@@ -18,11 +17,12 @@ use bangbang_session::{LauncherState, ObjectIdentity, SessionId};
 use crate::LauncherError;
 use crate::grant_manifest::{PreparedGrantBatch, SocketDirectoryAnchor};
 
+use super::scoped_cwd::{ScopedCwdOperationError, with_scoped_cwd};
+#[cfg(test)]
+use super::scoped_cwd::{current_directory_identity, directory_descriptor_identity};
+
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 const CONNECT_INTERRUPTED_RETRY_LIMIT: usize = 8;
-// Darwin has no descriptor-relative Unix-socket connect. Serialize the brief
-// cwd switch shared by pager startup and the vhost-user supervisor.
-static CWD_CONNECT_LOCK: Mutex<()> = Mutex::new(());
 
 /// Session-bound serial connector for worker vhost-user requests.
 pub(crate) struct LauncherVhostUserBroker {
@@ -141,73 +141,18 @@ fn send(
         .map_err(|_| LauncherError::VhostUserBroker)
 }
 
-struct CwdGuard {
-    saved: Option<OwnedFd>,
-    identity: ObjectIdentity,
-}
-
-impl CwdGuard {
-    fn enter(
-        anchor_descriptor: RawFd,
-        anchor_identity: ObjectIdentity,
-    ) -> Result<Self, LauncherError> {
-        // SAFETY: The fixed relative directory path is NUL-terminated; success
-        // returns a fresh close-on-exec directory descriptor.
-        let saved = unsafe {
-            libc::open(
-                c".".as_ptr(),
-                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-            )
-        };
-        if saved < 0 {
-            return Err(LauncherError::VhostUserBroker);
-        }
-        // SAFETY: `saved` is the fresh descriptor returned above.
-        let saved = unsafe { OwnedFd::from_raw_fd(saved) };
-        let identity =
-            descriptor_identity(saved.as_raw_fd()).map_err(|_| LauncherError::VhostUserBroker)?;
-        let guard = Self {
-            saved: Some(saved),
-            identity,
-        };
-        // SAFETY: The retained manifest descriptor is a live directory anchor.
-        if unsafe { libc::fchdir(anchor_descriptor) } != 0
-            || current_directory_identity().map_err(|_| LauncherError::VhostUserBroker)?
-                != anchor_identity
-        {
-            return Err(LauncherError::VhostUserBroker);
-        }
-        Ok(guard)
-    }
-
-    fn restore(&mut self) -> Result<(), LauncherError> {
-        let saved = self.saved.as_ref().ok_or(LauncherError::VhostUserBroker)?;
-        // SAFETY: `saved` remains a live descriptor for the original cwd.
-        if unsafe { libc::fchdir(saved.as_raw_fd()) } != 0
-            || current_directory_identity().map_err(|_| LauncherError::VhostUserBroker)?
-                != self.identity
-        {
-            return Err(LauncherError::VhostUserBroker);
-        }
-        self.saved.take();
-        Ok(())
-    }
-}
-
-impl Drop for CwdGuard {
-    fn drop(&mut self) {
-        if let Some(saved) = self.saved.as_ref() {
-            // SAFETY: Best-effort restoration uses the still-owned original cwd.
-            let _ = unsafe { libc::fchdir(saved.as_raw_fd()) };
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScopedConnectError {
     Failure(io::ErrorKind),
     Rejected,
     Invalid,
+}
+
+fn map_scoped_cwd_error(error: ScopedCwdOperationError<ScopedConnectError>) -> ScopedConnectError {
+    match error {
+        ScopedCwdOperationError::Boundary(_) => ScopedConnectError::Invalid,
+        ScopedCwdOperationError::Operation(error) => error,
+    }
 }
 
 /// Result of beginning one descriptor-relative nonblocking connection.
@@ -262,12 +207,7 @@ pub(crate) fn begin_anchored_exact_nonblocking(
     {
         return Err(ScopedConnectError::Invalid);
     }
-    let _cwd_connect = CWD_CONNECT_LOCK
-        .lock()
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let mut guard = CwdGuard::enter(anchor_descriptor, anchor_identity)
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let result = (|| {
+    with_scoped_cwd(anchor_descriptor, anchor_identity, || {
         let source_identity = relative_connect_target_identity_with_mode(
             name,
             expected_uid,
@@ -337,9 +277,8 @@ pub(crate) fn begin_anchored_exact_nonblocking(
             }
             return Err(ScopedConnectError::Failure(error.kind()));
         }
-    })();
-    guard.restore().map_err(|_| ScopedConnectError::Invalid)?;
-    result
+    })
+    .map_err(map_scoped_cwd_error)
 }
 
 /// Completes a writable nonblocking connection and repeats exact pathname validation.
@@ -356,12 +295,7 @@ pub(crate) fn finish_anchored_exact_nonblocking(
             io::Error::from_raw_os_error(socket_error).kind(),
         ));
     }
-    let _cwd_connect = CWD_CONNECT_LOCK
-        .lock()
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let mut guard = CwdGuard::enter(pending.anchor_descriptor, pending.anchor_identity)
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let result = (|| {
+    with_scoped_cwd(pending.anchor_descriptor, pending.anchor_identity, || {
         let after = relative_connect_target_identity_with_mode(
             &pending.name,
             pending.expected_uid,
@@ -376,9 +310,8 @@ pub(crate) fn finish_anchored_exact_nonblocking(
             pending.stream,
             pending.source_identity,
         ))
-    })();
-    guard.restore().map_err(|_| ScopedConnectError::Invalid)?;
-    result
+    })
+    .map_err(map_scoped_cwd_error)
 }
 
 /// Revalidates one exact anchored socket child without opening a connection.
@@ -392,12 +325,7 @@ pub(crate) fn validate_anchored_socket_child(
     expected_mode: u32,
     expected_identity: ObjectIdentity,
 ) -> Result<(), ScopedConnectError> {
-    let _cwd_connect = CWD_CONNECT_LOCK
-        .lock()
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let mut guard = CwdGuard::enter(anchor_descriptor, anchor_identity)
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let result =
+    with_scoped_cwd(anchor_descriptor, anchor_identity, || {
         relative_connect_target_identity_with_mode(name, expected_uid, expected_gid, expected_mode)
             .and_then(|identity| {
                 if identity == expected_identity {
@@ -405,9 +333,9 @@ pub(crate) fn validate_anchored_socket_child(
                 } else {
                     Err(ScopedConnectError::Rejected)
                 }
-            });
-    guard.restore().map_err(|_| ScopedConnectError::Invalid)?;
-    result
+            })
+    })
+    .map_err(map_scoped_cwd_error)
 }
 
 /// Returns whether one fixed child is absent beneath an exact retained anchor.
@@ -417,33 +345,29 @@ pub(crate) fn anchored_socket_child_is_absent(
     anchor_identity: ObjectIdentity,
     name: &CStr,
 ) -> Result<bool, ScopedConnectError> {
-    let _cwd_connect = CWD_CONNECT_LOCK
-        .lock()
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let mut guard = CwdGuard::enter(anchor_descriptor, anchor_identity)
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let mut stat = MaybeUninit::<libc::stat>::uninit();
-    // SAFETY: The bounded fixed child and writable stat storage remain valid.
-    let result = unsafe {
-        libc::fstatat(
-            libc::AT_FDCWD,
-            name.as_ptr(),
-            stat.as_mut_ptr(),
-            libc::AT_SYMLINK_NOFOLLOW,
-        )
-    };
-    let result = if result == 0 {
-        Ok(false)
-    } else {
-        let error = io::Error::last_os_error();
-        if error.kind() == io::ErrorKind::NotFound {
-            Ok(true)
+    with_scoped_cwd(anchor_descriptor, anchor_identity, || {
+        let mut stat = MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: The bounded fixed child and writable stat storage remain valid.
+        let result = unsafe {
+            libc::fstatat(
+                libc::AT_FDCWD,
+                name.as_ptr(),
+                stat.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if result == 0 {
+            Ok(false)
         } else {
-            Err(ScopedConnectError::Failure(error.kind()))
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::NotFound {
+                Ok(true)
+            } else {
+                Err(ScopedConnectError::Failure(error.kind()))
+            }
         }
-    };
-    guard.restore().map_err(|_| ScopedConnectError::Invalid)?;
-    result
+    })
+    .map_err(map_scoped_cwd_error)
 }
 
 fn connect_scoped(
@@ -469,14 +393,10 @@ pub(crate) fn connect_anchored_exact(
     if timeout.is_zero() || name.to_bytes().is_empty() || name.to_bytes().contains(&b'/') {
         return Err(ScopedConnectError::Invalid);
     }
-    let _cwd_connect = CWD_CONNECT_LOCK
-        .lock()
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let mut guard = CwdGuard::enter(anchor_descriptor, anchor_identity)
-        .map_err(|_| ScopedConnectError::Invalid)?;
-    let result = connect_relative_child(name, timeout);
-    guard.restore().map_err(|_| ScopedConnectError::Invalid)?;
-    result
+    with_scoped_cwd(anchor_descriptor, anchor_identity, || {
+        connect_relative_child(name, timeout)
+    })
+    .map_err(map_scoped_cwd_error)
 }
 
 fn connect_relative_child(
@@ -537,46 +457,6 @@ fn connect_relative_child(
     }
     validate_connected_peer(descriptor.as_raw_fd(), name)?;
     Ok((UnixStream::from(descriptor), before))
-}
-
-fn current_directory_identity() -> Result<ObjectIdentity, ScopedConnectError> {
-    let mut stat = MaybeUninit::<libc::stat>::uninit();
-    // SAFETY: The fixed relative name is live and output storage is writable.
-    if unsafe {
-        libc::fstatat(
-            libc::AT_FDCWD,
-            c".".as_ptr(),
-            stat.as_mut_ptr(),
-            libc::AT_SYMLINK_NOFOLLOW,
-        )
-    } != 0
-    {
-        return Err(ScopedConnectError::Failure(
-            io::Error::last_os_error().kind(),
-        ));
-    }
-    // SAFETY: Successful fstatat initialized the complete structure.
-    let stat = unsafe { stat.assume_init() };
-    if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
-        return Err(ScopedConnectError::Invalid);
-    }
-    Ok(stat_identity(&stat))
-}
-
-fn descriptor_identity(descriptor: RawFd) -> Result<ObjectIdentity, ScopedConnectError> {
-    let mut stat = MaybeUninit::<libc::stat>::uninit();
-    // SAFETY: The descriptor remains live and output storage is writable.
-    if unsafe { libc::fstat(descriptor, stat.as_mut_ptr()) } != 0 {
-        return Err(ScopedConnectError::Failure(
-            io::Error::last_os_error().kind(),
-        ));
-    }
-    // SAFETY: Successful fstat initialized the complete structure.
-    let stat = unsafe { stat.assume_init() };
-    if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
-        return Err(ScopedConnectError::Invalid);
-    }
-    Ok(stat_identity(&stat))
 }
 
 fn relative_connect_target_identity(name: &CStr) -> Result<ObjectIdentity, ScopedConnectError> {
@@ -959,6 +839,7 @@ mod tests {
                 Command::new(std::env::current_exe().expect("test executable should exist"))
                     .arg("scoped_connect_uses_exact_anchor_and_restores_cwd")
                     .arg("--nocapture")
+                    .current_dir("/")
                     .env(SCOPED_CONNECT_CHILD_ENV, "1")
                     .status()
                     .expect("isolated cwd test should launch");
@@ -974,8 +855,8 @@ mod tests {
         let listener = UnixListener::bind(anchor_path.join("backend.sock"))
             .expect("anchored listener should bind");
         let anchor_file = File::open(&anchor_path).expect("anchor directory should open");
-        let identity =
-            descriptor_identity(anchor_file.as_raw_fd()).expect("anchor identity should inspect");
+        let identity = directory_descriptor_identity(anchor_file.as_raw_fd())
+            .expect("anchor identity should inspect");
         let anchor = SocketDirectoryAnchor::for_test(anchor_file.as_raw_fd(), identity);
         let child = bangbang_session::SocketChild::parse("backend.sock")
             .expect("socket child should parse");

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -889,6 +889,7 @@ fn continue_runtime_session(
     const RUNTIME_LAUNCHER_ARTIFACT: &str = "bangbang-elevated-runtime-launcher-v2-runtime-drop-runtime-retain-root-runtime-unmapped-status: elevated runtime-BBA1-BBN1-launcher-created-session";
     const RUNTIME_LAUNCHER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-runtime-launcher-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
     const GUEST_LAUNCHER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-guest-launcher-boundaries-v1-guest-no-api-drop-guest-no-api-retain-root-guest-no-api-unmapped-guest-api-drop-guest-api-retain-root-guest-api-unmapped-BBW1-guest-resource-witness-guest-grant-accepted-guest-transport-contamination-guest-hvf-witness-guest-terminal-evidence-api-instance-start-bangbang-grant:evidence-guest-kernel-bangbang-grant:evidence-guest-serial";
+    const API_LISTENER_LAUNCHER_BOUNDARY_ARTIFACT: &str = "bangbang-elevated-api-listener-launcher-v1-BBL1-request-bind-transfer-adoption-final-child-one-right";
 
     use std::io::Write;
     use std::os::fd::AsRawFd;
@@ -904,6 +905,7 @@ fn continue_runtime_session(
     std::hint::black_box(RUNTIME_LAUNCHER_ARTIFACT);
     std::hint::black_box(RUNTIME_LAUNCHER_BOUNDARY_ARTIFACT);
     std::hint::black_box(GUEST_LAUNCHER_BOUNDARY_ARTIFACT);
+    std::hint::black_box(API_LISTENER_LAUNCHER_BOUNDARY_ARTIFACT);
     let blocked = |stage, category| {
         Ok(elevated_runtime_blocked(
             bootstrap, &semantics, stage, category,
@@ -1587,6 +1589,10 @@ fn elevated_runtime_blocked(
         | ProbeStage::LifecycleTerminal
         | ProbeStage::RuntimeCleanup => RuntimeResultClass::LifecycleBoundary,
         ProbeStage::ApiSocketPublication
+        | ProbeStage::ApiListenerRequest
+        | ProbeStage::ApiListenerBind
+        | ProbeStage::ApiListenerTransfer
+        | ProbeStage::ApiListenerAdoption
         | ProbeStage::ApiLoggerConfiguration
         | ProbeStage::ApiMetricsConfiguration
         | ProbeStage::ApiSerialConfiguration

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -109,6 +109,9 @@ const ELEVATED_RUNTIME_AUTHORITY_RECORD: &[u8] = b"BBN1";
 const ELEVATED_RUNTIME_GRANT_CASE: &[u8] = b"target-runtime";
 const ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES: &[u8] = b"bangbang-elevated-runtime-launcher-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
 const ELEVATED_RUNTIME_WORKER_BOUNDARIES: &[u8] = b"bangbang-elevated-runtime-worker-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary";
+const ELEVATED_API_LISTENER_LAUNCHER_BOUNDARY: &[u8] = b"bangbang-elevated-api-listener-launcher-v1-BBL1-request-bind-transfer-adoption-final-child-one-right";
+const ELEVATED_API_LISTENER_WORKER_BOUNDARY: &[u8] =
+    b"bangbang-elevated-api-listener-worker-v1-BBL1-request-ack-adoption-record-readiness";
 const ELEVATED_GUEST_MARKERS: &[&[u8]] = &[
     b"guest-no-api-drop",
     b"guest-no-api-retain-root",
@@ -121,6 +124,10 @@ const ELEVATED_GUEST_MARKERS: &[&[u8]] = &[
     b"guest-grant-accepted",
     b"guest-transport-contamination",
     b"guest-resource-witness",
+    b"api-listener-request",
+    b"api-listener-bind",
+    b"api-listener-transfer",
+    b"api-listener-adoption",
     b"api-socket-publication",
     b"api-logger-configuration",
     b"api-metrics-configuration",
@@ -13144,6 +13151,8 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             ELEVATED_RUNTIME_GRANT_CASE,
             ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES,
             ELEVATED_RUNTIME_WORKER_BOUNDARIES,
+            ELEVATED_API_LISTENER_LAUNCHER_BOUNDARY,
+            ELEVATED_API_LISTENER_WORKER_BOUNDARY,
         ]
         .into_iter()
         .chain(ELEVATED_GUEST_MARKERS.iter().copied())
@@ -13192,6 +13201,8 @@ fn normal_production_bundle_statically_and_dynamically_excludes_elevated_probe()
             ELEVATED_RUNTIME_GRANT_CASE,
             ELEVATED_RUNTIME_LAUNCHER_BOUNDARIES,
             ELEVATED_RUNTIME_WORKER_BOUNDARIES,
+            ELEVATED_API_LISTENER_LAUNCHER_BOUNDARY,
+            ELEVATED_API_LISTENER_WORKER_BOUNDARY,
         ]
         .into_iter()
         .chain(ELEVATED_GUEST_MARKERS.iter().copied())

--- a/crates/session/src/elevated_probe.rs
+++ b/crates/session/src/elevated_probe.rs
@@ -26,6 +26,8 @@ pub const CONTINUATION_ACK_BYTES: usize = 48;
 pub const RUNTIME_SESSION_AUTHORITY_BYTES: usize = 120;
 /// Encoded post-grant guest-evidence record length.
 pub const GUEST_EVIDENCE_RECORD_BYTES: usize = 96;
+/// Encoded fixed API-listener request or acknowledgment length.
+pub const API_LISTENER_RECORD_BYTES: usize = 112;
 /// Exact no-API startup-config grant ID.
 pub const GUEST_CONFIG_GRANT_ID: &str = "evidence-guest-config";
 /// Exact guest kernel grant ID.
@@ -141,6 +143,11 @@ const RUNTIME_SESSION_AUTHORITY_MAGIC: [u8; 4] = *b"BBN1";
 const RUNTIME_SESSION_AUTHORITY_VERSION: u16 = 1;
 const GUEST_EVIDENCE_MAGIC: [u8; 4] = *b"BBW1";
 const GUEST_EVIDENCE_VERSION: u16 = 1;
+const API_LISTENER_MAGIC: [u8; 4] = *b"BBL1";
+const API_LISTENER_VERSION: u16 = 1;
+const API_LISTENER_PHASE: u8 = 1;
+const API_LISTENER_OPERATION: u8 = 1;
+const API_LISTENER_SEQUENCE: u32 = 1;
 const RUNTIME_WORKER_FAILURE_EXIT_BASE: u8 = 64;
 
 /// Exact evidence mode selected by the explicit root wrapper.
@@ -480,6 +487,14 @@ pub enum ProbeStage {
     GuestTerminalEvidence = 52,
     /// Clean every guest output, socket, and session object.
     GuestCleanup = 53,
+    /// Receive the fixed worker request for launcher-created API authority.
+    ApiListenerRequest = 54,
+    /// Bind and validate the fixed final API listener beneath its anchor.
+    ApiListenerBind = 55,
+    /// Transfer the exact launcher-created API listener to the worker.
+    ApiListenerTransfer = 56,
+    /// Adopt, record, and validate the transferred API listener in the worker.
+    ApiListenerAdoption = 57,
 }
 
 impl ProbeStage {
@@ -540,6 +555,10 @@ impl ProbeStage {
             Self::GuestEndpointDeath => "guest-endpoint-death",
             Self::GuestTerminalEvidence => "guest-terminal-evidence",
             Self::GuestCleanup => "guest-cleanup",
+            Self::ApiListenerRequest => "api-listener-request",
+            Self::ApiListenerBind => "api-listener-bind",
+            Self::ApiListenerTransfer => "api-listener-transfer",
+            Self::ApiListenerAdoption => "api-listener-adoption",
         }
     }
 
@@ -598,6 +617,10 @@ impl ProbeStage {
             51 => Ok(Self::GuestEndpointDeath),
             52 => Ok(Self::GuestTerminalEvidence),
             53 => Ok(Self::GuestCleanup),
+            54 => Ok(Self::ApiListenerRequest),
+            55 => Ok(Self::ApiListenerBind),
+            56 => Ok(Self::ApiListenerTransfer),
+            57 => Ok(Self::ApiListenerAdoption),
             _ => Err(ProbeProtocolError),
         }
     }
@@ -682,6 +705,14 @@ pub enum RuntimeFault {
     GuestGrantAccepted = 35,
     /// Inject one descriptor-free datagram outside the guest witness protocol.
     GuestTransportContamination = 36,
+    /// Stop before accepting the fixed API-listener request.
+    ApiListenerRequest = 37,
+    /// Stop while binding the fixed final API listener.
+    ApiListenerBind = 38,
+    /// Stop while transferring the launcher-created API listener.
+    ApiListenerTransfer = 39,
+    /// Stop while the worker adopts and records the transferred listener.
+    ApiListenerAdoption = 40,
 }
 
 impl RuntimeFault {
@@ -725,6 +756,10 @@ impl RuntimeFault {
             "guest-cleanup" => Some(Self::GuestCleanup),
             "guest-grant-accepted" => Some(Self::GuestGrantAccepted),
             "guest-transport-contamination" => Some(Self::GuestTransportContamination),
+            "api-listener-request" => Some(Self::ApiListenerRequest),
+            "api-listener-bind" => Some(Self::ApiListenerBind),
+            "api-listener-transfer" => Some(Self::ApiListenerTransfer),
+            "api-listener-adoption" => Some(Self::ApiListenerAdoption),
             _ => None,
         }
     }
@@ -768,6 +803,10 @@ impl RuntimeFault {
             34 => Ok(Self::GuestCleanup),
             35 => Ok(Self::GuestGrantAccepted),
             36 => Ok(Self::GuestTransportContamination),
+            37 => Ok(Self::ApiListenerRequest),
+            38 => Ok(Self::ApiListenerBind),
+            39 => Ok(Self::ApiListenerTransfer),
+            40 => Ok(Self::ApiListenerAdoption),
             _ => Err(ProbeProtocolError),
         }
     }
@@ -813,6 +852,10 @@ impl RuntimeFault {
             Self::GuestCleanup => "guest-cleanup",
             Self::GuestGrantAccepted => "guest-grant-accepted",
             Self::GuestTransportContamination => "guest-transport-contamination",
+            Self::ApiListenerRequest => "api-listener-request",
+            Self::ApiListenerBind => "api-listener-bind",
+            Self::ApiListenerTransfer => "api-listener-transfer",
+            Self::ApiListenerAdoption => "api-listener-adoption",
         }
     }
 
@@ -857,6 +900,10 @@ impl RuntimeFault {
             Self::GuestCleanup => Some(ProbeStage::GuestCleanup),
             Self::GuestGrantAccepted => Some(ProbeStage::GrantAccepted),
             Self::GuestTransportContamination => Some(ProbeStage::GuestResourceWitness),
+            Self::ApiListenerRequest => Some(ProbeStage::ApiListenerRequest),
+            Self::ApiListenerBind => Some(ProbeStage::ApiListenerBind),
+            Self::ApiListenerTransfer => Some(ProbeStage::ApiListenerTransfer),
+            Self::ApiListenerAdoption => Some(ProbeStage::ApiListenerAdoption),
         }
     }
 }
@@ -1463,6 +1510,252 @@ impl RuntimeSessionAuthority {
 impl fmt::Debug for RuntimeSessionAuthority {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("RuntimeSessionAuthority(<redacted>)")
+    }
+}
+
+/// Direction of the one fixed API-listener authority exchange.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ApiListenerKind {
+    /// Worker requests the fixed final API listener without ancillary authority.
+    Request = 1,
+    /// Launcher acknowledges the request with exactly one listener descriptor.
+    Ack = 2,
+}
+
+impl ApiListenerKind {
+    fn from_byte(value: u8) -> Result<Self, ProbeProtocolError> {
+        match value {
+            1 => Ok(Self::Request),
+            2 => Ok(Self::Ack),
+            _ => Err(ProbeProtocolError),
+        }
+    }
+}
+
+/// Canonical request or acknowledgment for the fixed elevated API listener.
+///
+/// The phase, sequence, operation, and child name are deliberately not caller
+/// selected. The one operation always names [`GUEST_API_SOCKET_CHILD`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ApiListenerRecord {
+    mode: ProbeMode,
+    kind: ApiListenerKind,
+    role: CredentialRole,
+    descriptor_count: u8,
+    nonce: SessionId,
+    session: SessionId,
+    path_identity: Option<ObjectIdentity>,
+}
+
+impl ApiListenerRecord {
+    /// Constructs the worker's descriptor-free request for the fixed listener.
+    pub fn worker_request(
+        mode: ProbeMode,
+        nonce: SessionId,
+        session: SessionId,
+    ) -> Result<Self, ProbeProtocolError> {
+        Self::new(
+            mode,
+            ApiListenerKind::Request,
+            CredentialRole::Worker,
+            0,
+            nonce,
+            session,
+            None,
+        )
+    }
+
+    /// Constructs the launcher's one-descriptor acknowledgment.
+    pub fn launcher_ack(
+        mode: ProbeMode,
+        nonce: SessionId,
+        session: SessionId,
+        path_identity: ObjectIdentity,
+    ) -> Result<Self, ProbeProtocolError> {
+        Self::new(
+            mode,
+            ApiListenerKind::Ack,
+            CredentialRole::Launcher,
+            1,
+            nonce,
+            session,
+            Some(path_identity),
+        )
+    }
+
+    fn new(
+        mode: ProbeMode,
+        kind: ApiListenerKind,
+        role: CredentialRole,
+        descriptor_count: u8,
+        nonce: SessionId,
+        session: SessionId,
+        path_identity: Option<ObjectIdentity>,
+    ) -> Result<Self, ProbeProtocolError> {
+        if mode.runtime_workload() != Some(RuntimeWorkload::GuestApi)
+            || nonce.is_pre_session()
+            || session.is_pre_session()
+        {
+            return Err(ProbeProtocolError);
+        }
+        let valid_shape = match (kind, role, descriptor_count, path_identity) {
+            (ApiListenerKind::Request, CredentialRole::Worker, 0, None) => true,
+            (
+                ApiListenerKind::Ack,
+                CredentialRole::Launcher,
+                1,
+                Some(ObjectIdentity { device, inode }),
+            ) => device != 0 && inode != 0,
+            _ => false,
+        };
+        if !valid_shape {
+            return Err(ProbeProtocolError);
+        }
+        Ok(Self {
+            mode,
+            kind,
+            role,
+            descriptor_count,
+            nonce,
+            session,
+            path_identity,
+        })
+    }
+
+    /// Returns the selected API guest mode.
+    #[must_use]
+    pub const fn mode(self) -> ProbeMode {
+        self.mode
+    }
+
+    /// Returns whether this is the request or acknowledgment.
+    #[must_use]
+    pub const fn kind(self) -> ApiListenerKind {
+        self.kind
+    }
+
+    /// Returns the exact sender role implied by the record kind.
+    #[must_use]
+    pub const fn role(self) -> CredentialRole {
+        self.role
+    }
+
+    /// Returns the exact ancillary-descriptor count implied by the record kind.
+    #[must_use]
+    pub const fn descriptor_count(self) -> u8 {
+        self.descriptor_count
+    }
+
+    /// Returns the bootstrap nonce.
+    #[must_use]
+    pub const fn nonce(self) -> SessionId {
+        self.nonce
+    }
+
+    /// Returns the lifecycle session identity.
+    #[must_use]
+    pub const fn session(self) -> SessionId {
+        self.session
+    }
+
+    /// Returns the final socket pathname identity carried only by an acknowledgment.
+    #[must_use]
+    pub const fn path_identity(self) -> Option<ObjectIdentity> {
+        self.path_identity
+    }
+
+    /// Returns the only child selected by this closed operation.
+    #[must_use]
+    pub const fn child(self) -> &'static str {
+        GUEST_API_SOCKET_CHILD
+    }
+
+    /// Returns whether every correlation and kind-specific field is exact.
+    #[must_use]
+    pub fn matches_expected(
+        self,
+        mode: ProbeMode,
+        kind: ApiListenerKind,
+        nonce: SessionId,
+        session: SessionId,
+        path_identity: Option<ObjectIdentity>,
+    ) -> bool {
+        let (role, descriptor_count) = match kind {
+            ApiListenerKind::Request => (CredentialRole::Worker, 0),
+            ApiListenerKind::Ack => (CredentialRole::Launcher, 1),
+        };
+        self.mode == mode
+            && self.kind == kind
+            && self.role == role
+            && self.descriptor_count == descriptor_count
+            && self.nonce == nonce
+            && self.session == session
+            && self.path_identity == path_identity
+    }
+
+    /// Encodes the fixed canonical listener-authority record.
+    #[must_use]
+    pub fn encode(self) -> [u8; API_LISTENER_RECORD_BYTES] {
+        let mut bytes = [0_u8; API_LISTENER_RECORD_BYTES];
+        bytes[0..4].copy_from_slice(&API_LISTENER_MAGIC);
+        bytes[4..6].copy_from_slice(&API_LISTENER_VERSION.to_be_bytes());
+        bytes[6] = self.mode as u8;
+        bytes[7] = API_LISTENER_PHASE;
+        bytes[8] = self.kind as u8;
+        bytes[9] = self.role as u8;
+        bytes[10] = API_LISTENER_OPERATION;
+        bytes[11] = self.descriptor_count;
+        bytes[12..16].copy_from_slice(&API_LISTENER_SEQUENCE.to_be_bytes());
+        bytes[16..48].copy_from_slice(self.nonce.as_bytes());
+        bytes[48..80].copy_from_slice(self.session.as_bytes());
+        if let Some(identity) = self.path_identity {
+            bytes[80..88].copy_from_slice(&identity.device.to_be_bytes());
+            bytes[88..96].copy_from_slice(&identity.inode.to_be_bytes());
+        }
+        bytes
+    }
+
+    /// Decodes and validates one exact canonical listener-authority record.
+    pub fn decode(bytes: &[u8; API_LISTENER_RECORD_BYTES]) -> Result<Self, ProbeProtocolError> {
+        if bytes[0..4] != API_LISTENER_MAGIC
+            || bytes[4..6] != API_LISTENER_VERSION.to_be_bytes()
+            || bytes[7] != API_LISTENER_PHASE
+            || bytes[10] != API_LISTENER_OPERATION
+            || u32::from_be_bytes(array(bytes, 12)?) != API_LISTENER_SEQUENCE
+            || bytes[96..112] != [0; 16]
+        {
+            return Err(ProbeProtocolError);
+        }
+        let kind = ApiListenerKind::from_byte(bytes[8])?;
+        let identity = ObjectIdentity {
+            device: u64::from_be_bytes(array(bytes, 80)?),
+            inode: u64::from_be_bytes(array(bytes, 88)?),
+        };
+        let path_identity = match kind {
+            ApiListenerKind::Request if identity.device == 0 && identity.inode == 0 => None,
+            ApiListenerKind::Ack => Some(identity),
+            _ => return Err(ProbeProtocolError),
+        };
+        let record = Self::new(
+            ProbeMode::from_byte(bytes[6])?,
+            kind,
+            CredentialRole::from_byte(bytes[9])?,
+            bytes[11],
+            SessionId::from_bytes(array(bytes, 16)?),
+            SessionId::from_bytes(array(bytes, 48)?),
+            path_identity,
+        )?;
+        if record.encode() != *bytes {
+            return Err(ProbeProtocolError);
+        }
+        Ok(record)
+    }
+}
+
+impl fmt::Debug for ApiListenerRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ApiListenerRecord(<redacted>)")
     }
 }
 
@@ -3181,6 +3474,10 @@ mod tests {
             ProbeStage::GuestEndpointDeath,
             ProbeStage::GuestTerminalEvidence,
             ProbeStage::GuestCleanup,
+            ProbeStage::ApiListenerRequest,
+            ProbeStage::ApiListenerBind,
+            ProbeStage::ApiListenerTransfer,
+            ProbeStage::ApiListenerAdoption,
         ] {
             let result = ProbeResult::failure(
                 ProbeMode::InheritedRoot,
@@ -3320,13 +3617,25 @@ mod tests {
                 36,
                 "guest-transport-contamination",
             ),
+            (RuntimeFault::ApiListenerRequest, 37, "api-listener-request"),
+            (RuntimeFault::ApiListenerBind, 38, "api-listener-bind"),
+            (
+                RuntimeFault::ApiListenerTransfer,
+                39,
+                "api-listener-transfer",
+            ),
+            (
+                RuntimeFault::ApiListenerAdoption,
+                40,
+                "api-listener-adoption",
+            ),
         ] {
             assert_eq!(RuntimeFault::parse(name), Some(fault));
             assert_eq!(RuntimeFault::from_byte(byte), Ok(fault));
             assert_eq!(fault.name(), name);
         }
         assert_eq!(RuntimeFault::parse("unknown"), None);
-        assert_eq!(RuntimeFault::from_byte(37), Err(ProbeProtocolError));
+        assert_eq!(RuntimeFault::from_byte(41), Err(ProbeProtocolError));
 
         for (result, name) in [
             (RuntimeResultClass::Complete, "complete"),
@@ -3522,6 +3831,135 @@ mod tests {
                 identity,
                 bootstrap.nonce(),
                 SessionId::pre_session(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn api_listener_records_are_canonical_closed_bound_and_redacted() {
+        let nonce = SessionId::from_bytes([0xa1; 32]);
+        let session = SessionId::from_bytes([0xa2; 32]);
+        let identity = ObjectIdentity {
+            device: 0x1234,
+            inode: 0x5678,
+        };
+        for mode in [
+            ProbeMode::GuestApiDrop,
+            ProbeMode::GuestApiRetainRoot,
+            ProbeMode::GuestApiUnmapped,
+        ] {
+            let records = [
+                ApiListenerRecord::worker_request(mode, nonce, session)
+                    .expect("request should construct"),
+                ApiListenerRecord::launcher_ack(mode, nonce, session, identity)
+                    .expect("acknowledgment should construct"),
+            ];
+            for record in records {
+                let encoded = record.encode();
+                assert_eq!(encoded.len(), API_LISTENER_RECORD_BYTES);
+                assert_eq!(ApiListenerRecord::decode(&encoded), Ok(record));
+                assert_eq!(record.mode(), mode);
+                assert_eq!(record.child(), GUEST_API_SOCKET_CHILD);
+                assert_eq!(record.nonce(), nonce);
+                assert_eq!(record.session(), session);
+                assert!(record.matches_expected(
+                    mode,
+                    record.kind(),
+                    nonce,
+                    session,
+                    record.path_identity(),
+                ));
+                assert_eq!(
+                    record.descriptor_count(),
+                    u8::from(record.kind() == ApiListenerKind::Ack)
+                );
+                assert_eq!(
+                    record.role(),
+                    match record.kind() {
+                        ApiListenerKind::Request => CredentialRole::Worker,
+                        ApiListenerKind::Ack => CredentialRole::Launcher,
+                    }
+                );
+                assert_eq!(format!("{record:?}"), "ApiListenerRecord(<redacted>)");
+                for index in 0..encoded.len() {
+                    let mut malformed = encoded;
+                    malformed[index] ^= 1;
+                    if let Ok(decoded) = ApiListenerRecord::decode(&malformed) {
+                        assert_ne!(decoded, record);
+                        assert!(!decoded.matches_expected(
+                            record.mode(),
+                            record.kind(),
+                            record.nonce(),
+                            record.session(),
+                            record.path_identity(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        let request = ApiListenerRecord::worker_request(ProbeMode::GuestApiDrop, nonce, session)
+            .expect("request should construct");
+        assert_eq!(request.path_identity(), None);
+        assert!(!request.matches_expected(
+            ProbeMode::GuestApiRetainRoot,
+            ApiListenerKind::Request,
+            nonce,
+            session,
+            None,
+        ));
+        assert!(!request.matches_expected(
+            ProbeMode::GuestApiDrop,
+            ApiListenerKind::Ack,
+            nonce,
+            session,
+            Some(identity),
+        ));
+        assert!(
+            ApiListenerRecord::worker_request(ProbeMode::GuestNoApiDrop, nonce, session).is_err()
+        );
+        assert!(
+            ApiListenerRecord::worker_request(
+                ProbeMode::GuestApiDrop,
+                SessionId::pre_session(),
+                session,
+            )
+            .is_err()
+        );
+        assert!(
+            ApiListenerRecord::launcher_ack(
+                ProbeMode::GuestApiDrop,
+                nonce,
+                session,
+                ObjectIdentity {
+                    device: 0,
+                    inode: 0,
+                },
+            )
+            .is_err()
+        );
+        assert!(
+            ApiListenerRecord::new(
+                ProbeMode::GuestApiDrop,
+                ApiListenerKind::Request,
+                CredentialRole::Launcher,
+                0,
+                nonce,
+                session,
+                None,
+            )
+            .is_err()
+        );
+        assert!(
+            ApiListenerRecord::new(
+                ProbeMode::GuestApiDrop,
+                ApiListenerKind::Ack,
+                CredentialRole::Launcher,
+                0,
+                nonce,
+                session,
+                Some(identity),
             )
             .is_err()
         );

--- a/crates/session/src/macos.rs
+++ b/crates/session/src/macos.rs
@@ -3,6 +3,8 @@
 use std::io;
 use std::os::fd::RawFd;
 
+#[cfg(feature = "elevated-bootstrap-probe")]
+pub mod api_listener;
 pub mod block_control;
 pub mod bookmark;
 pub mod grant_registry;

--- a/crates/session/src/macos/api_listener.rs
+++ b/crates/session/src/macos/api_listener.rs
@@ -1,0 +1,258 @@
+//! Strict typed transport for the one elevated API-listener authority.
+
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixDatagram;
+
+use crate::elevated_probe::{API_LISTENER_RECORD_BYTES, ApiListenerKind, ApiListenerRecord};
+
+use super::grant_transport::{GrantTransportError, receive_raw, send_raw};
+
+/// One validated acknowledgment and its exactly owned listener descriptor.
+#[derive(Debug)]
+pub struct ReceivedApiListener {
+    /// Canonical launcher acknowledgment bound to the current session.
+    pub record: ApiListenerRecord,
+    /// Exactly one close-on-exec listener authority received from the launcher.
+    pub listener: OwnedFd,
+}
+
+/// Sends the exact descriptor-free worker request.
+pub fn send_api_listener_request(
+    socket: &UnixDatagram,
+    record: ApiListenerRecord,
+) -> Result<(), GrantTransportError> {
+    if record.kind() != ApiListenerKind::Request || record.descriptor_count() != 0 {
+        return Err(GrantTransportError::Invalid);
+    }
+    send_raw(socket.as_raw_fd(), &record.encode(), &[])
+}
+
+/// Receives the exact descriptor-free worker request.
+pub fn receive_api_listener_request(
+    socket: &UnixDatagram,
+) -> Result<ApiListenerRecord, GrantTransportError> {
+    let (record, descriptors) = receive_record(socket)?;
+    if record.kind() != ApiListenerKind::Request
+        || record.descriptor_count() != 0
+        || !descriptors.is_empty()
+    {
+        return Err(GrantTransportError::Invalid);
+    }
+    Ok(record)
+}
+
+/// Sends the exact launcher acknowledgment and one borrowed listener alias.
+///
+/// The caller retains ownership of `listener` on every result, including
+/// interrupted or would-block sends.
+pub fn send_api_listener_ack(
+    socket: &UnixDatagram,
+    record: ApiListenerRecord,
+    listener: RawFd,
+) -> Result<(), GrantTransportError> {
+    if record.kind() != ApiListenerKind::Ack || record.descriptor_count() != 1 {
+        return Err(GrantTransportError::Invalid);
+    }
+    send_raw(socket.as_raw_fd(), &record.encode(), &[listener])
+}
+
+/// Receives the exact launcher acknowledgment and one owned listener alias.
+pub fn receive_api_listener_ack(
+    socket: &UnixDatagram,
+) -> Result<ReceivedApiListener, GrantTransportError> {
+    let (record, descriptors) = receive_record(socket)?;
+    if record.kind() != ApiListenerKind::Ack
+        || record.descriptor_count() != 1
+        || descriptors.len() != 1
+    {
+        return Err(GrantTransportError::Invalid);
+    }
+    let mut descriptors = descriptors.into_iter();
+    let listener = descriptors.next().ok_or(GrantTransportError::Invalid)?;
+    if descriptors.next().is_some() {
+        return Err(GrantTransportError::Invalid);
+    }
+    Ok(ReceivedApiListener { record, listener })
+}
+
+fn receive_record(
+    socket: &UnixDatagram,
+) -> Result<(ApiListenerRecord, Vec<OwnedFd>), GrantTransportError> {
+    let mut payload = [0_u8; API_LISTENER_RECORD_BYTES];
+    let (length, descriptors) = receive_raw(socket, &mut payload)?;
+    if length != payload.len() {
+        return Err(GrantTransportError::Invalid);
+    }
+    let record = ApiListenerRecord::decode(&payload).map_err(|_| GrantTransportError::Invalid)?;
+    Ok((record, descriptors))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Read as _;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::UnixStream;
+
+    use crate::elevated_probe::{GuestEvidencePhase, GuestEvidenceRecord, ProbeMode};
+    use crate::{ObjectIdentity, SessionId};
+
+    use super::*;
+
+    fn request() -> ApiListenerRecord {
+        ApiListenerRecord::worker_request(
+            ProbeMode::GuestApiDrop,
+            SessionId::from_bytes([1; 32]),
+            SessionId::from_bytes([2; 32]),
+        )
+        .expect("request should construct")
+    }
+
+    fn acknowledgment() -> ApiListenerRecord {
+        ApiListenerRecord::launcher_ack(
+            ProbeMode::GuestApiDrop,
+            SessionId::from_bytes([1; 32]),
+            SessionId::from_bytes([2; 32]),
+            ObjectIdentity {
+                device: 3,
+                inode: 4,
+            },
+        )
+        .expect("acknowledgment should construct")
+    }
+
+    #[test]
+    fn request_and_one_descriptor_acknowledgment_round_trip_exactly() {
+        let (worker, launcher) = UnixDatagram::pair().expect("datagram pair should open");
+        send_api_listener_request(&worker, request()).expect("request should send");
+        assert_eq!(receive_api_listener_request(&launcher), Ok(request()));
+
+        let file = File::open("/dev/null").expect("fixture should open");
+        send_api_listener_ack(&launcher, acknowledgment(), file.as_raw_fd())
+            .expect("acknowledgment should send");
+        let received = receive_api_listener_ack(&worker).expect("acknowledgment should receive");
+        assert_eq!(received.record, acknowledgment());
+        // SAFETY: F_GETFD reads flags from the live owned descriptor.
+        let flags = unsafe { libc::fcntl(received.listener.as_raw_fd(), libc::F_GETFD) };
+        assert_ne!(flags & libc::FD_CLOEXEC, 0);
+    }
+
+    #[test]
+    fn senders_reject_the_wrong_record_kind_without_sending() {
+        let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should open");
+        let file = File::open("/dev/null").expect("fixture should open");
+        assert_eq!(
+            send_api_listener_request(&sender, acknowledgment()),
+            Err(GrantTransportError::Invalid)
+        );
+        assert_eq!(
+            send_api_listener_ack(&sender, request(), file.as_raw_fd()),
+            Err(GrantTransportError::Invalid)
+        );
+        receiver
+            .set_nonblocking(true)
+            .expect("receiver should become nonblocking");
+        assert!(matches!(
+            receive_api_listener_request(&receiver),
+            Err(GrantTransportError::Io(std::io::ErrorKind::WouldBlock))
+        ));
+    }
+
+    #[test]
+    fn request_rejects_rights_truncation_excess_and_wrong_family() {
+        let file = File::open("/dev/null").expect("fixture should open");
+        let guest = GuestEvidenceRecord::worker_request(
+            ProbeMode::GuestApiDrop,
+            GuestEvidencePhase::ResourceClaim,
+            SessionId::from_bytes([1; 32]),
+            SessionId::from_bytes([2; 32]),
+        )
+        .expect("guest record should construct");
+        for (payload, descriptors) in [
+            (request().encode().to_vec(), vec![file.as_raw_fd()]),
+            (
+                request().encode()[..API_LISTENER_RECORD_BYTES - 1].to_vec(),
+                vec![],
+            ),
+            (vec![7; API_LISTENER_RECORD_BYTES + 1], vec![]),
+            (acknowledgment().encode().to_vec(), vec![]),
+            (guest.encode().to_vec(), vec![]),
+        ] {
+            let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should open");
+            send_raw(sender.as_raw_fd(), &payload, &descriptors)
+                .expect("hostile record should reach receiver");
+            assert_eq!(
+                receive_api_listener_request(&receiver),
+                Err(GrantTransportError::Invalid)
+            );
+        }
+    }
+
+    #[test]
+    fn acknowledgment_rejects_missing_extra_and_wrong_state_rights() {
+        let file = File::open("/dev/null").expect("fixture should open");
+        for (payload, descriptors) in [
+            (acknowledgment().encode().to_vec(), vec![]),
+            (
+                acknowledgment().encode().to_vec(),
+                vec![file.as_raw_fd(), file.as_raw_fd()],
+            ),
+            (request().encode().to_vec(), vec![file.as_raw_fd()]),
+            (
+                acknowledgment().encode()[..API_LISTENER_RECORD_BYTES - 1].to_vec(),
+                vec![file.as_raw_fd()],
+            ),
+            (
+                vec![7; API_LISTENER_RECORD_BYTES + 1],
+                vec![file.as_raw_fd()],
+            ),
+        ] {
+            let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should open");
+            send_raw(sender.as_raw_fd(), &payload, &descriptors)
+                .expect("hostile record should reach receiver");
+            assert!(matches!(
+                receive_api_listener_ack(&receiver),
+                Err(GrantTransportError::Invalid)
+            ));
+        }
+    }
+
+    #[test]
+    fn wrong_queued_record_is_consumed_without_skipping_the_next_request() {
+        let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should open");
+        send_raw(sender.as_raw_fd(), &acknowledgment().encode(), &[])
+            .expect("wrong-state record should send");
+        send_api_listener_request(&sender, request()).expect("request should send");
+        assert_eq!(
+            receive_api_listener_request(&receiver),
+            Err(GrantTransportError::Invalid)
+        );
+        assert_eq!(receive_api_listener_request(&receiver), Ok(request()));
+    }
+
+    #[test]
+    fn rejected_request_right_is_closed_before_returning() {
+        let (sender, receiver) = UnixDatagram::pair().expect("datagram pair should open");
+        let (transferred, mut peer) = UnixStream::pair().expect("stream pair should open");
+        send_raw(
+            sender.as_raw_fd(),
+            &request().encode(),
+            &[transferred.as_raw_fd()],
+        )
+        .expect("wrong-state right should reach receiver");
+        drop(transferred);
+
+        assert_eq!(
+            receive_api_listener_request(&receiver),
+            Err(GrantTransportError::Invalid)
+        );
+        peer.set_nonblocking(true)
+            .expect("peer should become nonblocking");
+        let mut byte = [0_u8; 1];
+        assert_eq!(
+            peer.read(&mut byte)
+                .expect("rejection must close the received right"),
+            0
+        );
+    }
+}

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -1250,11 +1250,15 @@ grant transaction. Mapped, retained-root, and SDK-maximum unmapped cases each
 completed three times, including the unchanged live-code checks, representative
 grant workload, `Proceed`/`Starting`/terminal ownership, and exact cleanup. This
 prefix now also completes exact grant-backed no-API guest/HVF execution, the
-fixed guest oracle, and guest-requested poweroff for all three identities. The
-contained API variants stop at the App Sandbox `api-socket-publication`
-boundary before any HTTP configuration or API-started guest. This is evidence
-for #1371, not a public launch policy or capability disposition; daemon/crash
-convergence and final uid/gid semantics remain unmeasured.
+fixed guest oracle, and guest-requested poweroff for all three identities.
+#1893's ordinary contained API binder stops at the App Sandbox
+`api-socket-publication` boundary. #1895's feature-only transitioned launcher
+instead binds the fixed final listener and transfers exactly one descriptor,
+then the same worker stops in the closed receive/adoption interval reported as
+`api-listener-adoption` / `other` before readiness. This is evidence for #1371,
+not a public launch policy or capability disposition; the exact failing
+operation and sub-cause, daemon/crash convergence, and final uid/gid semantics
+remain unmeasured.
 
 This is macOS containment, not direct Linux jailer/seccomp equivalence. The
 session namespace itself grants no host resource. The bounded startup channel
@@ -2773,21 +2777,29 @@ This does not broaden the supported API/device surface or claim arbitrary
 kernel/distribution boot, production containment, guest networking, artifact
 redistribution/authentication or byte-reproducible ext4.
 
-The separate #1893 exact-root evidence composes the same checked guest inputs
-with the fixed production launcher and mandatory App Sandbox + Hypervisor
-worker after numeric credential transition. Mapped, retained-root no-drop, and
-SDK-maximum unmapped no-API modes all complete the real HVF guest, fixed oracle,
-guest-requested poweroff, and exact cleanup. This is positive post-transition
-guest evidence for the config-file path, not a public uid/gid policy.
+The separate #1893 / #1895 exact-root evidence composes the same checked guest
+inputs with the fixed production launcher and mandatory App Sandbox +
+Hypervisor worker after numeric credential transition. Mapped, retained-root
+no-drop, and SDK-maximum unmapped no-API modes all complete the real HVF guest,
+fixed oracle, guest-requested poweroff, and exact cleanup. This is positive
+post-transition guest evidence for the config-file path, not a public uid/gid
+policy.
 
 The corresponding contained API modes stop earlier at the measured
 `api-socket-publication` boundary. Mapped and unmapped signed binder images fail
 while App Sandbox is reinitialized after the root-originated transition;
 retained-root reaches binder code but App Sandbox denies its descriptor-rooted
 staging-socket create. No HTTP configuration or API-started guest runs in that
-shape. The ordinary rootless API workflow above remains complete, so the
-blocked evidence is specifically the post-transition App Sandbox publication
-composition. Adding a different helper/signing role or private sandbox
+historical #1893 shape. #1895 removes only that binder: the transitioned
+launcher directly binds final `evidence-api.sock` beneath its retained exact
+anchor, transfers exactly one listener descriptor, and releases its alias in
+all three identity classes. The already-running signed worker then stops in the
+stable closed receive/adoption interval reported as `api-listener-adoption` /
+`other` before durable ownership, readiness, HTTP, or HVF. The ordinary
+rootless API workflow above remains complete, so the blocked evidence is
+specifically the post-transition signed worker receive/adoption composition.
+The closed result does not identify its exact failing operation or kernel/
+sandbox sub-cause. Adding a different helper/signing role or private sandbox
 authority is not treated as Firecracker API parity or as an implementation in
 this slice.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -96,10 +96,14 @@ bind the same session/inode, and the launcher proves the lock through an
 independent description before committing grants. The representative grant
 workload, `Proceed`/`Starting`/terminal ownership, reap, and exact cleanup all
 complete. The same test-only authority now also completes real no-API
-guest/HVF execution for all three identities. Its contained API path stops at
-the separately measured App Sandbox `api-socket-publication` boundary before
-HTTP configuration. This does not establish public uid/gid policy, API-started
-guest execution, or daemon/crash convergence.
+guest/HVF execution for all three identities. #1893's ordinary contained API
+binder stops at the App Sandbox `api-socket-publication` boundary. #1895's
+feature-only launcher-created path advances through direct final bind and an
+exactly-one-descriptor transfer, then the same worker stops in the closed
+receive/adoption interval reported as `api-listener-adoption` / `other` before
+durable ownership or readiness. This does not establish public uid/gid policy,
+API-started guest execution, the exact failing operation or sub-cause, or
+daemon/crash convergence.
 
 ## Certified Linux Runtime Isolation Exclusions
 
@@ -3543,10 +3547,29 @@ remain correctly signed and the same no-API worker completes real HVF, so this
 is not a missing-HVF or generic signature result. Bypassing it would require a
 new non-sandboxed helper/signing role, a private sandbox extension mechanism,
 or another process topology; #1893 does not weaken the mandatory worker profile
-or treat those alternatives as equivalent. API configuration, API-started
-guest execution, and later API faults are consequently ineligible. Daemon/
-crash convergence remains unmeasured. The complete boundary, alternatives,
-exact cleanup rules, reproduction command, and future-OS nonclaim are in the checked
+or treat those alternatives as equivalent.
+
+#1895 preserved that historical binder evidence and changed only the
+feature-only producer. After the worker consumed the fixed API grant, its
+canonical zero-right `BBL1` request caused the permanently transitioned
+launcher to enter the retained exact anchor, bind final `evidence-api.sock`,
+validate target ownership and listener state, restore cwd, and send one
+canonical acknowledgment plus exactly one descriptor. All three identity
+classes repeated three times through successful transfer and launcher alias
+release; two mapped attempts reached the same point concurrently. The signed
+worker then stopped in the stable closed receive/adoption interval reported as
+`api-listener-adoption` / `other` before durable record, readiness, HTTP, or
+HVF. Deterministic faults are reachable through adoption, every result cleans
+exactly, and independent final scans find zero root, workspace, socket,
+launcher, or worker residue. The closed result does not distinguish the exact
+failing operation or kernel/sandbox sub-cause within that interval. It returns
+the parent to fresh Challenge rather than selecting a helper,
+sandbox change, topology change, or platform-impossible disposition.
+
+API configuration, API-started guest execution, and later API faults are
+consequently ineligible. Daemon/crash convergence remains unmeasured. The
+complete boundary, alternatives, exact cleanup rules, reproduction command,
+and future-OS nonclaim are in the checked
 [elevated bootstrap evidence](../compat/firecracker/v1.16.0/elevated-bootstrap-evidence.md).
 
 The six rows remain audit outcomes until #1371 challenges the controlled result

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2099,8 +2099,8 @@ merged-main OID are checked and recorded by the pull-request workflow.
 ## Explicit Elevated Bootstrap Evidence
 
 The #1373 direct-worker, #1884 inherited-root, #1885 no-chroot credential,
-#1889 / #1891 target-owned runtime-continuation, and #1893 post-transition
-guest proofs are deliberately
+#1889 / #1891 target-owned runtime-continuation, #1893 post-transition guest,
+and #1895 launcher-created API-listener proofs are deliberately
 separate from `scripts/run-integration-tests.sh`. Normal validation never
 invokes `sudo`, prompts for a password, or treats missing root/HVF support as a
 passing skip.
@@ -2125,8 +2125,9 @@ acknowledgment, `BBN1` session authority, representative grant activation, and c
 vocabulary are absent. It then builds both ends with disabled-by-default
 evidence features, checks role-specific credential/runtime markers, adds four
 visible test-only resource markers plus the ordinary-user-verified guest
-artifacts, and uses the normal production packager, signature split,
-entitlements, Hardened Runtime, and inspections.
+artifacts, requires the launcher/worker-specific `BBL1` handoff markers in only
+their evidence binaries, and uses the normal production packager, signature
+split, entitlements, Hardened Runtime, and inspections.
 
 On a capable Apple Silicon host, calculate the explicit numeric target before
 elevation and invoke the wrapper through `sudo` (substitute the captured
@@ -2195,10 +2196,12 @@ credential, `BBA1`, `BBN1`, lifecycle, or grant prefix. Guest artifacts must be
 prepared and digest-verified before elevation; the exact-root run only verifies
 and opens the sealed copies. The matrix repeats every identity/workload three
 times, runs two concurrent mapped no-API successes and two concurrent mapped
-API boundary cases, and then exercises every fault still reachable before the
-measured API publication stop. It also checks worker-first and launcher-first
-death, immutable-input tampering, post-adoption pathname replacement, exact
-output ledgers, and final zero residue. Launcher-first cleanup removes only the
+API boundary cases, and then exercises every no-API fault plus API listener
+request, bind, transfer, and adoption faults reachable before the measured
+stop. It also checks worker-first and launcher-first no-API death,
+immutable-input tampering for both workloads, successful no-API post-adoption
+pathname replacement, API preopened-anchor replacement rejection, exact output
+ledgers, and final zero residue. Launcher-first cleanup removes only the
 pre-recorded empty session after both signed endpoints have exited and rejects
 an identity replacement.
 
@@ -2213,12 +2216,20 @@ and exact cleanup. The SDK-maximum result retained both live-code checks and is
 therefore a changed same-check witness, not a bypass. Real no-API guests then
 completed late reattestation, grant-backed startup, HVF creation, the fixed
 guest oracle, guest-requested poweroff, and cleanup for all three identities.
-All three contained API cases stopped at the value-free
+The historical #1893 contained API cases stopped at the value-free
 `api-socket-publication` boundary: mapped/unmapped App Sandbox initialization
 failed before binder application entry, while retained-root App Sandbox denied
-the descriptor-rooted staging-socket create. API configuration and later API
-faults are therefore ineligible in this measured shape. Daemon/crash
-convergence remains unmeasured.
+the descriptor-rooted staging-socket create. #1895 preserves that result and
+uses one dedicated zero-right `BBL1` request so the transitioned launcher binds
+fixed final `evidence-api.sock` beneath its retained exact anchor and replies
+with exactly one listener descriptor. All three identities completed direct
+bind and transfer, including launcher alias release, before the same signed
+worker stopped in the closed receive/adoption interval reported as
+`api-listener-adoption` / `other`; two mapped attempts reproduced that boundary
+concurrently. No durable listener record, readiness, HTTP configuration, or
+API-started HVF guest followed. The exact failing operation and sub-cause remain
+unclaimed, and API configuration plus later faults are ineligible in this
+measured shape. Daemon/crash convergence remains unmeasured.
 Stream credentials remained
 connection-time snapshots, datagram credentials were unsupported, opaque
 datagram tokens changed only for credential transitions, and live peer PIDs

--- a/scripts/build-elevated-bootstrap-probe.sh
+++ b/scripts/build-elevated-bootstrap-probe.sh
@@ -99,6 +99,8 @@ grant_activation="--bangbang-internal-grant-probe-v1"
 grant_runtime_case="target-runtime"
 runtime_launcher_boundary_artifact="bangbang-elevated-runtime-launcher-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary"
 runtime_worker_boundary_artifact="bangbang-elevated-runtime-worker-boundaries-v2-pre-ack-post-ack-session-create-session-open-authority-send-authority-receive-authority-validate-session-lock-session-enter-prepared-namespace-grant-transfer-proceed-terminal-continuation-ack-lifecycle-hello-runtime-session-create-runtime-session-open-runtime-authority-send-runtime-authority-receive-runtime-authority-validate-runtime-session-lock-runtime-session-enter-lifecycle-prepared-runtime-namespace-grant-accepted-lifecycle-proceed-lifecycle-terminal-runtime-cleanup-complete-continuation-boundary-identity-boundary-explicit-root-boundary-namespace-boundary-grant-boundary-lifecycle-boundary"
+api_listener_launcher_boundary_artifact="bangbang-elevated-api-listener-launcher-v1-BBL1-request-bind-transfer-adoption-final-child-one-right"
+api_listener_worker_boundary_artifact="bangbang-elevated-api-listener-worker-v1-BBL1-request-ack-adoption-record-readiness"
 guest_no_api_drop_mode="guest-no-api-drop"
 guest_no_api_retain_mode="guest-no-api-retain-root"
 guest_no_api_unmapped_mode="guest-no-api-unmapped"
@@ -127,6 +129,10 @@ guest_isolation_markers=(
   guest-grant-accepted
   guest-transport-contamination
   guest-resource-witness
+  api-listener-request
+  api-listener-bind
+  api-listener-transfer
+  api-listener-adoption
   api-socket-publication
   api-logger-configuration
   api-metrics-configuration
@@ -197,6 +203,8 @@ probe_markers=(
   "$grant_runtime_case"
   "$runtime_launcher_boundary_artifact"
   "$runtime_worker_boundary_artifact"
+  "$api_listener_launcher_boundary_artifact"
+  "$api_listener_worker_boundary_artifact"
   "$guest_no_api_drop_mode"
   "$guest_no_api_retain_mode"
   "$guest_no_api_unmapped_mode"
@@ -282,7 +290,8 @@ for marker_value in \
   "$guest_terminal_evidence" \
   "$guest_api_start" \
   "$guest_kernel_reference" \
-  "$guest_serial_reference"; do
+  "$guest_serial_reference" \
+  "$api_listener_launcher_boundary_artifact"; do
   if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$launcher_bin"; then
     echo "evidence launcher is missing the guest continuation boundary" >&2
     exit 1
@@ -333,7 +342,8 @@ for marker_value in \
   "$guest_hvf_witness" \
   "$guest_terminal_evidence" \
   "$guest_kernel_reference" \
-  "$guest_serial_reference"; do
+  "$guest_serial_reference" \
+  "$api_listener_worker_boundary_artifact"; do
   if ! LC_ALL=C /usr/bin/grep -a -F -q -- "$marker_value" "$worker_bin"; then
     echo "evidence worker is missing the guest continuation boundary" >&2
     exit 1

--- a/scripts/elevated_guest_matrix.py
+++ b/scripts/elevated_guest_matrix.py
@@ -135,6 +135,10 @@ FAULT_CASES = (
         "invalid-input",
     ),
     FaultCase("guest-resource-witness", "guest-resource-witness", "grant-boundary", "no-api"),
+    FaultCase("api-listener-request", "api-listener-request", "api-boundary", "api"),
+    FaultCase("api-listener-bind", "api-listener-bind", "api-boundary", "api"),
+    FaultCase("api-listener-transfer", "api-listener-transfer", "api-boundary", "api"),
+    FaultCase("api-listener-adoption", "api-listener-adoption", "api-boundary", "api"),
     FaultCase("api-socket-publication", "api-socket-publication", "api-boundary", "api"),
     FaultCase("api-logger-configuration", "api-logger-configuration", "api-boundary", "api"),
     FaultCase("api-metrics-configuration", "api-metrics-configuration", "api-boundary", "api"),
@@ -157,24 +161,65 @@ FAULT_CASES = (
         "no-api",
     ),
     FaultCase("guest-cleanup", "guest-cleanup", "guest-boundary", "no-api"),
-)
-
-API_PUBLICATION_BOUNDARY = FaultCase(
-    "api-socket-publication",
-    "api-socket-publication",
-    "api-boundary",
-    "api",
+    FaultCase("guest-hvf-witness", "guest-hvf-witness", "hvf-boundary", "api"),
+    FaultCase("guest-hvf-create", "guest-hvf-create", "hvf-boundary", "api"),
+    FaultCase("guest-execution", "guest-execution", "guest-boundary", "api"),
+    FaultCase("guest-oracle", "guest-oracle", "guest-boundary", "api"),
+    FaultCase("guest-poweroff", "guest-poweroff", "guest-boundary", "api"),
+    FaultCase("guest-timeout", "guest-timeout", "guest-boundary", "api"),
+    FaultCase(
+        "guest-terminal-evidence",
+        "guest-terminal-evidence",
+        "guest-boundary",
+        "api",
+    ),
+    FaultCase("guest-cleanup", "guest-cleanup", "guest-boundary", "api"),
 )
 
 MATRIX_SUMMARY = (
-    "guest-matrix: api-mapped=blocked-api-publication "
-    "api-retained-root=blocked-api-publication-no-drop "
-    "api-unmapped=blocked-api-publication no-api-mapped=complete "
+    "guest-matrix: api-mapped=blocked-listener-adoption "
+    "api-retained-root=blocked-listener-adoption-no-drop "
+    "api-unmapped=blocked-listener-adoption no-api-mapped=complete "
     "no-api-retained-root=complete-no-drop no-api-unmapped=complete "
-    "repeats=three concurrency=no-api-isolated-api-blocked "
-    "faults=no-api-reachable-complete-api-later-ineligible "
-    "deaths=worker-first-launcher-first tamper=rejected "
-    "adoption-replacement=no-api-preopened-api-ineligible cleanup=exact"
+    "repeats=three concurrency=no-api-complete-api-isolated-blocked "
+    "faults=no-api-reachable-api-through-adoption "
+    "deaths=no-api-worker-first-launcher-first tamper=rejected-both-workloads "
+    "adoption-replacement=no-api-preopened-api-rejected-at-grant cleanup=exact"
+)
+
+API_BOUNDARIES = {
+    "mapped": FaultCase(
+        "api-listener-adoption",
+        "api-listener-adoption",
+        "api-boundary",
+        "api",
+    ),
+    "retained-root": FaultCase(
+        "api-listener-adoption",
+        "api-listener-adoption",
+        "api-boundary",
+        "api",
+    ),
+    "unmapped": FaultCase(
+        "api-listener-adoption",
+        "api-listener-adoption",
+        "api-boundary",
+        "api",
+    ),
+}
+
+REACHABLE_API_FAULTS = {
+    "api-listener-request",
+    "api-listener-bind",
+    "api-listener-transfer",
+    "api-listener-adoption",
+}
+
+API_PREOPENED_REPLACEMENT_BOUNDARY = FaultCase(
+    "",
+    "grant-accepted",
+    "grant-boundary",
+    "api",
 )
 
 
@@ -669,13 +714,13 @@ class Fixture:
             if self.paths[name].stat().st_size > MAX_OUTPUT_BYTES:
                 _fail("fault-output-bound")
 
-    def validate_api_publication_block_outputs(self) -> None:
+    def validate_api_boundary_block_outputs(self) -> None:
         self.validate_shape(require_outputs=True)
         if any(
             self.paths[name].stat().st_size != 0
             for name in ("logger", "metrics", "serial")
         ):
-            _fail("api-publication-output-prefix")
+            _fail("api-transfer-output-prefix")
 
     def capture_runtime_session(self) -> tuple[Path, ObjectIdentity]:
         root = ObjectIdentity.capture(self.root)
@@ -881,18 +926,13 @@ def expected_fault_line(case: ModeCase, fault: FaultCase) -> str:
     )
 
 
-def expected_api_publication_block_output(case: ModeCase) -> str:
+def api_boundary(case: ModeCase) -> FaultCase:
     if case.workload != "api":
-        _fail("api-publication-case")
-    return (
-        "bangbang 0.1.0\n"
-        "hvf target supported: true\n"
-        "operation=shutdown outcome=abnormal\n"
-        "event=process-exit category=process-failure\n"
-        "bangbang: API server error: failed to bind contained API socket: "
-        "private anchored socket operation failed\n"
-        f"{expected_fault_line(case, API_PUBLICATION_BOUNDARY)}"
-    )
+        _fail("api-boundary-case")
+    try:
+        return API_BOUNDARIES[case.identity]
+    except KeyError as error:
+        raise MatrixError("api-boundary-identity") from error
 
 
 def _decode_output(output: bytes) -> str:
@@ -1017,18 +1057,56 @@ def assert_success(launcher: Path, fixture: Fixture) -> None:
     status, raw_output = run_process(fixture.command(launcher))
     output = _decode_output(raw_output).rstrip("\n")
     validate_redacted(output, fixture)
-    if status != 0 or output != expected_success_output(fixture.case):
-        _fail("success-result")
+    if status != 0:
+        prefix = f"status: elevated runtime {fixture.case.mode} blocked stage="
+        for line in output.splitlines():
+            if line.startswith(prefix):
+                fields = line.removeprefix(prefix).split()
+                stage = fields[0] if fields else ""
+                category = next(
+                    (field.removeprefix("error=") for field in fields if field.startswith("error=")),
+                    "",
+                )
+                if (
+                    stage
+                    and category
+                    and all(character.isalnum() or character == "-" for character in stage)
+                    and all(character.isalnum() or character == "-" for character in category)
+                ):
+                    _fail(
+                        f"success-result-{fixture.case.mode}-blocked-{stage}-{category}"
+                    )
+        _fail(f"success-result-{fixture.case.mode}-exit")
+    if output != expected_success_output(fixture.case):
+        _fail(f"success-result-{fixture.case.mode}-output")
     fixture.validate_success_outputs()
 
 
-def assert_api_publication_blocked(launcher: Path, fixture: Fixture) -> None:
+def assert_api_transfer_blocked(launcher: Path, fixture: Fixture) -> None:
+    if fixture.case.workload != "api":
+        _fail("api-transfer-case")
     status, raw_output = run_process(fixture.command(launcher))
     output = _decode_output(raw_output).rstrip("\n")
     validate_redacted(output, fixture)
-    if status != 3 or output != expected_api_publication_block_output(fixture.case):
-        _fail("api-publication-result")
-    fixture.validate_api_publication_block_outputs()
+    expected = expected_fault_line(fixture.case, api_boundary(fixture.case))
+    if (
+        status != 3
+        or expected not in output.splitlines()
+        or expected_success_line(fixture.case) in output.splitlines()
+        or "status: API server listening" in output.splitlines()
+    ):
+        prefix = f"status: elevated runtime {fixture.case.mode} blocked stage="
+        for line in output.splitlines():
+            if line.startswith(prefix):
+                fields = line.removeprefix(prefix).split()
+                stage = fields[0] if fields else "unknown"
+                category = next(
+                    (field.removeprefix("error=") for field in fields if field.startswith("error=")),
+                    "unknown",
+                )
+                _fail(f"api-transfer-result-{fixture.case.mode}-{stage}-{category}")
+        _fail(f"api-transfer-result-{fixture.case.mode}-exit")
+    fixture.validate_api_boundary_block_outputs()
 
 
 def assert_adoption_replacement(
@@ -1056,9 +1134,32 @@ def assert_adoption_replacement(
             raise MatrixError("adoption-process-timeout") from error
         output = _decode_output(raw_output).rstrip("\n")
         validate_redacted(output, fixture)
-        if process.returncode != 0 or output != expected_success_output(fixture.case):
-            _fail("adoption-process-result")
-        fixture.validate_success_outputs()
+        if fixture.case.workload == "api":
+            expected = expected_fault_line(
+                fixture.case,
+                API_PREOPENED_REPLACEMENT_BOUNDARY,
+            )
+            if process.returncode != 3 or expected not in output.splitlines():
+                prefix = f"status: elevated runtime {fixture.case.mode} blocked stage="
+                for line in output.splitlines():
+                    if line.startswith(prefix):
+                        fields = line.removeprefix(prefix).split()
+                        stage = fields[0] if fields else "unknown"
+                        category = next(
+                            (
+                                field.removeprefix("error=")
+                                for field in fields
+                                if field.startswith("error=")
+                            ),
+                            "unknown",
+                        )
+                        _fail(f"adoption-process-result-api-{stage}-{category}")
+                _fail("adoption-process-result-api")
+            fixture.validate_fault_outputs()
+        else:
+            if process.returncode != 0 or output != expected_success_output(fixture.case):
+                _fail("adoption-process-result-no-api")
+            fixture.validate_success_outputs()
         fixture.validate_runtime_replacements()
         sidecar_mutation.validate()
     finally:
@@ -1151,7 +1252,7 @@ def run_concurrent(
     launcher: Path,
     fixtures: list[Fixture],
     *,
-    api_publication_blocked: bool = False,
+    api_transfer_blocked: bool = False,
 ) -> None:
     processes = [
         subprocess.Popen(
@@ -1177,17 +1278,14 @@ def run_concurrent(
                 raise MatrixError("concurrent-timeout") from error
             decoded = _decode_output(output).rstrip("\n")
             validate_redacted(decoded, fixture)
-            expected_status = 3 if api_publication_blocked else 0
-            expected_output = (
-                expected_api_publication_block_output(fixture.case)
-                if api_publication_blocked
-                else expected_success_output(fixture.case)
-            )
-            if process.returncode != expected_status or decoded != expected_output:
-                _fail("concurrent-result")
-            if api_publication_blocked:
-                fixture.validate_api_publication_block_outputs()
+            if api_transfer_blocked:
+                expected = expected_fault_line(fixture.case, api_boundary(fixture.case))
+                if process.returncode != 3 or expected not in decoded.splitlines():
+                    _fail("concurrent-result")
+                fixture.validate_api_boundary_block_outputs()
             else:
+                if process.returncode != 0 or decoded != expected_success_output(fixture.case):
+                    _fail("concurrent-result")
                 fixture.validate_success_outputs()
     finally:
         for process in processes:
@@ -1224,7 +1322,7 @@ def run_matrix(
                 fixture = Fixture(resources, case, target_uid, target_gid)
                 live.append(fixture)
                 if case.workload == "api":
-                    assert_api_publication_blocked(launcher, fixture)
+                    assert_api_transfer_blocked(launcher, fixture)
                 else:
                     assert_success(launcher, fixture)
                 verify_resources(resources, resource_ledger)
@@ -1238,13 +1336,13 @@ def run_matrix(
             run_concurrent(
                 launcher,
                 fixtures,
-                api_publication_blocked=workload == "api",
+                api_transfer_blocked=workload == "api",
             )
             verify_resources(resources, resource_ledger)
             for fixture in fixtures:
                 fixture.cleanup()
         for fault in FAULT_CASES:
-            if fault.workload == "api":
+            if fault.workload == "api" and fault.fault not in REACHABLE_API_FAULTS:
                 continue
             fixture = Fixture(
                 resources,
@@ -1267,26 +1365,27 @@ def run_matrix(
             assert_endpoint_death(launcher, fixture, first)
             verify_resources(resources, resource_ledger)
             fixture.cleanup()
-        tamper_fixture = Fixture(
-            sidecar,
-            mode_for("no-api"),
-            target_uid,
-            target_gid,
-        )
-        live.append(tamper_fixture)
-        tamper_mutation = SidecarMutation(sidecar, sidecar_ledger, "no-api")
-        try:
-            assert_tampered_resource_rejected(
-                launcher,
-                tamper_fixture,
-                tamper_mutation,
+        for workload in ("no-api", "api"):
+            tamper_fixture = Fixture(
+                sidecar,
+                mode_for(workload),
+                target_uid,
+                target_gid,
             )
-        finally:
-            tamper_mutation.restore()
-        verify_resources(sidecar, sidecar_ledger)
-        verify_resources(resources, resource_ledger)
-        tamper_fixture.cleanup()
-        for workload in ("no-api",):
+            live.append(tamper_fixture)
+            tamper_mutation = SidecarMutation(sidecar, sidecar_ledger, workload)
+            try:
+                assert_tampered_resource_rejected(
+                    launcher,
+                    tamper_fixture,
+                    tamper_mutation,
+                )
+            finally:
+                tamper_mutation.restore()
+            verify_resources(sidecar, sidecar_ledger)
+            verify_resources(resources, resource_ledger)
+            tamper_fixture.cleanup()
+        for workload in ("no-api", "api"):
             fixture = Fixture(
                 sidecar,
                 mode_for(workload),
@@ -1302,7 +1401,10 @@ def run_matrix(
                     fixture.restore_runtime_authorities()
                 finally:
                     mutation.restore()
-            fixture.validate_success_outputs()
+            if workload == "api":
+                fixture.validate_fault_outputs()
+            else:
+                fixture.validate_success_outputs()
             verify_resources(sidecar, sidecar_ledger)
             verify_resources(resources, resource_ledger)
             fixture.cleanup()

--- a/scripts/run-elevated-bootstrap-probe.sh
+++ b/scripts/run-elevated-bootstrap-probe.sh
@@ -1749,7 +1749,7 @@ guest_matrix_output="$(/usr/bin/python3 "$repo_root/scripts/elevated_guest_matri
   --sidecar "$guest_sidecar" \
   --target-uid "$target_uid" \
   --target-gid "$target_gid")"
-expected_guest_matrix="guest-matrix: api-mapped=blocked-api-publication api-retained-root=blocked-api-publication-no-drop api-unmapped=blocked-api-publication no-api-mapped=complete no-api-retained-root=complete-no-drop no-api-unmapped=complete repeats=three concurrency=no-api-isolated-api-blocked faults=no-api-reachable-complete-api-later-ineligible deaths=worker-first-launcher-first tamper=rejected adoption-replacement=no-api-preopened-api-ineligible cleanup=exact"
+expected_guest_matrix="guest-matrix: api-mapped=blocked-listener-adoption api-retained-root=blocked-listener-adoption-no-drop api-unmapped=blocked-listener-adoption no-api-mapped=complete no-api-retained-root=complete-no-drop no-api-unmapped=complete repeats=three concurrency=no-api-complete-api-isolated-blocked faults=no-api-reachable-api-through-adoption deaths=no-api-worker-first-launcher-first tamper=rejected-both-workloads adoption-replacement=no-api-preopened-api-rejected-at-grant cleanup=exact"
 if [[ "$guest_matrix_output" != "$expected_guest_matrix" ]]; then
   echo "bangbang elevated bootstrap proof: guest matrix output invalid" >&2
   exit 1

--- a/scripts/tests/test_elevated_guest_matrix.py
+++ b/scripts/tests/test_elevated_guest_matrix.py
@@ -155,6 +155,10 @@ class ElevatedGuestMatrixTests(unittest.TestCase):
                 "guest-grant-accepted",
                 "guest-transport-contamination",
                 "guest-resource-witness",
+                "api-listener-request",
+                "api-listener-bind",
+                "api-listener-transfer",
+                "api-listener-adoption",
                 "api-socket-publication",
                 "api-logger-configuration",
                 "api-metrics-configuration",
@@ -164,6 +168,14 @@ class ElevatedGuestMatrixTests(unittest.TestCase):
                 "api-drive-configuration",
                 "api-instance-start",
                 "no-api-startup",
+                "guest-hvf-witness",
+                "guest-hvf-create",
+                "guest-execution",
+                "guest-oracle",
+                "guest-poweroff",
+                "guest-timeout",
+                "guest-terminal-evidence",
+                "guest-cleanup",
                 "guest-hvf-witness",
                 "guest-hvf-create",
                 "guest-execution",
@@ -182,6 +194,15 @@ class ElevatedGuestMatrixTests(unittest.TestCase):
             self.assertIn(f"result={fault.result}", line)
             self.assertNotIn("/private/", line)
             self.assertNotIn("bangbang-grant:", line)
+        self.assertEqual(
+            matrix.REACHABLE_API_FAULTS,
+            {
+                "api-listener-request",
+                "api-listener-bind",
+                "api-listener-transfer",
+                "api-listener-adoption",
+            },
+        )
 
     def test_success_output_is_closed_over_worker_and_launcher_lines(self) -> None:
         no_api = matrix.expected_success_output(matrix.mode_for("no-api"))
@@ -193,19 +214,19 @@ class ElevatedGuestMatrixTests(unittest.TestCase):
         self.assertIn("status: VM running without API", no_api)
         self.assertIn("status: API server listening", api)
 
-    def test_measured_api_publication_boundary_is_exact_and_value_free(self) -> None:
+    def test_measured_api_adoption_boundary_is_exact_and_value_free(self) -> None:
         for identity in ("mapped", "retained-root", "unmapped"):
             case = matrix.mode_for("api", identity)
-            output = matrix.expected_api_publication_block_output(case)
-            self.assertEqual(len(output.splitlines()), 6)
-            self.assertIn("stage=api-socket-publication", output)
+            boundary = matrix.api_boundary(case)
+            output = matrix.expected_fault_line(case, boundary)
+            self.assertIn("stage=api-listener-adoption", output)
             self.assertIn("error=other", output)
             self.assertIn("result=api-boundary", output)
             self.assertNotIn("/private/", output)
             self.assertNotIn("bangbang-grant:", output)
-        self.assertIn("api-mapped=blocked-api-publication", matrix.MATRIX_SUMMARY)
+        self.assertIn("api-mapped=blocked-listener-adoption", matrix.MATRIX_SUMMARY)
         self.assertIn("no-api-mapped=complete", matrix.MATRIX_SUMMARY)
-        self.assertIn("api-later-ineligible", matrix.MATRIX_SUMMARY)
+        self.assertIn("api-through-adoption", matrix.MATRIX_SUMMARY)
 
     def test_post_adoption_barrier_is_internal_and_precedes_worker_envelope(self) -> None:
         fixture = object.__new__(matrix.Fixture)
@@ -282,10 +303,10 @@ class ElevatedGuestMatrixTests(unittest.TestCase):
             '/usr/bin/python3 "$repo_root/scripts/elevated_guest_matrix.py"', wrapper
         )
         self.assertIn('--sidecar "$guest_sidecar"', wrapper)
-        self.assertIn("deaths=worker-first-launcher-first", wrapper)
-        self.assertIn("tamper=rejected", wrapper)
+        self.assertIn("deaths=no-api-worker-first-launcher-first", wrapper)
+        self.assertIn("tamper=rejected-both-workloads", wrapper)
         self.assertIn(
-            "adoption-replacement=no-api-preopened-api-ineligible",
+            "adoption-replacement=no-api-preopened-api-rejected-at-grant",
             wrapper,
         )
 


### PR DESCRIPTION
## Summary

- add a dedicated canonical `BBL1` zero/one-right listener handoff over the authenticated guest-evidence datagram
- let the permanently transitioned launcher bind fixed final `evidence-api.sock`, transfer exactly one listener, retain strict cleanup ownership, and share one verified process-wide scoped-cwd boundary with anchored connects
- let the contained worker validate and adopt the final listener, sync the existing ownership record before readiness, and preserve exact replacement-safe cleanup
- extend signed evidence, repeat/concurrency/fault/tamper/replacement coverage, artifact isolation, and checked compatibility/security/testing documentation

## Measured result

On macOS 26.5.2 / SDK 26.5 / arm64 with HVF and exact root authority, mapped, retained-root/no-drop, and SDK-maximum unmapped API cases each complete the fixed request, direct final bind, exactly-one-descriptor send, and launcher alias release. The signed worker then stops in the closed receive/adoption interval reported as `api-listener-adoption` / `other`, before durable ownership, readiness, HTTP, or API-started HVF. All three no-API identities still complete the real guest/HVF/oracle/poweroff/terminal/cleanup path.

Repeats, two concurrent mapped API attempts, deterministic listener faults, immutable-input tamper for both workloads, no-API death orders, preopened replacement rejection, and independent residue checks pass. Final residue is zero for roots, workspaces, sockets, launchers, and workers.

## Scope exclusions

- no public API, CLI, lifecycle-v5, worker entitlement/profile, signing-role, ordinary binder, current-user, or capability-disposition changes
- no helper, sandbox/profile change, staging fallback, lifetime broker, daemon/crash convergence, public uid/gid/chroot policy, or platform-impossible classification
- the exact failing worker operation and kernel/App Sandbox sub-cause within the receive/adoption interval remain unclaimed

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target Clippy gates with `-D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `python3 -m unittest discover -s scripts/tests` (89 passed)
- fresh signed exact-root elevated matrix without skip (all closed gates passed; zero residue)
- `scripts/run-integration-tests.sh` without `--allow-unsupported` (all signed HVF, guest boot, App Sandbox, production bundle, and executable groups passed)

Closes #1895

Parent context: #1888
