### PR TITLE
feat: add production credential foundation

### DIFF
--- a/crates/launcher/src/launch_policy.rs
+++ b/crates/launcher/src/launch_policy.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use bangbang_session::{
     MAX_VMNET_ACTIVE_INTERFACES, MAX_VMNET_BRIDGE_NAMES, VmnetAuthority, WorkerPolicy,
+    credential::CredentialTarget,
 };
 
 use crate::grant_manifest::{LaunchInput, PreparedGrantBatch};
@@ -78,6 +79,72 @@ pub(crate) struct PreparedLaunch {
     pub(crate) grants: PreparedGrantBatch,
     pub(crate) worker_policy: WorkerPolicy,
     pub(crate) worker_profile: crate::macos::code_sign::WorkerProfile,
+    pub(crate) identity: LaunchIdentity,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LaunchIdentity {
+    Current { uid: u32, gid: u32 },
+    RootRetained(CredentialTarget),
+    RootTransition(CredentialTarget),
+}
+
+impl LaunchIdentity {
+    pub(crate) const fn is_current(self) -> bool {
+        matches!(self, Self::Current { .. })
+    }
+
+    const fn uid(self) -> u32 {
+        match self {
+            Self::Current { uid, .. } => uid,
+            Self::RootRetained(target) | Self::RootTransition(target) => target.uid(),
+        }
+    }
+
+    const fn gid(self) -> u32 {
+        match self {
+            Self::Current { gid, .. } => gid,
+            Self::RootRetained(target) | Self::RootTransition(target) => target.gid(),
+        }
+    }
+}
+
+impl std::fmt::Debug for LaunchIdentity {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("LaunchIdentity(<redacted>)")
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct CallerCredentials {
+    uid: u32,
+    effective_uid: u32,
+    gid: u32,
+    effective_gid: u32,
+}
+
+impl CallerCredentials {
+    const fn new(uid: u32, effective_uid: u32, gid: u32, effective_gid: u32) -> Self {
+        Self {
+            uid,
+            effective_uid,
+            gid,
+            effective_gid,
+        }
+    }
+
+    const fn current(self) -> Result<(u32, u32), LauncherError> {
+        if self.uid != self.effective_uid || self.gid != self.effective_gid {
+            return Err(LauncherError::InvalidLaunchPolicy);
+        }
+        Ok((self.uid, self.gid))
+    }
+}
+
+impl std::fmt::Debug for CallerCredentials {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("CallerCredentials(<redacted>)")
+    }
 }
 
 impl std::fmt::Debug for PreparedLaunch {
@@ -176,21 +243,30 @@ impl LaunchRequest {
         &self,
         worker_executable: &Path,
         daemonized: bool,
-    ) -> Result<(), LauncherError> {
-        let (uid, gid) = current_credentials()?;
+    ) -> Result<LaunchIdentity, LauncherError> {
+        let caller = current_credentials();
         match &self.jailer {
             Some(jailer)
                 if jailer.exec_file == worker_executable
                     && jailer.exec_file.is_absolute()
-                    && jailer.uid == uid
-                    && jailer.gid == gid
                     && jailer.daemonize == daemonized =>
             {
-                Ok(())
+                classify_launch_identity(caller, jailer.uid, jailer.gid)
             }
-            None if !daemonized => Ok(()),
+            None if !daemonized => {
+                let (uid, gid) = caller.current()?;
+                classify_launch_identity(caller, uid, gid)
+            }
             Some(_) | None => Err(LauncherError::InvalidLaunchPolicy),
         }
+    }
+
+    pub(crate) fn validate_current(
+        &self,
+        worker_executable: &Path,
+        daemonized: bool,
+    ) -> Result<LaunchIdentity, LauncherError> {
+        require_current_identity(self.validate(worker_executable, daemonized)?)
     }
 
     pub(crate) fn prepare(
@@ -200,7 +276,7 @@ impl LaunchRequest {
         daemonized: bool,
         worker_profile: crate::macos::code_sign::WorkerProfile,
     ) -> Result<PreparedLaunch, LauncherError> {
-        self.validate(worker_executable, daemonized)?;
+        let identity = self.validate(worker_executable, daemonized)?;
         let vmnet_authority = self
             .jailer
             .as_ref()
@@ -209,7 +285,7 @@ impl LaunchRequest {
             return Err(LauncherError::InvalidLaunchPolicy);
         }
         let (mut worker_args, grants) = self.grants.prepare()?;
-        let (uid, gid) = current_credentials()?;
+        let (uid, gid) = (identity.uid(), identity.gid());
         let (no_file, file_size) = if let Some(jailer) = self.jailer {
             let mut injected = vec![
                 OsString::from(ID_OPTION),
@@ -233,6 +309,7 @@ impl LaunchRequest {
             worker_policy: WorkerPolicy::new(uid, gid, no_file, file_size, daemonized)
                 .with_vmnet_authority(vmnet_authority),
             worker_profile,
+            identity,
         })
     }
 }
@@ -458,7 +535,7 @@ fn parse_u32(value: &str) -> Result<u32, LauncherError> {
         .map_err(|_| LauncherError::InvalidLaunchPolicy)
 }
 
-fn current_credentials() -> Result<(u32, u32), LauncherError> {
+fn current_credentials() -> CallerCredentials {
     // SAFETY: These credential getters take no pointers and have no failure mode.
     let (uid, effective_uid, gid, effective_gid) = unsafe {
         (
@@ -468,10 +545,44 @@ fn current_credentials() -> Result<(u32, u32), LauncherError> {
             libc::getegid(),
         )
     };
-    if uid != effective_uid || gid != effective_gid {
+    CallerCredentials::new(uid, effective_uid, gid, effective_gid)
+}
+
+fn classify_launch_identity(
+    caller: CallerCredentials,
+    requested_uid: u32,
+    requested_gid: u32,
+) -> Result<LaunchIdentity, LauncherError> {
+    let (current_uid, current_gid) = caller.current()?;
+    if (requested_uid, requested_gid) == (current_uid, current_gid)
+        && (current_uid, current_gid) != (0, 0)
+    {
+        return Ok(LaunchIdentity::Current {
+            uid: requested_uid,
+            gid: requested_gid,
+        });
+    }
+    if (current_uid, current_gid) != (0, 0) {
         return Err(LauncherError::InvalidLaunchPolicy);
     }
-    Ok((uid, gid))
+    let target = CredentialTarget::new(requested_uid, requested_gid)
+        .map_err(|_| LauncherError::InvalidLaunchPolicy)?;
+    match target.mode() {
+        bangbang_session::credential::CredentialMode::RetainedRoot => {
+            Ok(LaunchIdentity::RootRetained(target))
+        }
+        bangbang_session::credential::CredentialMode::Transition => {
+            Ok(LaunchIdentity::RootTransition(target))
+        }
+    }
+}
+
+fn require_current_identity(identity: LaunchIdentity) -> Result<LaunchIdentity, LauncherError> {
+    if identity.is_current() {
+        Ok(identity)
+    } else {
+        Err(LauncherError::InvalidLaunchPolicy)
+    }
 }
 
 fn clock_microseconds(clock: libc::clockid_t) -> Result<u64, LauncherError> {
@@ -515,7 +626,9 @@ mod tests {
     }
 
     fn base(worker: &Path) -> Vec<OsString> {
-        let (uid, gid) = current_credentials().expect("test credentials should be ordinary");
+        let (uid, gid) = current_credentials()
+            .current()
+            .expect("test credentials should be ordinary");
         vec![
             JAILER_ACTIVATION.into(),
             ID_OPTION.into(),
@@ -1051,7 +1164,12 @@ mod tests {
         else {
             panic!("run command expected");
         };
-        assert_eq!(request.validate(worker, false), Ok(()));
+        assert!(
+            request
+                .validate(worker, false)
+                .expect("current policy should validate")
+                .is_current()
+        );
         assert_eq!(
             request.validate(Path::new("/fixed/other-worker"), false),
             Err(LauncherError::InvalidLaunchPolicy)
@@ -1061,7 +1179,9 @@ mod tests {
             Err(LauncherError::InvalidLaunchPolicy)
         );
 
-        let (uid, gid) = current_credentials().expect("credentials should be ordinary");
+        let (uid, gid) = current_credentials()
+            .current()
+            .expect("credentials should be ordinary");
         for (index, value) in [(6, uid.wrapping_add(1)), (8, gid.wrapping_add(1))] {
             let mut args = base(worker);
             args[index] = value.to_string().into();
@@ -1083,10 +1203,78 @@ mod tests {
         else {
             panic!("run command expected");
         };
-        assert_eq!(daemon_request.validate(worker, true), Ok(()));
+        assert!(
+            daemon_request
+                .validate(worker, true)
+                .expect("current daemon policy should validate")
+                .is_current()
+        );
         assert_eq!(
             daemon_request.validate(worker, false),
             Err(LauncherError::InvalidLaunchPolicy)
+        );
+    }
+
+    #[test]
+    fn launch_identity_classifier_covers_current_and_exact_root_targets() {
+        let ordinary = CallerCredentials::new(501, 501, 20, 20);
+        assert_eq!(
+            classify_launch_identity(ordinary, 501, 20),
+            Ok(LaunchIdentity::Current { uid: 501, gid: 20 })
+        );
+        assert_eq!(
+            classify_launch_identity(ordinary, 502, 20),
+            Err(LauncherError::InvalidLaunchPolicy)
+        );
+
+        let unusual_current = CallerCredentials::new(0, 0, 20, 20);
+        assert_eq!(
+            classify_launch_identity(unusual_current, 0, 20),
+            Ok(LaunchIdentity::Current { uid: 0, gid: 20 })
+        );
+
+        let root = CallerCredentials::new(0, 0, 0, 0);
+        let retained = classify_launch_identity(root, 0, 0).expect("root no-drop");
+        assert!(matches!(retained, LaunchIdentity::RootRetained(_)));
+        assert_eq!(
+            require_current_identity(retained),
+            Err(LauncherError::InvalidLaunchPolicy)
+        );
+        let transition = classify_launch_identity(root, 501, 20).expect("root transition");
+        assert!(matches!(transition, LaunchIdentity::RootTransition(_)));
+        assert_eq!(
+            require_current_identity(transition),
+            Err(LauncherError::InvalidLaunchPolicy)
+        );
+        assert!(matches!(
+            classify_launch_identity(root, u32::MAX, u32::MAX),
+            Ok(LaunchIdentity::RootTransition(_))
+        ));
+        assert_eq!(
+            classify_launch_identity(root, 0, 20),
+            Err(LauncherError::InvalidLaunchPolicy)
+        );
+        assert_eq!(
+            classify_launch_identity(root, 501, 0),
+            Err(LauncherError::InvalidLaunchPolicy)
+        );
+
+        for mismatched in [
+            CallerCredentials::new(501, 0, 20, 20),
+            CallerCredentials::new(501, 501, 20, 0),
+        ] {
+            assert_eq!(
+                classify_launch_identity(mismatched, 501, 20),
+                Err(LauncherError::InvalidLaunchPolicy)
+            );
+        }
+        assert_eq!(
+            format!("{:?}", CallerCredentials::new(1, 1, 2, 2)),
+            "CallerCredentials(<redacted>)"
+        );
+        assert_eq!(
+            format!("{:?}", LaunchIdentity::Current { uid: 1, gid: 2 }),
+            "LaunchIdentity(<redacted>)"
         );
     }
 

--- a/crates/launcher/src/macos/daemon.rs
+++ b/crates/launcher/src/macos/daemon.rs
@@ -151,7 +151,7 @@ pub(crate) fn launch_parent(
     executable: &Path,
     layout: &BundleLayout,
 ) -> Result<(), LauncherError> {
-    request.validate(layout.worker_executable(), true)?;
+    request.validate_current(layout.worker_executable(), true)?;
     let signals = DaemonSignals::install()?;
     let (mut child, mut stream) = spawn_daemon_suspended(executable, request.raw_args().to_vec())?;
     super::code_sign::validate_launcher_process(child.pid())?;

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -150,6 +150,12 @@ where
                 )),
             };
         }
+        #[cfg(feature = "elevated-bootstrap-probe")]
+        if elevated_probe.is_none() {
+            request.validate_current(layout.worker_executable(), request.requests_daemonize())?;
+        }
+        #[cfg(not(feature = "elevated-bootstrap-probe"))]
+        request.validate_current(layout.worker_executable(), request.requests_daemonize())?;
         if let Some(mut bootstrap) = child_bootstrap {
             #[cfg(feature = "elevated-bootstrap-probe")]
             if elevated_probe.is_some() {
@@ -1863,6 +1869,9 @@ fn launch_prepared(
 
     use bangbang_session::{LauncherLifecycle, SessionId};
 
+    if !launch.identity.is_current() {
+        return Err(LauncherError::InvalidLaunchPolicy);
+    }
     let wakeups = crate::macos::supervise::SignalWakeups::install()?;
     let session_id = SessionId::generate().map_err(|_| LauncherError::SessionProtocol)?;
     let mut lifecycle = LauncherLifecycle::new(session_id);

--- a/crates/session/src/credential.rs
+++ b/crates/session/src/credential.rs
@@ -1,0 +1,1116 @@
+//! Stable production credential targets, outcomes, and private records.
+
+use std::fmt;
+
+use crate::SessionId;
+
+const VERSION: u16 = 1;
+const BOOTSTRAP_MAGIC: [u8; 4] = *b"BCB1";
+const ATTESTATION_MAGIC: [u8; 4] = *b"BCA1";
+const TRANSPORT_COUNT: u8 = 2;
+
+/// Encoded size of one production credential bootstrap record.
+pub const CREDENTIAL_BOOTSTRAP_BYTES: usize = 64;
+/// Encoded size of one production credential attestation record.
+pub const CREDENTIAL_ATTESTATION_BYTES: usize = 64;
+
+/// Bounded failure returned for malformed production credential values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CredentialProtocolError;
+
+impl fmt::Display for CredentialProtocolError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("invalid credential protocol value")
+    }
+}
+
+impl std::error::Error for CredentialProtocolError {}
+
+/// Exact production credential behavior selected for both signed endpoints.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialMode {
+    /// Retain exact real, effective, and saved root credentials without mutation.
+    RetainedRoot = 1,
+    /// Permanently transition from root to one nonzero numeric identity.
+    Transition = 2,
+}
+
+impl CredentialMode {
+    pub(crate) const fn from_byte(value: u8) -> Result<Self, CredentialProtocolError> {
+        match value {
+            1 => Ok(Self::RetainedRoot),
+            2 => Ok(Self::Transition),
+            _ => Err(CredentialProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free mode spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::RetainedRoot => "retained-root",
+            Self::Transition => "transition",
+        }
+    }
+}
+
+/// Validated numeric identity shared by the launcher and worker.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CredentialTarget {
+    uid: u32,
+    gid: u32,
+    mode: CredentialMode,
+}
+
+impl CredentialTarget {
+    /// Validates one exact production credential target.
+    pub const fn new(uid: u32, gid: u32) -> Result<Self, CredentialProtocolError> {
+        let mode = match (uid == 0, gid == 0) {
+            (true, true) => CredentialMode::RetainedRoot,
+            (false, false) => CredentialMode::Transition,
+            (true, false) | (false, true) => return Err(CredentialProtocolError),
+        };
+        Ok(Self { uid, gid, mode })
+    }
+
+    /// Returns the selected credential behavior.
+    #[must_use]
+    pub const fn mode(self) -> CredentialMode {
+        self.mode
+    }
+
+    /// Returns the exact target user ID for policy construction.
+    #[must_use]
+    pub const fn uid(self) -> u32 {
+        self.uid
+    }
+
+    /// Returns the exact target group ID for policy construction.
+    #[must_use]
+    pub const fn gid(self) -> u32 {
+        self.gid
+    }
+}
+
+impl fmt::Debug for CredentialTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialTarget(<redacted>)")
+    }
+}
+
+/// Fixed process role in a production credential exchange.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialRole {
+    /// The unsandboxed outer launcher endpoint.
+    Launcher = 1,
+    /// The mandatory App Sandbox and Hypervisor worker endpoint.
+    Worker = 2,
+}
+
+impl CredentialRole {
+    pub(crate) const fn from_byte(value: u8) -> Result<Self, CredentialProtocolError> {
+        match value {
+            1 => Ok(Self::Launcher),
+            2 => Ok(Self::Worker),
+            _ => Err(CredentialProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free role spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Launcher => "launcher",
+            Self::Worker => "worker",
+        }
+    }
+}
+
+/// Redacted operating-system failure category.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialErrorCategory {
+    /// The kernel rejected the operation for lack of authority.
+    PermissionDenied = 1,
+    /// The private record or an input was malformed.
+    InvalidInput = 2,
+    /// Another value-free operating-system failure occurred.
+    Other = 3,
+}
+
+impl CredentialErrorCategory {
+    /// Maps a standard I/O category without retaining raw errno or values.
+    #[must_use]
+    pub const fn from_io_kind(kind: std::io::ErrorKind) -> Self {
+        match kind {
+            std::io::ErrorKind::PermissionDenied => Self::PermissionDenied,
+            std::io::ErrorKind::InvalidInput | std::io::ErrorKind::InvalidData => {
+                Self::InvalidInput
+            }
+            _ => Self::Other,
+        }
+    }
+
+    /// Returns the stable diagnostic spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::PermissionDenied => "permission-denied",
+            Self::InvalidInput => "invalid-input",
+            Self::Other => "other",
+        }
+    }
+
+    pub(crate) const fn from_byte(value: u8) -> Result<Self, CredentialProtocolError> {
+        match value {
+            1 => Ok(Self::PermissionDenied),
+            2 => Ok(Self::InvalidInput),
+            3 => Ok(Self::Other),
+            _ => Err(CredentialProtocolError),
+        }
+    }
+}
+
+/// Stable credential operation or validation step.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialStep {
+    /// Validate initial real/effective root and capture supplementary groups.
+    InitialIdentity = 1,
+    /// Clear the supplementary group list.
+    ClearGroups = 2,
+    /// Validate the cleared supplementary group list.
+    ValidateClearedGroups = 3,
+    /// Set the target real/effective/saved group identity.
+    SetGid = 4,
+    /// Set the target real/effective/saved user identity.
+    SetUid = 5,
+    /// Validate final real/effective identity and supplementary groups.
+    ValidateFinalIdentity = 6,
+    /// Prove user identity zero cannot be restored.
+    RestoreUid = 7,
+    /// Prove group identity zero cannot be restored.
+    RestoreGid = 8,
+    /// Prove root supplementary groups cannot be restored.
+    RestoreGroups = 9,
+    /// Observe connected stream and datagram peer surfaces.
+    PeerObservation = 10,
+    /// Validate the closed multi-phase credential exchange.
+    Protocol = 11,
+}
+
+impl CredentialStep {
+    pub(crate) const fn from_byte(value: u8) -> Result<Self, CredentialProtocolError> {
+        match value {
+            1 => Ok(Self::InitialIdentity),
+            2 => Ok(Self::ClearGroups),
+            3 => Ok(Self::ValidateClearedGroups),
+            4 => Ok(Self::SetGid),
+            5 => Ok(Self::SetUid),
+            6 => Ok(Self::ValidateFinalIdentity),
+            7 => Ok(Self::RestoreUid),
+            8 => Ok(Self::RestoreGid),
+            9 => Ok(Self::RestoreGroups),
+            10 => Ok(Self::PeerObservation),
+            11 => Ok(Self::Protocol),
+            _ => Err(CredentialProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free step spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::InitialIdentity => "initial-identity",
+            Self::ClearGroups => "clear-groups",
+            Self::ValidateClearedGroups => "validate-cleared-groups",
+            Self::SetGid => "set-gid",
+            Self::SetUid => "set-uid",
+            Self::ValidateFinalIdentity => "validate-final-identity",
+            Self::RestoreUid => "restore-uid",
+            Self::RestoreGid => "restore-gid",
+            Self::RestoreGroups => "restore-groups",
+            Self::PeerObservation => "peer-observation",
+            Self::Protocol => "protocol",
+        }
+    }
+}
+
+/// Last complete prefix of the ordered credential transition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialPrefix {
+    /// No credential transition step completed.
+    None = 0,
+    /// Initial root identity and groups were validated.
+    Initial = 1,
+    /// Supplementary groups were cleared and revalidated.
+    GroupsCleared = 2,
+    /// Target gid was installed.
+    GidSet = 3,
+    /// Target uid was installed.
+    UidSet = 4,
+    /// Final target identity and effective-group-only access list were validated.
+    FinalIdentity = 5,
+    /// Root restoration attempts all failed and final state remained exact.
+    Irreversible = 6,
+    /// Retained-root state remained identical without credential mutation.
+    RetainedRoot = 7,
+}
+
+impl CredentialPrefix {
+    pub(crate) const fn from_byte(value: u8) -> Result<Self, CredentialProtocolError> {
+        match value {
+            0 => Ok(Self::None),
+            1 => Ok(Self::Initial),
+            2 => Ok(Self::GroupsCleared),
+            3 => Ok(Self::GidSet),
+            4 => Ok(Self::UidSet),
+            5 => Ok(Self::FinalIdentity),
+            6 => Ok(Self::Irreversible),
+            7 => Ok(Self::RetainedRoot),
+            _ => Err(CredentialProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free prefix spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Initial => "initial",
+            Self::GroupsCleared => "groups-cleared",
+            Self::GidSet => "gid-set",
+            Self::UidSet => "uid-set",
+            Self::FinalIdentity => "final-identity",
+            Self::Irreversible => "irreversible",
+            Self::RetainedRoot => "retained-root",
+        }
+    }
+}
+
+/// Value-free classification of one process or peer identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialIdentityClass {
+    /// No identity was observed in this record slot.
+    NotObserved = 0,
+    /// Exact initial root identity.
+    InitialRoot = 1,
+    /// Exact requested nonzero target identity.
+    Target = 2,
+    /// Root is both the initial and requested retained identity.
+    InitialAndTarget = 3,
+    /// A supported query returned another identity class.
+    Other = 4,
+    /// The public query is unsupported for this socket surface.
+    Unsupported = 5,
+}
+
+impl CredentialIdentityClass {
+    pub(crate) const fn from_byte(value: u8) -> Result<Self, CredentialProtocolError> {
+        match value {
+            0 => Ok(Self::NotObserved),
+            1 => Ok(Self::InitialRoot),
+            2 => Ok(Self::Target),
+            3 => Ok(Self::InitialAndTarget),
+            4 => Ok(Self::Other),
+            5 => Ok(Self::Unsupported),
+            _ => Err(CredentialProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free identity spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::NotObserved => "not-observed",
+            Self::InitialRoot => "initial-root",
+            Self::Target => "target",
+            Self::InitialAndTarget => "initial-and-target",
+            Self::Other => "other",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// Value-free classification of one process supplementary-group state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CredentialGroupClass {
+    /// No group state was observed in this record slot.
+    NotObserved = 0,
+    /// Exact initial supplementary groups were retained.
+    Initial = 1,
+    /// Darwin reports only the current effective gid after supplementary groups are cleared.
+    EffectiveOnly = 2,
+    /// Another group state was observed.
+    Other = 3,
+}
+
+impl CredentialGroupClass {
+    pub(crate) const fn from_byte(value: u8) -> Result<Self, CredentialProtocolError> {
+        match value {
+            0 => Ok(Self::NotObserved),
+            1 => Ok(Self::Initial),
+            2 => Ok(Self::EffectiveOnly),
+            3 => Ok(Self::Other),
+            _ => Err(CredentialProtocolError),
+        }
+    }
+
+    /// Returns the stable value-free supplementary-group spelling.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::NotObserved => "not-observed",
+            Self::Initial => "initial",
+            Self::EffectiveOnly => "effective-only",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// Value-free final self state reported by one credential endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CredentialSelfState {
+    identity: CredentialIdentityClass,
+    groups: CredentialGroupClass,
+}
+
+impl CredentialSelfState {
+    /// Constructs one final self-state classification.
+    #[must_use]
+    pub const fn new(identity: CredentialIdentityClass, groups: CredentialGroupClass) -> Self {
+        Self { identity, groups }
+    }
+
+    /// Returns the identity class.
+    #[must_use]
+    pub const fn identity(self) -> CredentialIdentityClass {
+        self.identity
+    }
+
+    /// Returns the supplementary-group class.
+    #[must_use]
+    pub const fn groups(self) -> CredentialGroupClass {
+        self.groups
+    }
+}
+
+/// Value-free failure details for a credential operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CredentialFailureValue {
+    step: CredentialStep,
+    category: CredentialErrorCategory,
+    prefix: CredentialPrefix,
+    state: CredentialSelfState,
+}
+
+impl CredentialFailureValue {
+    /// Constructs one exact failure value.
+    #[must_use]
+    pub const fn new(
+        step: CredentialStep,
+        category: CredentialErrorCategory,
+        prefix: CredentialPrefix,
+        state: CredentialSelfState,
+    ) -> Self {
+        Self {
+            step,
+            category,
+            prefix,
+            state,
+        }
+    }
+
+    /// Returns the failed operation or validation step.
+    #[must_use]
+    pub const fn step(self) -> CredentialStep {
+        self.step
+    }
+
+    /// Returns the redacted operating-system category.
+    #[must_use]
+    pub const fn category(self) -> CredentialErrorCategory {
+        self.category
+    }
+
+    /// Returns the last complete ordered prefix.
+    #[must_use]
+    pub const fn prefix(self) -> CredentialPrefix {
+        self.prefix
+    }
+
+    /// Returns the value-free self state at failure.
+    #[must_use]
+    pub const fn state(self) -> CredentialSelfState {
+        self.state
+    }
+}
+
+/// Live PID observation for one connected local socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PeerPidClass {
+    /// No PID query was made in this record slot.
+    NotObserved = 0,
+    /// The public query returned the exact expected live PID.
+    Exact = 1,
+    /// The public query retained the fixed socketpair creator PID.
+    SocketCreator = 2,
+    /// The public query returned another positive PID.
+    Mismatch = 3,
+    /// The public query is unsupported for this socket surface.
+    Unsupported = 4,
+}
+
+/// Opaque audit-token observation relative to the initial connected peer token.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PeerTokenClass {
+    /// No token query was made in this record slot.
+    NotObserved = 0,
+    /// The initial opaque peer token was captured.
+    Baseline = 1,
+    /// The later opaque peer token is byte-for-byte unchanged.
+    Unchanged = 2,
+    /// The later opaque peer token changed without decoding its fields.
+    Changed = 3,
+    /// The public query is unsupported for this socket surface.
+    Unsupported = 4,
+}
+
+/// Bounded semantic observations for one stream/datagram peer boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PeerObservation {
+    stream_eid: CredentialIdentityClass,
+    stream_cred: CredentialIdentityClass,
+    stream_pid: PeerPidClass,
+    datagram_cred: CredentialIdentityClass,
+    datagram_pid: PeerPidClass,
+    datagram_token: PeerTokenClass,
+}
+
+impl PeerObservation {
+    /// The exact empty observation used for a phase that has not run.
+    pub const NONE: Self = Self {
+        stream_eid: CredentialIdentityClass::NotObserved,
+        stream_cred: CredentialIdentityClass::NotObserved,
+        stream_pid: PeerPidClass::NotObserved,
+        datagram_cred: CredentialIdentityClass::NotObserved,
+        datagram_pid: PeerPidClass::NotObserved,
+        datagram_token: PeerTokenClass::NotObserved,
+    };
+
+    /// Constructs one complete value-free observation.
+    pub fn new(
+        stream_eid: CredentialIdentityClass,
+        stream_cred: CredentialIdentityClass,
+        stream_pid: PeerPidClass,
+        datagram_cred: CredentialIdentityClass,
+        datagram_pid: PeerPidClass,
+        datagram_token: PeerTokenClass,
+    ) -> Result<Self, CredentialProtocolError> {
+        let observation = Self {
+            stream_eid,
+            stream_cred,
+            stream_pid,
+            datagram_cred,
+            datagram_pid,
+            datagram_token,
+        };
+        if observation.is_none()
+            || (!matches!(stream_eid, CredentialIdentityClass::NotObserved)
+                && !matches!(stream_cred, CredentialIdentityClass::NotObserved)
+                && !matches!(stream_pid, PeerPidClass::NotObserved)
+                && !matches!(datagram_cred, CredentialIdentityClass::NotObserved)
+                && !matches!(datagram_pid, PeerPidClass::NotObserved)
+                && !matches!(datagram_token, PeerTokenClass::NotObserved))
+        {
+            Ok(observation)
+        } else {
+            Err(CredentialProtocolError)
+        }
+    }
+
+    /// Returns whether no observation was recorded.
+    #[must_use]
+    pub const fn is_none(self) -> bool {
+        matches!(self.stream_eid, CredentialIdentityClass::NotObserved)
+            && matches!(self.stream_cred, CredentialIdentityClass::NotObserved)
+            && matches!(self.stream_pid, PeerPidClass::NotObserved)
+            && matches!(self.datagram_cred, CredentialIdentityClass::NotObserved)
+            && matches!(self.datagram_pid, PeerPidClass::NotObserved)
+            && matches!(self.datagram_token, PeerTokenClass::NotObserved)
+    }
+
+    /// Returns the stream `getpeereid` class.
+    #[must_use]
+    pub const fn stream_eid(self) -> CredentialIdentityClass {
+        self.stream_eid
+    }
+
+    /// Returns the stream `LOCAL_PEERCRED` class.
+    #[must_use]
+    pub const fn stream_cred(self) -> CredentialIdentityClass {
+        self.stream_cred
+    }
+
+    /// Returns the stream live-PID class.
+    #[must_use]
+    pub const fn stream_pid(self) -> PeerPidClass {
+        self.stream_pid
+    }
+
+    /// Returns the datagram `LOCAL_PEERCRED` class.
+    #[must_use]
+    pub const fn datagram_cred(self) -> CredentialIdentityClass {
+        self.datagram_cred
+    }
+
+    /// Returns the datagram live-PID class.
+    #[must_use]
+    pub const fn datagram_pid(self) -> PeerPidClass {
+        self.datagram_pid
+    }
+
+    /// Returns the opaque datagram token class.
+    #[must_use]
+    pub const fn datagram_token(self) -> PeerTokenClass {
+        self.datagram_token
+    }
+}
+
+/// Strict fixed-size production credential bootstrap.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CredentialBootstrap {
+    target: CredentialTarget,
+    nonce: SessionId,
+}
+
+impl CredentialBootstrap {
+    /// Constructs a bootstrap bound to one fresh session nonce.
+    pub fn new(
+        target: CredentialTarget,
+        nonce: SessionId,
+    ) -> Result<Self, CredentialProtocolError> {
+        if nonce.is_pre_session() {
+            return Err(CredentialProtocolError);
+        }
+        Ok(Self { target, nonce })
+    }
+
+    /// Returns the exact validated credential target.
+    #[must_use]
+    pub const fn target(self) -> CredentialTarget {
+        self.target
+    }
+
+    /// Returns the nonce binding this private exchange.
+    #[must_use]
+    pub const fn nonce(self) -> SessionId {
+        self.nonce
+    }
+
+    /// Encodes this record into its canonical fixed-size form.
+    #[must_use]
+    pub fn encode(self) -> [u8; CREDENTIAL_BOOTSTRAP_BYTES] {
+        let mut bytes = [0_u8; CREDENTIAL_BOOTSTRAP_BYTES];
+        bytes[..4].copy_from_slice(&BOOTSTRAP_MAGIC);
+        bytes[4..6].copy_from_slice(&VERSION.to_be_bytes());
+        bytes[6] = self.target.mode() as u8;
+        bytes[7] = TRANSPORT_COUNT;
+        bytes[8..12].copy_from_slice(&self.target.uid().to_be_bytes());
+        bytes[12..16].copy_from_slice(&self.target.gid().to_be_bytes());
+        bytes[16..48].copy_from_slice(self.nonce.as_bytes());
+        bytes
+    }
+
+    /// Decodes and canonically validates one fixed-size record.
+    pub fn decode(
+        bytes: &[u8; CREDENTIAL_BOOTSTRAP_BYTES],
+    ) -> Result<Self, CredentialProtocolError> {
+        if bytes[..4] != BOOTSTRAP_MAGIC
+            || bytes[4..6] != VERSION.to_be_bytes()
+            || bytes[7] != TRANSPORT_COUNT
+            || bytes[48..] != [0; 16]
+        {
+            return Err(CredentialProtocolError);
+        }
+        let mode = CredentialMode::from_byte(bytes[6])?;
+        let target = CredentialTarget::new(
+            u32::from_be_bytes(array(bytes, 8)?),
+            u32::from_be_bytes(array(bytes, 12)?),
+        )?;
+        if target.mode() != mode {
+            return Err(CredentialProtocolError);
+        }
+        let record = Self::new(target, SessionId::from_bytes(array(bytes, 16)?))?;
+        if record.encode() != *bytes {
+            return Err(CredentialProtocolError);
+        }
+        Ok(record)
+    }
+}
+
+impl fmt::Debug for CredentialBootstrap {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialBootstrap(<redacted>)")
+    }
+}
+
+/// Value-free result carried by a production credential attestation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CredentialAttestationValue {
+    /// The exact terminal postcondition completed.
+    Success {
+        /// Exact final self-state classification.
+        state: CredentialSelfState,
+        /// Complete ordered credential prefix.
+        prefix: CredentialPrefix,
+    },
+    /// The operation stopped at one exact redacted boundary.
+    Failure(CredentialFailureValue),
+}
+
+/// Strict fixed-size production credential attestation.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CredentialAttestation {
+    target: CredentialTarget,
+    role: CredentialRole,
+    nonce: SessionId,
+    value: CredentialAttestationValue,
+}
+
+impl CredentialAttestation {
+    /// Constructs the only canonical success value for a target.
+    pub fn success(
+        target: CredentialTarget,
+        role: CredentialRole,
+        nonce: SessionId,
+        state: CredentialSelfState,
+        prefix: CredentialPrefix,
+    ) -> Result<Self, CredentialProtocolError> {
+        let expected = terminal_state(target);
+        if nonce.is_pre_session() || (state, prefix) != expected {
+            return Err(CredentialProtocolError);
+        }
+        Ok(Self {
+            target,
+            role,
+            nonce,
+            value: CredentialAttestationValue::Success { state, prefix },
+        })
+    }
+
+    /// Constructs one canonical value-free failure attestation.
+    pub fn failure(
+        target: CredentialTarget,
+        role: CredentialRole,
+        nonce: SessionId,
+        failure: CredentialFailureValue,
+    ) -> Result<Self, CredentialProtocolError> {
+        if nonce.is_pre_session() || !valid_failure(target, failure) {
+            return Err(CredentialProtocolError);
+        }
+        Ok(Self {
+            target,
+            role,
+            nonce,
+            value: CredentialAttestationValue::Failure(failure),
+        })
+    }
+
+    /// Returns the exact validated target.
+    #[must_use]
+    pub const fn target(self) -> CredentialTarget {
+        self.target
+    }
+
+    /// Returns the process role producing this record.
+    #[must_use]
+    pub const fn role(self) -> CredentialRole {
+        self.role
+    }
+
+    /// Returns the nonce binding this record to its bootstrap.
+    #[must_use]
+    pub const fn nonce(self) -> SessionId {
+        self.nonce
+    }
+
+    /// Returns the exact value-free attestation outcome.
+    #[must_use]
+    pub const fn value(self) -> CredentialAttestationValue {
+        self.value
+    }
+
+    /// Encodes this record into its canonical fixed-size form.
+    #[must_use]
+    pub fn encode(self) -> [u8; CREDENTIAL_ATTESTATION_BYTES] {
+        let mut bytes = [0_u8; CREDENTIAL_ATTESTATION_BYTES];
+        bytes[..4].copy_from_slice(&ATTESTATION_MAGIC);
+        bytes[4..6].copy_from_slice(&VERSION.to_be_bytes());
+        bytes[6] = self.target.mode() as u8;
+        bytes[7] = self.role as u8;
+        let (outcome, state, prefix, step, category) = match self.value {
+            CredentialAttestationValue::Success { state, prefix } => (1, state, prefix, 0, 0),
+            CredentialAttestationValue::Failure(failure) => (
+                2,
+                failure.state(),
+                failure.prefix(),
+                failure.step() as u8,
+                failure.category() as u8,
+            ),
+        };
+        bytes[8] = outcome;
+        bytes[9] = prefix as u8;
+        bytes[10] = state.identity() as u8;
+        bytes[11] = state.groups() as u8;
+        bytes[12] = step;
+        bytes[13] = category;
+        bytes[16..20].copy_from_slice(&self.target.uid().to_be_bytes());
+        bytes[20..24].copy_from_slice(&self.target.gid().to_be_bytes());
+        bytes[24..56].copy_from_slice(self.nonce.as_bytes());
+        bytes
+    }
+
+    /// Decodes and canonically validates one fixed-size record.
+    pub fn decode(
+        bytes: &[u8; CREDENTIAL_ATTESTATION_BYTES],
+    ) -> Result<Self, CredentialProtocolError> {
+        if bytes[..4] != ATTESTATION_MAGIC
+            || bytes[4..6] != VERSION.to_be_bytes()
+            || bytes[14..16] != [0; 2]
+            || bytes[56..] != [0; 8]
+        {
+            return Err(CredentialProtocolError);
+        }
+        let mode = CredentialMode::from_byte(bytes[6])?;
+        let role = CredentialRole::from_byte(bytes[7])?;
+        let target = CredentialTarget::new(
+            u32::from_be_bytes(array(bytes, 16)?),
+            u32::from_be_bytes(array(bytes, 20)?),
+        )?;
+        if target.mode() != mode {
+            return Err(CredentialProtocolError);
+        }
+        let nonce = SessionId::from_bytes(array(bytes, 24)?);
+        let state = CredentialSelfState::new(
+            CredentialIdentityClass::from_byte(bytes[10])?,
+            CredentialGroupClass::from_byte(bytes[11])?,
+        );
+        let record = match bytes[8] {
+            1 if bytes[12] == 0 && bytes[13] == 0 => Self::success(
+                target,
+                role,
+                nonce,
+                state,
+                CredentialPrefix::from_byte(bytes[9])?,
+            )?,
+            2 => Self::failure(
+                target,
+                role,
+                nonce,
+                CredentialFailureValue::new(
+                    CredentialStep::from_byte(bytes[12])?,
+                    CredentialErrorCategory::from_byte(bytes[13])?,
+                    CredentialPrefix::from_byte(bytes[9])?,
+                    state,
+                ),
+            )?,
+            _ => return Err(CredentialProtocolError),
+        };
+        if record.encode() != *bytes {
+            return Err(CredentialProtocolError);
+        }
+        Ok(record)
+    }
+}
+
+impl fmt::Debug for CredentialAttestation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialAttestation(<redacted>)")
+    }
+}
+
+const fn terminal_state(target: CredentialTarget) -> (CredentialSelfState, CredentialPrefix) {
+    match target.mode() {
+        CredentialMode::RetainedRoot => (
+            CredentialSelfState::new(
+                CredentialIdentityClass::InitialAndTarget,
+                CredentialGroupClass::Initial,
+            ),
+            CredentialPrefix::RetainedRoot,
+        ),
+        CredentialMode::Transition => (
+            CredentialSelfState::new(
+                CredentialIdentityClass::Target,
+                CredentialGroupClass::EffectiveOnly,
+            ),
+            CredentialPrefix::Irreversible,
+        ),
+    }
+}
+
+const fn valid_failure(target: CredentialTarget, failure: CredentialFailureValue) -> bool {
+    if matches!(
+        failure.state().identity(),
+        CredentialIdentityClass::NotObserved | CredentialIdentityClass::Unsupported
+    ) || matches!(failure.state().groups(), CredentialGroupClass::NotObserved)
+    {
+        return false;
+    }
+    matches!(
+        (target.mode(), failure.step(), failure.prefix()),
+        (_, CredentialStep::InitialIdentity, CredentialPrefix::None)
+            | (
+                CredentialMode::RetainedRoot,
+                CredentialStep::ValidateFinalIdentity,
+                CredentialPrefix::Initial,
+            )
+            | (
+                CredentialMode::RetainedRoot,
+                CredentialStep::PeerObservation | CredentialStep::Protocol,
+                CredentialPrefix::RetainedRoot,
+            )
+            | (
+                CredentialMode::Transition,
+                CredentialStep::ClearGroups | CredentialStep::ValidateClearedGroups,
+                CredentialPrefix::Initial,
+            )
+            | (
+                CredentialMode::Transition,
+                CredentialStep::SetGid,
+                CredentialPrefix::GroupsCleared
+            )
+            | (
+                CredentialMode::Transition,
+                CredentialStep::SetUid,
+                CredentialPrefix::GidSet
+            )
+            | (
+                CredentialMode::Transition,
+                CredentialStep::ValidateFinalIdentity,
+                CredentialPrefix::UidSet | CredentialPrefix::FinalIdentity,
+            )
+            | (
+                CredentialMode::Transition,
+                CredentialStep::RestoreUid
+                    | CredentialStep::RestoreGid
+                    | CredentialStep::RestoreGroups,
+                CredentialPrefix::FinalIdentity,
+            )
+            | (
+                CredentialMode::Transition,
+                CredentialStep::PeerObservation | CredentialStep::Protocol,
+                CredentialPrefix::Irreversible,
+            )
+    )
+}
+
+fn array<const N: usize>(bytes: &[u8], offset: usize) -> Result<[u8; N], CredentialProtocolError> {
+    bytes
+        .get(offset..offset + N)
+        .and_then(|slice| slice.try_into().ok())
+        .ok_or(CredentialProtocolError)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nonce() -> SessionId {
+        SessionId::from_bytes([7; 32])
+    }
+
+    #[test]
+    fn targets_are_exact_and_redacted() {
+        let retained = CredentialTarget::new(0, 0).expect("retained root");
+        assert_eq!(retained.mode(), CredentialMode::RetainedRoot);
+        let transition = CredentialTarget::new(u32::MAX, u32::MAX).expect("nonzero target");
+        assert_eq!(transition.mode(), CredentialMode::Transition);
+        assert_eq!(format!("{transition:?}"), "CredentialTarget(<redacted>)");
+        assert!(CredentialTarget::new(0, 1).is_err());
+        assert!(CredentialTarget::new(1, 0).is_err());
+    }
+
+    #[test]
+    fn bootstrap_roundtrip_is_strict_and_redacted() {
+        let record =
+            CredentialBootstrap::new(CredentialTarget::new(501, 20).expect("target"), nonce())
+                .expect("bootstrap");
+        let encoded = record.encode();
+        assert_eq!(CredentialBootstrap::decode(&encoded), Ok(record));
+        assert_eq!(format!("{record:?}"), "CredentialBootstrap(<redacted>)");
+        assert!(CredentialBootstrap::new(record.target(), SessionId::pre_session()).is_err());
+
+        for index in [0, 4, 6, 7, 48, 63] {
+            let mut malformed = encoded;
+            malformed[index] ^= 0xff;
+            assert!(
+                CredentialBootstrap::decode(&malformed).is_err(),
+                "index {index}"
+            );
+        }
+        let mut mixed_target = encoded;
+        mixed_target[8..12].copy_from_slice(&0_u32.to_be_bytes());
+        assert!(CredentialBootstrap::decode(&mixed_target).is_err());
+        let mut pre_session = encoded;
+        pre_session[16..48].fill(0);
+        assert!(CredentialBootstrap::decode(&pre_session).is_err());
+    }
+
+    #[test]
+    fn success_and_failure_attestations_roundtrip_canonically() {
+        for (target, state, prefix) in [
+            (
+                CredentialTarget::new(0, 0).expect("root"),
+                CredentialSelfState::new(
+                    CredentialIdentityClass::InitialAndTarget,
+                    CredentialGroupClass::Initial,
+                ),
+                CredentialPrefix::RetainedRoot,
+            ),
+            (
+                CredentialTarget::new(501, 20).expect("target"),
+                CredentialSelfState::new(
+                    CredentialIdentityClass::Target,
+                    CredentialGroupClass::EffectiveOnly,
+                ),
+                CredentialPrefix::Irreversible,
+            ),
+        ] {
+            let record = CredentialAttestation::success(
+                target,
+                CredentialRole::Worker,
+                nonce(),
+                state,
+                prefix,
+            )
+            .expect("success");
+            assert_eq!(CredentialAttestation::decode(&record.encode()), Ok(record));
+            assert_eq!(format!("{record:?}"), "CredentialAttestation(<redacted>)");
+        }
+
+        let target = CredentialTarget::new(501, 20).expect("target");
+        let failure = CredentialFailureValue::new(
+            CredentialStep::SetUid,
+            CredentialErrorCategory::PermissionDenied,
+            CredentialPrefix::GidSet,
+            CredentialSelfState::new(
+                CredentialIdentityClass::InitialRoot,
+                CredentialGroupClass::EffectiveOnly,
+            ),
+        );
+        let record =
+            CredentialAttestation::failure(target, CredentialRole::Launcher, nonce(), failure)
+                .expect("failure");
+        assert_eq!(CredentialAttestation::decode(&record.encode()), Ok(record));
+    }
+
+    #[test]
+    fn attestation_rejects_noncanonical_shapes_and_reserved_bytes() {
+        let target = CredentialTarget::new(501, 20).expect("target");
+        assert!(
+            CredentialAttestation::success(
+                target,
+                CredentialRole::Launcher,
+                nonce(),
+                CredentialSelfState::new(
+                    CredentialIdentityClass::InitialAndTarget,
+                    CredentialGroupClass::Initial,
+                ),
+                CredentialPrefix::RetainedRoot,
+            )
+            .is_err()
+        );
+        let record = CredentialAttestation::success(
+            target,
+            CredentialRole::Launcher,
+            nonce(),
+            CredentialSelfState::new(
+                CredentialIdentityClass::Target,
+                CredentialGroupClass::EffectiveOnly,
+            ),
+            CredentialPrefix::Irreversible,
+        )
+        .expect("success");
+        for index in [0, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 56, 63] {
+            let mut malformed = record.encode();
+            malformed[index] ^= 0xff;
+            assert!(
+                CredentialAttestation::decode(&malformed).is_err(),
+                "index {index}"
+            );
+        }
+        let mut mixed_target = record.encode();
+        mixed_target[16..20].copy_from_slice(&0_u32.to_be_bytes());
+        assert!(CredentialAttestation::decode(&mixed_target).is_err());
+        let mut pre_session = record.encode();
+        pre_session[24..56].fill(0);
+        assert!(CredentialAttestation::decode(&pre_session).is_err());
+
+        let contradictory = CredentialFailureValue::new(
+            CredentialStep::SetUid,
+            CredentialErrorCategory::PermissionDenied,
+            CredentialPrefix::Irreversible,
+            CredentialSelfState::new(
+                CredentialIdentityClass::Target,
+                CredentialGroupClass::EffectiveOnly,
+            ),
+        );
+        assert!(
+            CredentialAttestation::failure(target, CredentialRole::Worker, nonce(), contradictory,)
+                .is_err()
+        );
+        let valid_failure = CredentialFailureValue::new(
+            CredentialStep::PeerObservation,
+            CredentialErrorCategory::Other,
+            CredentialPrefix::Irreversible,
+            CredentialSelfState::new(
+                CredentialIdentityClass::Target,
+                CredentialGroupClass::EffectiveOnly,
+            ),
+        );
+        assert!(
+            CredentialAttestation::failure(
+                target,
+                CredentialRole::Worker,
+                SessionId::pre_session(),
+                valid_failure,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn peer_observation_requires_all_or_none() {
+        assert!(PeerObservation::NONE.is_none());
+        assert!(
+            PeerObservation::new(
+                CredentialIdentityClass::Target,
+                CredentialIdentityClass::Target,
+                PeerPidClass::Exact,
+                CredentialIdentityClass::Unsupported,
+                PeerPidClass::Exact,
+                PeerTokenClass::Unsupported,
+            )
+            .is_ok()
+        );
+        assert!(
+            PeerObservation::new(
+                CredentialIdentityClass::NotObserved,
+                CredentialIdentityClass::Target,
+                PeerPidClass::Exact,
+                CredentialIdentityClass::Target,
+                PeerPidClass::Exact,
+                PeerTokenClass::Baseline,
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/session/src/elevated_credential.rs
+++ b/crates/session/src/elevated_credential.rs
@@ -1,36 +1,27 @@
-//! Darwin credential-transition and peer-observation primitives for the test-only probe.
+//! Compatibility adapter from the test-only evidence protocol to production credentials.
 
-use std::io;
-use std::mem::MaybeUninit;
 use std::os::fd::RawFd;
 
-use crate::elevated_probe::{
-    CredentialFailureValue, CredentialGroupClass, CredentialIdentityClass, CredentialPrefix,
-    CredentialSelfState, CredentialStep, PeerObservation, PeerPidClass, PeerTokenClass,
-    ProbeErrorCategory, ProbeMode,
-};
-
-const MAX_SUPPLEMENTARY_GROUPS: usize = 1_024;
-const XUCRED_VERSION: libc::c_uint = 0;
-const AUDIT_TOKEN_WORDS: usize = 8;
+use crate::credential as production;
+use crate::elevated_probe as probe;
 
 /// Complete value-free postcondition of one process credential transition.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct CredentialTransition {
-    state: CredentialSelfState,
-    prefix: CredentialPrefix,
+    state: probe::CredentialSelfState,
+    prefix: probe::CredentialPrefix,
 }
 
 impl CredentialTransition {
     /// Returns the exact final self-state class.
     #[must_use]
-    pub const fn state(self) -> CredentialSelfState {
+    pub const fn state(self) -> probe::CredentialSelfState {
         self.state
     }
 
     /// Returns the complete ordered prefix.
     #[must_use]
-    pub const fn prefix(self) -> CredentialPrefix {
+    pub const fn prefix(self) -> probe::CredentialPrefix {
         self.prefix
     }
 }
@@ -42,9 +33,7 @@ impl std::fmt::Debug for CredentialTransition {
 }
 
 /// Opaque initial peer state retained only for later semantic comparison.
-pub struct PeerBaseline {
-    datagram_token: TokenBaseline,
-}
+pub struct PeerBaseline(crate::macos::credential::PeerBaseline);
 
 impl std::fmt::Debug for PeerBaseline {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -52,50 +41,31 @@ impl std::fmt::Debug for PeerBaseline {
     }
 }
 
-enum TokenBaseline {
-    Unsupported,
-    Value([u32; AUDIT_TOKEN_WORDS]),
-}
-
 /// Performs the exact no-chroot credential transition for one evidence endpoint.
 pub fn transition_process(
-    mode: ProbeMode,
+    mode: probe::ProbeMode,
     target_uid: u32,
     target_gid: u32,
-) -> Result<CredentialTransition, CredentialFailureValue> {
-    transition_with(&mut DarwinCredentialOps, mode, target_uid, target_gid)
+) -> Result<CredentialTransition, probe::CredentialFailureValue> {
+    let target = target(mode, target_uid, target_gid).map_err(invalid_failure)?;
+    crate::macos::credential::transition_process(target)
+        .map(map_transition)
+        .map_err(map_failure)
 }
 
 /// Re-attests the exact local post-transition identity before runtime work.
 pub fn attest_current_process(
-    mode: ProbeMode,
+    mode: probe::ProbeMode,
     target_uid: u32,
     target_gid: u32,
-) -> Result<CredentialSelfState, ProbeErrorCategory> {
-    if !mode.continues_runtime() || !mode.accepts_target(target_uid, target_gid) {
-        return Err(ProbeErrorCategory::InvalidInput);
+) -> Result<probe::CredentialSelfState, probe::ProbeErrorCategory> {
+    if !mode.continues_runtime() {
+        return Err(probe::ProbeErrorCategory::InvalidInput);
     }
-    let mut ops = DarwinCredentialOps;
-    let identities = ops.ids();
-    let groups = ops.groups().map_err(ProbeErrorCategory::from_io_kind)?;
-    if mode.retains_root() {
-        if identities != (0, 0, 0, 0) {
-            return Err(ProbeErrorCategory::PermissionDenied);
-        }
-        return Ok(CredentialSelfState::new(
-            CredentialIdentityClass::InitialAndTarget,
-            CredentialGroupClass::Initial,
-        ));
-    }
-    if identities != (target_uid, target_uid, target_gid, target_gid)
-        || groups.as_slice() != [target_gid]
-    {
-        return Err(ProbeErrorCategory::PermissionDenied);
-    }
-    Ok(CredentialSelfState::new(
-        CredentialIdentityClass::Target,
-        CredentialGroupClass::EffectiveOnly,
-    ))
+    let target = target(mode, target_uid, target_gid)?;
+    crate::macos::credential::attest_current_process(target)
+        .map(map_state)
+        .map_err(map_category)
 }
 
 /// Captures the initial connected stream/datagram peer observation.
@@ -106,30 +76,18 @@ pub fn observe_initial_peer(
     socket_creator_pid: libc::pid_t,
     target_uid: u32,
     target_gid: u32,
-) -> Result<(PeerObservation, PeerBaseline), ProbeErrorCategory> {
-    validate_socket_type(stream, libc::SOCK_STREAM)?;
-    validate_socket_type(datagram, libc::SOCK_DGRAM)?;
-    let stream_eid = stream_eid(stream, target_uid, target_gid)?;
-    let stream_cred = local_peercred(stream, false, target_uid, target_gid)?;
-    let stream_pid = exact_peer_pid(stream, expected_pid, None)?;
-    let datagram_cred = local_peercred(datagram, true, target_uid, target_gid)?;
-    let datagram_pid = exact_peer_pid(datagram, expected_pid, Some(socket_creator_pid))?;
-    let (datagram_token, baseline) = initial_token(datagram)?;
-    let observation = PeerObservation::new(
-        stream_eid,
-        stream_cred,
-        stream_pid,
-        datagram_cred,
-        datagram_pid,
-        datagram_token,
+) -> Result<(probe::PeerObservation, PeerBaseline), probe::ProbeErrorCategory> {
+    let target = production::CredentialTarget::new(target_uid, target_gid)
+        .map_err(|_| probe::ProbeErrorCategory::InvalidInput)?;
+    let (observation, baseline) = crate::macos::credential::observe_initial_peer(
+        stream,
+        datagram,
+        expected_pid,
+        socket_creator_pid,
+        target,
     )
-    .map_err(|_| ProbeErrorCategory::InvalidInput)?;
-    Ok((
-        observation,
-        PeerBaseline {
-            datagram_token: baseline,
-        },
-    ))
+    .map_err(map_category)?;
+    Ok((map_observation(observation)?, PeerBaseline(baseline)))
 }
 
 /// Captures one later peer observation relative to the exact initial baseline.
@@ -141,958 +99,217 @@ pub fn observe_later_peer(
     target_uid: u32,
     target_gid: u32,
     baseline: &PeerBaseline,
-) -> Result<PeerObservation, ProbeErrorCategory> {
-    validate_socket_type(stream, libc::SOCK_STREAM)?;
-    validate_socket_type(datagram, libc::SOCK_DGRAM)?;
-    PeerObservation::new(
-        stream_eid(stream, target_uid, target_gid)?,
-        local_peercred(stream, false, target_uid, target_gid)?,
-        exact_peer_pid(stream, expected_pid, None)?,
-        local_peercred(datagram, true, target_uid, target_gid)?,
-        exact_peer_pid(datagram, expected_pid, Some(socket_creator_pid))?,
-        later_token(datagram, &baseline.datagram_token)?,
+) -> Result<probe::PeerObservation, probe::ProbeErrorCategory> {
+    let target = production::CredentialTarget::new(target_uid, target_gid)
+        .map_err(|_| probe::ProbeErrorCategory::InvalidInput)?;
+    crate::macos::credential::observe_later_peer(
+        stream,
+        datagram,
+        expected_pid,
+        socket_creator_pid,
+        target,
+        &baseline.0,
     )
-    .map_err(|_| ProbeErrorCategory::InvalidInput)
+    .map_err(map_category)
+    .and_then(map_observation)
 }
 
-trait CredentialOps {
-    fn ids(&mut self) -> (u32, u32, u32, u32);
-    fn groups(&mut self) -> Result<Vec<u32>, io::ErrorKind>;
-    fn clear_groups(&mut self) -> Result<(), io::ErrorKind>;
-    fn set_gid(&mut self, gid: u32) -> Result<(), io::ErrorKind>;
-    fn set_uid(&mut self, uid: u32) -> Result<(), io::ErrorKind>;
-    fn restore_groups(&mut self) -> Result<(), io::ErrorKind>;
-}
-
-struct DarwinCredentialOps;
-
-impl CredentialOps for DarwinCredentialOps {
-    fn ids(&mut self) -> (u32, u32, u32, u32) {
-        // SAFETY: Credential getters have no pointer or ownership contract.
-        unsafe {
-            (
-                libc::getuid(),
-                libc::geteuid(),
-                libc::getgid(),
-                libc::getegid(),
-            )
-        }
-    }
-
-    fn groups(&mut self) -> Result<Vec<u32>, io::ErrorKind> {
-        // SAFETY: A zero-length query does not dereference the null pointer.
-        let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
-        let count = usize::try_from(count).map_err(|_| io::Error::last_os_error().kind())?;
-        if count > MAX_SUPPLEMENTARY_GROUPS {
-            return Err(io::ErrorKind::InvalidData);
-        }
-        let mut groups = vec![0; count];
-        let pointer = if groups.is_empty() {
-            std::ptr::null_mut()
-        } else {
-            groups.as_mut_ptr()
-        };
-        let capacity =
-            libc::c_int::try_from(groups.len()).map_err(|_| io::ErrorKind::InvalidData)?;
-        // SAFETY: `pointer` is null for zero capacity or points to `capacity`
-        // writable gid slots for the duration of the synchronous call.
-        let actual = unsafe { libc::getgroups(capacity, pointer) };
-        let actual = usize::try_from(actual).map_err(|_| io::Error::last_os_error().kind())?;
-        if actual != groups.len() {
-            return Err(io::ErrorKind::InvalidData);
-        }
-        Ok(groups)
-    }
-
-    fn clear_groups(&mut self) -> Result<(), io::ErrorKind> {
-        // SAFETY: A zero-length group update does not dereference the null pointer.
-        cvt(unsafe { libc::setgroups(0, std::ptr::null()) })
-    }
-
-    fn set_gid(&mut self, gid: u32) -> Result<(), io::ErrorKind> {
-        // SAFETY: The numeric gid is passed by value and no state is borrowed.
-        cvt(unsafe { libc::setgid(gid) })
-    }
-
-    fn set_uid(&mut self, uid: u32) -> Result<(), io::ErrorKind> {
-        // SAFETY: The numeric uid is passed by value and no state is borrowed.
-        cvt(unsafe { libc::setuid(uid) })
-    }
-
-    fn restore_groups(&mut self) -> Result<(), io::ErrorKind> {
-        let root: libc::gid_t = 0;
-        // SAFETY: `root` is one live gid value for the synchronous call.
-        cvt(unsafe { libc::setgroups(1, &raw const root) })
-    }
-}
-
-fn transition_with<O: CredentialOps>(
-    ops: &mut O,
-    mode: ProbeMode,
-    target_uid: u32,
-    target_gid: u32,
-) -> Result<CredentialTransition, CredentialFailureValue> {
-    let retains_root = if mode == ProbeMode::CredentialControl {
-        target_uid == 0 && target_gid == 0
-    } else if mode.is_credential_pair() {
-        mode.retains_root()
-    } else {
-        return Err(CredentialFailureValue::new(
-            CredentialStep::InitialIdentity,
-            ProbeErrorCategory::InvalidInput,
-            CredentialPrefix::None,
-            CredentialSelfState::new(CredentialIdentityClass::Other, CredentialGroupClass::Other),
-        ));
-    };
-    if !mode.accepts_target(target_uid, target_gid) {
-        return Err(CredentialFailureValue::new(
-            CredentialStep::InitialIdentity,
-            ProbeErrorCategory::InvalidInput,
-            CredentialPrefix::None,
-            CredentialSelfState::new(CredentialIdentityClass::Other, CredentialGroupClass::Other),
-        ));
-    }
-
-    let initial_groups = ops.groups().map_err(|kind| {
-        failure(
-            ops,
-            CredentialStep::InitialIdentity,
-            kind,
-            CredentialPrefix::None,
-            target_uid,
-            target_gid,
-            &[],
-        )
-    })?;
-    if ops.ids() != (0, 0, 0, 0) {
-        return Err(failure_category(
-            ops,
-            CredentialStep::InitialIdentity,
-            ProbeErrorCategory::PermissionDenied,
-            CredentialPrefix::None,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        ));
-    }
-
-    if retains_root {
-        let final_groups = ops.groups().map_err(|kind| {
-            failure(
-                ops,
-                CredentialStep::ValidateFinalIdentity,
-                kind,
-                CredentialPrefix::Initial,
-                target_uid,
-                target_gid,
-                &initial_groups,
-            )
-        })?;
-        if ops.ids() != (0, 0, 0, 0) || final_groups != initial_groups {
-            return Err(failure_category(
-                ops,
-                CredentialStep::ValidateFinalIdentity,
-                ProbeErrorCategory::InvalidInput,
-                CredentialPrefix::Initial,
-                target_uid,
-                target_gid,
-                &initial_groups,
-            ));
-        }
-        return Ok(CredentialTransition {
-            state: CredentialSelfState::new(
-                CredentialIdentityClass::InitialAndTarget,
-                CredentialGroupClass::Initial,
-            ),
-            prefix: CredentialPrefix::RetainedRoot,
-        });
-    }
-
-    ops.clear_groups().map_err(|kind| {
-        failure(
-            ops,
-            CredentialStep::ClearGroups,
-            kind,
-            CredentialPrefix::Initial,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        )
-    })?;
-    let groups = ops.groups().map_err(|kind| {
-        failure(
-            ops,
-            CredentialStep::ValidateClearedGroups,
-            kind,
-            CredentialPrefix::Initial,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        )
-    })?;
-    if groups.as_slice() != [0] {
-        return Err(failure_category(
-            ops,
-            CredentialStep::ValidateClearedGroups,
-            ProbeErrorCategory::InvalidInput,
-            CredentialPrefix::Initial,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        ));
-    }
-
-    ops.set_gid(target_gid).map_err(|kind| {
-        failure(
-            ops,
-            CredentialStep::SetGid,
-            kind,
-            CredentialPrefix::GroupsCleared,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        )
-    })?;
-    ops.set_uid(target_uid).map_err(|kind| {
-        failure(
-            ops,
-            CredentialStep::SetUid,
-            kind,
-            CredentialPrefix::GidSet,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        )
-    })?;
-
-    validate_target(ops, target_uid, target_gid).map_err(|kind| {
-        failure(
-            ops,
-            CredentialStep::ValidateFinalIdentity,
-            kind,
-            CredentialPrefix::UidSet,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        )
-    })?;
-
-    expect_permission_denied(ops.set_uid(0)).map_err(|category| {
-        failure_category(
-            ops,
-            CredentialStep::RestoreUid,
-            category,
-            CredentialPrefix::FinalIdentity,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        )
-    })?;
-    expect_permission_denied(ops.set_gid(0)).map_err(|category| {
-        failure_category(
-            ops,
-            CredentialStep::RestoreGid,
-            category,
-            CredentialPrefix::FinalIdentity,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        )
-    })?;
-    expect_permission_denied(ops.restore_groups()).map_err(|category| {
-        failure_category(
-            ops,
-            CredentialStep::RestoreGroups,
-            category,
-            CredentialPrefix::FinalIdentity,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        )
-    })?;
-    validate_target(ops, target_uid, target_gid).map_err(|kind| {
-        failure(
-            ops,
-            CredentialStep::ValidateFinalIdentity,
-            kind,
-            CredentialPrefix::FinalIdentity,
-            target_uid,
-            target_gid,
-            &initial_groups,
-        )
-    })?;
-
-    Ok(CredentialTransition {
-        state: CredentialSelfState::new(
-            CredentialIdentityClass::Target,
-            CredentialGroupClass::EffectiveOnly,
-        ),
-        prefix: CredentialPrefix::Irreversible,
-    })
-}
-
-fn validate_target<O: CredentialOps>(
-    ops: &mut O,
-    target_uid: u32,
-    target_gid: u32,
-) -> Result<(), io::ErrorKind> {
-    if ops.ids() != (target_uid, target_uid, target_gid, target_gid) {
-        return Err(io::ErrorKind::InvalidData);
-    }
-    if ops.groups()?.as_slice() != [target_gid] {
-        return Err(io::ErrorKind::InvalidData);
-    }
-    Ok(())
-}
-
-fn expect_permission_denied(result: Result<(), io::ErrorKind>) -> Result<(), ProbeErrorCategory> {
-    match result {
-        Err(io::ErrorKind::PermissionDenied) => Ok(()),
-        Ok(()) => Err(ProbeErrorCategory::Other),
-        Err(kind) => Err(ProbeErrorCategory::from_io_kind(kind)),
-    }
-}
-
-fn failure<O: CredentialOps>(
-    ops: &mut O,
-    step: CredentialStep,
-    kind: io::ErrorKind,
-    prefix: CredentialPrefix,
-    target_uid: u32,
-    target_gid: u32,
-    initial_groups: &[u32],
-) -> CredentialFailureValue {
-    failure_category(
-        ops,
-        step,
-        ProbeErrorCategory::from_io_kind(kind),
-        prefix,
-        target_uid,
-        target_gid,
-        initial_groups,
-    )
-}
-
-fn failure_category<O: CredentialOps>(
-    ops: &mut O,
-    step: CredentialStep,
-    category: ProbeErrorCategory,
-    prefix: CredentialPrefix,
-    target_uid: u32,
-    target_gid: u32,
-    initial_groups: &[u32],
-) -> CredentialFailureValue {
-    CredentialFailureValue::new(
-        step,
-        category,
-        prefix,
-        classify_self(ops, target_uid, target_gid, initial_groups),
-    )
-}
-
-fn classify_self<O: CredentialOps>(
-    ops: &mut O,
-    target_uid: u32,
-    target_gid: u32,
-    initial_groups: &[u32],
-) -> CredentialSelfState {
-    let (uid, euid, gid, egid) = ops.ids();
-    let identity = if (uid, euid, gid, egid) == (0, 0, 0, 0) {
-        if target_uid == 0 && target_gid == 0 {
-            CredentialIdentityClass::InitialAndTarget
-        } else {
-            CredentialIdentityClass::InitialRoot
-        }
-    } else if (uid, euid, gid, egid) == (target_uid, target_uid, target_gid, target_gid) {
-        CredentialIdentityClass::Target
-    } else {
-        CredentialIdentityClass::Other
-    };
-    let groups = match ops.groups() {
-        Ok(groups) if groups == initial_groups => CredentialGroupClass::Initial,
-        Ok(groups) if groups.as_slice() == [gid] => CredentialGroupClass::EffectiveOnly,
-        Ok(_) | Err(_) => CredentialGroupClass::Other,
-    };
-    CredentialSelfState::new(identity, groups)
-}
-
-fn cvt(result: libc::c_int) -> Result<(), io::ErrorKind> {
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error().kind())
-    }
-}
-
-fn validate_socket_type(fd: RawFd, expected: libc::c_int) -> Result<(), ProbeErrorCategory> {
-    let mut actual = 0;
-    let mut length = libc::socklen_t::try_from(std::mem::size_of::<libc::c_int>())
-        .map_err(|_| ProbeErrorCategory::InvalidInput)?;
-    // SAFETY: `actual` and `length` are writable for the synchronous option query.
-    if unsafe {
-        libc::getsockopt(
-            fd,
-            libc::SOL_SOCKET,
-            libc::SO_TYPE,
-            (&raw mut actual).cast(),
-            &raw mut length,
-        )
-    } != 0
-    {
-        return Err(ProbeErrorCategory::from_io_kind(
-            io::Error::last_os_error().kind(),
-        ));
-    }
-    if usize::try_from(length).ok() != Some(std::mem::size_of::<libc::c_int>())
-        || actual != expected
-    {
-        return Err(ProbeErrorCategory::InvalidInput);
-    }
-    Ok(())
-}
-
-fn stream_eid(
-    fd: RawFd,
-    target_uid: u32,
-    target_gid: u32,
-) -> Result<CredentialIdentityClass, ProbeErrorCategory> {
-    let mut uid = 0;
-    let mut gid = 0;
-    // SAFETY: Both credential outputs are writable and `fd` remains owned by the caller.
-    if unsafe { libc::getpeereid(fd, &raw mut uid, &raw mut gid) } != 0 {
-        return Err(ProbeErrorCategory::from_io_kind(
-            io::Error::last_os_error().kind(),
-        ));
-    }
-    Ok(classify_peer(uid, gid, target_uid, target_gid))
-}
-
-fn local_peercred(
-    fd: RawFd,
-    allow_unsupported: bool,
-    target_uid: u32,
-    target_gid: u32,
-) -> Result<CredentialIdentityClass, ProbeErrorCategory> {
-    let mut credential = MaybeUninit::<libc::xucred>::zeroed();
-    let mut length = libc::socklen_t::try_from(std::mem::size_of::<libc::xucred>())
-        .map_err(|_| ProbeErrorCategory::InvalidInput)?;
-    // SAFETY: The output points to `length` writable bytes and neither pointer is retained.
-    if unsafe {
-        libc::getsockopt(
-            fd,
-            libc::SOL_LOCAL,
-            libc::LOCAL_PEERCRED,
-            credential.as_mut_ptr().cast(),
-            &raw mut length,
-        )
-    } != 0
-    {
-        let error = io::Error::last_os_error();
-        if allow_unsupported && unsupported_errno(error.raw_os_error()) {
-            return Ok(CredentialIdentityClass::Unsupported);
-        }
-        return Err(ProbeErrorCategory::from_io_kind(error.kind()));
-    }
-    if usize::try_from(length).ok() != Some(std::mem::size_of::<libc::xucred>()) {
-        return Err(ProbeErrorCategory::InvalidInput);
-    }
-    // SAFETY: Successful `getsockopt` initialized the complete fixed-size structure.
-    let credential = unsafe { credential.assume_init() };
-    let group_count = usize::try_from(credential.cr_ngroups)
-        .ok()
-        .filter(|count| *count <= credential.cr_groups.len())
-        .ok_or(ProbeErrorCategory::InvalidInput)?;
-    if credential.cr_version != XUCRED_VERSION {
-        return Err(ProbeErrorCategory::InvalidInput);
-    }
-    if group_count == 0 {
-        return Ok(CredentialIdentityClass::Other);
-    }
-    Ok(classify_peer(
-        credential.cr_uid,
-        credential.cr_groups[0],
-        target_uid,
-        target_gid,
-    ))
-}
-
-fn exact_peer_pid(
-    fd: RawFd,
-    expected: libc::pid_t,
-    socket_creator: Option<libc::pid_t>,
-) -> Result<PeerPidClass, ProbeErrorCategory> {
-    classify_peer_pid(crate::macos::peer_pid(fd), expected, socket_creator)
-}
-
-fn classify_peer_pid(
-    result: io::Result<libc::pid_t>,
-    expected: libc::pid_t,
-    socket_creator: Option<libc::pid_t>,
-) -> Result<PeerPidClass, ProbeErrorCategory> {
-    match result {
-        Ok(pid) if pid == expected => Ok(PeerPidClass::Exact),
-        Ok(pid) if Some(pid) == socket_creator => Ok(PeerPidClass::SocketCreator),
-        Ok(_) => Err(ProbeErrorCategory::PermissionDenied),
-        Err(error) if socket_creator.is_some() && unsupported_errno(error.raw_os_error()) => {
-            Ok(PeerPidClass::Unsupported)
-        }
-        Err(error) => Err(ProbeErrorCategory::from_io_kind(error.kind())),
-    }
-}
-
-fn initial_token(fd: RawFd) -> Result<(PeerTokenClass, TokenBaseline), ProbeErrorCategory> {
-    match peer_token(fd)? {
-        Some(token) => Ok((PeerTokenClass::Baseline, TokenBaseline::Value(token))),
-        None => Ok((PeerTokenClass::Unsupported, TokenBaseline::Unsupported)),
-    }
-}
-
-fn later_token(fd: RawFd, baseline: &TokenBaseline) -> Result<PeerTokenClass, ProbeErrorCategory> {
-    match (baseline, peer_token(fd)?) {
-        (TokenBaseline::Unsupported, None) => Ok(PeerTokenClass::Unsupported),
-        (TokenBaseline::Value(expected), Some(actual)) if expected == &actual => {
-            Ok(PeerTokenClass::Unchanged)
-        }
-        (TokenBaseline::Value(_), Some(_)) => Ok(PeerTokenClass::Changed),
-        (TokenBaseline::Unsupported, Some(_)) | (TokenBaseline::Value(_), None) => {
-            Err(ProbeErrorCategory::InvalidInput)
-        }
-    }
-}
-
-fn peer_token(fd: RawFd) -> Result<Option<[u32; AUDIT_TOKEN_WORDS]>, ProbeErrorCategory> {
-    let mut token = [0_u32; AUDIT_TOKEN_WORDS];
-    let mut length = libc::socklen_t::try_from(std::mem::size_of_val(&token))
-        .map_err(|_| ProbeErrorCategory::InvalidInput)?;
-    // SAFETY: `token` points to `length` writable bytes and no pointer is retained.
-    if unsafe {
-        libc::getsockopt(
-            fd,
-            libc::SOL_LOCAL,
-            libc::LOCAL_PEERTOKEN,
-            token.as_mut_ptr().cast(),
-            &raw mut length,
-        )
-    } != 0
-    {
-        let error = io::Error::last_os_error();
-        if unsupported_errno(error.raw_os_error()) {
-            return Ok(None);
-        }
-        return Err(ProbeErrorCategory::from_io_kind(error.kind()));
-    }
-    if usize::try_from(length).ok() != Some(std::mem::size_of_val(&token)) {
-        return Err(ProbeErrorCategory::InvalidInput);
-    }
-    Ok(Some(token))
-}
-
-const fn unsupported_errno(errno: Option<libc::c_int>) -> bool {
-    matches!(
-        errno,
-        Some(libc::EINVAL) | Some(libc::ENOPROTOOPT) | Some(libc::EOPNOTSUPP)
-    )
-}
-
-const fn classify_peer(
+fn target(
+    mode: probe::ProbeMode,
     uid: u32,
     gid: u32,
-    target_uid: u32,
-    target_gid: u32,
-) -> CredentialIdentityClass {
-    if uid == 0 && gid == 0 {
-        if target_uid == 0 && target_gid == 0 {
-            CredentialIdentityClass::InitialAndTarget
-        } else {
-            CredentialIdentityClass::InitialRoot
+) -> Result<production::CredentialTarget, probe::ProbeErrorCategory> {
+    if (!mode.is_credential_pair() && mode != probe::ProbeMode::CredentialControl)
+        || !mode.accepts_target(uid, gid)
+    {
+        return Err(probe::ProbeErrorCategory::InvalidInput);
+    }
+    production::CredentialTarget::new(uid, gid).map_err(|_| probe::ProbeErrorCategory::InvalidInput)
+}
+
+const fn invalid_failure(category: probe::ProbeErrorCategory) -> probe::CredentialFailureValue {
+    probe::CredentialFailureValue::new(
+        probe::CredentialStep::InitialIdentity,
+        category,
+        probe::CredentialPrefix::None,
+        probe::CredentialSelfState::new(
+            probe::CredentialIdentityClass::Other,
+            probe::CredentialGroupClass::Other,
+        ),
+    )
+}
+
+const fn map_transition(
+    value: crate::macos::credential::CredentialTransition,
+) -> CredentialTransition {
+    CredentialTransition {
+        state: map_state(value.state()),
+        prefix: map_prefix(value.prefix()),
+    }
+}
+
+const fn map_failure(value: production::CredentialFailureValue) -> probe::CredentialFailureValue {
+    probe::CredentialFailureValue::new(
+        map_step(value.step()),
+        map_category(value.category()),
+        map_prefix(value.prefix()),
+        map_state(value.state()),
+    )
+}
+
+fn map_observation(
+    value: production::PeerObservation,
+) -> Result<probe::PeerObservation, probe::ProbeErrorCategory> {
+    if value.is_none() {
+        return Ok(probe::PeerObservation::NONE);
+    }
+    probe::PeerObservation::new(
+        map_identity(value.stream_eid()),
+        map_identity(value.stream_cred()),
+        map_pid(value.stream_pid()),
+        map_identity(value.datagram_cred()),
+        map_pid(value.datagram_pid()),
+        map_token(value.datagram_token()),
+    )
+    .map_err(|_| probe::ProbeErrorCategory::InvalidInput)
+}
+
+const fn map_category(value: production::CredentialErrorCategory) -> probe::ProbeErrorCategory {
+    match value {
+        production::CredentialErrorCategory::PermissionDenied => {
+            probe::ProbeErrorCategory::PermissionDenied
         }
-    } else if uid == target_uid && gid == target_gid {
-        CredentialIdentityClass::Target
-    } else {
-        CredentialIdentityClass::Other
+        production::CredentialErrorCategory::InvalidInput => {
+            probe::ProbeErrorCategory::InvalidInput
+        }
+        production::CredentialErrorCategory::Other => probe::ProbeErrorCategory::Other,
+    }
+}
+
+const fn map_step(value: production::CredentialStep) -> probe::CredentialStep {
+    match value {
+        production::CredentialStep::InitialIdentity => probe::CredentialStep::InitialIdentity,
+        production::CredentialStep::ClearGroups => probe::CredentialStep::ClearGroups,
+        production::CredentialStep::ValidateClearedGroups => {
+            probe::CredentialStep::ValidateClearedGroups
+        }
+        production::CredentialStep::SetGid => probe::CredentialStep::SetGid,
+        production::CredentialStep::SetUid => probe::CredentialStep::SetUid,
+        production::CredentialStep::ValidateFinalIdentity => {
+            probe::CredentialStep::ValidateFinalIdentity
+        }
+        production::CredentialStep::RestoreUid => probe::CredentialStep::RestoreUid,
+        production::CredentialStep::RestoreGid => probe::CredentialStep::RestoreGid,
+        production::CredentialStep::RestoreGroups => probe::CredentialStep::RestoreGroups,
+        production::CredentialStep::PeerObservation => probe::CredentialStep::PeerObservation,
+        production::CredentialStep::Protocol => probe::CredentialStep::Protocol,
+    }
+}
+
+const fn map_prefix(value: production::CredentialPrefix) -> probe::CredentialPrefix {
+    match value {
+        production::CredentialPrefix::None => probe::CredentialPrefix::None,
+        production::CredentialPrefix::Initial => probe::CredentialPrefix::Initial,
+        production::CredentialPrefix::GroupsCleared => probe::CredentialPrefix::GroupsCleared,
+        production::CredentialPrefix::GidSet => probe::CredentialPrefix::GidSet,
+        production::CredentialPrefix::UidSet => probe::CredentialPrefix::UidSet,
+        production::CredentialPrefix::FinalIdentity => probe::CredentialPrefix::FinalIdentity,
+        production::CredentialPrefix::Irreversible => probe::CredentialPrefix::Irreversible,
+        production::CredentialPrefix::RetainedRoot => probe::CredentialPrefix::RetainedRoot,
+    }
+}
+
+const fn map_identity(
+    value: production::CredentialIdentityClass,
+) -> probe::CredentialIdentityClass {
+    match value {
+        production::CredentialIdentityClass::NotObserved => {
+            probe::CredentialIdentityClass::NotObserved
+        }
+        production::CredentialIdentityClass::InitialRoot => {
+            probe::CredentialIdentityClass::InitialRoot
+        }
+        production::CredentialIdentityClass::Target => probe::CredentialIdentityClass::Target,
+        production::CredentialIdentityClass::InitialAndTarget => {
+            probe::CredentialIdentityClass::InitialAndTarget
+        }
+        production::CredentialIdentityClass::Other => probe::CredentialIdentityClass::Other,
+        production::CredentialIdentityClass::Unsupported => {
+            probe::CredentialIdentityClass::Unsupported
+        }
+    }
+}
+
+const fn map_groups(value: production::CredentialGroupClass) -> probe::CredentialGroupClass {
+    match value {
+        production::CredentialGroupClass::NotObserved => probe::CredentialGroupClass::NotObserved,
+        production::CredentialGroupClass::Initial => probe::CredentialGroupClass::Initial,
+        production::CredentialGroupClass::EffectiveOnly => {
+            probe::CredentialGroupClass::EffectiveOnly
+        }
+        production::CredentialGroupClass::Other => probe::CredentialGroupClass::Other,
+    }
+}
+
+const fn map_state(value: production::CredentialSelfState) -> probe::CredentialSelfState {
+    probe::CredentialSelfState::new(map_identity(value.identity()), map_groups(value.groups()))
+}
+
+const fn map_pid(value: production::PeerPidClass) -> probe::PeerPidClass {
+    match value {
+        production::PeerPidClass::NotObserved => probe::PeerPidClass::NotObserved,
+        production::PeerPidClass::Exact => probe::PeerPidClass::Exact,
+        production::PeerPidClass::SocketCreator => probe::PeerPidClass::SocketCreator,
+        production::PeerPidClass::Mismatch => probe::PeerPidClass::Mismatch,
+        production::PeerPidClass::Unsupported => probe::PeerPidClass::Unsupported,
+    }
+}
+
+const fn map_token(value: production::PeerTokenClass) -> probe::PeerTokenClass {
+    match value {
+        production::PeerTokenClass::NotObserved => probe::PeerTokenClass::NotObserved,
+        production::PeerTokenClass::Baseline => probe::PeerTokenClass::Baseline,
+        production::PeerTokenClass::Unchanged => probe::PeerTokenClass::Unchanged,
+        production::PeerTokenClass::Changed => probe::PeerTokenClass::Changed,
+        production::PeerTokenClass::Unsupported => probe::PeerTokenClass::Unsupported,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::os::fd::AsRawFd;
-    use std::os::unix::net::{UnixDatagram, UnixStream};
-
     use super::*;
 
-    #[derive(Clone)]
-    struct FakeOps {
-        ids: (u32, u32, u32, u32),
-        groups: Vec<u32>,
-        fail_step: Option<CredentialStep>,
-        groups_fail_at: Option<usize>,
-        group_calls: usize,
-        clear_postcondition_mismatch: bool,
-        target_postcondition_mismatch: bool,
-        restore_uid_result: Result<(), io::ErrorKind>,
-        restore_gid_result: Result<(), io::ErrorKind>,
-        restore_groups_result: Result<(), io::ErrorKind>,
-        calls: Vec<&'static str>,
-    }
-
-    impl FakeOps {
-        fn root() -> Self {
-            Self {
-                ids: (0, 0, 0, 0),
-                groups: vec![0, 1],
-                fail_step: None,
-                groups_fail_at: None,
-                group_calls: 0,
-                clear_postcondition_mismatch: false,
-                target_postcondition_mismatch: false,
-                restore_uid_result: Err(io::ErrorKind::PermissionDenied),
-                restore_gid_result: Err(io::ErrorKind::PermissionDenied),
-                restore_groups_result: Err(io::ErrorKind::PermissionDenied),
-                calls: Vec::new(),
-            }
-        }
-
-        fn fail(&self, step: CredentialStep) -> Result<(), io::ErrorKind> {
-            if self.fail_step == Some(step) {
-                Err(io::ErrorKind::PermissionDenied)
-            } else {
-                Ok(())
-            }
-        }
-    }
-
-    impl CredentialOps for FakeOps {
-        fn ids(&mut self) -> (u32, u32, u32, u32) {
-            self.ids
-        }
-
-        fn groups(&mut self) -> Result<Vec<u32>, io::ErrorKind> {
-            self.group_calls += 1;
-            if self.groups_fail_at == Some(self.group_calls) {
-                return Err(io::ErrorKind::InvalidData);
-            }
-            Ok(self.groups.clone())
-        }
-
-        fn clear_groups(&mut self) -> Result<(), io::ErrorKind> {
-            self.calls.push("setgroups-empty");
-            self.fail(CredentialStep::ClearGroups)?;
-            self.groups = if self.clear_postcondition_mismatch {
-                vec![self.ids.3, 7]
-            } else {
-                vec![self.ids.3]
-            };
-            Ok(())
-        }
-
-        fn set_gid(&mut self, gid: u32) -> Result<(), io::ErrorKind> {
-            if gid == 0 && self.ids.0 != 0 {
-                self.calls.push("setgid-root");
-                if self.restore_gid_result.is_ok() {
-                    self.ids.2 = 0;
-                    self.ids.3 = 0;
-                    if self.groups.len() == 1 {
-                        self.groups[0] = 0;
-                    }
-                }
-                return self.restore_gid_result;
-            }
-            self.calls.push("setgid-target");
-            self.fail(CredentialStep::SetGid)?;
-            self.ids.2 = gid;
-            self.ids.3 = gid;
-            if self.groups.len() == 1 {
-                self.groups[0] = gid;
-            }
-            Ok(())
-        }
-
-        fn set_uid(&mut self, uid: u32) -> Result<(), io::ErrorKind> {
-            if uid == 0 {
-                self.calls.push("setuid-root");
-                if self.restore_uid_result.is_ok() {
-                    self.ids.0 = 0;
-                    self.ids.1 = 0;
-                }
-                return self.restore_uid_result;
-            }
-            self.calls.push("setuid-target");
-            self.fail(CredentialStep::SetUid)?;
-            self.ids.0 = uid;
-            self.ids.1 = if self.target_postcondition_mismatch {
-                uid.wrapping_add(1)
-            } else {
-                uid
-            };
-            Ok(())
-        }
-
-        fn restore_groups(&mut self) -> Result<(), io::ErrorKind> {
-            self.calls.push("setgroups-root");
-            if self.restore_groups_result.is_ok() {
-                self.groups = vec![0];
-            }
-            self.restore_groups_result
-        }
-    }
-
     #[test]
-    fn ordered_drop_clears_groups_sets_gid_then_uid_and_proves_irreversibility() {
-        let mut ops = FakeOps::root();
-        let result = transition_with(&mut ops, ProbeMode::CredentialDrop, 501, 20)
-            .expect("complete transition should succeed");
-        assert_eq!(result.prefix(), CredentialPrefix::Irreversible);
+    fn mode_adapter_accepts_only_exact_credential_modes() {
         assert_eq!(
-            result.state(),
-            CredentialSelfState::new(
-                CredentialIdentityClass::Target,
-                CredentialGroupClass::EffectiveOnly,
-            )
+            target(probe::ProbeMode::CredentialDrop, 501, 20)
+                .expect("mapped target")
+                .mode(),
+            production::CredentialMode::Transition
         );
         assert_eq!(
-            ops.calls,
-            [
-                "setgroups-empty",
-                "setgid-target",
-                "setuid-target",
-                "setuid-root",
-                "setgid-root",
-                "setgroups-root"
-            ]
+            target(probe::ProbeMode::CredentialRetainRoot, 0, 0)
+                .expect("retained root")
+                .mode(),
+            production::CredentialMode::RetainedRoot
         );
+        assert!(target(probe::ProbeMode::Drop, 501, 20).is_err());
+        assert!(target(probe::ProbeMode::CredentialDrop, 0, 0).is_err());
+        assert!(target(probe::ProbeMode::CredentialControl, 0, 1).is_err());
     }
 
     #[test]
-    fn retained_root_calls_no_mutating_credential_operation() {
-        let mut ops = FakeOps::root();
-        let result = transition_with(&mut ops, ProbeMode::CredentialRetainRoot, 0, 0)
-            .expect("retained root should validate");
-        assert_eq!(result.prefix(), CredentialPrefix::RetainedRoot);
-        assert!(ops.calls.is_empty());
-    }
-
-    #[test]
-    fn every_mutating_failure_stops_at_the_exact_prefix() {
-        for (step, prefix) in [
-            (CredentialStep::ClearGroups, CredentialPrefix::Initial),
-            (CredentialStep::SetGid, CredentialPrefix::GroupsCleared),
-            (CredentialStep::SetUid, CredentialPrefix::GidSet),
-        ] {
-            let mut ops = FakeOps::root();
-            ops.fail_step = Some(step);
-            let failure = transition_with(&mut ops, ProbeMode::CredentialDrop, 501, 20)
-                .expect_err("injected failure should stop");
-            assert_eq!(failure.step(), step);
-            assert_eq!(failure.prefix(), prefix);
-        }
-    }
-
-    #[test]
-    fn every_group_query_boundary_stops_with_its_exact_prefix() {
-        for (call, step, prefix) in [
-            (1, CredentialStep::InitialIdentity, CredentialPrefix::None),
-            (
-                2,
-                CredentialStep::ValidateClearedGroups,
-                CredentialPrefix::Initial,
+    fn adapter_containers_remain_redacted() {
+        let transition = CredentialTransition {
+            state: probe::CredentialSelfState::new(
+                probe::CredentialIdentityClass::Target,
+                probe::CredentialGroupClass::EffectiveOnly,
             ),
-            (
-                3,
-                CredentialStep::ValidateFinalIdentity,
-                CredentialPrefix::UidSet,
-            ),
-            (
-                4,
-                CredentialStep::ValidateFinalIdentity,
-                CredentialPrefix::FinalIdentity,
-            ),
-        ] {
-            let mut ops = FakeOps::root();
-            ops.groups_fail_at = Some(call);
-            let failure = transition_with(&mut ops, ProbeMode::CredentialDrop, 501, 20)
-                .expect_err("injected group query failure should stop");
-            assert_eq!(failure.step(), step);
-            assert_eq!(failure.prefix(), prefix);
-            assert_eq!(failure.category(), ProbeErrorCategory::InvalidInput);
-        }
-    }
-
-    #[test]
-    fn postcondition_mismatches_stop_before_restoration_or_ordinary_work() {
-        let mut clear_mismatch = FakeOps::root();
-        clear_mismatch.clear_postcondition_mismatch = true;
-        let failure = transition_with(&mut clear_mismatch, ProbeMode::CredentialDrop, 501, 20)
-            .expect_err("extra supplementary groups must fail");
-        assert_eq!(failure.step(), CredentialStep::ValidateClearedGroups);
-        assert_eq!(failure.prefix(), CredentialPrefix::Initial);
-        assert_eq!(clear_mismatch.calls, ["setgroups-empty"]);
-
-        let mut target_mismatch = FakeOps::root();
-        target_mismatch.target_postcondition_mismatch = true;
-        let failure = transition_with(&mut target_mismatch, ProbeMode::CredentialDrop, 501, 20)
-            .expect_err("mixed target identity must fail");
-        assert_eq!(failure.step(), CredentialStep::ValidateFinalIdentity);
-        assert_eq!(failure.prefix(), CredentialPrefix::UidSet);
+            prefix: probe::CredentialPrefix::Irreversible,
+        };
         assert_eq!(
-            target_mismatch.calls,
-            ["setgroups-empty", "setgid-target", "setuid-target"]
-        );
-    }
-
-    #[test]
-    fn every_root_restoration_outcome_other_than_permission_denied_fails_closed() {
-        let mut uid_restored = FakeOps::root();
-        uid_restored.restore_uid_result = Ok(());
-        let failure = transition_with(&mut uid_restored, ProbeMode::CredentialDrop, 501, 20)
-            .expect_err("restored uid zero must fail closed");
-        assert_eq!(failure.step(), CredentialStep::RestoreUid);
-        assert_eq!(failure.category(), ProbeErrorCategory::Other);
-        assert_eq!(failure.prefix(), CredentialPrefix::FinalIdentity);
-
-        let mut uid_other_error = FakeOps::root();
-        uid_other_error.restore_uid_result = Err(io::ErrorKind::InvalidData);
-        let failure = transition_with(&mut uid_other_error, ProbeMode::CredentialDrop, 501, 20)
-            .expect_err("non-permission uid failure remains distinct");
-        assert_eq!(failure.step(), CredentialStep::RestoreUid);
-        assert_eq!(failure.category(), ProbeErrorCategory::InvalidInput);
-
-        let mut gid_restored = FakeOps::root();
-        gid_restored.restore_gid_result = Ok(());
-        let failure = transition_with(&mut gid_restored, ProbeMode::CredentialDrop, 501, 20)
-            .expect_err("restored gid zero must fail closed");
-        assert_eq!(failure.step(), CredentialStep::RestoreGid);
-        assert_eq!(failure.category(), ProbeErrorCategory::Other);
-
-        let mut groups_restored = FakeOps::root();
-        groups_restored.restore_groups_result = Ok(());
-        let failure = transition_with(&mut groups_restored, ProbeMode::CredentialDrop, 501, 20)
-            .expect_err("restored root access group must fail closed");
-        assert_eq!(failure.step(), CredentialStep::RestoreGroups);
-        assert_eq!(failure.category(), ProbeErrorCategory::Other);
-    }
-
-    #[test]
-    fn initial_identity_and_retained_root_postconditions_are_exact() {
-        let mut nonroot = FakeOps::root();
-        nonroot.ids = (501, 501, 20, 20);
-        let failure = transition_with(&mut nonroot, ProbeMode::CredentialDrop, 501, 20)
-            .expect_err("nonroot initial identity must fail");
-        assert_eq!(failure.step(), CredentialStep::InitialIdentity);
-        assert_eq!(failure.category(), ProbeErrorCategory::PermissionDenied);
-        assert!(nonroot.calls.is_empty());
-
-        let mut retained_query_failure = FakeOps::root();
-        retained_query_failure.groups_fail_at = Some(2);
-        let failure = transition_with(
-            &mut retained_query_failure,
-            ProbeMode::CredentialRetainRoot,
-            0,
-            0,
-        )
-        .expect_err("retained-root final group query must be exact");
-        assert_eq!(failure.step(), CredentialStep::ValidateFinalIdentity);
-        assert_eq!(failure.prefix(), CredentialPrefix::Initial);
-        assert!(retained_query_failure.calls.is_empty());
-    }
-
-    #[test]
-    fn peer_classification_never_exposes_numeric_values() {
-        assert_eq!(
-            classify_peer(0, 0, 501, 20),
-            CredentialIdentityClass::InitialRoot
-        );
-        assert_eq!(
-            classify_peer(501, 20, 501, 20),
-            CredentialIdentityClass::Target
-        );
-        assert_eq!(
-            format!(
-                "{:?}",
-                CredentialTransition {
-                    state: CredentialSelfState::new(
-                        CredentialIdentityClass::Target,
-                        CredentialGroupClass::EffectiveOnly
-                    ),
-                    prefix: CredentialPrefix::Irreversible,
-                }
-            ),
+            format!("{transition:?}"),
             "CredentialTransition(<redacted>)"
-        );
-    }
-
-    #[test]
-    fn connected_stream_and_datagram_observations_keep_identity_surfaces_separate() {
-        let (stream, _stream_peer) = UnixStream::pair().expect("stream pair");
-        let (datagram, datagram_peer) = UnixDatagram::pair().expect("datagram pair");
-        datagram.send(b"p").expect("datagram possession send");
-        let mut possession = [0_u8; 1];
-        datagram_peer
-            .recv(&mut possession)
-            .expect("datagram possession receive");
-        // SAFETY: Credential/PID getters have no pointer or ownership contract.
-        let (pid, uid, gid) = unsafe { (libc::getpid(), libc::geteuid(), libc::getegid()) };
-        let (initial, baseline) =
-            observe_initial_peer(stream.as_raw_fd(), datagram.as_raw_fd(), pid, pid, uid, gid)
-                .expect("current-process peer observations should succeed");
-        assert_eq!(initial.stream_eid(), CredentialIdentityClass::Target);
-        assert_eq!(initial.stream_cred(), CredentialIdentityClass::Target);
-        assert_eq!(initial.stream_pid(), PeerPidClass::Exact);
-        assert!(matches!(
-            initial.datagram_cred(),
-            CredentialIdentityClass::Target | CredentialIdentityClass::Unsupported
-        ));
-        assert_eq!(initial.datagram_pid(), PeerPidClass::Exact);
-        assert!(matches!(
-            initial.datagram_token(),
-            PeerTokenClass::Baseline | PeerTokenClass::Unsupported
-        ));
-        let later = observe_later_peer(
-            stream.as_raw_fd(),
-            datagram.as_raw_fd(),
-            pid,
-            pid,
-            uid,
-            gid,
-            &baseline,
-        )
-        .expect("later current-process observation should succeed");
-        assert_eq!(later.stream_pid(), PeerPidClass::Exact);
-        assert_eq!(later.datagram_pid(), PeerPidClass::Exact);
-        assert!(matches!(
-            later.datagram_token(),
-            PeerTokenClass::Unchanged | PeerTokenClass::Unsupported
-        ));
-        assert_eq!(format!("{baseline:?}"), "PeerBaseline(<redacted>)");
-
-        assert_eq!(
-            exact_peer_pid(datagram.as_raw_fd(), pid.wrapping_add(1), Some(pid)),
-            Ok(PeerPidClass::SocketCreator)
-        );
-        assert!(exact_peer_pid(datagram.as_raw_fd(), pid.wrapping_add(1), None).is_err());
-        assert_eq!(
-            classify_peer_pid(
-                Err(io::Error::from_raw_os_error(libc::ENOPROTOOPT)),
-                pid,
-                Some(pid),
-            ),
-            Ok(PeerPidClass::Unsupported)
-        );
-        assert!(
-            classify_peer_pid(
-                Err(io::Error::from_raw_os_error(libc::ENOPROTOOPT)),
-                pid,
-                None,
-            )
-            .is_err(),
-            "stream LOCAL_PEERPID remains a required surface"
-        );
-        assert!(stream_eid(datagram.as_raw_fd(), uid, gid).is_err());
-        assert!(
-            matches!(
-                observe_initial_peer(datagram.as_raw_fd(), stream.as_raw_fd(), pid, pid, uid, gid,),
-                Err(ProbeErrorCategory::InvalidInput)
-            ),
-            "stream and datagram descriptor roles must not be interchangeable"
         );
     }
 }

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -1,6 +1,7 @@
 //! Private launcher-worker session protocol and macOS ownership primitives.
 
 mod codec;
+pub mod credential;
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
 #[doc(hidden)]
 pub mod elevated_credential;

--- a/crates/session/src/macos.rs
+++ b/crates/session/src/macos.rs
@@ -7,6 +7,7 @@ use std::os::fd::RawFd;
 pub mod api_listener;
 pub mod block_control;
 pub mod bookmark;
+pub mod credential;
 pub mod grant_registry;
 pub mod grant_transport;
 #[cfg(feature = "elevated-bootstrap-probe")]

--- a/crates/session/src/macos/credential.rs
+++ b/crates/session/src/macos/credential.rs
@@ -1,0 +1,1079 @@
+//! Darwin production credential-transition and peer-observation primitives.
+
+use std::io;
+use std::mem::MaybeUninit;
+use std::os::fd::RawFd;
+
+use crate::credential::{
+    CredentialErrorCategory, CredentialFailureValue, CredentialGroupClass, CredentialIdentityClass,
+    CredentialMode, CredentialPrefix, CredentialSelfState, CredentialStep, CredentialTarget,
+    PeerObservation, PeerPidClass, PeerTokenClass,
+};
+
+const MAX_SUPPLEMENTARY_GROUPS: usize = 1_024;
+const XUCRED_VERSION: libc::c_uint = 0;
+const AUDIT_TOKEN_WORDS: usize = 8;
+
+/// Complete value-free postcondition of one process credential transition.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CredentialTransition {
+    state: CredentialSelfState,
+    prefix: CredentialPrefix,
+}
+
+impl CredentialTransition {
+    /// Returns the exact final self-state class.
+    #[must_use]
+    pub const fn state(self) -> CredentialSelfState {
+        self.state
+    }
+
+    /// Returns the complete ordered prefix.
+    #[must_use]
+    pub const fn prefix(self) -> CredentialPrefix {
+        self.prefix
+    }
+}
+
+impl std::fmt::Debug for CredentialTransition {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("CredentialTransition(<redacted>)")
+    }
+}
+
+/// Opaque initial peer state retained only for later semantic comparison.
+pub struct PeerBaseline {
+    datagram_token: TokenBaseline,
+}
+
+impl std::fmt::Debug for PeerBaseline {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("PeerBaseline(<redacted>)")
+    }
+}
+
+enum TokenBaseline {
+    Unsupported,
+    Value([u32; AUDIT_TOKEN_WORDS]),
+}
+
+/// Performs the exact no-chroot credential transition for one production endpoint.
+pub fn transition_process(
+    target: CredentialTarget,
+) -> Result<CredentialTransition, CredentialFailureValue> {
+    transition_with(&mut DarwinCredentialOps, target)
+}
+
+/// Re-attests the exact local post-transition identity before runtime work.
+pub fn attest_current_process(
+    target: CredentialTarget,
+) -> Result<CredentialSelfState, CredentialErrorCategory> {
+    let mut ops = DarwinCredentialOps;
+    let identities = ops.ids();
+    let groups = ops
+        .groups()
+        .map_err(CredentialErrorCategory::from_io_kind)?;
+    if target.mode() == CredentialMode::RetainedRoot {
+        if identities != (0, 0, 0, 0) {
+            return Err(CredentialErrorCategory::PermissionDenied);
+        }
+        return Ok(CredentialSelfState::new(
+            CredentialIdentityClass::InitialAndTarget,
+            CredentialGroupClass::Initial,
+        ));
+    }
+    if identities != (target.uid(), target.uid(), target.gid(), target.gid())
+        || groups.as_slice() != [target.gid()]
+    {
+        return Err(CredentialErrorCategory::PermissionDenied);
+    }
+    Ok(CredentialSelfState::new(
+        CredentialIdentityClass::Target,
+        CredentialGroupClass::EffectiveOnly,
+    ))
+}
+
+/// Captures the initial connected stream/datagram peer observation.
+pub fn observe_initial_peer(
+    stream: RawFd,
+    datagram: RawFd,
+    expected_pid: libc::pid_t,
+    socket_creator_pid: libc::pid_t,
+    target: CredentialTarget,
+) -> Result<(PeerObservation, PeerBaseline), CredentialErrorCategory> {
+    validate_socket_type(stream, libc::SOCK_STREAM)?;
+    validate_socket_type(datagram, libc::SOCK_DGRAM)?;
+    let stream_eid = stream_eid(stream, target.uid(), target.gid())?;
+    let stream_cred = local_peercred(stream, false, target.uid(), target.gid())?;
+    let stream_pid = exact_peer_pid(stream, expected_pid, None)?;
+    let datagram_cred = local_peercred(datagram, true, target.uid(), target.gid())?;
+    let datagram_pid = exact_peer_pid(datagram, expected_pid, Some(socket_creator_pid))?;
+    let (datagram_token, baseline) = initial_token(datagram)?;
+    let observation = PeerObservation::new(
+        stream_eid,
+        stream_cred,
+        stream_pid,
+        datagram_cred,
+        datagram_pid,
+        datagram_token,
+    )
+    .map_err(|_| CredentialErrorCategory::InvalidInput)?;
+    Ok((
+        observation,
+        PeerBaseline {
+            datagram_token: baseline,
+        },
+    ))
+}
+
+/// Captures one later peer observation relative to the exact initial baseline.
+pub fn observe_later_peer(
+    stream: RawFd,
+    datagram: RawFd,
+    expected_pid: libc::pid_t,
+    socket_creator_pid: libc::pid_t,
+    target: CredentialTarget,
+    baseline: &PeerBaseline,
+) -> Result<PeerObservation, CredentialErrorCategory> {
+    validate_socket_type(stream, libc::SOCK_STREAM)?;
+    validate_socket_type(datagram, libc::SOCK_DGRAM)?;
+    PeerObservation::new(
+        stream_eid(stream, target.uid(), target.gid())?,
+        local_peercred(stream, false, target.uid(), target.gid())?,
+        exact_peer_pid(stream, expected_pid, None)?,
+        local_peercred(datagram, true, target.uid(), target.gid())?,
+        exact_peer_pid(datagram, expected_pid, Some(socket_creator_pid))?,
+        later_token(datagram, &baseline.datagram_token)?,
+    )
+    .map_err(|_| CredentialErrorCategory::InvalidInput)
+}
+
+trait CredentialOps {
+    fn ids(&mut self) -> (u32, u32, u32, u32);
+    fn groups(&mut self) -> Result<Vec<u32>, io::ErrorKind>;
+    fn clear_groups(&mut self) -> Result<(), io::ErrorKind>;
+    fn set_gid(&mut self, gid: u32) -> Result<(), io::ErrorKind>;
+    fn set_uid(&mut self, uid: u32) -> Result<(), io::ErrorKind>;
+    fn restore_groups(&mut self) -> Result<(), io::ErrorKind>;
+}
+
+struct DarwinCredentialOps;
+
+impl CredentialOps for DarwinCredentialOps {
+    fn ids(&mut self) -> (u32, u32, u32, u32) {
+        // SAFETY: Credential getters have no pointer or ownership contract.
+        unsafe {
+            (
+                libc::getuid(),
+                libc::geteuid(),
+                libc::getgid(),
+                libc::getegid(),
+            )
+        }
+    }
+
+    fn groups(&mut self) -> Result<Vec<u32>, io::ErrorKind> {
+        // SAFETY: A zero-length query does not dereference the null pointer.
+        let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+        let count = usize::try_from(count).map_err(|_| io::Error::last_os_error().kind())?;
+        if count > MAX_SUPPLEMENTARY_GROUPS {
+            return Err(io::ErrorKind::InvalidData);
+        }
+        let mut groups = vec![0; count];
+        let pointer = if groups.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            groups.as_mut_ptr()
+        };
+        let capacity =
+            libc::c_int::try_from(groups.len()).map_err(|_| io::ErrorKind::InvalidData)?;
+        // SAFETY: `pointer` is null for zero capacity or points to `capacity`
+        // writable gid slots for the duration of the synchronous call.
+        let actual = unsafe { libc::getgroups(capacity, pointer) };
+        let actual = usize::try_from(actual).map_err(|_| io::Error::last_os_error().kind())?;
+        if actual != groups.len() {
+            return Err(io::ErrorKind::InvalidData);
+        }
+        Ok(groups)
+    }
+
+    fn clear_groups(&mut self) -> Result<(), io::ErrorKind> {
+        // SAFETY: A zero-length group update does not dereference the null pointer.
+        cvt(unsafe { libc::setgroups(0, std::ptr::null()) })
+    }
+
+    fn set_gid(&mut self, gid: u32) -> Result<(), io::ErrorKind> {
+        // SAFETY: The numeric gid is passed by value and no state is borrowed.
+        cvt(unsafe { libc::setgid(gid) })
+    }
+
+    fn set_uid(&mut self, uid: u32) -> Result<(), io::ErrorKind> {
+        // SAFETY: The numeric uid is passed by value and no state is borrowed.
+        cvt(unsafe { libc::setuid(uid) })
+    }
+
+    fn restore_groups(&mut self) -> Result<(), io::ErrorKind> {
+        let root: libc::gid_t = 0;
+        // SAFETY: `root` is one live gid value for the synchronous call.
+        cvt(unsafe { libc::setgroups(1, &raw const root) })
+    }
+}
+
+fn transition_with<O: CredentialOps>(
+    ops: &mut O,
+    target: CredentialTarget,
+) -> Result<CredentialTransition, CredentialFailureValue> {
+    let target_uid = target.uid();
+    let target_gid = target.gid();
+    let retains_root = target.mode() == CredentialMode::RetainedRoot;
+
+    let initial_groups = ops.groups().map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::InitialIdentity,
+            kind,
+            CredentialPrefix::None,
+            target_uid,
+            target_gid,
+            &[],
+        )
+    })?;
+    if ops.ids() != (0, 0, 0, 0) {
+        return Err(failure_category(
+            ops,
+            CredentialStep::InitialIdentity,
+            CredentialErrorCategory::PermissionDenied,
+            CredentialPrefix::None,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        ));
+    }
+
+    if retains_root {
+        let final_groups = ops.groups().map_err(|kind| {
+            failure(
+                ops,
+                CredentialStep::ValidateFinalIdentity,
+                kind,
+                CredentialPrefix::Initial,
+                target_uid,
+                target_gid,
+                &initial_groups,
+            )
+        })?;
+        if ops.ids() != (0, 0, 0, 0) || final_groups != initial_groups {
+            return Err(failure_category(
+                ops,
+                CredentialStep::ValidateFinalIdentity,
+                CredentialErrorCategory::InvalidInput,
+                CredentialPrefix::Initial,
+                target_uid,
+                target_gid,
+                &initial_groups,
+            ));
+        }
+        return Ok(CredentialTransition {
+            state: CredentialSelfState::new(
+                CredentialIdentityClass::InitialAndTarget,
+                CredentialGroupClass::Initial,
+            ),
+            prefix: CredentialPrefix::RetainedRoot,
+        });
+    }
+
+    ops.clear_groups().map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::ClearGroups,
+            kind,
+            CredentialPrefix::Initial,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    let groups = ops.groups().map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::ValidateClearedGroups,
+            kind,
+            CredentialPrefix::Initial,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    if groups.as_slice() != [0] {
+        return Err(failure_category(
+            ops,
+            CredentialStep::ValidateClearedGroups,
+            CredentialErrorCategory::InvalidInput,
+            CredentialPrefix::Initial,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        ));
+    }
+
+    ops.set_gid(target_gid).map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::SetGid,
+            kind,
+            CredentialPrefix::GroupsCleared,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    ops.set_uid(target_uid).map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::SetUid,
+            kind,
+            CredentialPrefix::GidSet,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+
+    validate_target(ops, target_uid, target_gid).map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::ValidateFinalIdentity,
+            kind,
+            CredentialPrefix::UidSet,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+
+    expect_permission_denied(ops.set_uid(0)).map_err(|category| {
+        failure_category(
+            ops,
+            CredentialStep::RestoreUid,
+            category,
+            CredentialPrefix::FinalIdentity,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    expect_permission_denied(ops.set_gid(0)).map_err(|category| {
+        failure_category(
+            ops,
+            CredentialStep::RestoreGid,
+            category,
+            CredentialPrefix::FinalIdentity,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    expect_permission_denied(ops.restore_groups()).map_err(|category| {
+        failure_category(
+            ops,
+            CredentialStep::RestoreGroups,
+            category,
+            CredentialPrefix::FinalIdentity,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+    validate_target(ops, target_uid, target_gid).map_err(|kind| {
+        failure(
+            ops,
+            CredentialStep::ValidateFinalIdentity,
+            kind,
+            CredentialPrefix::FinalIdentity,
+            target_uid,
+            target_gid,
+            &initial_groups,
+        )
+    })?;
+
+    Ok(CredentialTransition {
+        state: CredentialSelfState::new(
+            CredentialIdentityClass::Target,
+            CredentialGroupClass::EffectiveOnly,
+        ),
+        prefix: CredentialPrefix::Irreversible,
+    })
+}
+
+fn validate_target<O: CredentialOps>(
+    ops: &mut O,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<(), io::ErrorKind> {
+    if ops.ids() != (target_uid, target_uid, target_gid, target_gid) {
+        return Err(io::ErrorKind::InvalidData);
+    }
+    if ops.groups()?.as_slice() != [target_gid] {
+        return Err(io::ErrorKind::InvalidData);
+    }
+    Ok(())
+}
+
+fn expect_permission_denied(
+    result: Result<(), io::ErrorKind>,
+) -> Result<(), CredentialErrorCategory> {
+    match result {
+        Err(io::ErrorKind::PermissionDenied) => Ok(()),
+        Ok(()) => Err(CredentialErrorCategory::Other),
+        Err(kind) => Err(CredentialErrorCategory::from_io_kind(kind)),
+    }
+}
+
+fn failure<O: CredentialOps>(
+    ops: &mut O,
+    step: CredentialStep,
+    kind: io::ErrorKind,
+    prefix: CredentialPrefix,
+    target_uid: u32,
+    target_gid: u32,
+    initial_groups: &[u32],
+) -> CredentialFailureValue {
+    failure_category(
+        ops,
+        step,
+        CredentialErrorCategory::from_io_kind(kind),
+        prefix,
+        target_uid,
+        target_gid,
+        initial_groups,
+    )
+}
+
+fn failure_category<O: CredentialOps>(
+    ops: &mut O,
+    step: CredentialStep,
+    category: CredentialErrorCategory,
+    prefix: CredentialPrefix,
+    target_uid: u32,
+    target_gid: u32,
+    initial_groups: &[u32],
+) -> CredentialFailureValue {
+    CredentialFailureValue::new(
+        step,
+        category,
+        prefix,
+        classify_self(ops, target_uid, target_gid, initial_groups),
+    )
+}
+
+fn classify_self<O: CredentialOps>(
+    ops: &mut O,
+    target_uid: u32,
+    target_gid: u32,
+    initial_groups: &[u32],
+) -> CredentialSelfState {
+    let (uid, euid, gid, egid) = ops.ids();
+    let identity = if (uid, euid, gid, egid) == (0, 0, 0, 0) {
+        if target_uid == 0 && target_gid == 0 {
+            CredentialIdentityClass::InitialAndTarget
+        } else {
+            CredentialIdentityClass::InitialRoot
+        }
+    } else if (uid, euid, gid, egid) == (target_uid, target_uid, target_gid, target_gid) {
+        CredentialIdentityClass::Target
+    } else {
+        CredentialIdentityClass::Other
+    };
+    let groups = match ops.groups() {
+        Ok(groups) if groups == initial_groups => CredentialGroupClass::Initial,
+        Ok(groups) if groups.as_slice() == [gid] => CredentialGroupClass::EffectiveOnly,
+        Ok(_) | Err(_) => CredentialGroupClass::Other,
+    };
+    CredentialSelfState::new(identity, groups)
+}
+
+fn cvt(result: libc::c_int) -> Result<(), io::ErrorKind> {
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error().kind())
+    }
+}
+
+fn validate_socket_type(fd: RawFd, expected: libc::c_int) -> Result<(), CredentialErrorCategory> {
+    let mut actual = 0;
+    let mut length = libc::socklen_t::try_from(std::mem::size_of::<libc::c_int>())
+        .map_err(|_| CredentialErrorCategory::InvalidInput)?;
+    // SAFETY: `actual` and `length` are writable for the synchronous option query.
+    if unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_TYPE,
+            (&raw mut actual).cast(),
+            &raw mut length,
+        )
+    } != 0
+    {
+        return Err(CredentialErrorCategory::from_io_kind(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    if usize::try_from(length).ok() != Some(std::mem::size_of::<libc::c_int>())
+        || actual != expected
+    {
+        return Err(CredentialErrorCategory::InvalidInput);
+    }
+    Ok(())
+}
+
+fn stream_eid(
+    fd: RawFd,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<CredentialIdentityClass, CredentialErrorCategory> {
+    let mut uid = 0;
+    let mut gid = 0;
+    // SAFETY: Both credential outputs are writable and `fd` remains owned by the caller.
+    if unsafe { libc::getpeereid(fd, &raw mut uid, &raw mut gid) } != 0 {
+        return Err(CredentialErrorCategory::from_io_kind(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    Ok(classify_peer(uid, gid, target_uid, target_gid))
+}
+
+fn local_peercred(
+    fd: RawFd,
+    allow_unsupported: bool,
+    target_uid: u32,
+    target_gid: u32,
+) -> Result<CredentialIdentityClass, CredentialErrorCategory> {
+    let mut credential = MaybeUninit::<libc::xucred>::zeroed();
+    let mut length = libc::socklen_t::try_from(std::mem::size_of::<libc::xucred>())
+        .map_err(|_| CredentialErrorCategory::InvalidInput)?;
+    // SAFETY: The output points to `length` writable bytes and neither pointer is retained.
+    if unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERCRED,
+            credential.as_mut_ptr().cast(),
+            &raw mut length,
+        )
+    } != 0
+    {
+        let error = io::Error::last_os_error();
+        if allow_unsupported && unsupported_errno(error.raw_os_error()) {
+            return Ok(CredentialIdentityClass::Unsupported);
+        }
+        return Err(CredentialErrorCategory::from_io_kind(error.kind()));
+    }
+    if usize::try_from(length).ok() != Some(std::mem::size_of::<libc::xucred>()) {
+        return Err(CredentialErrorCategory::InvalidInput);
+    }
+    // SAFETY: Successful `getsockopt` initialized the complete fixed-size structure.
+    let credential = unsafe { credential.assume_init() };
+    let group_count = usize::try_from(credential.cr_ngroups)
+        .ok()
+        .filter(|count| *count <= credential.cr_groups.len())
+        .ok_or(CredentialErrorCategory::InvalidInput)?;
+    if credential.cr_version != XUCRED_VERSION {
+        return Err(CredentialErrorCategory::InvalidInput);
+    }
+    if group_count == 0 {
+        return Ok(CredentialIdentityClass::Other);
+    }
+    Ok(classify_peer(
+        credential.cr_uid,
+        credential.cr_groups[0],
+        target_uid,
+        target_gid,
+    ))
+}
+
+fn exact_peer_pid(
+    fd: RawFd,
+    expected: libc::pid_t,
+    socket_creator: Option<libc::pid_t>,
+) -> Result<PeerPidClass, CredentialErrorCategory> {
+    classify_peer_pid(crate::macos::peer_pid(fd), expected, socket_creator)
+}
+
+fn classify_peer_pid(
+    result: io::Result<libc::pid_t>,
+    expected: libc::pid_t,
+    socket_creator: Option<libc::pid_t>,
+) -> Result<PeerPidClass, CredentialErrorCategory> {
+    match result {
+        Ok(pid) if pid == expected => Ok(PeerPidClass::Exact),
+        Ok(pid) if Some(pid) == socket_creator => Ok(PeerPidClass::SocketCreator),
+        Ok(_) => Err(CredentialErrorCategory::PermissionDenied),
+        Err(error) if socket_creator.is_some() && unsupported_errno(error.raw_os_error()) => {
+            Ok(PeerPidClass::Unsupported)
+        }
+        Err(error) => Err(CredentialErrorCategory::from_io_kind(error.kind())),
+    }
+}
+
+fn initial_token(fd: RawFd) -> Result<(PeerTokenClass, TokenBaseline), CredentialErrorCategory> {
+    match peer_token(fd)? {
+        Some(token) => Ok((PeerTokenClass::Baseline, TokenBaseline::Value(token))),
+        None => Ok((PeerTokenClass::Unsupported, TokenBaseline::Unsupported)),
+    }
+}
+
+fn later_token(
+    fd: RawFd,
+    baseline: &TokenBaseline,
+) -> Result<PeerTokenClass, CredentialErrorCategory> {
+    match (baseline, peer_token(fd)?) {
+        (TokenBaseline::Unsupported, None) => Ok(PeerTokenClass::Unsupported),
+        (TokenBaseline::Value(expected), Some(actual)) if expected == &actual => {
+            Ok(PeerTokenClass::Unchanged)
+        }
+        (TokenBaseline::Value(_), Some(_)) => Ok(PeerTokenClass::Changed),
+        (TokenBaseline::Unsupported, Some(_)) | (TokenBaseline::Value(_), None) => {
+            Err(CredentialErrorCategory::InvalidInput)
+        }
+    }
+}
+
+fn peer_token(fd: RawFd) -> Result<Option<[u32; AUDIT_TOKEN_WORDS]>, CredentialErrorCategory> {
+    let mut token = [0_u32; AUDIT_TOKEN_WORDS];
+    let mut length = libc::socklen_t::try_from(std::mem::size_of_val(&token))
+        .map_err(|_| CredentialErrorCategory::InvalidInput)?;
+    // SAFETY: `token` points to `length` writable bytes and no pointer is retained.
+    if unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERTOKEN,
+            token.as_mut_ptr().cast(),
+            &raw mut length,
+        )
+    } != 0
+    {
+        let error = io::Error::last_os_error();
+        if unsupported_errno(error.raw_os_error()) {
+            return Ok(None);
+        }
+        return Err(CredentialErrorCategory::from_io_kind(error.kind()));
+    }
+    if usize::try_from(length).ok() != Some(std::mem::size_of_val(&token)) {
+        return Err(CredentialErrorCategory::InvalidInput);
+    }
+    Ok(Some(token))
+}
+
+const fn unsupported_errno(errno: Option<libc::c_int>) -> bool {
+    matches!(
+        errno,
+        Some(libc::EINVAL) | Some(libc::ENOPROTOOPT) | Some(libc::EOPNOTSUPP)
+    )
+}
+
+const fn classify_peer(
+    uid: u32,
+    gid: u32,
+    target_uid: u32,
+    target_gid: u32,
+) -> CredentialIdentityClass {
+    if uid == 0 && gid == 0 {
+        if target_uid == 0 && target_gid == 0 {
+            CredentialIdentityClass::InitialAndTarget
+        } else {
+            CredentialIdentityClass::InitialRoot
+        }
+    } else if uid == target_uid && gid == target_gid {
+        CredentialIdentityClass::Target
+    } else {
+        CredentialIdentityClass::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::{UnixDatagram, UnixStream};
+
+    use super::*;
+
+    fn target(uid: u32, gid: u32) -> CredentialTarget {
+        CredentialTarget::new(uid, gid).expect("test target should be valid")
+    }
+
+    #[derive(Clone)]
+    struct FakeOps {
+        ids: (u32, u32, u32, u32),
+        groups: Vec<u32>,
+        fail_step: Option<CredentialStep>,
+        groups_fail_at: Option<usize>,
+        group_calls: usize,
+        clear_postcondition_mismatch: bool,
+        target_postcondition_mismatch: bool,
+        restore_uid_result: Result<(), io::ErrorKind>,
+        restore_gid_result: Result<(), io::ErrorKind>,
+        restore_groups_result: Result<(), io::ErrorKind>,
+        calls: Vec<&'static str>,
+    }
+
+    impl FakeOps {
+        fn root() -> Self {
+            Self {
+                ids: (0, 0, 0, 0),
+                groups: vec![0, 1],
+                fail_step: None,
+                groups_fail_at: None,
+                group_calls: 0,
+                clear_postcondition_mismatch: false,
+                target_postcondition_mismatch: false,
+                restore_uid_result: Err(io::ErrorKind::PermissionDenied),
+                restore_gid_result: Err(io::ErrorKind::PermissionDenied),
+                restore_groups_result: Err(io::ErrorKind::PermissionDenied),
+                calls: Vec::new(),
+            }
+        }
+
+        fn fail(&self, step: CredentialStep) -> Result<(), io::ErrorKind> {
+            if self.fail_step == Some(step) {
+                Err(io::ErrorKind::PermissionDenied)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl CredentialOps for FakeOps {
+        fn ids(&mut self) -> (u32, u32, u32, u32) {
+            self.ids
+        }
+
+        fn groups(&mut self) -> Result<Vec<u32>, io::ErrorKind> {
+            self.group_calls += 1;
+            if self.groups_fail_at == Some(self.group_calls) {
+                return Err(io::ErrorKind::InvalidData);
+            }
+            Ok(self.groups.clone())
+        }
+
+        fn clear_groups(&mut self) -> Result<(), io::ErrorKind> {
+            self.calls.push("setgroups-empty");
+            self.fail(CredentialStep::ClearGroups)?;
+            self.groups = if self.clear_postcondition_mismatch {
+                vec![self.ids.3, 7]
+            } else {
+                vec![self.ids.3]
+            };
+            Ok(())
+        }
+
+        fn set_gid(&mut self, gid: u32) -> Result<(), io::ErrorKind> {
+            if gid == 0 && self.ids.0 != 0 {
+                self.calls.push("setgid-root");
+                if self.restore_gid_result.is_ok() {
+                    self.ids.2 = 0;
+                    self.ids.3 = 0;
+                    if self.groups.len() == 1 {
+                        self.groups[0] = 0;
+                    }
+                }
+                return self.restore_gid_result;
+            }
+            self.calls.push("setgid-target");
+            self.fail(CredentialStep::SetGid)?;
+            self.ids.2 = gid;
+            self.ids.3 = gid;
+            if self.groups.len() == 1 {
+                self.groups[0] = gid;
+            }
+            Ok(())
+        }
+
+        fn set_uid(&mut self, uid: u32) -> Result<(), io::ErrorKind> {
+            if uid == 0 {
+                self.calls.push("setuid-root");
+                if self.restore_uid_result.is_ok() {
+                    self.ids.0 = 0;
+                    self.ids.1 = 0;
+                }
+                return self.restore_uid_result;
+            }
+            self.calls.push("setuid-target");
+            self.fail(CredentialStep::SetUid)?;
+            self.ids.0 = uid;
+            self.ids.1 = if self.target_postcondition_mismatch {
+                uid.wrapping_add(1)
+            } else {
+                uid
+            };
+            Ok(())
+        }
+
+        fn restore_groups(&mut self) -> Result<(), io::ErrorKind> {
+            self.calls.push("setgroups-root");
+            if self.restore_groups_result.is_ok() {
+                self.groups = vec![0];
+            }
+            self.restore_groups_result
+        }
+    }
+
+    #[test]
+    fn ordered_drop_clears_groups_sets_gid_then_uid_and_proves_irreversibility() {
+        let mut ops = FakeOps::root();
+        let result =
+            transition_with(&mut ops, target(501, 20)).expect("complete transition should succeed");
+        assert_eq!(result.prefix(), CredentialPrefix::Irreversible);
+        assert_eq!(
+            result.state(),
+            CredentialSelfState::new(
+                CredentialIdentityClass::Target,
+                CredentialGroupClass::EffectiveOnly,
+            )
+        );
+        assert_eq!(
+            ops.calls,
+            [
+                "setgroups-empty",
+                "setgid-target",
+                "setuid-target",
+                "setuid-root",
+                "setgid-root",
+                "setgroups-root"
+            ]
+        );
+    }
+
+    #[test]
+    fn retained_root_calls_no_mutating_credential_operation() {
+        let mut ops = FakeOps::root();
+        let result =
+            transition_with(&mut ops, target(0, 0)).expect("retained root should validate");
+        assert_eq!(result.prefix(), CredentialPrefix::RetainedRoot);
+        assert!(ops.calls.is_empty());
+    }
+
+    #[test]
+    fn every_mutating_failure_stops_at_the_exact_prefix() {
+        for (step, prefix) in [
+            (CredentialStep::ClearGroups, CredentialPrefix::Initial),
+            (CredentialStep::SetGid, CredentialPrefix::GroupsCleared),
+            (CredentialStep::SetUid, CredentialPrefix::GidSet),
+        ] {
+            let mut ops = FakeOps::root();
+            ops.fail_step = Some(step);
+            let failure = transition_with(&mut ops, target(501, 20))
+                .expect_err("injected failure should stop");
+            assert_eq!(failure.step(), step);
+            assert_eq!(failure.prefix(), prefix);
+        }
+    }
+
+    #[test]
+    fn every_group_query_boundary_stops_with_its_exact_prefix() {
+        for (call, step, prefix) in [
+            (1, CredentialStep::InitialIdentity, CredentialPrefix::None),
+            (
+                2,
+                CredentialStep::ValidateClearedGroups,
+                CredentialPrefix::Initial,
+            ),
+            (
+                3,
+                CredentialStep::ValidateFinalIdentity,
+                CredentialPrefix::UidSet,
+            ),
+            (
+                4,
+                CredentialStep::ValidateFinalIdentity,
+                CredentialPrefix::FinalIdentity,
+            ),
+        ] {
+            let mut ops = FakeOps::root();
+            ops.groups_fail_at = Some(call);
+            let failure = transition_with(&mut ops, target(501, 20))
+                .expect_err("injected group query failure should stop");
+            assert_eq!(failure.step(), step);
+            assert_eq!(failure.prefix(), prefix);
+            assert_eq!(failure.category(), CredentialErrorCategory::InvalidInput);
+        }
+    }
+
+    #[test]
+    fn postcondition_mismatches_stop_before_restoration_or_ordinary_work() {
+        let mut clear_mismatch = FakeOps::root();
+        clear_mismatch.clear_postcondition_mismatch = true;
+        let failure = transition_with(&mut clear_mismatch, target(501, 20))
+            .expect_err("extra supplementary groups must fail");
+        assert_eq!(failure.step(), CredentialStep::ValidateClearedGroups);
+        assert_eq!(failure.prefix(), CredentialPrefix::Initial);
+        assert_eq!(clear_mismatch.calls, ["setgroups-empty"]);
+
+        let mut target_mismatch = FakeOps::root();
+        target_mismatch.target_postcondition_mismatch = true;
+        let failure = transition_with(&mut target_mismatch, target(501, 20))
+            .expect_err("mixed target identity must fail");
+        assert_eq!(failure.step(), CredentialStep::ValidateFinalIdentity);
+        assert_eq!(failure.prefix(), CredentialPrefix::UidSet);
+        assert_eq!(
+            target_mismatch.calls,
+            ["setgroups-empty", "setgid-target", "setuid-target"]
+        );
+    }
+
+    #[test]
+    fn every_root_restoration_outcome_other_than_permission_denied_fails_closed() {
+        let mut uid_restored = FakeOps::root();
+        uid_restored.restore_uid_result = Ok(());
+        let failure = transition_with(&mut uid_restored, target(501, 20))
+            .expect_err("restored uid zero must fail closed");
+        assert_eq!(failure.step(), CredentialStep::RestoreUid);
+        assert_eq!(failure.category(), CredentialErrorCategory::Other);
+        assert_eq!(failure.prefix(), CredentialPrefix::FinalIdentity);
+
+        let mut uid_other_error = FakeOps::root();
+        uid_other_error.restore_uid_result = Err(io::ErrorKind::InvalidData);
+        let failure = transition_with(&mut uid_other_error, target(501, 20))
+            .expect_err("non-permission uid failure remains distinct");
+        assert_eq!(failure.step(), CredentialStep::RestoreUid);
+        assert_eq!(failure.category(), CredentialErrorCategory::InvalidInput);
+
+        let mut gid_restored = FakeOps::root();
+        gid_restored.restore_gid_result = Ok(());
+        let failure = transition_with(&mut gid_restored, target(501, 20))
+            .expect_err("restored gid zero must fail closed");
+        assert_eq!(failure.step(), CredentialStep::RestoreGid);
+        assert_eq!(failure.category(), CredentialErrorCategory::Other);
+
+        let mut groups_restored = FakeOps::root();
+        groups_restored.restore_groups_result = Ok(());
+        let failure = transition_with(&mut groups_restored, target(501, 20))
+            .expect_err("restored root access group must fail closed");
+        assert_eq!(failure.step(), CredentialStep::RestoreGroups);
+        assert_eq!(failure.category(), CredentialErrorCategory::Other);
+    }
+
+    #[test]
+    fn initial_identity_and_retained_root_postconditions_are_exact() {
+        let mut nonroot = FakeOps::root();
+        nonroot.ids = (501, 501, 20, 20);
+        let failure = transition_with(&mut nonroot, target(501, 20))
+            .expect_err("nonroot initial identity must fail");
+        assert_eq!(failure.step(), CredentialStep::InitialIdentity);
+        assert_eq!(
+            failure.category(),
+            CredentialErrorCategory::PermissionDenied
+        );
+        assert!(nonroot.calls.is_empty());
+
+        let mut retained_query_failure = FakeOps::root();
+        retained_query_failure.groups_fail_at = Some(2);
+        let failure = transition_with(&mut retained_query_failure, target(0, 0))
+            .expect_err("retained-root final group query must be exact");
+        assert_eq!(failure.step(), CredentialStep::ValidateFinalIdentity);
+        assert_eq!(failure.prefix(), CredentialPrefix::Initial);
+        assert!(retained_query_failure.calls.is_empty());
+    }
+
+    #[test]
+    fn peer_classification_never_exposes_numeric_values() {
+        assert_eq!(
+            classify_peer(0, 0, 501, 20),
+            CredentialIdentityClass::InitialRoot
+        );
+        assert_eq!(
+            classify_peer(501, 20, 501, 20),
+            CredentialIdentityClass::Target
+        );
+        assert_eq!(
+            format!(
+                "{:?}",
+                CredentialTransition {
+                    state: CredentialSelfState::new(
+                        CredentialIdentityClass::Target,
+                        CredentialGroupClass::EffectiveOnly
+                    ),
+                    prefix: CredentialPrefix::Irreversible,
+                }
+            ),
+            "CredentialTransition(<redacted>)"
+        );
+    }
+
+    #[test]
+    fn connected_stream_and_datagram_observations_keep_identity_surfaces_separate() {
+        let (stream, _stream_peer) = UnixStream::pair().expect("stream pair");
+        let (datagram, datagram_peer) = UnixDatagram::pair().expect("datagram pair");
+        datagram.send(b"p").expect("datagram possession send");
+        let mut possession = [0_u8; 1];
+        datagram_peer
+            .recv(&mut possession)
+            .expect("datagram possession receive");
+        // SAFETY: Credential/PID getters have no pointer or ownership contract.
+        let (pid, uid, gid) = unsafe { (libc::getpid(), libc::geteuid(), libc::getegid()) };
+        let target = target(uid, gid);
+        let (initial, baseline) =
+            observe_initial_peer(stream.as_raw_fd(), datagram.as_raw_fd(), pid, pid, target)
+                .expect("current-process peer observations should succeed");
+        assert_eq!(initial.stream_eid(), CredentialIdentityClass::Target);
+        assert_eq!(initial.stream_cred(), CredentialIdentityClass::Target);
+        assert_eq!(initial.stream_pid(), PeerPidClass::Exact);
+        assert!(matches!(
+            initial.datagram_cred(),
+            CredentialIdentityClass::Target | CredentialIdentityClass::Unsupported
+        ));
+        assert_eq!(initial.datagram_pid(), PeerPidClass::Exact);
+        assert!(matches!(
+            initial.datagram_token(),
+            PeerTokenClass::Baseline | PeerTokenClass::Unsupported
+        ));
+        let later = observe_later_peer(
+            stream.as_raw_fd(),
+            datagram.as_raw_fd(),
+            pid,
+            pid,
+            target,
+            &baseline,
+        )
+        .expect("later current-process observation should succeed");
+        assert_eq!(later.stream_pid(), PeerPidClass::Exact);
+        assert_eq!(later.datagram_pid(), PeerPidClass::Exact);
+        assert!(matches!(
+            later.datagram_token(),
+            PeerTokenClass::Unchanged | PeerTokenClass::Unsupported
+        ));
+        assert_eq!(format!("{baseline:?}"), "PeerBaseline(<redacted>)");
+
+        assert_eq!(
+            exact_peer_pid(datagram.as_raw_fd(), pid.wrapping_add(1), Some(pid)),
+            Ok(PeerPidClass::SocketCreator)
+        );
+        assert!(exact_peer_pid(datagram.as_raw_fd(), pid.wrapping_add(1), None).is_err());
+        assert_eq!(
+            classify_peer_pid(
+                Err(io::Error::from_raw_os_error(libc::ENOPROTOOPT)),
+                pid,
+                Some(pid),
+            ),
+            Ok(PeerPidClass::Unsupported)
+        );
+        assert!(
+            classify_peer_pid(
+                Err(io::Error::from_raw_os_error(libc::ENOPROTOOPT)),
+                pid,
+                None,
+            )
+            .is_err(),
+            "stream LOCAL_PEERPID remains a required surface"
+        );
+        assert!(stream_eid(datagram.as_raw_fd(), uid, gid).is_err());
+        assert!(
+            matches!(
+                observe_initial_peer(datagram.as_raw_fd(), stream.as_raw_fd(), pid, pid, target,),
+                Err(CredentialErrorCategory::InvalidInput)
+            ),
+            "stream and datagram descriptor roles must not be interchangeable"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add an always-built production credential target, transition state, peer observation, and canonical bootstrap/attestation wire model
- move the proven Darwin credential transition core behind production names while retaining the feature-gated evidence probe as a thin adapter
- classify current, retained-root, and root-transition launcher identities with redacted diagnostics and strict mixed-identity rejection
- keep normal product execution fail-closed for elevated identities until the complete product bootstrap is wired by later child issues

## Scope exclusions

- does not enable or claim public root-only jailer execution
- does not resolve or claim chroot support or aggregate jailer completion
- does not change compatibility overlays or user-facing capability documentation

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- the five signed Apple-target Clippy commands documented in `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (96/96)
- signed HVF lifecycle (101/101), guest boot (30/30), and App Sandbox (8/8)
- `scripts/run-integration-tests.sh --test executable_hvf_e2e` (81/81)
- `scripts/run-integration-tests.sh --test production_bundle` (75/76 on the final full rerun; the sole network/MMDS malformed-HTTP timing failure passed its immediate exact rerun and also reproduced with the launcher files restored to `main`)
- exact-root elevated evidence matrix: mapped, retained-root, and unmapped credential/runtime cases; API/no-API guests; repeats, concurrency, faults, death orders, signals, replacement, daemon coverage; zero root/workspace/socket/launcher/worker residue

Closes #1902

Parent context: #1374
