### PR TITLE
fix: eliminate residual restored-vsock EOF

### DIFF
--- a/compat/firecracker/v1.16.0/logger-contract.md
+++ b/compat/firecracker/v1.16.0/logger-contract.md
@@ -117,6 +117,14 @@ interrupt delivery; product-PCI endpoint owners cover MSI delivery. MMDS
 detours and transactional token-key rotation are fixed outcomes, and neither
 token nor key material can enter a record.
 
+Issue #1922 adds fixed direction-specific vsock lifecycle outcomes for guest
+RST/SHUTDOWN, local stream EOF/read failure, connection deadlines, reset
+queue/delivery, and guest RW disposition. These remain in the same semantic
+producer class and fixed-capacity batch. Local EOF/read and deadline outcomes
+use the bounded `logger-rate.vsock.endpoint-outcome` sub-budget, independent of
+the primary `logger-rate.vsock.outcome` state, so ordinary data-plane success
+records cannot hide the first endpoint-lifecycle observation.
+
 Issue #1816 closes balloon, virtio-mem, entropy, serial, and time/identity
 outcomes. Balloon, virtio-mem, and entropy observers consume complete typed
 queue summaries shared by MMIO and product PCI. Virtio-mem configuration

--- a/compat/firecracker/v1.16.0/logger-producer-audit.json
+++ b/compat/firecracker/v1.16.0/logger-producer-audit.json
@@ -1649,7 +1649,7 @@
         "outcome"
       ],
       "disposition": "implemented",
-      "rationale": "All mapped upstream calls converge on one bounded vsock queue, connection, reset, or interrupt outcome per nonzero notification-batch category. The device-owned observer covers MMIO and product PCI, emits failure categories before success categories, and discards sockets, paths, connection keys, ports, packet headers, payloads, errors, descriptors, addresses, byte counts, and guest values.",
+      "rationale": "All mapped upstream calls converge on one bounded vsock queue, connection, reset, or interrupt outcome per nonzero notification-batch category. The device-owned observer covers MMIO and product PCI, emits failure categories before success categories, and discards sockets, paths, connection keys, ports, packet headers, payloads, errors, descriptors, addresses, byte counts, and guest values. Fixed local-stream EOF/read and connection-deadline outcomes use an additional bounded logger-rate.vsock.endpoint-outcome sub-budget so ordinary data-plane success records cannot hide the first endpoint-lifecycle observation.",
       "compiled_events": [
         "vsock"
       ],
@@ -1672,7 +1672,7 @@
         {
           "kind": "local",
           "path": "crates/runtime/src/logger/rate_limiter.rs",
-          "anchor": "independent vsock outcome limiter identity"
+          "anchor": "independent vsock outcome and endpoint-evidence limiter identities"
         },
         {
           "kind": "local",

--- a/compat/firecracker/v1.16.0/metrics-device-producer-audit.json
+++ b/compat/firecracker/v1.16.0/metrics-device-producer-audit.json
@@ -11794,7 +11794,7 @@
         {
           "kind": "local",
           "path": "crates/runtime/src/vsock.rs",
-          "anchor": "fn observe_host_readiness(&self, readiness: &[VsockHostReadiness], poll_failed: bool) {"
+          "anchor": "fn observe_host_readiness(&mut self, readiness: &[VsockHostReadiness], poll_failed: bool) {"
         }
       ],
       "validation": [
@@ -11876,7 +11876,7 @@
         {
           "kind": "local",
           "path": "crates/runtime/src/vsock.rs",
-          "anchor": "fn expire_connections(&mut self, now: Instant) {"
+          "anchor": "fn expire_connections(&mut self, now: Instant) -> VirtioVsockConnectionLifecycleDispatch {"
         }
       ],
       "validation": [
@@ -12040,7 +12040,7 @@
         {
           "kind": "local",
           "path": "crates/runtime/src/vsock.rs",
-          "anchor": "fn observe_host_readiness(&self, readiness: &[VsockHostReadiness], poll_failed: bool) {"
+          "anchor": "fn observe_host_readiness(&mut self, readiness: &[VsockHostReadiness], poll_failed: bool) {"
         }
       ],
       "validation": [

--- a/compat/firecracker/v1.16.0/vsock-contract.md
+++ b/compat/firecracker/v1.16.0/vsock-contract.md
@@ -32,7 +32,9 @@ The immutable upstream baseline is Firecracker commit
   metrics, and teardown in `crates/runtime/src/{vsock,metrics}.rs`,
   `crates/hvf/src/startup.rs`, and `crates/bangbang/src/vmm.rs`.
 - **AUTHORITY** — exact direct listener/connector ownership and exact
-  App Sandbox grant/listener/broker adoption with no ambient fallback in
+  App Sandbox grant/listener/broker adoption, including authenticated
+  role-and-inode-bound listener-transfer acknowledgment before binder exit,
+  with no ambient fallback in
   `crates/bangbang/src/{anchored_socket,contained_session,vsock_restore,vmm}.rs`
   and `crates/launcher/src/macos/socket_broker.rs`.
 - **SNAPSHOT** — exact native-v2 2.12 kind 13, MMIO/PCI placement, public

--- a/crates/bangbang/src/anchored_socket.rs
+++ b/crates/bangbang/src/anchored_socket.rs
@@ -39,6 +39,9 @@ const BINDER_COMMAND_VERSION: u8 = 1;
 const RESPONSE_BYTES: usize = 24;
 const RESPONSE_MAGIC: [u8; 4] = *b"BBB1";
 const RESPONSE_VERSION: u8 = 1;
+const BINDER_ACK_BYTES: usize = 24;
+const BINDER_ACK_MAGIC: [u8; 4] = *b"BBA1";
+const BINDER_ACK_VERSION: u8 = 1;
 const HELLO_BYTES: usize = 8;
 const HELLO_MAGIC: [u8; 4] = *b"BBH1";
 const HELLO_VERSION: u8 = 1;
@@ -387,6 +390,14 @@ fn run_binder_inner() -> Result<(), AnchoredSocketError> {
     if let Err(error) = send_listener(&socket, role, identity, listener.as_raw_fd()) {
         let _ = unlink_relative_if_socket(staging, Some(identity));
         return Err(error);
+    }
+    let mut acknowledgment = [0_u8; BINDER_ACK_BYTES];
+    if socket.read_exact(&mut acknowledgment).is_err()
+        || parse_binder_ack(&acknowledgment) != Ok((role, identity))
+        || verify_peer(socket.as_raw_fd(), parent).is_err()
+    {
+        let _ = unlink_relative_if_socket(staging, Some(identity));
+        return Err(AnchoredSocketError::Binder);
     }
     Ok(())
 }
@@ -807,6 +818,8 @@ fn spawn_binder(
         return Err(AnchoredSocketError::Invalid);
     }
     validate_listener_descriptor(listener.as_raw_fd(), role)?;
+    verify_peer(parent.as_raw_fd(), pid).map_err(|_| AnchoredSocketError::Binder)?;
+    send_exact_frame(&parent, &binder_ack(role, identity)?)?;
     binder.wait_until(BINDER_TIMEOUT)?;
     Ok((listener, identity))
 }
@@ -1372,6 +1385,46 @@ fn parse_response(bytes: &[u8]) -> Result<(ResourceRole, ObjectIdentity), Anchor
     if bytes.len() != RESPONSE_BYTES
         || bytes.get(..4) != Some(RESPONSE_MAGIC.as_slice())
         || bytes.get(4) != Some(&RESPONSE_VERSION)
+        || bytes.get(6..8) != Some([0, 0].as_slice())
+    {
+        return Err(AnchoredSocketError::Invalid);
+    }
+    let role = socket_role(*bytes.get(5).ok_or(AnchoredSocketError::Invalid)?)
+        .ok_or(AnchoredSocketError::Invalid)?;
+    let device = u64::from_be_bytes(
+        bytes
+            .get(8..16)
+            .ok_or(AnchoredSocketError::Invalid)?
+            .try_into()
+            .map_err(|_| AnchoredSocketError::Invalid)?,
+    );
+    let inode = u64::from_be_bytes(
+        bytes
+            .get(16..24)
+            .ok_or(AnchoredSocketError::Invalid)?
+            .try_into()
+            .map_err(|_| AnchoredSocketError::Invalid)?,
+    );
+    Ok((role, ObjectIdentity { device, inode }))
+}
+
+fn binder_ack(
+    role: ResourceRole,
+    identity: ObjectIdentity,
+) -> Result<[u8; BINDER_ACK_BYTES], AnchoredSocketError> {
+    let mut acknowledgment = [0_u8; BINDER_ACK_BYTES];
+    acknowledgment[..4].copy_from_slice(&BINDER_ACK_MAGIC);
+    acknowledgment[4] = BINDER_ACK_VERSION;
+    acknowledgment[5] = role_byte(role)?;
+    acknowledgment[8..16].copy_from_slice(&identity.device.to_be_bytes());
+    acknowledgment[16..24].copy_from_slice(&identity.inode.to_be_bytes());
+    Ok(acknowledgment)
+}
+
+fn parse_binder_ack(bytes: &[u8]) -> Result<(ResourceRole, ObjectIdentity), AnchoredSocketError> {
+    if bytes.len() != BINDER_ACK_BYTES
+        || bytes.get(..4) != Some(BINDER_ACK_MAGIC.as_slice())
+        || bytes.get(4) != Some(&BINDER_ACK_VERSION)
         || bytes.get(6..8) != Some([0, 0].as_slice())
     {
         return Err(AnchoredSocketError::Invalid);
@@ -2083,6 +2136,15 @@ mod tests {
             listener.as_raw_fd(),
         )
         .expect("elevated listener should transfer");
+        let mut acknowledgment = [0_u8; BINDER_ACK_BYTES];
+        let mut transport_reader = &transport;
+        transport_reader
+            .read_exact(&mut acknowledgment)
+            .expect("elevated listener adoption should be acknowledged");
+        assert_eq!(
+            parse_binder_ack(&acknowledgment),
+            Ok((ResourceRole::ApiSocketDirectory, identity))
+        );
     }
 
     #[cfg(feature = "elevated-bootstrap-probe")]
@@ -2128,6 +2190,12 @@ mod tests {
         let (listener, role, identity) =
             receive_listener(&parent).expect("relative listener child should return one listener");
         assert_eq!(role, ResourceRole::ApiSocketDirectory);
+        send_exact_frame(
+            &parent,
+            &binder_ack(ResourceRole::ApiSocketDirectory, identity)
+                .expect("listener acknowledgment should encode"),
+        )
+        .expect("relative listener child should receive adoption acknowledgment");
         assert!(
             process
                 .wait()
@@ -2364,6 +2432,14 @@ mod tests {
             };
             let encoded = response(role, identity).expect("response should encode");
             assert_eq!(parse_response(&encoded), Ok((role, identity)));
+            let acknowledgment = binder_ack(role, identity).expect("acknowledgment should encode");
+            assert_eq!(parse_binder_ack(&acknowledgment), Ok((role, identity)));
+            let mut malformed_acknowledgment = acknowledgment;
+            malformed_acknowledgment[6] = 1;
+            assert_eq!(
+                parse_binder_ack(&malformed_acknowledgment),
+                Err(AnchoredSocketError::Invalid)
+            );
             let command = binder_command(role, identity).expect("binder command should encode");
             assert_eq!(parse_binder_command(&command), Ok((role, identity)));
 

--- a/crates/bangbang/src/anchored_socket.rs
+++ b/crates/bangbang/src/anchored_socket.rs
@@ -2089,7 +2089,6 @@ fn cvt_spawn(result: libc::c_int) -> Result<(), AnchoredSocketError> {
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::io::{Read as _, Write as _};
     use std::os::unix::fs::{FileTypeExt as _, PermissionsExt as _};
     use std::os::unix::process::CommandExt as _;
     use std::process::{Command, Stdio};

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -4080,7 +4080,9 @@ mod tests {
         let fixture = fixture.trim();
         let graph_bytes = fixture
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")
@@ -4269,7 +4271,9 @@ mod tests {
     fn decode_fixture_hex(hex: &str) -> Vec<u8> {
         let hex = hex.split_whitespace().collect::<String>();
         hex.as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")
@@ -4292,7 +4296,9 @@ mod tests {
             .split_whitespace()
             .collect::<String>()
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/bangbang/src/grant_integration_probe.rs
+++ b/crates/bangbang/src/grant_integration_probe.rs
@@ -1287,7 +1287,7 @@ fn restore_device_key() -> Result<SnapshotV2DeviceKey, ContainedSessionError> {
     bytes
         .try_reserve_exact(hex.len() / 2)
         .map_err(|_| ContainedSessionError)?;
-    for pair in hex.chunks_exact(2) {
+    for pair in hex.as_chunks::<2>().0 {
         let pair = std::str::from_utf8(pair).map_err(|_| ContainedSessionError)?;
         bytes.push(u8::from_str_radix(pair, 16).map_err(|_| ContainedSessionError)?);
     }

--- a/crates/bangbang/src/snapshot_restore_resources.rs
+++ b/crates/bangbang/src/snapshot_restore_resources.rs
@@ -6393,7 +6393,9 @@ mod tests {
         let bytes = fixture
             .trim()
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")
@@ -6411,7 +6413,9 @@ mod tests {
         let mut bytes = fixture
             .trim()
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")
@@ -6449,7 +6453,9 @@ mod tests {
         let mut bytes = fixture
             .trim()
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")
@@ -6495,7 +6501,9 @@ mod tests {
         let bytes = fixture
             .trim()
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/bangbang/src/snapshot_serial_restore.rs
+++ b/crates/bangbang/src/snapshot_serial_restore.rs
@@ -1414,7 +1414,9 @@ mod tests {
         )
         .trim()
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             u8::from_str_radix(
                 std::str::from_utf8(pair).expect("fixture pair should be UTF-8"),

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -46445,7 +46445,9 @@ mod tests {
         let hex = hex.split_ascii_whitespace().collect::<String>();
         assert!(hex.len().is_multiple_of(2));
         hex.as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -11596,6 +11596,8 @@ mod macos_arm64 {
             },
             transport,
             &source,
+            &source_api,
+            &source_metrics,
         );
         assert_eq!(
             source_host_ports,
@@ -12232,6 +12234,8 @@ mod macos_arm64 {
         exchange: SnapshotVsockExchange,
         context: &str,
         process: &BangbangProcess,
+        api_socket: &Path,
+        metrics_path: &Path,
     ) -> (Vec<UnixStream>, Vec<u32>) {
         let SnapshotVsockExchange {
             request_kind,
@@ -12272,9 +12276,20 @@ mod macos_arm64 {
                 .expect("source host stream payload should write");
             let expected = snapshot_vsock_payload(response_kind, index, response_size);
             let mut received = vec![0_u8; expected.len()];
-            stream
-                .read_exact(&mut received)
-                .expect("source host stream acknowledgement should read");
+            stream.read_exact(&mut received).unwrap_or_else(|error| {
+                let flush = http_put_json(
+                    api_socket,
+                    "/actions",
+                    r#"{"action_type":"FlushMetrics"}"#,
+                );
+                let metrics = fs::read_to_string(metrics_path)
+                    .unwrap_or_else(|metrics_error| format!("<unavailable: {metrics_error}>"));
+                panic!(
+                    "{context} source host stream {index} acknowledgement should read: {:?}; metrics flush:\n{flush}\nmetrics:\n{metrics}\nstdout:\n{}",
+                    error.kind(),
+                    process.stdout_snapshot()
+                )
+            });
             assert_eq!(
                 received, expected,
                 "{context} source host stream {index} acknowledgement should match"

--- a/crates/hvf/src/snapshot_bundle.rs
+++ b/crates/hvf/src/snapshot_bundle.rs
@@ -1545,7 +1545,9 @@ pub(crate) mod tests {
             .collect();
         assert!(digits.len().is_multiple_of(2));
         digits
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| (hex_digit(pair[0]) << 4) | hex_digit(pair[1]))
             .collect()
     }

--- a/crates/hvf/src/snapshot_v2/tests.rs
+++ b/crates/hvf/src/snapshot_v2/tests.rs
@@ -435,7 +435,9 @@ pub(crate) fn fixture_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.split_ascii_whitespace().collect::<String>();
     assert!(hex.len().is_multiple_of(2));
     hex.as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
             u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/hvf/src/snapshot_v2_balloon_platform.rs
+++ b/crates/hvf/src/snapshot_v2_balloon_platform.rs
@@ -1414,7 +1414,9 @@ mod tests {
             .filter(|byte| !byte.is_ascii_whitespace())
             .collect();
         compact
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 u8::from_str_radix(
                     std::str::from_utf8(pair).expect("fixture hex should be UTF-8"),

--- a/crates/hvf/src/snapshot_v2_entropy_platform.rs
+++ b/crates/hvf/src/snapshot_v2_entropy_platform.rs
@@ -624,7 +624,9 @@ pub(crate) mod tests {
     fn fixture_bytes(hex: &str) -> Vec<u8> {
         hex.trim()
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 u8::from_str_radix(
                     std::str::from_utf8(pair).expect("fixture hex should be UTF-8"),

--- a/crates/hvf/src/snapshot_v2_multi_block_platform.rs
+++ b/crates/hvf/src/snapshot_v2_multi_block_platform.rs
@@ -1128,7 +1128,9 @@ pub(crate) mod tests {
     fn fixture_bytes(hex: &str) -> Vec<u8> {
         hex.trim()
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/hvf/src/snapshot_v2_network_platform.rs
+++ b/crates/hvf/src/snapshot_v2_network_platform.rs
@@ -3598,7 +3598,9 @@ mod fixture_identity_tests {
         let compact = fixture.split_ascii_whitespace().collect::<String>();
         compact
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 u8::from_str_radix(
                     std::str::from_utf8(pair).expect("fixture should be ASCII"),

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -4070,9 +4070,12 @@ fn property_u32_cells_equal(node: &Node, name: &str, expected: &[u32]) -> bool {
         return false;
     };
     raw.len() == expected.len().saturating_mul(4)
-        && raw.chunks_exact(4).zip(expected).all(|(chunk, expected)| {
-            <[u8; 4]>::try_from(chunk).map(u32::from_be_bytes).ok() == Some(*expected)
-        })
+        && raw
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .zip(expected)
+            .all(|(chunk, expected)| u32::from_be_bytes(*chunk) == *expected)
 }
 
 fn property_u64_cells_equal(node: &Node, name: &str, expected: &[u64]) -> bool {
@@ -4080,9 +4083,12 @@ fn property_u64_cells_equal(node: &Node, name: &str, expected: &[u64]) -> bool {
         return false;
     };
     raw.len() == expected.len().saturating_mul(8)
-        && raw.chunks_exact(8).zip(expected).all(|(chunk, expected)| {
-            <[u8; 8]>::try_from(chunk).map(u64::from_be_bytes).ok() == Some(*expected)
-        })
+        && raw
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .zip(expected)
+            .all(|(chunk, expected)| u64::from_be_bytes(*chunk) == *expected)
 }
 
 fn memory_property_matches_binding(node: &Node, binding: &SnapshotV2MemoryBinding) -> bool {
@@ -4092,7 +4098,9 @@ fn memory_property_matches_binding(node: &Node, binding: &SnapshotV2MemoryBindin
     if raw.len() != binding.extents().len().saturating_mul(16) {
         return false;
     }
-    raw.chunks_exact(16)
+    raw.as_chunks::<16>()
+        .0
+        .iter()
         .zip(binding.extents())
         .enumerate()
         .all(|(index, (chunk, extent))| {

--- a/crates/hvf/src/snapshot_v2_storage_platform.rs
+++ b/crates/hvf/src/snapshot_v2_storage_platform.rs
@@ -2055,7 +2055,9 @@ pub(crate) mod tests {
     fn fixture_bytes(hex: &str) -> Vec<u8> {
         hex.trim()
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 u8::from_str_radix(
                     std::str::from_utf8(pair).expect("fixture hex should be UTF-8"),

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -239,7 +239,7 @@ use bangbang_runtime::vsock::{
     VIRTIO_VSOCK_DEVICE_ID, VIRTIO_VSOCK_QUEUE_SIZES, VirtioVsockCaptureValidation,
     VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockMmioCaptureState,
     VirtioVsockPciCaptureState, VirtioVsockReconstructionResource, VsockConfig, VsockHostReadiness,
-    VsockHostWakeup, VsockMmioDeviceRegistration, VsockMmioLayout,
+    VsockHostReadinessRegistration, VsockHostWakeup, VsockMmioDeviceRegistration, VsockMmioLayout,
     attach_vsock_metrics_to_mmio_handler, observe_vsock_host_readiness_for_mmio_handler,
 };
 use bangbang_runtime::{BackendError, VmBackend, VmmController};
@@ -31353,6 +31353,13 @@ where
         self.session.start_run_loop_wakeup_monitor()
     }
 
+    fn observe_run_loop_vsock_readiness(
+        &mut self,
+        observation: &HvfArm64BootVsockReadinessObservation,
+    ) {
+        self.session.observe_run_loop_vsock_readiness(observation);
+    }
+
     fn take_run_loop_wakeup_request(&mut self) -> bool {
         self.session.take_run_loop_wakeup_request()
     }
@@ -32638,6 +32645,8 @@ fn start_run_loop_wakeup_monitor(
     let mut write_fds = Vec::new();
     let mut vsock_read_fds = Vec::new();
     let mut vsock_write_fds = Vec::new();
+    let mut vsock_read_registrations = Vec::new();
+    let mut vsock_readiness_generation = 0;
     let mut deadline = None;
     let mut has_block_wakeup_fds = async_block_fd.is_some();
     let has_serial_input_fd = serial_input_fd.is_some();
@@ -32657,13 +32666,21 @@ fn start_run_loop_wakeup_monitor(
         let mut mmio_dispatcher = lock_boot_mmio_dispatcher_runtime(dispatcher)
             .map_err(|source| HvfArm64BootRunLoopWakeupMonitorError::MmioDispatcher { source })?;
         if runtime_resources.vsock_device.is_some() {
-            let (device_read_fds, device_write_fds, vsock_deadline) =
+            let (
+                device_read_fds,
+                device_write_fds,
+                vsock_deadline,
+                device_readiness_generation,
+                device_read_registrations,
+            ) =
                 runtime_resources
                     .vsock_wakeup(&mut mmio_dispatcher)
                     .map_err(|source| {
                         HvfArm64BootRunLoopWakeupMonitorError::CollectVsockWakeupFds { source }
                     })?
                     .into_parts();
+            vsock_readiness_generation = device_readiness_generation;
+            vsock_read_registrations = device_read_registrations;
             read_fds
                 .try_reserve_exact(device_read_fds.len())
                 .map_err(
@@ -32707,7 +32724,13 @@ fn start_run_loop_wakeup_monitor(
         }
     }
     if let Some(devices) = pci_vsock {
-        let (pci_read_fds, pci_write_fds, pci_deadline) = devices
+        let (
+            pci_read_fds,
+            pci_write_fds,
+            pci_deadline,
+            pci_readiness_generation,
+            pci_read_registrations,
+        ) = devices
             .vsock_wakeup()
             .map_err(
                 |source| HvfArm64BootRunLoopWakeupMonitorError::PciVsockWakeup {
@@ -32717,6 +32740,8 @@ fn start_run_loop_wakeup_monitor(
             .ok_or_else(|| HvfArm64BootRunLoopWakeupMonitorError::PciVsockWakeup {
                 message: "PCI vsock endpoint disappeared".to_string(),
             })?;
+        vsock_readiness_generation = pci_readiness_generation;
+        vsock_read_registrations = pci_read_registrations;
         read_fds
             .try_reserve_exact(pci_read_fds.len())
             .map_err(|source| HvfArm64BootRunLoopWakeupMonitorError::PollFdAllocation { source })?;
@@ -32754,6 +32779,8 @@ fn start_run_loop_wakeup_monitor(
             host_write_fds: write_fds,
             vsock_read_fds,
             vsock_write_fds,
+            vsock_read_registrations,
+            vsock_readiness_generation,
             deadline,
             has_block_wakeup_fds,
             has_serial_input_fd,
@@ -33018,9 +33045,8 @@ trait BootSessionRunLoopSession {
 
     fn observe_run_loop_vsock_readiness(
         &mut self,
-        _observation: &HvfArm64BootVsockReadinessObservation,
-    ) {
-    }
+        observation: &HvfArm64BootVsockReadinessObservation,
+    );
 
     fn take_run_loop_wakeup_request(&mut self) -> bool {
         false
@@ -34040,6 +34066,8 @@ struct HvfArm64BootRunLoopWakeupInputs {
     host_write_fds: Vec<RawFd>,
     vsock_read_fds: Vec<RawFd>,
     vsock_write_fds: Vec<RawFd>,
+    vsock_read_registrations: Vec<VsockHostReadinessRegistration>,
+    vsock_readiness_generation: u64,
     deadline: Option<Instant>,
     has_block_wakeup_fds: bool,
     has_serial_input_fd: bool,
@@ -34099,6 +34127,8 @@ impl HvfArm64BootRunLoopWakeupMonitor {
             host_write_fds,
             mut vsock_read_fds,
             mut vsock_write_fds,
+            vsock_read_registrations,
+            vsock_readiness_generation,
             deadline,
             has_block_wakeup_fds,
             has_serial_input_fd,
@@ -34135,7 +34165,11 @@ impl HvfArm64BootRunLoopWakeupMonitor {
                     pollfd_count,
                     stop_reader,
                     deadline,
-                    &vsock_fds,
+                    HvfArm64BootVsockPollSnapshot::new(
+                        &vsock_fds,
+                        &vsock_read_registrations,
+                        vsock_readiness_generation,
+                    ),
                     vcpu_control,
                     wakeup_token,
                 )
@@ -34264,12 +34298,33 @@ fn run_loop_wakeup_pollfds(
     Ok(pollfds)
 }
 
+#[derive(Debug, Clone, Copy)]
+struct HvfArm64BootVsockPollSnapshot<'a> {
+    descriptors: &'a [RawFd],
+    read_registrations: &'a [VsockHostReadinessRegistration],
+    readiness_generation: u64,
+}
+
+impl<'a> HvfArm64BootVsockPollSnapshot<'a> {
+    const fn new(
+        descriptors: &'a [RawFd],
+        read_registrations: &'a [VsockHostReadinessRegistration],
+        readiness_generation: u64,
+    ) -> Self {
+        Self {
+            descriptors,
+            read_registrations,
+            readiness_generation,
+        }
+    }
+}
+
 fn run_loop_wakeup_monitor(
     pollfds: &mut [libc::pollfd],
     pollfd_count: libc::nfds_t,
     _stop_reader: UnixStream,
     deadline: Option<Instant>,
-    vsock_fds: &[RawFd],
+    vsock_poll_snapshot: HvfArm64BootVsockPollSnapshot<'_>,
     vcpu_control: HvfVcpuRunControl,
     wakeup_token: HvfArm64BootRunLoopWakeupToken,
 ) -> HvfArm64BootRunLoopWakeupObservation {
@@ -34277,7 +34332,7 @@ fn run_loop_wakeup_monitor(
         pollfds,
         pollfd_count,
         deadline,
-        vsock_fds,
+        vsock_poll_snapshot,
         Instant::now,
         |pollfds, pollfd_count, timeout| {
             // SAFETY: `pollfds` is a valid mutable slice for `pollfd_count`
@@ -34301,7 +34356,7 @@ fn run_loop_wakeup_monitor_with(
     pollfds: &mut [libc::pollfd],
     pollfd_count: libc::nfds_t,
     deadline: Option<Instant>,
-    vsock_fds: &[RawFd],
+    vsock_poll_snapshot: HvfArm64BootVsockPollSnapshot<'_>,
     mut now: impl FnMut() -> Instant,
     mut poll: impl FnMut(
         &mut [libc::pollfd],
@@ -34325,7 +34380,7 @@ fn run_loop_wakeup_monitor_with(
                     wakeup_requested: true,
                     vsock: HvfArm64BootVsockReadinessObservation {
                         events: Vec::new(),
-                        poll_failed: !vsock_fds.is_empty(),
+                        poll_failed: !vsock_poll_snapshot.descriptors.is_empty(),
                     },
                 };
             }
@@ -34335,6 +34390,9 @@ fn run_loop_wakeup_monitor_with(
             return HvfArm64BootRunLoopWakeupObservation::default();
         };
         if pollfd_has_wakeup_event(stop_pollfd.revents) {
+            // The owning run-loop step has completed, so every descriptor observation in this
+            // poll snapshot is stale by construction. Read readiness is level-triggered and will
+            // be observed again by the next monitor against the next exact registration set.
             return HvfArm64BootRunLoopWakeupObservation::default();
         }
         let fd_wakeup = pollfds
@@ -34348,9 +34406,34 @@ fn run_loop_wakeup_monitor_with(
                 .skip(1)
                 .filter(|pollfd| {
                     pollfd_has_wakeup_event(pollfd.revents)
-                        && vsock_fds.binary_search(&pollfd.fd).is_ok()
+                        && vsock_poll_snapshot
+                            .descriptors
+                            .binary_search(&pollfd.fd)
+                            .is_ok()
                 })
-                .map(|pollfd| VsockHostReadiness::from_poll_revents(pollfd.fd, pollfd.revents))
+                .map(|pollfd| {
+                    vsock_poll_snapshot
+                        .read_registrations
+                        .iter()
+                        .copied()
+                        .find(|registration| registration.descriptor() == pollfd.fd)
+                        .map_or_else(
+                            || {
+                                VsockHostReadiness::from_poll_revents(
+                                    pollfd.fd,
+                                    pollfd.revents,
+                                    vsock_poll_snapshot.readiness_generation,
+                                )
+                            },
+                            |registration| {
+                                VsockHostReadiness::for_registration(
+                                    registration,
+                                    pollfd.revents,
+                                    vsock_poll_snapshot.readiness_generation,
+                                )
+                            },
+                        )
+                })
                 .collect();
             return HvfArm64BootRunLoopWakeupObservation {
                 wakeup_requested: true,
@@ -38761,7 +38844,8 @@ mod tests {
     use bangbang_runtime::vsock::{
         VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_PACKET_HEADER_SIZE,
         VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX, VirtioVsockPacketHeader,
-        VsockConfigInput, VsockMmioLayout, attach_vsock_metrics_to_mmio_handler,
+        VsockConfigInput, VsockHostReadinessRegistration, VsockMmioLayout,
+        attach_vsock_metrics_to_mmio_handler,
     };
 
     use super::{
@@ -39101,7 +39185,7 @@ mod tests {
             &mut pollfds,
             1,
             Some(deadline),
-            &[],
+            super::HvfArm64BootVsockPollSnapshot::new(&[], &[], 0),
             || times.pop_front().expect("each poll should sample time"),
             |pollfds, count, timeout| {
                 assert_eq!(pollfds.len(), 1);
@@ -39141,7 +39225,11 @@ mod tests {
             &mut pollfds,
             2,
             Some(now),
-            &[11],
+            super::HvfArm64BootVsockPollSnapshot::new(
+                &[11],
+                &[VsockHostReadinessRegistration::unclassified(11)],
+                7,
+            ),
             || now,
             |pollfds, _, timeout| {
                 assert_eq!(timeout, 0);
@@ -39178,7 +39266,11 @@ mod tests {
             &mut pollfds,
             2,
             Some(now),
-            &[11],
+            super::HvfArm64BootVsockPollSnapshot::new(
+                &[11],
+                &[VsockHostReadinessRegistration::unclassified(11)],
+                8,
+            ),
             || now,
             |pollfds, _, timeout| {
                 assert_eq!(timeout, 0);
@@ -39193,6 +39285,7 @@ mod tests {
         assert!(!observation.vsock.poll_failed);
         assert_eq!(observation.vsock.events.len(), 1);
         assert_eq!(observation.vsock.events[0].descriptor(), 11);
+        assert_eq!(observation.vsock.events[0].generation(), 8);
         assert!(observation.vsock.events[0].readable());
         assert!(observation.vsock.events[0].writable());
         assert!(observation.vsock.events[0].error());
@@ -39215,7 +39308,11 @@ mod tests {
             &mut pollfds,
             1,
             None,
-            &[10],
+            super::HvfArm64BootVsockPollSnapshot::new(
+                &[10],
+                &[VsockHostReadinessRegistration::unclassified(10)],
+                9,
+            ),
             || now,
             |_, _, timeout| {
                 assert_eq!(timeout, -1);
@@ -39244,6 +39341,8 @@ mod tests {
                 host_write_fds: Vec::new(),
                 vsock_read_fds: Vec::new(),
                 vsock_write_fds: Vec::new(),
+                vsock_read_registrations: Vec::new(),
+                vsock_readiness_generation: 0,
                 deadline: Some(Instant::now() + Duration::from_secs(60 * 60)),
                 has_block_wakeup_fds: false,
                 has_serial_input_fd: false,
@@ -42223,6 +42322,12 @@ mod tests {
             } else {
                 super::HvfArm64BootRunLoopWakeupMonitor::completed_for_test(completed_wakeup)
             })
+        }
+
+        fn observe_run_loop_vsock_readiness(
+            &mut self,
+            _observation: &super::HvfArm64BootVsockReadinessObservation,
+        ) {
         }
 
         fn take_run_loop_wakeup_request(&mut self) -> bool {

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -3787,7 +3787,9 @@ fn prop_u32_cells(node: &device_tree::Node, name: &str) -> Vec<u32> {
     let raw = node.prop_raw(name).expect("property should exist");
     assert_eq!(raw.len() % 4, 0, "{name} property should contain u32 cells");
 
-    raw.chunks_exact(4)
+    raw.as_chunks::<4>()
+        .0
+        .iter()
         .map(|chunk| u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
         .collect()
 }
@@ -3797,7 +3799,9 @@ fn prop_u64_cells(node: &device_tree::Node, name: &str) -> Vec<u64> {
     let raw = node.prop_raw(name).expect("property should exist");
     assert_eq!(raw.len() % 8, 0, "{name} property should contain u64 cells");
 
-    raw.chunks_exact(8)
+    raw.as_chunks::<8>()
+        .0
+        .iter()
         .map(|chunk| {
             u64::from_be_bytes([
                 chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -19066,8 +19066,10 @@ fn psci_1_0_and_smccc_1_1_discovery_match_the_advertised_guest_contract() {
         .read_slice(&mut result_bytes, results)
         .expect("discovery results should read after terminal exit");
     let actual = result_bytes
-        .chunks_exact(size_of::<u64>())
-        .map(|bytes| u64::from_le_bytes(bytes.try_into().expect("result chunk should be u64")))
+        .as_chunks::<{ size_of::<u64>() }>()
+        .0
+        .iter()
+        .map(|bytes| u64::from_le_bytes(*bytes))
         .collect::<Vec<_>>();
     let mut expected = FEATURE_QUERIES
         .iter()

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -1930,9 +1930,6 @@ fn run_production_vsock_snapshot_continuation(
         .unwrap_or_else(|error| {
             panic!("production {transport} old snapshot-vsock connection should arrive: {error}")
         });
-    drop(old_listener);
-    fs::remove_file(&old_port_path)
-        .expect("production snapshot-vsock old listener path should clean up");
     old_stream
         .set_nonblocking(true)
         .expect("production old snapshot-vsock stream should be nonblocking");
@@ -1943,6 +1940,11 @@ fn run_production_vsock_snapshot_continuation(
         old_ready, SNAPSHOT_VSOCK_OLD_READY,
         "production {transport} old readiness should match"
     );
+    // Accept can win before the launcher completes its post-connect identity
+    // check and SCM_RIGHTS handoff. Exact guest readiness proves that boundary.
+    drop(old_listener);
+    fs::remove_file(&old_port_path)
+        .expect("production snapshot-vsock old listener path should clean up");
 
     assert_http_status(
         &http_request(&source.socket, "PATCH", "/vm", r#"{"state":"Paused"}"#),
@@ -2193,9 +2195,6 @@ fn run_production_vsock_snapshot_destination(
         .unwrap_or_else(|error| {
             panic!("production {case} restored fresh vsock connection should arrive: {error}")
         });
-    drop(fresh_listener);
-    fs::remove_file(&fresh_port_path)
-        .expect("production restored snapshot-vsock listener path should clean up");
     fresh_stream
         .set_nonblocking(true)
         .expect("production restored fresh vsock stream should be nonblocking");
@@ -2206,6 +2205,11 @@ fn run_production_vsock_snapshot_destination(
         fresh_ready, SNAPSHOT_VSOCK_FRESH_READY,
         "production {case} fresh readiness should match"
     );
+    // Keep pathname authority through the launcher's identity check and FD
+    // handoff; exact restored-guest readiness proves both have completed.
+    drop(fresh_listener);
+    fs::remove_file(&fresh_port_path)
+        .expect("production restored snapshot-vsock listener path should clean up");
     write_all_nonblocking(&mut fresh_stream, SNAPSHOT_VSOCK_FRESH_ACK, PROCESS_TIMEOUT)
         .expect("production restored fresh vsock acknowledgement should write");
     wait_for_stream_eof_nonblocking(&mut fresh_stream, PROCESS_TIMEOUT)
@@ -2383,6 +2387,8 @@ fn run_certified_production_vsock_snapshot_restore(
             &source_fixture.socket(),
             &format!("production {transport} source"),
             &source,
+            &source_logger.opened,
+            &source_fixture.snapshot.opened_metrics,
         );
     assert_eq!(
         source_host_ports,
@@ -3143,13 +3149,14 @@ fn run_certified_production_vsock_destination(
         204,
         &format!("load production {case} certified vsock snapshot"),
     );
+    let state = http_get(&running.socket, "/");
     assert!(
-        http_get(&running.socket, "/").contains(if resume_vm {
+        state.contains(if resume_vm {
             r#""state":"Running""#
         } else {
             r#""state":"Paused""#
         }),
-        "production {case} certified destination must publish the requested resume state"
+        "production {case} certified destination must publish the requested resume state: {state}"
     );
     let config = http_get(&running.socket, "/vm/config");
     assert_http_status(
@@ -3208,20 +3215,22 @@ fn run_certified_production_vsock_destination(
         &fixture.snapshot.opened_metrics,
     );
     drop(fresh_guest_streams);
-    for (index, stream) in host_streams.iter_mut().enumerate() {
-        let local_port =
-            read_certified_production_vsock_connect_ok(stream, PROCESS_TIMEOUT).unwrap_or_else(
-                |error| {
-                    panic!(
-                        "production {case} preserved-listener stream {index} should connect: {error}; {}",
-                        certified_production_vsock_failure_diagnostics(
-                            &running,
-                            &logger.opened,
-                            &fixture.snapshot.opened_metrics,
-                        )
-                    )
-                },
-            );
+    for index in 0..host_streams.len() {
+        let local_port = match read_certified_production_vsock_connect_ok(
+            &mut host_streams[index],
+            PROCESS_TIMEOUT,
+        ) {
+            Ok(local_port) => local_port,
+            Err(error) => panic!(
+                "production {case} preserved-listener stream {index} should connect: {error}; host stream states: {}; {}",
+                certified_production_vsock_host_stream_states(&host_streams),
+                certified_production_vsock_failure_diagnostics(
+                    &running,
+                    &logger.opened,
+                    &fixture.snapshot.opened_metrics,
+                )
+            ),
+        };
         assert_eq!(
             local_port,
             saved_cursor
@@ -3230,23 +3239,26 @@ fn run_certified_production_vsock_destination(
             "production {case} clone host-local cursor must continue independently at stream {index}"
         );
         let mut guest_reply = vec![0_u8; 4096];
-        read_exact_nonblocking(stream, &mut guest_reply, PROCESS_TIMEOUT).unwrap_or_else(|error| {
+        if let Err(error) =
+            read_exact_nonblocking(&mut host_streams[index], &mut guest_reply, PROCESS_TIMEOUT)
+        {
             panic!(
-                "production {case} host stream {index} guest reply should arrive: {error}; {}",
+                "production {case} host stream {index} guest reply should arrive: {error}; host stream states: {}; {}",
+                certified_production_vsock_host_stream_states(&host_streams),
                 certified_production_vsock_failure_diagnostics(
                     &running,
                     &logger.opened,
                     &fixture.snapshot.opened_metrics,
                 )
-            )
-        });
+            );
+        }
         assert_eq!(
             guest_reply,
             certified_snapshot_vsock_payload("FRESH_H2G_REPLY", index, 4096),
             "production {case} host stream {index} guest reply must remain isolated"
         );
         write_all_nonblocking(
-            stream,
+            &mut host_streams[index],
             &certified_snapshot_vsock_payload("FRESH_H2G", index, 4096),
             PROCESS_TIMEOUT,
         )
@@ -3260,23 +3272,24 @@ fn run_certified_production_vsock_destination(
                 )
             )
         });
-        stream
+        host_streams[index]
             .shutdown(std::net::Shutdown::Write)
             .unwrap_or_else(|error| {
                 panic!("production {case} host stream {index} should half-close: {error}")
             });
-        wait_for_stream_eof_nonblocking(stream, PROCESS_TIMEOUT).unwrap_or_else(|error| {
-            panic!(
-                "production {case} host stream {index} EOF should arrive: {error}; {}",
-                certified_production_vsock_failure_diagnostics(
-                    &running,
-                    &logger.opened,
-                    &fixture.snapshot.opened_metrics,
+        wait_for_stream_eof_nonblocking(&mut host_streams[index], PROCESS_TIMEOUT).unwrap_or_else(
+            |error| {
+                panic!(
+                    "production {case} host stream {index} EOF should arrive: {error}; {}",
+                    certified_production_vsock_failure_diagnostics(
+                        &running,
+                        &logger.opened,
+                        &fixture.snapshot.opened_metrics,
+                    )
                 )
-            )
-        });
+            },
+        );
     }
-
     for marker in [
         SNAPSHOT_VSOCK_CERTIFY_RESET_OBSERVED,
         SNAPSHOT_VSOCK_CERTIFY_FRESH_G2H_OK,
@@ -3549,6 +3562,8 @@ fn connect_certified_production_vsock_source_host_streams(
     socket: &Path,
     context: &str,
     running: &RunningSerialApiLauncher,
+    logger: &Path,
+    metrics: &Path,
 ) -> (Vec<UnixStream>, Vec<u32>) {
     let mut streams = Vec::with_capacity(1);
     let mut local_ports = Vec::with_capacity(1);
@@ -3586,8 +3601,15 @@ fn connect_certified_production_vsock_source_host_streams(
         .expect("production source host payload should write");
         let expected = certified_snapshot_vsock_payload("SOURCE_H2G_ACK", index, 128);
         let mut received = vec![0_u8; expected.len()];
-        read_exact_nonblocking(&mut stream, &mut received, PROCESS_TIMEOUT)
-            .expect("production source host acknowledgement should arrive");
+        read_exact_nonblocking(&mut stream, &mut received, PROCESS_TIMEOUT).unwrap_or_else(
+            |error| {
+                panic!(
+                    "{context} source host acknowledgement {index} should arrive: {error}; host stream state: {}; {}",
+                    certified_production_vsock_host_stream_states(std::slice::from_ref(&stream)),
+                    certified_production_vsock_failure_diagnostics(running, logger, metrics)
+                )
+            },
+        );
         assert_eq!(
             received, expected,
             "{context} source host acknowledgement should remain isolated"
@@ -3658,6 +3680,40 @@ fn read_certified_production_vsock_connect_ok(
     local_port
         .parse::<u32>()
         .map_err(|_| "CONNECT response had an invalid local port".to_owned())
+}
+
+fn certified_production_vsock_host_stream_states(streams: &[UnixStream]) -> String {
+    streams
+        .iter()
+        .enumerate()
+        .map(|(index, stream)| {
+            let mut byte = 0_u8;
+            // SAFETY: `byte` is writable for this non-consuming one-byte peek,
+            // and the borrowed stream descriptor remains live for the call.
+            let result = unsafe {
+                libc::recv(
+                    stream.as_raw_fd(),
+                    (&raw mut byte).cast(),
+                    1,
+                    libc::MSG_PEEK | libc::MSG_DONTWAIT,
+                )
+            };
+            let state = if result > 0 {
+                "readable".to_owned()
+            } else if result == 0 {
+                "eof".to_owned()
+            } else {
+                let error = std::io::Error::last_os_error();
+                if error.kind() == std::io::ErrorKind::WouldBlock {
+                    "open".to_owned()
+                } else {
+                    format!("error:{:?}", error.kind())
+                }
+            };
+            format!("{index}:{state}")
+        })
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 fn certified_snapshot_vsock_payload(kind: &str, index: usize, size: usize) -> Vec<u8> {
@@ -8773,21 +8829,25 @@ fn normal_bundle_routes_guest_vsock_through_launcher_broker_without_helpers() {
         assert_eq!(port, expected_port);
         let stream = wait_for_unix_listener_accept(&listener, PROCESS_TIMEOUT)
             .unwrap_or_else(|error| panic!("guest vsock port {port} should connect: {error}"));
-        drop(listener);
-        fs::remove_file(&path).expect("host-owned vsock port path should clean up");
         stream
             .set_nonblocking(true)
             .expect("accepted vsock stream should remain nonblocking");
-        streams.push(stream);
+        streams.push((path, Some(listener), stream));
     }
 
-    for (stream, &(_, guest_payload, _)) in streams.iter_mut().zip(GRANTED_VSOCK_EXCHANGES) {
+    for ((path, listener, stream), &(_, guest_payload, _)) in
+        streams.iter_mut().zip(GRANTED_VSOCK_EXCHANGES)
+    {
         let mut received = vec![0_u8; guest_payload.len()];
         read_exact_nonblocking(stream, &mut received, PROCESS_TIMEOUT)
             .expect("guest vsock payload should arrive");
         assert_eq!(received, guest_payload);
+        // The exact payload proves the launcher's pathname identity check and
+        // SCM_RIGHTS handoff completed before pathname authority is withdrawn.
+        drop(listener.take());
+        fs::remove_file(path).expect("host-owned vsock port path should clean up");
     }
-    for (stream, &(_, _, host_payload)) in streams.iter_mut().zip(GRANTED_VSOCK_EXCHANGES) {
+    for ((_, _, stream), &(_, _, host_payload)) in streams.iter_mut().zip(GRANTED_VSOCK_EXCHANGES) {
         write_all_nonblocking(stream, host_payload, PROCESS_TIMEOUT)
             .expect("host vsock reply should write");
     }

--- a/crates/runtime/src/balloon.rs
+++ b/crates/runtime/src/balloon.rs
@@ -934,7 +934,7 @@ impl VirtioBalloonPfnPayload {
         let mut pfns = Vec::new();
         pfns.try_reserve_exact(count)
             .map_err(|source| VirtioBalloonPfnPayloadParseError::PfnAllocation { count, source })?;
-        for chunk in bytes.chunks_exact(VIRTIO_BALLOON_PFN_SIZE) {
+        for chunk in bytes.as_chunks::<VIRTIO_BALLOON_PFN_SIZE>().0 {
             let mut pfn = [0; VIRTIO_BALLOON_PFN_SIZE];
             pfn.copy_from_slice(chunk);
             pfns.push(u32::from_le_bytes(pfn));
@@ -1956,7 +1956,7 @@ impl VirtioBalloonStatisticsDescriptor {
         let mut stats = BalloonOptionalStats::default();
         let mut stat_count = 0;
         let mut recognized_stat_count = 0;
-        for chunk in bytes.chunks_exact(VIRTIO_BALLOON_STAT_SIZE) {
+        for chunk in bytes.as_chunks::<VIRTIO_BALLOON_STAT_SIZE>().0 {
             let mut stat_bytes = [0; VIRTIO_BALLOON_STAT_SIZE];
             stat_bytes.copy_from_slice(chunk);
             stat_count += 1;

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -7299,7 +7299,9 @@ mod tests {
     fn prop_u32_cells(node: &Node, name: &str) -> Vec<u32> {
         node.prop_raw(name)
             .expect("property should exist")
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|chunk| u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
             .collect()
     }
@@ -7307,7 +7309,9 @@ mod tests {
     fn prop_u64_cells(node: &Node, name: &str) -> Vec<u64> {
         node.prop_raw(name)
             .expect("property should exist")
-            .chunks_exact(8)
+            .as_chunks::<8>()
+            .0
+            .iter()
             .map(|chunk| {
                 u64::from_be_bytes([
                     chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],

--- a/crates/runtime/src/logger.rs
+++ b/crates/runtime/src/logger.rs
@@ -673,6 +673,28 @@ impl VsockOutcomeLogRateLimiter {
     }
 }
 
+/// Keeps the bounded endpoint-close evidence budget independent from frequent
+/// successful vsock data-plane records. A guest can still exhaust this budget,
+/// but ordinary RX/TX traffic cannot hide the first local EOF or read failure.
+#[derive(Debug, Clone, Default)]
+struct VsockEndpointOutcomeLogRateLimiter {
+    inner: LoggerRateLimiters,
+}
+
+impl VsockEndpointOutcomeLogRateLimiter {
+    #[cfg(test)]
+    fn with_clock(clock: Arc<dyn LogRateLimiterClock>) -> Self {
+        Self {
+            inner: LoggerRateLimiters::with_clock(clock),
+        }
+    }
+
+    fn check(&self) -> LogRateLimitDecision {
+        self.inner
+            .check(LoggerRateLimitIdentity::VsockEndpointOutcome)
+    }
+}
+
 impl ObservabilityWorkerLogRateLimiter {
     #[cfg(test)]
     fn with_clock(clock: Arc<dyn LogRateLimiterClock>) -> Self {
@@ -876,6 +898,7 @@ struct GuestLoggerInner {
     serial_rate_limiter: SerialOutcomeLogRateLimiter,
     time_identity_rate_limiter: TimeIdentityOutcomeLogRateLimiter,
     vsock_rate_limiter: VsockOutcomeLogRateLimiter,
+    vsock_endpoint_rate_limiter: VsockEndpointOutcomeLogRateLimiter,
 }
 
 impl fmt::Debug for GuestLogger {
@@ -905,6 +928,10 @@ impl fmt::Debug for GuestLogger {
                 &self.inner.time_identity_rate_limiter,
             )
             .field("vsock_rate_limiter", &self.inner.vsock_rate_limiter)
+            .field(
+                "vsock_endpoint_rate_limiter",
+                &self.inner.vsock_endpoint_rate_limiter,
+            )
             .finish()
     }
 }
@@ -960,7 +987,7 @@ impl GuestLogger {
             outcomes
                 .into_iter()
                 .map(|outcome| (outcome.level(), LoggerEvent::Balloon(outcome))),
-            || self.inner.balloon_rate_limiter.check(),
+            |_| self.inner.balloon_rate_limiter.check(),
         );
     }
 
@@ -993,7 +1020,7 @@ impl GuestLogger {
             outcomes
                 .into_iter()
                 .map(|outcome| (outcome.level(), LoggerEvent::Entropy(outcome))),
-            || self.inner.entropy_rate_limiter.check(),
+            |_| self.inner.entropy_rate_limiter.check(),
         );
     }
 
@@ -1016,7 +1043,7 @@ impl GuestLogger {
             outcomes
                 .into_iter()
                 .map(|outcome| (outcome.level(), LoggerEvent::MemoryHotplug(outcome))),
-            || self.inner.memory_hotplug_rate_limiter.check(),
+            |_| self.inner.memory_hotplug_rate_limiter.check(),
         );
     }
 
@@ -1062,11 +1089,18 @@ impl GuestLogger {
 
     #[track_caller]
     pub fn log_vsock(&self, outcome: LoggerVsockOutcome) {
+        let check_limiter = || {
+            if outcome.uses_endpoint_rate_limiter() {
+                self.inner.vsock_endpoint_rate_limiter.check()
+            } else {
+                self.inner.vsock_rate_limiter.check()
+            }
+        };
         self.log_limited(
             outcome.level(),
             DEVICE_LOG_MODULE,
             LoggerEvent::Vsock(outcome),
-            || self.inner.vsock_rate_limiter.check(),
+            check_limiter,
         );
     }
 
@@ -1076,7 +1110,12 @@ impl GuestLogger {
             outcomes
                 .into_iter()
                 .map(|outcome| (outcome.level(), LoggerEvent::Vsock(outcome))),
-            || self.inner.vsock_rate_limiter.check(),
+            |event| match event {
+                LoggerEvent::Vsock(outcome) if outcome.uses_endpoint_rate_limiter() => {
+                    self.inner.vsock_endpoint_rate_limiter.check()
+                }
+                _ => self.inner.vsock_rate_limiter.check(),
+            },
         );
     }
 
@@ -1136,7 +1175,7 @@ impl GuestLogger {
     fn log_limited_summary(
         &self,
         events: impl IntoIterator<Item = (LoggerLevel, LoggerEvent)>,
-        mut check_limiter: impl FnMut() -> LogRateLimitDecision,
+        mut check_limiter: impl FnMut(&LoggerEvent) -> LogRateLimitDecision,
     ) {
         if !module_filter_allows(self.inner.module.as_deref(), DEVICE_LOG_MODULE) {
             return;
@@ -1151,7 +1190,7 @@ impl GuestLogger {
             if !self.inner.level.allows(level) {
                 continue;
             }
-            match check_limiter() {
+            match check_limiter(&event) {
                 LogRateLimitDecision::Admitted {
                     suppressed: recovered,
                 } => {
@@ -1221,6 +1260,7 @@ pub struct LoggerState {
     serial_rate_limiter: SerialOutcomeLogRateLimiter,
     time_identity_rate_limiter: TimeIdentityOutcomeLogRateLimiter,
     vsock_rate_limiter: VsockOutcomeLogRateLimiter,
+    vsock_endpoint_rate_limiter: VsockEndpointOutcomeLogRateLimiter,
     delivery_config: LoggerDeliveryConfig,
 }
 
@@ -1256,6 +1296,10 @@ impl fmt::Debug for LoggerState {
                 &self.time_identity_rate_limiter,
             )
             .field("vsock_rate_limiter", &self.vsock_rate_limiter)
+            .field(
+                "vsock_endpoint_rate_limiter",
+                &self.vsock_endpoint_rate_limiter,
+            )
             .field("delivery_config", &self.delivery_config)
             .finish()
     }
@@ -1309,6 +1353,7 @@ impl LoggerState {
             serial_rate_limiter: SerialOutcomeLogRateLimiter::default(),
             time_identity_rate_limiter: TimeIdentityOutcomeLogRateLimiter::default(),
             vsock_rate_limiter: VsockOutcomeLogRateLimiter::default(),
+            vsock_endpoint_rate_limiter: VsockEndpointOutcomeLogRateLimiter::default(),
             delivery_config: LoggerDeliveryConfig::default(),
         }
     }
@@ -1619,6 +1664,7 @@ impl LoggerState {
                 serial_rate_limiter: self.serial_rate_limiter.clone(),
                 time_identity_rate_limiter: self.time_identity_rate_limiter.clone(),
                 vsock_rate_limiter: self.vsock_rate_limiter.clone(),
+                vsock_endpoint_rate_limiter: self.vsock_endpoint_rate_limiter.clone(),
             }),
         }
     }
@@ -1784,7 +1830,7 @@ mod tests {
         NetworkOutcomeLogRateLimiter, ObservabilityWorkerLogRateLimiter, PmemOutcomeLogRateLimiter,
         ProcessStartupOutcome, ProcessTerminalCategory, SerialOutcomeLogRateLimiter,
         SharedLoggerMetrics, TimeIdentityOutcomeLogRateLimiter, TransportOutcomeLogRateLimiter,
-        VsockOutcomeLogRateLimiter,
+        VsockEndpointOutcomeLogRateLimiter, VsockOutcomeLogRateLimiter,
     };
     use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
 
@@ -2379,9 +2425,9 @@ mod tests {
         let logger = state.guest_logger();
 
         logger.log_vsock_summary([
-            LoggerVsockOutcome::GuestConnectionDropped,
-            LoggerVsockOutcome::TxSucceeded,
-            LoggerVsockOutcome::ConnectionResetQueued,
+            LoggerVsockOutcome::HostStreamGuestConnectionReadFailed,
+            LoggerVsockOutcome::GuestRwHostConnectionMissing,
+            LoggerVsockOutcome::ConnectionResetDelivered,
         ]);
         gate.wait_until_entered();
         assert_eq!(
@@ -2394,10 +2440,50 @@ mod tests {
         assert!(logger.wait_for_delivery_for_test());
         assert_eq!(
             *output.lock().expect("output lock should succeed"),
-            b"device-kind=vsock operation=guest-connection outcome=dropped\n\
-              device-kind=vsock operation=tx outcome=succeeded\n\
-              device-kind=vsock operation=connection-reset outcome=queued\n"
+            b"device-kind=vsock operation=host-stream-guest-connection outcome=read-failed\n\
+              device-kind=vsock operation=guest-rw-host-connection outcome=missing\n\
+              device-kind=vsock operation=connection-reset outcome=delivered\n"
         );
+    }
+
+    #[test]
+    fn vsock_endpoint_summary_survives_saturated_data_plane_limiter() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let metrics = SharedLoggerMetrics::default();
+        let clock = Arc::new(TestClock::default());
+        let mut state = LoggerState::with_shared_metrics(metrics.clone());
+        state.vsock_rate_limiter = VsockOutcomeLogRateLimiter::with_clock(clock.clone());
+        state.vsock_endpoint_rate_limiter = VsockEndpointOutcomeLogRateLimiter::with_clock(clock);
+        state.configure_test_writer(SharedWriter(output.clone()));
+        let logger = state.guest_logger();
+
+        for _ in 0..10 {
+            logger.log_vsock(LoggerVsockOutcome::RxSucceeded);
+        }
+        logger.log_vsock_summary([
+            LoggerVsockOutcome::HostStreamHostConnectionClosed,
+            LoggerVsockOutcome::GuestConnectionClosed,
+            LoggerVsockOutcome::TxSucceeded,
+        ]);
+
+        assert!(logger.wait_for_delivery_for_test());
+        let output = String::from_utf8(output.lock().expect("output lock should succeed").clone())
+            .expect("vsock output should be UTF-8");
+        assert_eq!(
+            output
+                .matches("device-kind=vsock operation=rx outcome=succeeded\n")
+                .count(),
+            10
+        );
+        assert_eq!(
+            output
+                .matches("device-kind=vsock operation=host-stream-host-connection outcome=closed\n")
+                .count(),
+            1
+        );
+        assert!(!output.contains("operation=guest-connection outcome=closed"));
+        assert!(!output.contains("operation=tx outcome=succeeded"));
+        assert_eq!(metrics.rate_limited_log_count(), 2);
     }
 
     #[test]

--- a/crates/runtime/src/logger/event.rs
+++ b/crates/runtime/src/logger/event.rs
@@ -906,14 +906,51 @@ pub enum LoggerVsockOutcome {
     GuestConnectionClosed,
     GuestConnectionIgnored,
     GuestConnectionDropped,
+    GuestRwHostConnectionForwarded,
+    GuestRwHostConnectionSuppressed,
+    GuestRwHostConnectionMissing,
+    GuestRwGuestConnectionForwarded,
+    GuestRwGuestConnectionSuppressed,
+    GuestRwGuestConnectionMissing,
+    GuestRstHostConnectionClosed,
+    GuestRstGuestConnectionClosed,
+    GuestRstIgnored,
+    GuestShutdownHostConnectionUpdated,
+    GuestShutdownHostConnectionClosed,
+    GuestShutdownGuestConnectionUpdated,
+    GuestShutdownGuestConnectionClosed,
+    GuestShutdownIgnored,
+    HostStreamHostConnectionClosed,
+    HostStreamHostConnectionReadFailed,
+    HostStreamGuestConnectionClosed,
+    HostStreamGuestConnectionReadFailed,
+    HostConnectionRequestDeadlineExpired,
+    HostConnectionShutdownDeadlineExpired,
+    GuestConnectionRequestDeadlineExpired,
+    GuestConnectionShutdownDeadlineExpired,
     ConnectionResetQueued,
     ConnectionResetDropped,
+    ConnectionResetDelivered,
     TransportResetSucceeded,
     TransportResetFailed,
     InterruptDeliveryFailed,
 }
 
 impl LoggerVsockOutcome {
+    pub(super) const fn uses_endpoint_rate_limiter(self) -> bool {
+        matches!(
+            self,
+            Self::HostStreamHostConnectionClosed
+                | Self::HostStreamHostConnectionReadFailed
+                | Self::HostStreamGuestConnectionClosed
+                | Self::HostStreamGuestConnectionReadFailed
+                | Self::HostConnectionRequestDeadlineExpired
+                | Self::HostConnectionShutdownDeadlineExpired
+                | Self::GuestConnectionRequestDeadlineExpired
+                | Self::GuestConnectionShutdownDeadlineExpired
+        )
+    }
+
     pub const fn operation(self) -> &'static str {
         match self {
             Self::RxSucceeded => "rx",
@@ -934,7 +971,34 @@ impl LoggerVsockOutcome {
             | Self::GuestConnectionClosed
             | Self::GuestConnectionIgnored
             | Self::GuestConnectionDropped => "guest-connection",
-            Self::ConnectionResetQueued | Self::ConnectionResetDropped => "connection-reset",
+            Self::GuestRwHostConnectionForwarded
+            | Self::GuestRwHostConnectionSuppressed
+            | Self::GuestRwHostConnectionMissing => "guest-rw-host-connection",
+            Self::GuestRwGuestConnectionForwarded
+            | Self::GuestRwGuestConnectionSuppressed
+            | Self::GuestRwGuestConnectionMissing => "guest-rw-guest-connection",
+            Self::GuestRstHostConnectionClosed => "guest-rst-host-connection",
+            Self::GuestRstGuestConnectionClosed => "guest-rst-guest-connection",
+            Self::GuestRstIgnored => "guest-rst",
+            Self::GuestShutdownHostConnectionUpdated | Self::GuestShutdownHostConnectionClosed => {
+                "guest-shutdown-host-connection"
+            }
+            Self::GuestShutdownGuestConnectionUpdated
+            | Self::GuestShutdownGuestConnectionClosed => "guest-shutdown-guest-connection",
+            Self::GuestShutdownIgnored => "guest-shutdown",
+            Self::HostStreamHostConnectionClosed | Self::HostStreamHostConnectionReadFailed => {
+                "host-stream-host-connection"
+            }
+            Self::HostStreamGuestConnectionClosed | Self::HostStreamGuestConnectionReadFailed => {
+                "host-stream-guest-connection"
+            }
+            Self::HostConnectionRequestDeadlineExpired => "host-connection-request-deadline",
+            Self::HostConnectionShutdownDeadlineExpired => "host-connection-shutdown-deadline",
+            Self::GuestConnectionRequestDeadlineExpired => "guest-connection-request-deadline",
+            Self::GuestConnectionShutdownDeadlineExpired => "guest-connection-shutdown-deadline",
+            Self::ConnectionResetQueued
+            | Self::ConnectionResetDropped
+            | Self::ConnectionResetDelivered => "connection-reset",
             Self::TransportResetSucceeded | Self::TransportResetFailed => "transport-reset",
             Self::InterruptDeliveryFailed => "interrupt-delivery",
         }
@@ -955,18 +1019,44 @@ impl LoggerVsockOutcome {
             Self::HostConnectionPending => "pending",
             Self::HostConnectionDropped | Self::GuestConnectionDropped => "dropped",
             Self::GuestConnectionRetained => "retained",
-            Self::GuestConnectionForwarded => "forwarded",
-            Self::GuestConnectionUpdated => "updated",
-            Self::GuestConnectionClosed => "closed",
-            Self::GuestConnectionIgnored => "ignored",
+            Self::GuestConnectionForwarded
+            | Self::GuestRwHostConnectionForwarded
+            | Self::GuestRwGuestConnectionForwarded => "forwarded",
+            Self::GuestConnectionUpdated
+            | Self::GuestShutdownHostConnectionUpdated
+            | Self::GuestShutdownGuestConnectionUpdated => "updated",
+            Self::GuestConnectionClosed
+            | Self::GuestRstHostConnectionClosed
+            | Self::GuestRstGuestConnectionClosed
+            | Self::GuestShutdownHostConnectionClosed
+            | Self::GuestShutdownGuestConnectionClosed
+            | Self::HostStreamHostConnectionClosed
+            | Self::HostStreamGuestConnectionClosed => "closed",
+            Self::GuestConnectionIgnored | Self::GuestRstIgnored | Self::GuestShutdownIgnored => {
+                "ignored"
+            }
+            Self::GuestRwHostConnectionSuppressed | Self::GuestRwGuestConnectionSuppressed => {
+                "suppressed"
+            }
+            Self::GuestRwHostConnectionMissing | Self::GuestRwGuestConnectionMissing => "missing",
+            Self::HostStreamHostConnectionReadFailed
+            | Self::HostStreamGuestConnectionReadFailed => "read-failed",
+            Self::HostConnectionRequestDeadlineExpired
+            | Self::HostConnectionShutdownDeadlineExpired
+            | Self::GuestConnectionRequestDeadlineExpired
+            | Self::GuestConnectionShutdownDeadlineExpired => "expired",
             Self::ConnectionResetQueued => "queued",
             Self::ConnectionResetDropped => "dropped",
+            Self::ConnectionResetDelivered => "delivered",
         }
     }
 
     pub(super) const fn level(self) -> LoggerLevel {
         match self {
-            Self::HostConnectionPending | Self::GuestConnectionIgnored => LoggerLevel::Debug,
+            Self::HostConnectionPending
+            | Self::GuestConnectionIgnored
+            | Self::GuestRstIgnored
+            | Self::GuestShutdownIgnored => LoggerLevel::Debug,
             Self::RxSucceeded
             | Self::TxSucceeded
             | Self::HostConnectionAccepted
@@ -975,17 +1065,38 @@ impl LoggerVsockOutcome {
             | Self::GuestConnectionForwarded
             | Self::GuestConnectionUpdated
             | Self::GuestConnectionClosed
+            | Self::GuestRwHostConnectionForwarded
+            | Self::GuestRwHostConnectionSuppressed
+            | Self::GuestRwGuestConnectionForwarded
+            | Self::GuestRwGuestConnectionSuppressed
+            | Self::GuestRstHostConnectionClosed
+            | Self::GuestRstGuestConnectionClosed
+            | Self::GuestShutdownHostConnectionUpdated
+            | Self::GuestShutdownHostConnectionClosed
+            | Self::GuestShutdownGuestConnectionUpdated
+            | Self::GuestShutdownGuestConnectionClosed
+            | Self::HostStreamHostConnectionClosed
+            | Self::HostStreamGuestConnectionClosed
             | Self::ConnectionResetQueued
+            | Self::ConnectionResetDelivered
             | Self::TransportResetSucceeded => LoggerLevel::Info,
             Self::RxBufferTooSmall
             | Self::QueueNotificationUnsupported
             | Self::HostConnectionDropped
             | Self::GuestConnectionDropped
+            | Self::GuestRwHostConnectionMissing
+            | Self::GuestRwGuestConnectionMissing
+            | Self::HostConnectionRequestDeadlineExpired
+            | Self::HostConnectionShutdownDeadlineExpired
+            | Self::GuestConnectionRequestDeadlineExpired
+            | Self::GuestConnectionShutdownDeadlineExpired
             | Self::ConnectionResetDropped => LoggerLevel::Warn,
             Self::RxBufferMalformed
             | Self::TxPacketMalformed
             | Self::QueueDispatchFailed
             | Self::QueueNotificationInactive
+            | Self::HostStreamHostConnectionReadFailed
+            | Self::HostStreamGuestConnectionReadFailed
             | Self::TransportResetFailed
             | Self::InterruptDeliveryFailed => LoggerLevel::Error,
         }
@@ -3708,6 +3819,138 @@ mod tests {
                 "dropped",
             ),
             (
+                LoggerVsockOutcome::GuestRwHostConnectionForwarded,
+                LoggerLevel::Info,
+                "guest-rw-host-connection",
+                "forwarded",
+            ),
+            (
+                LoggerVsockOutcome::GuestRwHostConnectionSuppressed,
+                LoggerLevel::Info,
+                "guest-rw-host-connection",
+                "suppressed",
+            ),
+            (
+                LoggerVsockOutcome::GuestRwHostConnectionMissing,
+                LoggerLevel::Warn,
+                "guest-rw-host-connection",
+                "missing",
+            ),
+            (
+                LoggerVsockOutcome::GuestRwGuestConnectionForwarded,
+                LoggerLevel::Info,
+                "guest-rw-guest-connection",
+                "forwarded",
+            ),
+            (
+                LoggerVsockOutcome::GuestRwGuestConnectionSuppressed,
+                LoggerLevel::Info,
+                "guest-rw-guest-connection",
+                "suppressed",
+            ),
+            (
+                LoggerVsockOutcome::GuestRwGuestConnectionMissing,
+                LoggerLevel::Warn,
+                "guest-rw-guest-connection",
+                "missing",
+            ),
+            (
+                LoggerVsockOutcome::GuestRstHostConnectionClosed,
+                LoggerLevel::Info,
+                "guest-rst-host-connection",
+                "closed",
+            ),
+            (
+                LoggerVsockOutcome::GuestRstGuestConnectionClosed,
+                LoggerLevel::Info,
+                "guest-rst-guest-connection",
+                "closed",
+            ),
+            (
+                LoggerVsockOutcome::GuestRstIgnored,
+                LoggerLevel::Debug,
+                "guest-rst",
+                "ignored",
+            ),
+            (
+                LoggerVsockOutcome::GuestShutdownHostConnectionUpdated,
+                LoggerLevel::Info,
+                "guest-shutdown-host-connection",
+                "updated",
+            ),
+            (
+                LoggerVsockOutcome::GuestShutdownHostConnectionClosed,
+                LoggerLevel::Info,
+                "guest-shutdown-host-connection",
+                "closed",
+            ),
+            (
+                LoggerVsockOutcome::GuestShutdownGuestConnectionUpdated,
+                LoggerLevel::Info,
+                "guest-shutdown-guest-connection",
+                "updated",
+            ),
+            (
+                LoggerVsockOutcome::GuestShutdownGuestConnectionClosed,
+                LoggerLevel::Info,
+                "guest-shutdown-guest-connection",
+                "closed",
+            ),
+            (
+                LoggerVsockOutcome::GuestShutdownIgnored,
+                LoggerLevel::Debug,
+                "guest-shutdown",
+                "ignored",
+            ),
+            (
+                LoggerVsockOutcome::HostStreamHostConnectionClosed,
+                LoggerLevel::Info,
+                "host-stream-host-connection",
+                "closed",
+            ),
+            (
+                LoggerVsockOutcome::HostStreamHostConnectionReadFailed,
+                LoggerLevel::Error,
+                "host-stream-host-connection",
+                "read-failed",
+            ),
+            (
+                LoggerVsockOutcome::HostStreamGuestConnectionClosed,
+                LoggerLevel::Info,
+                "host-stream-guest-connection",
+                "closed",
+            ),
+            (
+                LoggerVsockOutcome::HostStreamGuestConnectionReadFailed,
+                LoggerLevel::Error,
+                "host-stream-guest-connection",
+                "read-failed",
+            ),
+            (
+                LoggerVsockOutcome::HostConnectionRequestDeadlineExpired,
+                LoggerLevel::Warn,
+                "host-connection-request-deadline",
+                "expired",
+            ),
+            (
+                LoggerVsockOutcome::HostConnectionShutdownDeadlineExpired,
+                LoggerLevel::Warn,
+                "host-connection-shutdown-deadline",
+                "expired",
+            ),
+            (
+                LoggerVsockOutcome::GuestConnectionRequestDeadlineExpired,
+                LoggerLevel::Warn,
+                "guest-connection-request-deadline",
+                "expired",
+            ),
+            (
+                LoggerVsockOutcome::GuestConnectionShutdownDeadlineExpired,
+                LoggerLevel::Warn,
+                "guest-connection-shutdown-deadline",
+                "expired",
+            ),
+            (
                 LoggerVsockOutcome::ConnectionResetQueued,
                 LoggerLevel::Info,
                 "connection-reset",
@@ -3718,6 +3961,12 @@ mod tests {
                 LoggerLevel::Warn,
                 "connection-reset",
                 "dropped",
+            ),
+            (
+                LoggerVsockOutcome::ConnectionResetDelivered,
+                LoggerLevel::Info,
+                "connection-reset",
+                "delivered",
             ),
             (
                 LoggerVsockOutcome::TransportResetSucceeded,

--- a/crates/runtime/src/logger/rate_limiter.rs
+++ b/crates/runtime/src/logger/rate_limiter.rs
@@ -51,6 +51,7 @@ pub(super) enum LoggerRateLimitIdentity {
     SerialOutcome,
     TimeIdentityOutcome,
     VsockOutcome,
+    VsockEndpointOutcome,
 }
 
 impl LoggerRateLimitIdentity {
@@ -70,11 +71,12 @@ impl LoggerRateLimitIdentity {
             Self::SerialOutcome => 11,
             Self::TimeIdentityOutcome => 12,
             Self::VsockOutcome => 13,
+            Self::VsockEndpointOutcome => 14,
         }
     }
 }
 
-const LOGGER_RATE_LIMIT_IDENTITIES: [LoggerRateLimitIdentity; 14] = [
+const LOGGER_RATE_LIMIT_IDENTITIES: [LoggerRateLimitIdentity; 15] = [
     LoggerRateLimitIdentity::BootTimer,
     LoggerRateLimitIdentity::ApiRequest,
     LoggerRateLimitIdentity::ObservabilityWorker,
@@ -89,6 +91,7 @@ const LOGGER_RATE_LIMIT_IDENTITIES: [LoggerRateLimitIdentity; 14] = [
     LoggerRateLimitIdentity::SerialOutcome,
     LoggerRateLimitIdentity::TimeIdentityOutcome,
     LoggerRateLimitIdentity::VsockOutcome,
+    LoggerRateLimitIdentity::VsockEndpointOutcome,
 ];
 const LOGGER_RATE_LIMIT_IDENTITY_COUNT: usize = LOGGER_RATE_LIMIT_IDENTITIES.len();
 

--- a/crates/runtime/src/metrics/firecracker.rs
+++ b/crates/runtime/src/metrics/firecracker.rs
@@ -1509,7 +1509,6 @@ fn metric_descriptor(
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
-    use std::io::Write as _;
     use std::time::Duration;
 
     use super::*;

--- a/crates/runtime/src/mmds_stack.rs
+++ b/crates/runtime/src/mmds_stack.rs
@@ -938,14 +938,11 @@ fn internet_checksum(bytes: &[u8]) -> u16 {
 }
 
 fn checksum_add(mut sum: u32, bytes: &[u8]) -> u32 {
-    let mut chunks = bytes.chunks_exact(2);
-    for chunk in &mut chunks {
-        let [first, second] = chunk else {
-            continue;
-        };
+    let (chunks, remainder) = bytes.as_chunks::<2>();
+    for [first, second] in chunks {
         sum = sum.saturating_add(u32::from(u16::from_be_bytes([*first, *second])));
     }
-    if let Some(byte) = chunks.remainder().first() {
+    if let Some(byte) = remainder.first() {
         sum = sum.saturating_add(u32::from(*byte) << 8);
     }
     sum

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -13277,7 +13277,9 @@ mod tests {
             let compact = fixture.split_ascii_whitespace().collect::<String>();
             compact
                 .as_bytes()
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|pair| {
                     u8::from_str_radix(
                         std::str::from_utf8(pair).expect("fixture should be ASCII"),

--- a/crates/runtime/src/network_packet.rs
+++ b/crates/runtime/src/network_packet.rs
@@ -1468,13 +1468,11 @@ fn ethernet_source_mac(packet: &[u8]) -> Option<[u8; ETHERNET_ADDRESS_LEN]> {
 }
 
 fn checksum_add(mut sum: u64, bytes: &[u8]) -> u64 {
-    let mut chunks = bytes.chunks_exact(2);
-    for chunk in &mut chunks {
-        if let Ok(word) = <[u8; 2]>::try_from(chunk) {
-            sum += u64::from(u16::from_be_bytes(word));
-        }
+    let (chunks, remainder) = bytes.as_chunks::<2>();
+    for word in chunks {
+        sum += u64::from(u16::from_be_bytes(*word));
     }
-    if let Some(byte) = chunks.remainder().first() {
+    if let Some(byte) = remainder.first() {
         sum += u64::from(*byte) << 8;
     }
     sum

--- a/crates/runtime/src/snapshot_artifact/tests.rs
+++ b/crates/runtime/src/snapshot_artifact/tests.rs
@@ -2962,7 +2962,9 @@ fn fixture_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.split_whitespace().collect::<String>();
     assert!(hex.len().is_multiple_of(2));
     hex.as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
             u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/runtime/src/snapshot_balloon_v2_9/tests.rs
+++ b/crates/runtime/src/snapshot_balloon_v2_9/tests.rs
@@ -1911,7 +1911,9 @@ fn fixture_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.split_whitespace().collect::<String>();
     assert!(hex.len().is_multiple_of(2));
     hex.as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
             u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/runtime/src/snapshot_device_v2/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2/tests.rs
@@ -215,7 +215,7 @@ fn fixture_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.trim();
     assert!(hex.len().is_multiple_of(2));
     let mut bytes = Vec::with_capacity(hex.len() / 2);
-    for pair in hex.as_bytes().chunks_exact(2) {
+    for pair in hex.as_bytes().as_chunks::<2>().0 {
         let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
         bytes.push(u8::from_str_radix(pair, 16).expect("fixture hex should decode"));
     }

--- a/crates/runtime/src/snapshot_device_v2_5/codec.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/codec.rs
@@ -157,7 +157,7 @@ pub(super) fn encode_with_policy<R: ReservePolicy>(
     for (record, sections) in graph
         .records
         .iter()
-        .zip(sections.chunks_exact(SECTION_COUNT_PER_RECORD))
+        .zip(sections.as_chunks::<SECTION_COUNT_PER_RECORD>().0)
     {
         let config = sections
             .first()

--- a/crates/runtime/src/snapshot_device_v2_5/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/tests.rs
@@ -320,7 +320,7 @@ fn fixture_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.trim();
     assert!(hex.len().is_multiple_of(2));
     let mut bytes = Vec::with_capacity(hex.len() / 2);
-    for pair in hex.as_bytes().chunks_exact(2) {
+    for pair in hex.as_bytes().as_chunks::<2>().0 {
         let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
         bytes.push(u8::from_str_radix(pair, 16).expect("fixture hex should decode"));
     }

--- a/crates/runtime/src/snapshot_device_v2_6/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/tests.rs
@@ -92,7 +92,9 @@ fn decode_hex(hex: &str) -> Vec<u8> {
     let hex = hex.trim();
     assert!(hex.len().is_multiple_of(2));
     hex.as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             u8::from_str_radix(
                 std::str::from_utf8(pair).expect("fixture pair should be UTF-8"),

--- a/crates/runtime/src/snapshot_diff_v2_13/tests.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/tests.rs
@@ -1096,14 +1096,14 @@ fn replace_u64(bytes: &mut [u8], offset: usize, value: u64) {
 
 fn decode_hex(text: &str) -> Vec<u8> {
     let text = text.trim();
-    let mut chunks = text.as_bytes().chunks_exact(2);
+    let (chunks, remainder) = text.as_bytes().as_chunks::<2>();
     let mut bytes = Vec::new();
     bytes.reserve_exact(chunks.len());
-    for chunk in &mut chunks {
+    for chunk in chunks {
         let pair = std::str::from_utf8(chunk).expect("fixture hex should be UTF-8");
         bytes.push(u8::from_str_radix(pair, 16).expect("fixture hex should decode"));
     }
-    assert!(chunks.remainder().is_empty(), "fixture hex must be even");
+    assert!(remainder.is_empty(), "fixture hex must be even");
     bytes
 }
 

--- a/crates/runtime/src/snapshot_diff_v2_13/writer/tests.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/writer/tests.rs
@@ -966,13 +966,13 @@ fn allocation_error() -> TryReserveError {
 
 fn decode_hex(text: &str) -> Vec<u8> {
     let text = text.trim();
-    let mut chunks = text.as_bytes().chunks_exact(2);
+    let (chunks, remainder) = text.as_bytes().as_chunks::<2>();
     let mut bytes = Vec::new();
     bytes.reserve_exact(chunks.len());
-    for chunk in &mut chunks {
+    for chunk in chunks {
         let pair = std::str::from_utf8(chunk).expect("fixture hex should be UTF-8");
         bytes.push(u8::from_str_radix(pair, 16).expect("fixture hex should decode"));
     }
-    assert!(chunks.remainder().is_empty());
+    assert!(remainder.is_empty());
     bytes
 }

--- a/crates/runtime/src/snapshot_entropy_v2_8/tests.rs
+++ b/crates/runtime/src/snapshot_entropy_v2_8/tests.rs
@@ -697,7 +697,9 @@ fn fixture_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.trim();
     assert!(hex.len().is_multiple_of(2));
     hex.as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
             u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
@@ -1207,7 +1207,9 @@ fn fixture_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.split_whitespace().collect::<String>();
     assert!(hex.len().is_multiple_of(2));
     hex.as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
             u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/runtime/src/snapshot_memory_v2/materialize.rs
+++ b/crates/runtime/src/snapshot_memory_v2/materialize.rs
@@ -641,7 +641,9 @@ mod tests {
         let compact = hex.split_whitespace().collect::<String>();
         compact
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
                 u8::from_str_radix(pair, 16).expect("fixture hex should decode")

--- a/crates/runtime/src/snapshot_network_restore_v2_11.rs
+++ b/crates/runtime/src/snapshot_network_restore_v2_11.rs
@@ -1564,7 +1564,9 @@ mod tests {
         let compact = fixture.split_ascii_whitespace().collect::<String>();
         compact
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 u8::from_str_radix(
                     std::str::from_utf8(pair).expect("fixture should be ASCII"),

--- a/crates/runtime/src/snapshot_network_v2_11/tests.rs
+++ b/crates/runtime/src/snapshot_network_v2_11/tests.rs
@@ -37,7 +37,9 @@ fn fixture_bytes(fixture: &str) -> Vec<u8> {
     );
     compact
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             u8::from_str_radix(
                 std::str::from_utf8(pair).expect("fixture should be ASCII"),

--- a/crates/runtime/src/snapshot_restore.rs
+++ b/crates/runtime/src/snapshot_restore.rs
@@ -1197,7 +1197,9 @@ mod tests {
         assert!(value.len().is_multiple_of(2));
         value
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 u8::from_str_radix(
                     std::str::from_utf8(pair).expect("hex pair should be UTF-8"),

--- a/crates/runtime/src/snapshot_serial_v2_7/tests.rs
+++ b/crates/runtime/src/snapshot_serial_v2_7/tests.rs
@@ -81,7 +81,9 @@ fn decode_hex(value: &str) -> Vec<u8> {
     assert!(value.len().is_multiple_of(2));
     value
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             u8::from_str_radix(
                 std::str::from_utf8(pair).expect("hex pair should be UTF-8"),

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
@@ -100,7 +100,9 @@ fn decode_hex(value: &str) -> Vec<u8> {
     assert!(value.len().is_multiple_of(2));
     value
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             u8::from_str_radix(
                 std::str::from_utf8(pair).expect("fixture pair should be UTF-8"),

--- a/crates/runtime/src/snapshot_vsock_v2_12/tests.rs
+++ b/crates/runtime/src/snapshot_vsock_v2_12/tests.rs
@@ -1008,7 +1008,7 @@ fn fixture_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.trim();
     assert!(hex.len().is_multiple_of(2));
     let mut bytes = Vec::with_capacity(hex.len() / 2);
-    for pair in hex.as_bytes().chunks_exact(2) {
+    for pair in hex.as_bytes().as_chunks::<2>().0 {
         let text = std::str::from_utf8(pair).expect("fixture pair should be UTF-8");
         bytes.push(u8::from_str_radix(text, 16).expect("fixture pair should be hexadecimal"));
     }

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -112,8 +112,8 @@ use crate::vsock::{
     VirtioVsockCaptureValidation, VirtioVsockDeviceCaptureError,
     VirtioVsockDeviceNotificationDispatch, VirtioVsockDeviceNotificationError,
     VirtioVsockMmioCaptureState, VirtioVsockMmioHandler, VirtioVsockTransportResetAttempt,
-    VirtioVsockTransportResetError, VsockConfig, VsockMmioDeviceRegistration, VsockMmioLayout,
-    VsockMmioRegistrationError,
+    VirtioVsockTransportResetError, VsockConfig, VsockHostReadinessRegistration,
+    VsockMmioDeviceRegistration, VsockMmioLayout, VsockMmioRegistrationError,
 };
 
 const MIB: u64 = 1024 * 1024;
@@ -705,6 +705,8 @@ pub struct Arm64BootVsockWakeup {
     host_read_fds: Vec<RawFd>,
     host_write_fds: Vec<RawFd>,
     deadline: Option<Instant>,
+    readiness_generation: u64,
+    read_registrations: Vec<VsockHostReadinessRegistration>,
 }
 
 impl Arm64BootVsockWakeup {
@@ -713,6 +715,8 @@ impl Arm64BootVsockWakeup {
             host_read_fds: Vec::new(),
             host_write_fds: Vec::new(),
             deadline: None,
+            readiness_generation: 0,
+            read_registrations: Vec::new(),
         }
     }
 
@@ -720,11 +724,15 @@ impl Arm64BootVsockWakeup {
         host_read_fds: Vec<RawFd>,
         host_write_fds: Vec<RawFd>,
         deadline: Option<Instant>,
+        readiness_generation: u64,
+        read_registrations: Vec<VsockHostReadinessRegistration>,
     ) -> Self {
         Self {
             host_read_fds,
             host_write_fds,
             deadline,
+            readiness_generation,
+            read_registrations,
         }
     }
 
@@ -740,8 +748,26 @@ impl Arm64BootVsockWakeup {
         self.deadline
     }
 
-    pub fn into_parts(self) -> (Vec<RawFd>, Vec<RawFd>, Option<Instant>) {
-        (self.host_read_fds, self.host_write_fds, self.deadline)
+    pub const fn readiness_generation(&self) -> u64 {
+        self.readiness_generation
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<RawFd>,
+        Vec<RawFd>,
+        Option<Instant>,
+        u64,
+        Vec<VsockHostReadinessRegistration>,
+    ) {
+        (
+            self.host_read_fds,
+            self.host_write_fds,
+            self.deadline,
+            self.readiness_generation,
+            self.read_registrations,
+        )
     }
 }
 
@@ -3649,9 +3675,17 @@ impl Arm64BootRuntimeResources {
         handler
             .activation_handler()
             .host_wakeup()
-            .map(|(read_fds, write_fds, deadline)| {
-                Arm64BootVsockWakeup::new(read_fds, write_fds, deadline)
-            })
+            .map(
+                |(read_fds, write_fds, deadline, readiness_generation, read_registrations)| {
+                    Arm64BootVsockWakeup::new(
+                        read_fds,
+                        write_fds,
+                        deadline,
+                        readiness_generation,
+                        read_registrations,
+                    )
+                },
+            )
             .map_err(|source| Arm64BootVsockWakeupFdsError::ResultAllocation { source })
     }
 

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -6005,8 +6005,15 @@ fn ensure_distinct_vmgenid_generation_id(
     retained: &[u8; ARM64_BOOT_VMGENID_SIZE],
 ) {
     for (candidate_half, retained_half) in candidate
-        .chunks_exact_mut(std::mem::size_of::<u64>())
-        .zip(retained.chunks_exact(std::mem::size_of::<u64>()))
+        .as_chunks_mut::<{ std::mem::size_of::<u64>() }>()
+        .0
+        .iter_mut()
+        .zip(
+            retained
+                .as_chunks::<{ std::mem::size_of::<u64>() }>()
+                .0
+                .iter(),
+        )
     {
         if candidate_half == retained_half
             && let Some(first_byte) = candidate_half.first_mut()
@@ -9457,7 +9464,9 @@ mod tests {
     fn prop_u32_cells(node: &Node, name: &str) -> Vec<u32> {
         node.prop_raw(name)
             .expect("property should exist")
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|chunk| u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
             .collect()
     }
@@ -9465,7 +9474,9 @@ mod tests {
     fn prop_u64_cells(node: &Node, name: &str) -> Vec<u64> {
         node.prop_raw(name)
             .expect("property should exist")
-            .chunks_exact(8)
+            .as_chunks::<8>()
+            .0
+            .iter()
             .map(|chunk| {
                 u64::from_be_bytes([
                     chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
@@ -10254,8 +10265,15 @@ mod tests {
         assert!(
             device
                 .generation_id
-                .chunks_exact(std::mem::size_of::<u64>())
-                .zip(retained.chunks_exact(std::mem::size_of::<u64>()))
+                .as_chunks::<{ std::mem::size_of::<u64>() }>()
+                .0
+                .iter()
+                .zip(
+                    retained
+                        .as_chunks::<{ std::mem::size_of::<u64>() }>()
+                        .0
+                        .iter(),
+                )
                 .all(|(candidate_half, retained_half)| candidate_half != retained_half)
         );
         assert!(device.generation_id.iter().any(|byte| *byte != 0));
@@ -10276,8 +10294,15 @@ mod tests {
         assert!(
             device
                 .generation_id
-                .chunks_exact(std::mem::size_of::<u64>())
-                .zip(retained.chunks_exact(std::mem::size_of::<u64>()))
+                .as_chunks::<{ std::mem::size_of::<u64>() }>()
+                .0
+                .iter()
+                .zip(
+                    retained
+                        .as_chunks::<{ std::mem::size_of::<u64>() }>()
+                        .0
+                        .iter(),
+                )
                 .all(|(candidate_half, retained_half)| candidate_half != retained_half)
         );
         assert!(device.generation_id.iter().any(|byte| *byte != 0));

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -97,7 +97,6 @@ const VIRTIO_VSOCK_EVENT_TRANSPORT_RESET_SIZE: u32 = mem::size_of::<u32>() as u3
 const NONBLOCKING_CONNECT_INTERRUPTED_RETRY_LIMIT: usize = 4;
 const VSOCK_GUEST_RW_PENDING_PACKET_LIMIT: usize = 4;
 const VSOCK_HOST_RW_PENDING_PACKET_LIMIT: usize = 4;
-const VSOCK_HOST_RW_POLL_BATCH_LIMIT: usize = VSOCK_HOST_RW_PENDING_PACKET_LIMIT;
 // Host stream bytes are prefetched before the next guest RX descriptor is available. Keep each
 // prefetched payload small enough for the supported Linux guest's receive buffers, including the
 // virtio-vsock packet header.
@@ -111,14 +110,69 @@ const VSOCK_HOST_CONNECT_COMMAND: &str = "connect";
 
 pub type VirtioVsockMmioHandler =
     VirtioMmioRegisterHandler<VirtioVsockConfigSpace, VirtioVsockDevice>;
-/// Host file descriptors and deadline that should wake a running vsock device.
-pub type VsockHostWakeup = (Vec<RawFd>, Vec<RawFd>, Option<Instant>);
+/// Host file descriptors, deadline, device generation, and read registrations for one poll.
+pub type VsockHostWakeup = (
+    Vec<RawFd>,
+    Vec<RawFd>,
+    Option<Instant>,
+    u64,
+    Vec<VsockHostReadinessRegistration>,
+);
+
+/// Exact connection identity attached to one host-read poll registration.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VsockHostReadinessTarget {
+    HostConnection(VsockHostConnectionKey),
+    GuestConnection(VsockGuestConnectionKey),
+}
+
+/// One descriptor registration captured before the host monitor begins polling.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VsockHostReadinessRegistration {
+    descriptor: RawFd,
+    target: Option<VsockHostReadinessTarget>,
+}
+
+impl VsockHostReadinessRegistration {
+    pub const fn unclassified(descriptor: RawFd) -> Self {
+        Self {
+            descriptor,
+            target: None,
+        }
+    }
+
+    pub const fn host_connection(descriptor: RawFd, key: VsockHostConnectionKey) -> Self {
+        Self {
+            descriptor,
+            target: Some(VsockHostReadinessTarget::HostConnection(key)),
+        }
+    }
+
+    pub const fn guest_connection(descriptor: RawFd, key: VsockGuestConnectionKey) -> Self {
+        Self {
+            descriptor,
+            target: Some(VsockHostReadinessTarget::GuestConnection(key)),
+        }
+    }
+
+    pub const fn descriptor(self) -> RawFd {
+        self.descriptor
+    }
+
+    pub const fn target(self) -> Option<VsockHostReadinessTarget> {
+        self.target
+    }
+}
 
 /// One host descriptor readiness observation retained by the VMM run loop.
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VsockHostReadiness {
     descriptor: RawFd,
+    generation: u64,
+    target: Option<VsockHostReadinessTarget>,
     readable: bool,
     writable: bool,
     error: bool,
@@ -127,9 +181,15 @@ pub struct VsockHostReadiness {
 }
 
 impl VsockHostReadiness {
-    pub const fn from_poll_revents(descriptor: RawFd, revents: libc::c_short) -> Self {
+    pub const fn from_poll_revents(
+        descriptor: RawFd,
+        revents: libc::c_short,
+        generation: u64,
+    ) -> Self {
         Self {
             descriptor,
+            generation,
+            target: None,
             readable: revents & libc::POLLIN != 0,
             writable: revents & libc::POLLOUT != 0,
             error: revents & libc::POLLERR != 0,
@@ -140,6 +200,31 @@ impl VsockHostReadiness {
 
     pub const fn descriptor(self) -> RawFd {
         self.descriptor
+    }
+
+    pub const fn generation(self) -> u64 {
+        self.generation
+    }
+
+    pub const fn for_registration(
+        registration: VsockHostReadinessRegistration,
+        revents: libc::c_short,
+        generation: u64,
+    ) -> Self {
+        Self {
+            descriptor: registration.descriptor(),
+            generation,
+            target: registration.target(),
+            readable: revents & libc::POLLIN != 0,
+            writable: revents & libc::POLLOUT != 0,
+            error: revents & libc::POLLERR != 0,
+            hangup: revents & libc::POLLHUP != 0,
+            invalid: revents & libc::POLLNVAL != 0,
+        }
+    }
+
+    pub const fn target(self) -> Option<VsockHostReadinessTarget> {
+        self.target
     }
 
     pub const fn readable(self) -> bool {
@@ -1938,6 +2023,13 @@ enum VsockHostRwPollOutcome {
     ReadError,
 }
 
+#[derive(Debug, Default)]
+struct VsockHostRwTablePollDispatch {
+    reset_headers: Vec<VirtioVsockPacketHeader>,
+    closed_connections: usize,
+    read_failed_connections: usize,
+}
+
 fn vsock_host_rw_poll_observation(
     outcome: VsockHostRwPollOutcome,
     read_bytes: usize,
@@ -1957,56 +2049,42 @@ fn poll_host_rw_payloads_from_stream(
     credit: &mut VsockConnectionCredit,
     scratch: &mut [u8],
 ) -> VsockHostRwPollOutcome {
-    let mut queued_payload = false;
-
-    for _ in 0..VSOCK_HOST_RW_POLL_BATCH_LIMIT {
-        if pending_host_rw_payloads.len() >= VSOCK_HOST_RW_PENDING_PACKET_LIMIT {
-            break;
-        }
-
-        let read_len = usize::try_from(credit.peer_available_credit())
-            .unwrap_or(usize::MAX)
-            .min(scratch.len());
-        if read_len == 0 {
-            credit.ensure_credit_request_if_exhausted();
-            break;
-        }
-        let Some(read_buffer) = scratch.get_mut(..read_len) else {
-            return VsockHostRwPollOutcome::ReadError;
-        };
-
-        match stream.read(read_buffer) {
-            Ok(0) => return VsockHostRwPollOutcome::Closed,
-            Ok(read_len) => {
-                let Some(bytes) = scratch.get(..read_len) else {
-                    return VsockHostRwPollOutcome::ReadError;
-                };
-                if !credit.reserve_peer_bytes(payload_len_u32(read_len)) {
-                    return VsockHostRwPollOutcome::ReadError;
-                }
-                pending_host_rw_payloads.push_back(bytes.to_vec());
-                queued_payload = true;
-            }
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
-                ) =>
-            {
-                return if queued_payload {
-                    VsockHostRwPollOutcome::Queued
-                } else {
-                    VsockHostRwPollOutcome::NoData
-                };
-            }
-            Err(_) => return VsockHostRwPollOutcome::ReadError,
-        }
+    if pending_host_rw_payloads.len() >= VSOCK_HOST_RW_PENDING_PACKET_LIMIT {
+        return VsockHostRwPollOutcome::NoData;
     }
 
-    if queued_payload {
-        VsockHostRwPollOutcome::Queued
-    } else {
-        VsockHostRwPollOutcome::NoData
+    let read_len = usize::try_from(credit.peer_available_credit())
+        .unwrap_or(usize::MAX)
+        .min(scratch.len());
+    if read_len == 0 {
+        credit.ensure_credit_request_if_exhausted();
+        return VsockHostRwPollOutcome::NoData;
+    }
+    let Some(read_buffer) = scratch.get_mut(..read_len) else {
+        return VsockHostRwPollOutcome::ReadError;
+    };
+
+    match stream.read(read_buffer) {
+        Ok(0) => VsockHostRwPollOutcome::Closed,
+        Ok(read_len) => {
+            let Some(bytes) = scratch.get(..read_len) else {
+                return VsockHostRwPollOutcome::ReadError;
+            };
+            if !credit.reserve_peer_bytes(payload_len_u32(read_len)) {
+                return VsockHostRwPollOutcome::ReadError;
+            }
+            pending_host_rw_payloads.push_back(bytes.to_vec());
+            VsockHostRwPollOutcome::Queued
+        }
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
+            ) =>
+        {
+            VsockHostRwPollOutcome::NoData
+        }
+        Err(_) => VsockHostRwPollOutcome::ReadError,
     }
 }
 
@@ -2775,12 +2853,6 @@ impl VsockHostConnectionTable {
         })
     }
 
-    fn has_pollable_host_rw_payloads(&self) -> bool {
-        self.connections
-            .values()
-            .any(VsockHostConnection::can_poll_host_rw_payload)
-    }
-
     fn pollable_host_rw_payload_fd_count(&self) -> usize {
         self.connections
             .values()
@@ -2788,13 +2860,22 @@ impl VsockHostConnectionTable {
             .count()
     }
 
-    fn push_pollable_host_rw_payload_fds(&self, fds: &mut Vec<RawFd>) {
-        fds.extend(
-            self.connections
-                .values()
-                .filter(|connection| connection.can_poll_host_rw_payload())
-                .map(|connection| connection.stream().as_raw_fd()),
-        );
+    fn push_pollable_host_rw_payload_fds(
+        &self,
+        fds: &mut Vec<RawFd>,
+        registrations: &mut Vec<VsockHostReadinessRegistration>,
+    ) {
+        for (key, connection) in self
+            .connections
+            .iter()
+            .filter(|(_, connection)| connection.can_poll_host_rw_payload())
+        {
+            let descriptor = connection.stream().as_raw_fd();
+            fds.push(descriptor);
+            registrations.push(VsockHostReadinessRegistration::host_connection(
+                descriptor, *key,
+            ));
+        }
     }
 
     fn owns_stream_fd(&self, descriptor: RawFd) -> bool {
@@ -2803,8 +2884,8 @@ impl VsockHostConnectionTable {
             .any(|connection| connection.stream().as_raw_fd() == descriptor)
     }
 
-    fn expects_readable_fd(&self, descriptor: RawFd) -> bool {
-        self.connections.values().any(|connection| {
+    fn matches_readiness_target(&self, descriptor: RawFd, key: VsockHostConnectionKey) -> bool {
+        self.connections.get(&key).is_some_and(|connection| {
             connection.can_poll_host_rw_payload() && connection.stream().as_raw_fd() == descriptor
         })
     }
@@ -2850,14 +2931,14 @@ impl VsockHostConnectionTable {
 
     fn poll_host_rw_payloads(
         &mut self,
+        ready_connections: &[VsockHostConnectionKey],
         scratch: &mut [u8],
         guest_cid: u32,
         now: Instant,
-    ) -> Vec<VirtioVsockPacketHeader> {
-        let keys = self.connections.keys().copied().collect::<Vec<_>>();
-        let mut reset_headers = Vec::new();
+    ) -> VsockHostRwTablePollDispatch {
+        let mut dispatch = VsockHostRwTablePollDispatch::default();
 
-        for key in keys {
+        for key in ready_connections.iter().copied() {
             let Some(connection) = self.connections.get_mut(&key) else {
                 continue;
             };
@@ -2872,17 +2953,19 @@ impl VsockHostConnectionTable {
                     self.metrics.record_observation(observation);
                     let transitioned = connection.mark_local_closed(now);
                     debug_assert!(transitioned);
+                    dispatch.closed_connections += 1;
                 }
                 VsockHostRwPollOutcome::ReadError => {
                     let header = connection.reset_packet_header(key, guest_cid);
                     let removed = self.remove_with_observation(key, observation);
                     debug_assert!(removed);
-                    reset_headers.push(header);
+                    dispatch.read_failed_connections += 1;
+                    dispatch.reset_headers.push(header);
                 }
             }
         }
 
-        reset_headers
+        dispatch
     }
 
     fn flush_pending_guest_rw_writes(&mut self, guest_cid: u32) -> Vec<VirtioVsockPacketHeader> {
@@ -4464,12 +4547,6 @@ impl VsockGuestConnectionTable {
         })
     }
 
-    fn has_pollable_host_rw_payloads(&self) -> bool {
-        self.connections
-            .values()
-            .any(VsockGuestConnection::can_poll_host_rw_payload)
-    }
-
     fn pollable_host_rw_payload_fd_count(&self) -> usize {
         self.connections
             .values()
@@ -4477,13 +4554,22 @@ impl VsockGuestConnectionTable {
             .count()
     }
 
-    fn push_pollable_host_rw_payload_fds(&self, fds: &mut Vec<RawFd>) {
-        fds.extend(
-            self.connections
-                .values()
-                .filter(|connection| connection.can_poll_host_rw_payload())
-                .map(|connection| connection.stream().as_raw_fd()),
-        );
+    fn push_pollable_host_rw_payload_fds(
+        &self,
+        fds: &mut Vec<RawFd>,
+        registrations: &mut Vec<VsockHostReadinessRegistration>,
+    ) {
+        for (key, connection) in self
+            .connections
+            .iter()
+            .filter(|(_, connection)| connection.can_poll_host_rw_payload())
+        {
+            let descriptor = connection.stream().as_raw_fd();
+            fds.push(descriptor);
+            registrations.push(VsockHostReadinessRegistration::guest_connection(
+                descriptor, *key,
+            ));
+        }
     }
 
     fn owns_stream_fd(&self, descriptor: RawFd) -> bool {
@@ -4492,8 +4578,8 @@ impl VsockGuestConnectionTable {
             .any(|connection| connection.stream().as_raw_fd() == descriptor)
     }
 
-    fn expects_readable_fd(&self, descriptor: RawFd) -> bool {
-        self.connections.values().any(|connection| {
+    fn matches_readiness_target(&self, descriptor: RawFd, key: VsockGuestConnectionKey) -> bool {
+        self.connections.get(&key).is_some_and(|connection| {
             connection.can_poll_host_rw_payload() && connection.stream().as_raw_fd() == descriptor
         })
     }
@@ -4539,14 +4625,14 @@ impl VsockGuestConnectionTable {
 
     fn poll_host_rw_payloads(
         &mut self,
+        ready_connections: &[VsockGuestConnectionKey],
         scratch: &mut [u8],
         guest_cid: u32,
         now: Instant,
-    ) -> Vec<VirtioVsockPacketHeader> {
-        let keys = self.connections.keys().copied().collect::<Vec<_>>();
-        let mut reset_headers = Vec::new();
+    ) -> VsockHostRwTablePollDispatch {
+        let mut dispatch = VsockHostRwTablePollDispatch::default();
 
-        for key in keys {
+        for key in ready_connections.iter().copied() {
             let Some(connection) = self.connections.get_mut(&key) else {
                 continue;
             };
@@ -4561,17 +4647,19 @@ impl VsockGuestConnectionTable {
                     self.metrics.record_observation(observation);
                     let transitioned = connection.mark_local_closed(now);
                     debug_assert!(transitioned);
+                    dispatch.closed_connections += 1;
                 }
                 VsockHostRwPollOutcome::ReadError => {
                     let header = connection.reset_packet_header(key, guest_cid);
                     let removed = self.remove_with_observation(key, observation);
                     debug_assert!(removed);
-                    reset_headers.push(header);
+                    dispatch.read_failed_connections += 1;
+                    dispatch.reset_headers.push(header);
                 }
             }
         }
 
-        reset_headers
+        dispatch
     }
 
     fn flush_pending_guest_rw_writes(&mut self, guest_cid: u32) -> Vec<VirtioVsockPacketHeader> {
@@ -4646,8 +4734,17 @@ impl VsockGuestConnectionTable {
 
         let key = VsockGuestConnectionKey::new(header.dst_port(), header.src_port());
         let Some(connection) = self.connections.get_mut(&key) else {
+            let key = VsockHostLocalPort::try_from_raw(header.dst_port()).map_or(
+                VsockGuestRwConnectionKey::Guest(key),
+                |local_port| {
+                    VsockGuestRwConnectionKey::Host(VsockHostConnectionKey::new(
+                        local_port,
+                        header.src_port(),
+                    ))
+                },
+            );
             return Some(VsockGuestRwOutcome::Dropped {
-                key: VsockGuestRwConnectionKey::Guest(key),
+                key,
                 source: VsockGuestRwForwardError::MissingConnection,
                 reset_header: None,
             });
@@ -9027,6 +9124,14 @@ pub struct VirtioVsockDevice {
     pending_host_connection_limit: usize,
     host_connections: VsockHostConnectionTable,
     guest_connections: VsockGuestConnectionTable,
+    // Every host poll snapshot is tied to this runtime-only generation. Queue dispatch can change
+    // descriptor ownership or connection phase while the monitor thread is polling, so an older
+    // generation must never be reclassified against the current descriptor table.
+    host_readiness_generation: u64,
+    // These keys are one-dispatch runtime observations. They are deliberately
+    // excluded from capture state and cleared when source work is normalized.
+    ready_host_connection_reads: Vec<VsockHostConnectionKey>,
+    ready_guest_connection_reads: Vec<VsockGuestConnectionKey>,
     kill_queue: VsockConnectionKillQueue,
     pending_guest_reset_packets: VecDeque<VirtioVsockPacketHeader>,
 }
@@ -9062,6 +9167,9 @@ impl VirtioVsockDevice {
             pending_host_connection_limit: VSOCK_PENDING_HOST_CONNECTION_LIMIT,
             host_connections,
             guest_connections,
+            host_readiness_generation: 0,
+            ready_host_connection_reads: Vec::new(),
+            ready_guest_connection_reads: Vec::new(),
             kill_queue: VsockConnectionKillQueue::new(),
             pending_guest_reset_packets: VecDeque::new(),
         }
@@ -9105,6 +9213,14 @@ impl VirtioVsockDevice {
 
     pub(crate) fn shares_capture_owner_identity(&self, identity: &Arc<()>) -> bool {
         Arc::ptr_eq(&self.capture_owner_identity, identity)
+    }
+
+    const fn host_readiness_generation(&self) -> u64 {
+        self.host_readiness_generation
+    }
+
+    fn advance_host_readiness_generation(&mut self) {
+        self.host_readiness_generation = self.host_readiness_generation.wrapping_add(1);
     }
 
     pub fn is_activated(&self) -> bool {
@@ -9162,8 +9278,15 @@ impl VirtioVsockDevice {
     pub(crate) fn host_wakeup(&self) -> Result<VsockHostWakeup, TryReserveError> {
         let mut read_fds = Vec::new();
         let mut write_fds = Vec::new();
+        let mut read_registrations = Vec::new();
         if !self.is_activated() {
-            return Ok((read_fds, write_fds, None));
+            return Ok((
+                read_fds,
+                write_fds,
+                None,
+                self.host_readiness_generation(),
+                read_registrations,
+            ));
         }
 
         let listener_fd_count = usize::from(
@@ -9175,6 +9298,7 @@ impl VirtioVsockDevice {
             .saturating_add(self.host_connections.pollable_host_rw_payload_fd_count())
             .saturating_add(self.guest_connections.pollable_host_rw_payload_fd_count());
         read_fds.try_reserve_exact(read_capacity)?;
+        read_registrations.try_reserve_exact(read_capacity)?;
         let write_capacity = self
             .host_connections
             .pending_guest_rw_write_fd_count()
@@ -9184,26 +9308,34 @@ impl VirtioVsockDevice {
         if listener_fd_count != 0
             && let Some(owner) = self.host_socket_owner.as_ref()
         {
-            read_fds.push(owner.listener.as_raw_fd());
+            let descriptor = owner.listener.as_raw_fd();
+            read_fds.push(descriptor);
+            read_registrations.push(VsockHostReadinessRegistration::unclassified(descriptor));
         }
-        read_fds.extend(
-            self.pending_host_connections
-                .iter()
-                .map(|connection| connection.stream().as_raw_fd()),
-        );
+        for connection in &self.pending_host_connections {
+            let descriptor = connection.stream().as_raw_fd();
+            read_fds.push(descriptor);
+            read_registrations.push(VsockHostReadinessRegistration::unclassified(descriptor));
+        }
         self.host_connections
-            .push_pollable_host_rw_payload_fds(&mut read_fds);
+            .push_pollable_host_rw_payload_fds(&mut read_fds, &mut read_registrations);
         self.guest_connections
-            .push_pollable_host_rw_payload_fds(&mut read_fds);
+            .push_pollable_host_rw_payload_fds(&mut read_fds, &mut read_registrations);
         self.host_connections
             .push_pending_guest_rw_write_fds(&mut write_fds);
         self.guest_connections
             .push_pending_guest_rw_write_fds(&mut write_fds);
 
-        Ok((read_fds, write_fds, self.earliest_deadline()))
+        Ok((
+            read_fds,
+            write_fds,
+            self.earliest_deadline(),
+            self.host_readiness_generation(),
+            read_registrations,
+        ))
     }
 
-    fn observe_host_readiness(&self, readiness: &[VsockHostReadiness], poll_failed: bool) {
+    fn observe_host_readiness(&mut self, readiness: &[VsockHostReadiness], poll_failed: bool) {
         let listener_fd = self
             .host_socket_owner
             .as_ref()
@@ -9212,8 +9344,20 @@ impl VirtioVsockDevice {
             && self.pending_host_connections.len() < self.pending_host_connection_limit;
         let mut muxer_failures = usize::from(poll_failed);
         let mut connection_failures = 0usize;
+        let readiness_allocation_failed = self
+            .ready_host_connection_reads
+            .try_reserve(readiness.len())
+            .is_err()
+            || self
+                .ready_guest_connection_reads
+                .try_reserve(readiness.len())
+                .is_err();
+        muxer_failures = muxer_failures.saturating_add(usize::from(readiness_allocation_failed));
 
         for event in readiness.iter().copied() {
+            if event.generation() != self.host_readiness_generation() {
+                continue;
+            }
             let descriptor = event.descriptor();
             let pending_connection = self
                 .pending_host_connections
@@ -9221,6 +9365,31 @@ impl VirtioVsockDevice {
                 .any(|connection| connection.stream().as_raw_fd() == descriptor);
             let host_connection = self.host_connections.owns_stream_fd(descriptor);
             let guest_connection = self.guest_connections.owns_stream_fd(descriptor);
+            let (ready_host_connection, ready_guest_connection) = match event.target() {
+                Some(VsockHostReadinessTarget::HostConnection(key))
+                    if self
+                        .host_connections
+                        .matches_readiness_target(descriptor, key) =>
+                {
+                    (Some(key), None)
+                }
+                Some(VsockHostReadinessTarget::GuestConnection(key))
+                    if self
+                        .guest_connections
+                        .matches_readiness_target(descriptor, key) =>
+                {
+                    (None, Some(key))
+                }
+                Some(_) => continue,
+                None if (event.readable() || event.error() || event.hangup())
+                    && (host_connection || guest_connection) =>
+                {
+                    // A listener or pending-handshake registration must not gain data-stream read
+                    // authority merely because its descriptor number now belongs to a connection.
+                    continue;
+                }
+                None => (None, None),
+            };
             let owned = listener_fd == Some(descriptor)
                 || pending_connection
                 || host_connection
@@ -9232,11 +9401,25 @@ impl VirtioVsockDevice {
 
             let readable_expected = (listener_readable && listener_fd == Some(descriptor))
                 || pending_connection
-                || self.host_connections.expects_readable_fd(descriptor)
-                || self.guest_connections.expects_readable_fd(descriptor);
+                || ready_host_connection.is_some()
+                || ready_guest_connection.is_some();
             if event.readable() && !readable_expected {
                 muxer_failures = muxer_failures.saturating_add(1);
                 continue;
+            }
+
+            if !readiness_allocation_failed && (event.readable() || event.error() || event.hangup())
+            {
+                if let Some(key) = ready_host_connection
+                    && !self.ready_host_connection_reads.contains(&key)
+                {
+                    self.ready_host_connection_reads.push(key);
+                }
+                if let Some(key) = ready_guest_connection
+                    && !self.ready_guest_connection_reads.contains(&key)
+                {
+                    self.ready_guest_connection_reads.push(key);
+                }
             }
 
             if event.writable()
@@ -9260,7 +9443,7 @@ impl VirtioVsockDevice {
 
     #[cfg(test)]
     fn host_read_wakeup_fds(&self) -> Result<Vec<RawFd>, TryReserveError> {
-        self.host_wakeup().map(|(read_fds, _, _)| read_fds)
+        self.host_wakeup().map(|(read_fds, _, _, _, _)| read_fds)
     }
 
     fn earliest_deadline(&self) -> Option<Instant> {
@@ -9588,6 +9771,7 @@ impl VirtioVsockDevice {
     }
 
     fn normalize_source_work(&mut self) {
+        self.advance_host_readiness_generation();
         self.pending_host_connections.clear();
         let removed_connections = self
             .host_connections
@@ -9595,6 +9779,8 @@ impl VirtioVsockDevice {
             .saturating_add(self.guest_connections.len());
         self.host_connections.connections.clear();
         self.guest_connections.connections.clear();
+        self.ready_host_connection_reads.clear();
+        self.ready_guest_connection_reads.clear();
         self.kill_queue = VsockConnectionKillQueue::new();
         self.pending_guest_reset_packets.clear();
         self.metrics.record_observation(
@@ -9804,6 +9990,7 @@ impl VirtioVsockDevice {
     }
 
     pub fn reset(&mut self) {
+        self.advance_host_readiness_generation();
         let removed_connections = self
             .host_connections
             .len()
@@ -9817,6 +10004,8 @@ impl VirtioVsockDevice {
         self.host_connections.attach_metrics(self.metrics.clone());
         self.guest_connections = VsockGuestConnectionTable::new();
         self.guest_connections.attach_metrics(self.metrics.clone());
+        self.ready_host_connection_reads.clear();
+        self.ready_guest_connection_reads.clear();
         self.kill_queue = VsockConnectionKillQueue::new();
         self.pending_guest_reset_packets.clear();
         self.metrics.record_observation(
@@ -10076,28 +10265,47 @@ impl VirtioVsockDevice {
         Ok(dispatch)
     }
 
-    fn poll_host_rw_payloads(&mut self, now: Instant) {
+    fn poll_ready_host_rw_payloads(
+        &mut self,
+        ready_host_connections: &[VsockHostConnectionKey],
+        ready_guest_connections: &[VsockGuestConnectionKey],
+        now: Instant,
+    ) -> VirtioVsockConnectionLifecycleDispatch {
+        let mut lifecycle = VirtioVsockConnectionLifecycleDispatch::default();
         if self.active_rx_queue.is_none() {
-            return;
+            return lifecycle;
         }
-        if !self.guest_connections.has_pollable_host_rw_payloads()
-            && !self.host_connections.has_pollable_host_rw_payloads()
-        {
-            return;
+        if ready_host_connections.is_empty() && ready_guest_connections.is_empty() {
+            return lifecycle;
         }
 
         let mut scratch = vec![0; VSOCK_HOST_RW_PREFETCH_PAYLOAD_LIMIT];
-        let mut reset_headers =
-            self.guest_connections
-                .poll_host_rw_payloads(&mut scratch, self.guest_cid, now);
-        reset_headers.extend(self.host_connections.poll_host_rw_payloads(
+        let guest_dispatch = self.guest_connections.poll_host_rw_payloads(
+            ready_guest_connections,
             &mut scratch,
             self.guest_cid,
             now,
-        ));
-        for header in reset_headers {
-            let _ = self.queue_guest_reset_packet(header);
+        );
+        lifecycle.host_stream_guest_connections_closed = guest_dispatch.closed_connections;
+        lifecycle.host_stream_guest_connections_read_failed =
+            guest_dispatch.read_failed_connections;
+        let host_dispatch = self.host_connections.poll_host_rw_payloads(
+            ready_host_connections,
+            &mut scratch,
+            self.guest_cid,
+            now,
+        );
+        lifecycle.host_stream_host_connections_closed = host_dispatch.closed_connections;
+        lifecycle.host_stream_host_connections_read_failed = host_dispatch.read_failed_connections;
+        for header in guest_dispatch
+            .reset_headers
+            .into_iter()
+            .chain(host_dispatch.reset_headers)
+        {
+            let queued = self.queue_guest_reset_packet(header);
+            lifecycle.record_reset(queued);
         }
+        lifecycle
     }
 
     fn flush_pending_guest_rw_writes(&mut self) {
@@ -10114,7 +10322,8 @@ impl VirtioVsockDevice {
         }
     }
 
-    fn expire_connections(&mut self, now: Instant) {
+    fn expire_connections(&mut self, now: Instant) -> VirtioVsockConnectionLifecycleDispatch {
+        let mut lifecycle = VirtioVsockConnectionLifecycleDispatch::default();
         if self.kill_queue.is_empty()
             && self.kill_queue.is_synchronized()
             && (self.host_connections.earliest_deadline().is_some()
@@ -10140,6 +10349,14 @@ impl VirtioVsockDevice {
                             .host_connections
                             .remove_with_observation(key, observation);
                         debug_assert!(removed);
+                        match entry.deadline.kind {
+                            VsockConnectionDeadlineKind::Request => {
+                                lifecycle.host_connection_request_deadlines_expired += 1;
+                            }
+                            VsockConnectionDeadlineKind::Shutdown => {
+                                lifecycle.host_connection_shutdown_deadlines_expired += 1;
+                            }
+                        }
                         header
                     }
                     VsockConnectionDeadlineKey::Guest(key) => {
@@ -10152,11 +10369,20 @@ impl VirtioVsockDevice {
                             .guest_connections
                             .remove_with_observation(key, observation);
                         debug_assert!(removed);
+                        match entry.deadline.kind {
+                            VsockConnectionDeadlineKind::Request => {
+                                lifecycle.guest_connection_request_deadlines_expired += 1;
+                            }
+                            VsockConnectionDeadlineKind::Shutdown => {
+                                lifecycle.guest_connection_shutdown_deadlines_expired += 1;
+                            }
+                        }
                         header
                     }
                 };
                 if let Some(header) = reset_header {
-                    let _ = self.queue_guest_reset_packet(header);
+                    let queued = self.queue_guest_reset_packet(header);
+                    lifecycle.record_reset(queued);
                 }
             }
 
@@ -10165,6 +10391,7 @@ impl VirtioVsockDevice {
             }
             self.rebuild_kill_queue(true);
         }
+        lifecycle
     }
 
     fn queue_guest_reset_packet(&mut self, header: VirtioVsockPacketHeader) -> bool {
@@ -10801,6 +11028,9 @@ impl VirtioVsockDevice {
         drained_notifications: Vec<usize>,
         now: Instant,
     ) -> Result<VirtioVsockDeviceNotificationDispatch, VirtioVsockDeviceNotificationError> {
+        let ready_host_connections = mem::take(&mut self.ready_host_connection_reads);
+        let ready_guest_connections = mem::take(&mut self.ready_guest_connection_reads);
+        self.advance_host_readiness_generation();
         let rx_notified = drained_notifications.contains(&VIRTIO_VSOCK_RX_QUEUE_INDEX);
         let tx_notified = drained_notifications.contains(&VIRTIO_VSOCK_TX_QUEUE_INDEX);
         let event_notified = drained_notifications.contains(&VIRTIO_VSOCK_EVENT_QUEUE_INDEX);
@@ -10810,6 +11040,7 @@ impl VirtioVsockDevice {
                     drained_notifications,
                     VirtioVsockHostRequestDispatch::new(),
                     VirtioVsockGuestTxControlDispatch::empty(),
+                    VirtioVsockConnectionLifecycleDispatch::default(),
                     None,
                     None,
                 ));
@@ -10856,9 +11087,13 @@ impl VirtioVsockDevice {
         }
 
         self.flush_pending_guest_rw_writes();
-        self.expire_connections(now);
+        let mut connection_lifecycle_dispatch = self.expire_connections(now);
         let host_request_dispatch = self.poll_host_request_connections();
-        self.poll_host_rw_payloads(now);
+        connection_lifecycle_dispatch.merge(self.poll_ready_host_rw_payloads(
+            &ready_host_connections,
+            &ready_guest_connections,
+            now,
+        ));
         let rx_notification_admitted = rx_notified && self.first_pending_rx_packet().is_some();
         let dispatch_tx = tx_notified;
 
@@ -10869,6 +11104,7 @@ impl VirtioVsockDevice {
                 drained_notifications,
                 host_request_dispatch,
                 VirtioVsockGuestTxControlDispatch::empty(),
+                connection_lifecycle_dispatch,
                 None,
                 None,
             ));
@@ -10890,7 +11126,6 @@ impl VirtioVsockDevice {
                     );
                     let guest_tx_control_dispatch =
                         self.dispatch_guest_tx_control_packets(memory, &dispatch, now);
-                    self.poll_host_rw_payloads(now);
                     (Some(dispatch), guest_tx_control_dispatch)
                 }
                 Err(source) => {
@@ -10904,6 +11139,7 @@ impl VirtioVsockDevice {
                         drained_notifications,
                         host_request_dispatch,
                         VirtioVsockGuestTxControlDispatch::empty(),
+                        connection_lifecycle_dispatch,
                         None,
                         None,
                     );
@@ -10941,6 +11177,7 @@ impl VirtioVsockDevice {
                         drained_notifications,
                         host_request_dispatch,
                         guest_tx_control_dispatch,
+                        connection_lifecycle_dispatch,
                         None,
                         tx_queue_dispatch,
                     );
@@ -10958,6 +11195,7 @@ impl VirtioVsockDevice {
             drained_notifications,
             host_request_dispatch,
             guest_tx_control_dispatch,
+            connection_lifecycle_dispatch,
             rx_queue_dispatch,
             tx_queue_dispatch,
         ))
@@ -11114,6 +11352,49 @@ impl VirtioVsockGuestTxControlDispatch {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct VirtioVsockConnectionLifecycleDispatch {
+    host_stream_host_connections_closed: usize,
+    host_stream_host_connections_read_failed: usize,
+    host_stream_guest_connections_closed: usize,
+    host_stream_guest_connections_read_failed: usize,
+    host_connection_request_deadlines_expired: usize,
+    host_connection_shutdown_deadlines_expired: usize,
+    guest_connection_request_deadlines_expired: usize,
+    guest_connection_shutdown_deadlines_expired: usize,
+    queued_resets: usize,
+    dropped_resets: usize,
+}
+
+impl VirtioVsockConnectionLifecycleDispatch {
+    fn merge(&mut self, other: Self) {
+        self.host_stream_host_connections_closed += other.host_stream_host_connections_closed;
+        self.host_stream_host_connections_read_failed +=
+            other.host_stream_host_connections_read_failed;
+        self.host_stream_guest_connections_closed += other.host_stream_guest_connections_closed;
+        self.host_stream_guest_connections_read_failed +=
+            other.host_stream_guest_connections_read_failed;
+        self.host_connection_request_deadlines_expired +=
+            other.host_connection_request_deadlines_expired;
+        self.host_connection_shutdown_deadlines_expired +=
+            other.host_connection_shutdown_deadlines_expired;
+        self.guest_connection_request_deadlines_expired +=
+            other.guest_connection_request_deadlines_expired;
+        self.guest_connection_shutdown_deadlines_expired +=
+            other.guest_connection_shutdown_deadlines_expired;
+        self.queued_resets += other.queued_resets;
+        self.dropped_resets += other.dropped_resets;
+    }
+
+    fn record_reset(&mut self, queued: bool) {
+        if queued {
+            self.queued_resets += 1;
+        } else {
+            self.dropped_resets += 1;
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct VirtioVsockDeviceNotificationDispatch {
     drained_notifications: Vec<usize>,
@@ -11126,6 +11407,7 @@ pub struct VirtioVsockDeviceNotificationDispatch {
     guest_rst_dispatch: VirtioVsockGuestRstDispatch,
     guest_shutdown_dispatch: VirtioVsockGuestShutdownDispatch,
     guest_reset_dispatch: VirtioVsockGuestResetDispatch,
+    connection_lifecycle_dispatch: VirtioVsockConnectionLifecycleDispatch,
     rx_queue_dispatch: Option<VirtioVsockRxQueueDispatch>,
     tx_queue_dispatch: Option<VirtioVsockTxQueueDispatch>,
 }
@@ -11135,6 +11417,7 @@ impl VirtioVsockDeviceNotificationDispatch {
         drained_notifications: Vec<usize>,
         host_request_dispatch: VirtioVsockHostRequestDispatch,
         guest_tx_control_dispatch: VirtioVsockGuestTxControlDispatch,
+        connection_lifecycle_dispatch: VirtioVsockConnectionLifecycleDispatch,
         rx_queue_dispatch: Option<VirtioVsockRxQueueDispatch>,
         tx_queue_dispatch: Option<VirtioVsockTxQueueDispatch>,
     ) -> Self {
@@ -11153,6 +11436,7 @@ impl VirtioVsockDeviceNotificationDispatch {
             guest_rst_dispatch: guest_tx_control_dispatch.guest_rst_dispatch,
             guest_shutdown_dispatch: guest_tx_control_dispatch.guest_shutdown_dispatch,
             guest_reset_dispatch: guest_tx_control_dispatch.reset_dispatch,
+            connection_lifecycle_dispatch,
             rx_queue_dispatch,
             tx_queue_dispatch,
         }
@@ -11237,8 +11521,31 @@ struct VsockNotificationObservation {
     guest_connection_closed: bool,
     guest_connection_ignored: bool,
     guest_connection_dropped: bool,
+    guest_rw_host_connection_forwarded: bool,
+    guest_rw_host_connection_suppressed: bool,
+    guest_rw_host_connection_missing: bool,
+    guest_rw_guest_connection_forwarded: bool,
+    guest_rw_guest_connection_suppressed: bool,
+    guest_rw_guest_connection_missing: bool,
+    guest_rst_host_connection_closed: bool,
+    guest_rst_guest_connection_closed: bool,
+    guest_rst_ignored: bool,
+    guest_shutdown_host_connection_updated: bool,
+    guest_shutdown_host_connection_closed: bool,
+    guest_shutdown_guest_connection_updated: bool,
+    guest_shutdown_guest_connection_closed: bool,
+    guest_shutdown_ignored: bool,
+    host_stream_host_connection_closed: bool,
+    host_stream_host_connection_read_failed: bool,
+    host_stream_guest_connection_closed: bool,
+    host_stream_guest_connection_read_failed: bool,
+    host_connection_request_deadline_expired: bool,
+    host_connection_shutdown_deadline_expired: bool,
+    guest_connection_request_deadline_expired: bool,
+    guest_connection_shutdown_deadline_expired: bool,
     connection_reset_queued: bool,
     connection_reset_dropped: bool,
+    connection_reset_delivered: bool,
 }
 
 impl VsockNotificationObservation {
@@ -11297,6 +11604,7 @@ impl VsockNotificationObservation {
         }
 
         self.ingest_host_request(dispatch.host_request_dispatch());
+        self.ingest_connection_lifecycle(&dispatch.connection_lifecycle_dispatch);
         self.ingest_guest_tx_control(&VirtioVsockGuestTxControlDispatch::new(
             *dispatch.guest_response_dispatch(),
             *dispatch.guest_request_dispatch(),
@@ -11330,6 +11638,12 @@ impl VsockNotificationObservation {
         self.guest_connection_forwarded |= rw.forwarded_packets() > 0;
         self.guest_connection_ignored |= rw.ignored_packets() > 0;
         self.guest_connection_dropped |= rw.dropped_connections() > 0;
+        self.guest_rw_host_connection_forwarded |= rw.forwarded_host_connection_packets() > 0;
+        self.guest_rw_guest_connection_forwarded |= rw.forwarded_guest_connection_packets() > 0;
+        self.guest_rw_host_connection_suppressed |= rw.suppressed_host_connection_packets() > 0;
+        self.guest_rw_guest_connection_suppressed |= rw.suppressed_guest_connection_packets() > 0;
+        self.guest_rw_host_connection_missing |= rw.missing_host_connection_packets() > 0;
+        self.guest_rw_guest_connection_missing |= rw.missing_guest_connection_packets() > 0;
 
         let credit = &dispatch.credit_dispatch;
         self.guest_connection_updated |= credit.update_packets() > 0 || credit.queued_updates() > 0;
@@ -11339,6 +11653,9 @@ impl VsockNotificationObservation {
         self.guest_connection_closed |=
             rst.closed_host_connections() > 0 || rst.closed_guest_connections() > 0;
         self.guest_connection_ignored |= rst.ignored_packets() > 0;
+        self.guest_rst_host_connection_closed |= rst.closed_host_connections() > 0;
+        self.guest_rst_guest_connection_closed |= rst.closed_guest_connections() > 0;
+        self.guest_rst_ignored |= rst.ignored_packets() > 0;
 
         let shutdown = &dispatch.guest_shutdown_dispatch;
         self.guest_connection_updated |=
@@ -11346,12 +11663,38 @@ impl VsockNotificationObservation {
         self.guest_connection_closed |=
             shutdown.closed_host_connections() > 0 || shutdown.closed_guest_connections() > 0;
         self.guest_connection_ignored |= shutdown.ignored_packets() > 0;
+        self.guest_shutdown_host_connection_updated |= shutdown.updated_host_connections() > 0;
+        self.guest_shutdown_guest_connection_updated |= shutdown.updated_guest_connections() > 0;
+        self.guest_shutdown_host_connection_closed |= shutdown.closed_host_connections() > 0;
+        self.guest_shutdown_guest_connection_closed |= shutdown.closed_guest_connections() > 0;
+        self.guest_shutdown_ignored |= shutdown.ignored_packets() > 0;
         self.connection_reset_queued |= shutdown.queued_resets() > 0;
         self.connection_reset_dropped |= shutdown.dropped_resets() > 0;
 
         let reset = &dispatch.reset_dispatch;
         self.connection_reset_queued |= reset.queued_resets() > 0;
         self.connection_reset_dropped |= reset.dropped_resets() > 0;
+    }
+
+    fn ingest_connection_lifecycle(&mut self, lifecycle: &VirtioVsockConnectionLifecycleDispatch) {
+        self.host_stream_host_connection_closed |=
+            lifecycle.host_stream_host_connections_closed > 0;
+        self.host_stream_host_connection_read_failed |=
+            lifecycle.host_stream_host_connections_read_failed > 0;
+        self.host_stream_guest_connection_closed |=
+            lifecycle.host_stream_guest_connections_closed > 0;
+        self.host_stream_guest_connection_read_failed |=
+            lifecycle.host_stream_guest_connections_read_failed > 0;
+        self.host_connection_request_deadline_expired |=
+            lifecycle.host_connection_request_deadlines_expired > 0;
+        self.host_connection_shutdown_deadline_expired |=
+            lifecycle.host_connection_shutdown_deadlines_expired > 0;
+        self.guest_connection_request_deadline_expired |=
+            lifecycle.guest_connection_request_deadlines_expired > 0;
+        self.guest_connection_shutdown_deadline_expired |=
+            lifecycle.guest_connection_shutdown_deadlines_expired > 0;
+        self.connection_reset_queued |= lifecycle.queued_resets > 0;
+        self.connection_reset_dropped |= lifecycle.dropped_resets > 0;
     }
 
     fn ingest_rx(&mut self, dispatch: &VirtioVsockRxQueueDispatch) {
@@ -11365,6 +11708,7 @@ impl VsockNotificationObservation {
         self.rx_succeeded |= delivered > 0;
         self.rx_buffer_malformed |= dispatch.buffer_parse_failures() > 0;
         self.rx_buffer_too_small |= dispatch.buffer_too_small_failures() > 0;
+        self.connection_reset_delivered |= dispatch.delivered_reset_packets() > 0;
     }
 
     fn ingest_tx(&mut self, dispatch: &VirtioVsockTxQueueDispatch) {
@@ -11407,8 +11751,96 @@ impl VsockNotificationObservation {
                 LoggerVsockOutcome::GuestConnectionDropped,
             ),
             (
+                self.host_stream_host_connection_read_failed,
+                LoggerVsockOutcome::HostStreamHostConnectionReadFailed,
+            ),
+            (
+                self.host_stream_guest_connection_read_failed,
+                LoggerVsockOutcome::HostStreamGuestConnectionReadFailed,
+            ),
+            (
+                self.guest_rw_host_connection_missing,
+                LoggerVsockOutcome::GuestRwHostConnectionMissing,
+            ),
+            (
+                self.guest_rw_guest_connection_missing,
+                LoggerVsockOutcome::GuestRwGuestConnectionMissing,
+            ),
+            (
+                self.host_connection_request_deadline_expired,
+                LoggerVsockOutcome::HostConnectionRequestDeadlineExpired,
+            ),
+            (
+                self.host_connection_shutdown_deadline_expired,
+                LoggerVsockOutcome::HostConnectionShutdownDeadlineExpired,
+            ),
+            (
+                self.guest_connection_request_deadline_expired,
+                LoggerVsockOutcome::GuestConnectionRequestDeadlineExpired,
+            ),
+            (
+                self.guest_connection_shutdown_deadline_expired,
+                LoggerVsockOutcome::GuestConnectionShutdownDeadlineExpired,
+            ),
+            (
                 self.connection_reset_dropped,
                 LoggerVsockOutcome::ConnectionResetDropped,
+            ),
+            (
+                self.guest_rst_host_connection_closed,
+                LoggerVsockOutcome::GuestRstHostConnectionClosed,
+            ),
+            (
+                self.guest_rst_guest_connection_closed,
+                LoggerVsockOutcome::GuestRstGuestConnectionClosed,
+            ),
+            (
+                self.guest_shutdown_host_connection_updated,
+                LoggerVsockOutcome::GuestShutdownHostConnectionUpdated,
+            ),
+            (
+                self.guest_shutdown_host_connection_closed,
+                LoggerVsockOutcome::GuestShutdownHostConnectionClosed,
+            ),
+            (
+                self.guest_shutdown_guest_connection_updated,
+                LoggerVsockOutcome::GuestShutdownGuestConnectionUpdated,
+            ),
+            (
+                self.guest_shutdown_guest_connection_closed,
+                LoggerVsockOutcome::GuestShutdownGuestConnectionClosed,
+            ),
+            (
+                self.host_stream_host_connection_closed,
+                LoggerVsockOutcome::HostStreamHostConnectionClosed,
+            ),
+            (
+                self.host_stream_guest_connection_closed,
+                LoggerVsockOutcome::HostStreamGuestConnectionClosed,
+            ),
+            (
+                self.connection_reset_queued,
+                LoggerVsockOutcome::ConnectionResetQueued,
+            ),
+            (
+                self.connection_reset_delivered,
+                LoggerVsockOutcome::ConnectionResetDelivered,
+            ),
+            (
+                self.guest_rw_host_connection_forwarded,
+                LoggerVsockOutcome::GuestRwHostConnectionForwarded,
+            ),
+            (
+                self.guest_rw_guest_connection_forwarded,
+                LoggerVsockOutcome::GuestRwGuestConnectionForwarded,
+            ),
+            (
+                self.guest_rw_host_connection_suppressed,
+                LoggerVsockOutcome::GuestRwHostConnectionSuppressed,
+            ),
+            (
+                self.guest_rw_guest_connection_suppressed,
+                LoggerVsockOutcome::GuestRwGuestConnectionSuppressed,
             ),
             (self.rx_succeeded, LoggerVsockOutcome::RxSucceeded),
             (self.tx_succeeded, LoggerVsockOutcome::TxSucceeded),
@@ -11419,10 +11851,6 @@ impl VsockNotificationObservation {
             (
                 self.host_connection_completed,
                 LoggerVsockOutcome::HostConnectionCompleted,
-            ),
-            (
-                self.host_connection_pending,
-                LoggerVsockOutcome::HostConnectionPending,
             ),
             (
                 self.guest_connection_retained,
@@ -11440,13 +11868,18 @@ impl VsockNotificationObservation {
                 self.guest_connection_closed,
                 LoggerVsockOutcome::GuestConnectionClosed,
             ),
+            (self.guest_rst_ignored, LoggerVsockOutcome::GuestRstIgnored),
+            (
+                self.guest_shutdown_ignored,
+                LoggerVsockOutcome::GuestShutdownIgnored,
+            ),
+            (
+                self.host_connection_pending,
+                LoggerVsockOutcome::HostConnectionPending,
+            ),
             (
                 self.guest_connection_ignored,
                 LoggerVsockOutcome::GuestConnectionIgnored,
-            ),
-            (
-                self.connection_reset_queued,
-                LoggerVsockOutcome::ConnectionResetQueued,
             ),
         ]
         .into_iter()
@@ -11573,6 +12006,12 @@ pub struct VirtioVsockGuestRwDispatch {
     rw_packets: usize,
     forwarded_packets: usize,
     forwarded_bytes: usize,
+    forwarded_host_connection_packets: usize,
+    forwarded_guest_connection_packets: usize,
+    suppressed_host_connection_packets: usize,
+    suppressed_guest_connection_packets: usize,
+    missing_host_connection_packets: usize,
+    missing_guest_connection_packets: usize,
     ignored_packets: usize,
     dropped_connections: usize,
 }
@@ -11583,6 +12022,12 @@ impl VirtioVsockGuestRwDispatch {
             rw_packets: 0,
             forwarded_packets: 0,
             forwarded_bytes: 0,
+            forwarded_host_connection_packets: 0,
+            forwarded_guest_connection_packets: 0,
+            suppressed_host_connection_packets: 0,
+            suppressed_guest_connection_packets: 0,
+            missing_host_connection_packets: 0,
+            missing_guest_connection_packets: 0,
             ignored_packets: 0,
             dropped_connections: 0,
         }
@@ -11600,6 +12045,30 @@ impl VirtioVsockGuestRwDispatch {
         self.forwarded_bytes
     }
 
+    pub const fn forwarded_host_connection_packets(&self) -> usize {
+        self.forwarded_host_connection_packets
+    }
+
+    pub const fn forwarded_guest_connection_packets(&self) -> usize {
+        self.forwarded_guest_connection_packets
+    }
+
+    pub const fn suppressed_host_connection_packets(&self) -> usize {
+        self.suppressed_host_connection_packets
+    }
+
+    pub const fn suppressed_guest_connection_packets(&self) -> usize {
+        self.suppressed_guest_connection_packets
+    }
+
+    pub const fn missing_host_connection_packets(&self) -> usize {
+        self.missing_host_connection_packets
+    }
+
+    pub const fn missing_guest_connection_packets(&self) -> usize {
+        self.missing_guest_connection_packets
+    }
+
     pub const fn ignored_packets(&self) -> usize {
         self.ignored_packets
     }
@@ -11612,13 +12081,28 @@ impl VirtioVsockGuestRwDispatch {
         self.rw_packets += 1;
         match outcome {
             VsockGuestRwOutcome::Forwarded { key, bytes } => {
-                let _ = key;
                 self.forwarded_packets += 1;
                 self.forwarded_bytes += bytes;
+                match key {
+                    VsockGuestRwConnectionKey::Host(_) => {
+                        self.forwarded_host_connection_packets += 1;
+                    }
+                    VsockGuestRwConnectionKey::Guest(_) => {
+                        self.forwarded_guest_connection_packets += 1;
+                    }
+                }
             }
             VsockGuestRwOutcome::Suppressed { key, reason } => {
-                let _ = (key, reason);
+                let _ = reason;
                 self.ignored_packets += 1;
+                match key {
+                    VsockGuestRwConnectionKey::Host(_) => {
+                        self.suppressed_host_connection_packets += 1;
+                    }
+                    VsockGuestRwConnectionKey::Guest(_) => {
+                        self.suppressed_guest_connection_packets += 1;
+                    }
+                }
             }
             VsockGuestRwOutcome::Ignored { reason } => {
                 let _ = reason;
@@ -11629,8 +12113,18 @@ impl VirtioVsockGuestRwDispatch {
                 source,
                 reset_header,
             } => {
-                let _ = (key, source, reset_header);
+                let _ = reset_header;
                 self.dropped_connections += 1;
+                if matches!(source, VsockGuestRwForwardError::MissingConnection) {
+                    match key {
+                        VsockGuestRwConnectionKey::Host(_) => {
+                            self.missing_host_connection_packets += 1;
+                        }
+                        VsockGuestRwConnectionKey::Guest(_) => {
+                            self.missing_guest_connection_packets += 1;
+                        }
+                    }
+                }
             }
         }
     }
@@ -12035,7 +12529,7 @@ impl VirtioVsockMmioHandler {
         readiness: &[VsockHostReadiness],
         poll_failed: bool,
     ) {
-        self.activation_handler()
+        self.activation_handler_mut()
             .observe_host_readiness(readiness, poll_failed);
     }
 
@@ -13211,6 +13705,12 @@ mod tests {
         assert_eq!(dispatch.rw_packets(), 0);
         assert_eq!(dispatch.forwarded_packets(), 0);
         assert_eq!(dispatch.forwarded_bytes(), 0);
+        assert_eq!(dispatch.forwarded_host_connection_packets(), 0);
+        assert_eq!(dispatch.forwarded_guest_connection_packets(), 0);
+        assert_eq!(dispatch.suppressed_host_connection_packets(), 0);
+        assert_eq!(dispatch.suppressed_guest_connection_packets(), 0);
+        assert_eq!(dispatch.missing_host_connection_packets(), 0);
+        assert_eq!(dispatch.missing_guest_connection_packets(), 0);
         assert_eq!(dispatch.ignored_packets(), 0);
         assert_eq!(dispatch.dropped_connections(), 0);
     }
@@ -13779,6 +14279,54 @@ mod tests {
         assert_host_ok_message(&mut client, key.local_port());
 
         (memory, handler, client, key)
+    }
+
+    fn observe_host_connection_readiness(
+        handler: &mut VirtioVsockMmioHandler,
+        key: VsockHostConnectionKey,
+        revents: libc::c_short,
+    ) {
+        let descriptor = handler
+            .activation_handler()
+            .host_connections
+            .connections
+            .get(&key)
+            .expect("host connection should exist for readiness")
+            .stream()
+            .as_raw_fd();
+        let generation = handler.activation_handler().host_readiness_generation();
+        handler.observe_vsock_host_readiness(
+            &[super::VsockHostReadiness::for_registration(
+                super::VsockHostReadinessRegistration::host_connection(descriptor, key),
+                revents,
+                generation,
+            )],
+            false,
+        );
+    }
+
+    fn observe_guest_connection_readiness(
+        handler: &mut VirtioVsockMmioHandler,
+        key: VsockGuestConnectionKey,
+        revents: libc::c_short,
+    ) {
+        let descriptor = handler
+            .activation_handler()
+            .guest_connections
+            .connections
+            .get(&key)
+            .expect("guest connection should exist for readiness")
+            .stream()
+            .as_raw_fd();
+        let generation = handler.activation_handler().host_readiness_generation();
+        handler.observe_vsock_host_readiness(
+            &[super::VsockHostReadiness::for_registration(
+                super::VsockHostReadinessRegistration::guest_connection(descriptor, key),
+                revents,
+                generation,
+            )],
+            false,
+        );
     }
 
     fn assert_host_ok_message(stream: &mut UnixStream, local_port: VsockHostLocalPort) {
@@ -16041,9 +16589,9 @@ mod tests {
     }
 
     #[test]
-    fn vsock_host_reads_are_packetized_to_prefetch_limit() {
+    fn vsock_host_reads_one_prefetch_packet_per_readiness() {
         let input_len = super::VSOCK_HOST_RW_PREFETCH_PAYLOAD_LIMIT
-            .checked_mul(super::VSOCK_HOST_RW_POLL_BATCH_LIMIT + 1)
+            .checked_mul(super::VSOCK_HOST_RW_PENDING_PACKET_LIMIT + 1)
             .expect("test input length should fit");
         let mut reader = io::Cursor::new(vec![0x5a; input_len]);
         let mut pending = VecDeque::new();
@@ -16062,21 +16610,23 @@ mod tests {
             ),
             super::VsockHostRwPollOutcome::Queued
         );
-        assert_eq!(pending.len(), super::VSOCK_HOST_RW_POLL_BATCH_LIMIT);
-        assert!(
-            pending
-                .iter()
-                .all(|payload| payload.len() == super::VSOCK_HOST_RW_PREFETCH_PAYLOAD_LIMIT)
+        assert_eq!(
+            pending.len(),
+            1,
+            "one readiness observation must authorize exactly one stream read"
         );
-        let queued_len = super::VSOCK_HOST_RW_PREFETCH_PAYLOAD_LIMIT
-            .checked_mul(super::VSOCK_HOST_RW_POLL_BATCH_LIMIT)
-            .expect("queued test length should fit");
-        assert_eq!(reader.position(), queued_len as u64);
-        assert_eq!(credit.reserved_peer_bytes, queued_len as u32);
+        assert_eq!(
+            reader.position(),
+            super::VSOCK_HOST_RW_PREFETCH_PAYLOAD_LIMIT as u64
+        );
+        assert_eq!(
+            credit.reserved_peer_bytes,
+            super::VSOCK_HOST_RW_PREFETCH_PAYLOAD_LIMIT as u32
+        );
     }
 
     #[test]
-    fn vsock_host_read_poll_distinguishes_clean_eof_and_terminal_error_after_queued_data() {
+    fn vsock_host_read_requires_new_readiness_before_terminal_state_after_data() {
         for (terminal, expected) in [
             (
                 TestReadAction::Bytes(Vec::new()),
@@ -16104,13 +16654,23 @@ mod tests {
                     &mut credit,
                     &mut scratch,
                 ),
-                expected
+                super::VsockHostRwPollOutcome::Queued
             );
             assert_eq!(
                 pending.front().map(Vec::as_slice),
                 Some(b"queued".as_slice())
             );
             assert_eq!(credit.reserved_peer_bytes, 6);
+            assert_eq!(
+                super::poll_host_rw_payloads_from_stream(
+                    &mut reader,
+                    &mut pending,
+                    &mut credit,
+                    &mut scratch,
+                ),
+                expected,
+                "the terminal read requires a distinct readiness observation"
+            );
         }
     }
 
@@ -19479,12 +20039,20 @@ mod tests {
             .pending_guest_rw_writes
             .push_payload(b"pending guest bytes")
             .expect("pending guest bytes should queue");
-        let (read_fds, write_fds, deadline) = device
+        let (read_fds, write_fds, deadline, generation, registrations) = device
             .host_wakeup()
             .expect("read/write wakeup snapshot should collect");
         assert_eq!(read_fds, [accepted_fd]);
         assert_eq!(write_fds, [accepted_fd]);
         assert_eq!(deadline, None);
+        assert_eq!(generation, device.host_readiness_generation());
+        assert_eq!(
+            registrations,
+            [super::VsockHostReadinessRegistration::host_connection(
+                accepted_fd,
+                key,
+            )]
+        );
     }
 
     #[test]
@@ -19512,13 +20080,20 @@ mod tests {
             .queue_pending_guest_rw_payload_for_test(b"pending guest bytes")
             .expect("pending guest bytes should queue");
 
-        let (read_fds, write_fds, deadline) = device
+        let (read_fds, write_fds, deadline, generation, registrations) = device
             .host_wakeup()
             .expect("write wakeup snapshot should collect");
 
         assert_eq!(read_fds, [stream_fd]);
         assert_eq!(write_fds, [stream_fd]);
         assert_eq!(deadline, None);
+        assert_eq!(generation, device.host_readiness_generation());
+        assert_eq!(
+            registrations,
+            [super::VsockHostReadinessRegistration::guest_connection(
+                stream_fd, key,
+            )]
+        );
     }
 
     #[test]
@@ -19568,24 +20143,25 @@ mod tests {
             device.guest_connections.deadline(guest_key),
         );
 
-        let (_, _, earliest) = device
+        let (_, _, earliest, _, _) = device
             .host_wakeup()
             .expect("wakeup snapshot should collect");
         assert_eq!(earliest, Some(now + Duration::from_secs(2)));
 
         assert!(device.guest_connections.remove(guest_key));
-        let (_, _, next) = device
+        let (_, _, next, _, _) = device
             .host_wakeup()
             .expect("wakeup snapshot should recompute after cancellation");
         assert_eq!(next, Some(now + Duration::from_secs(3)));
 
         device.reset();
-        let (read_fds, write_fds, deadline) = device
+        let (read_fds, write_fds, deadline, _, registrations) = device
             .host_wakeup()
             .expect("inactive wakeup snapshot should be empty");
         assert!(read_fds.is_empty());
         assert!(write_fds.is_empty());
         assert_eq!(deadline, None);
+        assert!(registrations.is_empty());
         assert_eq!(
             super::vsock_deadline_after(now, Duration::MAX),
             now,
@@ -20550,8 +21126,31 @@ mod tests {
             guest_connection_closed: true,
             guest_connection_ignored: true,
             guest_connection_dropped: true,
+            guest_rw_host_connection_forwarded: true,
+            guest_rw_host_connection_suppressed: true,
+            guest_rw_host_connection_missing: true,
+            guest_rw_guest_connection_forwarded: true,
+            guest_rw_guest_connection_suppressed: true,
+            guest_rw_guest_connection_missing: true,
+            guest_rst_host_connection_closed: true,
+            guest_rst_guest_connection_closed: true,
+            guest_rst_ignored: true,
+            guest_shutdown_host_connection_updated: true,
+            guest_shutdown_host_connection_closed: true,
+            guest_shutdown_guest_connection_updated: true,
+            guest_shutdown_guest_connection_closed: true,
+            guest_shutdown_ignored: true,
+            host_stream_host_connection_closed: true,
+            host_stream_host_connection_read_failed: true,
+            host_stream_guest_connection_closed: true,
+            host_stream_guest_connection_read_failed: true,
+            host_connection_request_deadline_expired: true,
+            host_connection_shutdown_deadline_expired: true,
+            guest_connection_request_deadline_expired: true,
+            guest_connection_shutdown_deadline_expired: true,
             connection_reset_queued: true,
             connection_reset_dropped: true,
+            connection_reset_delivered: true,
         };
 
         assert_eq!(
@@ -20565,20 +21164,125 @@ mod tests {
                 LoggerVsockOutcome::QueueNotificationUnsupported,
                 LoggerVsockOutcome::HostConnectionDropped,
                 LoggerVsockOutcome::GuestConnectionDropped,
+                LoggerVsockOutcome::HostStreamHostConnectionReadFailed,
+                LoggerVsockOutcome::HostStreamGuestConnectionReadFailed,
+                LoggerVsockOutcome::GuestRwHostConnectionMissing,
+                LoggerVsockOutcome::GuestRwGuestConnectionMissing,
+                LoggerVsockOutcome::HostConnectionRequestDeadlineExpired,
+                LoggerVsockOutcome::HostConnectionShutdownDeadlineExpired,
+                LoggerVsockOutcome::GuestConnectionRequestDeadlineExpired,
+                LoggerVsockOutcome::GuestConnectionShutdownDeadlineExpired,
                 LoggerVsockOutcome::ConnectionResetDropped,
+                LoggerVsockOutcome::GuestRstHostConnectionClosed,
+                LoggerVsockOutcome::GuestRstGuestConnectionClosed,
+                LoggerVsockOutcome::GuestShutdownHostConnectionUpdated,
+                LoggerVsockOutcome::GuestShutdownHostConnectionClosed,
+                LoggerVsockOutcome::GuestShutdownGuestConnectionUpdated,
+                LoggerVsockOutcome::GuestShutdownGuestConnectionClosed,
+                LoggerVsockOutcome::HostStreamHostConnectionClosed,
+                LoggerVsockOutcome::HostStreamGuestConnectionClosed,
+                LoggerVsockOutcome::ConnectionResetQueued,
+                LoggerVsockOutcome::ConnectionResetDelivered,
+                LoggerVsockOutcome::GuestRwHostConnectionForwarded,
+                LoggerVsockOutcome::GuestRwGuestConnectionForwarded,
+                LoggerVsockOutcome::GuestRwHostConnectionSuppressed,
+                LoggerVsockOutcome::GuestRwGuestConnectionSuppressed,
                 LoggerVsockOutcome::RxSucceeded,
                 LoggerVsockOutcome::TxSucceeded,
                 LoggerVsockOutcome::HostConnectionAccepted,
                 LoggerVsockOutcome::HostConnectionCompleted,
-                LoggerVsockOutcome::HostConnectionPending,
                 LoggerVsockOutcome::GuestConnectionRetained,
                 LoggerVsockOutcome::GuestConnectionForwarded,
                 LoggerVsockOutcome::GuestConnectionUpdated,
                 LoggerVsockOutcome::GuestConnectionClosed,
+                LoggerVsockOutcome::GuestRstIgnored,
+                LoggerVsockOutcome::GuestShutdownIgnored,
+                LoggerVsockOutcome::HostConnectionPending,
                 LoggerVsockOutcome::GuestConnectionIgnored,
-                LoggerVsockOutcome::ConnectionResetQueued,
             ]
         );
+    }
+
+    #[test]
+    fn vsock_logger_preserves_endpoint_specific_lifecycle_outcomes() {
+        let mut guest_tx = super::VirtioVsockGuestTxControlDispatch::empty();
+        guest_tx.rw_dispatch.forwarded_packets = 2;
+        guest_tx.rw_dispatch.forwarded_host_connection_packets = 1;
+        guest_tx.rw_dispatch.forwarded_guest_connection_packets = 1;
+        guest_tx.rw_dispatch.ignored_packets = 2;
+        guest_tx.rw_dispatch.suppressed_host_connection_packets = 1;
+        guest_tx.rw_dispatch.suppressed_guest_connection_packets = 1;
+        guest_tx.rw_dispatch.dropped_connections = 2;
+        guest_tx.rw_dispatch.missing_host_connection_packets = 1;
+        guest_tx.rw_dispatch.missing_guest_connection_packets = 1;
+        guest_tx.guest_rst_dispatch.closed_host_connections = 1;
+        guest_tx.guest_rst_dispatch.closed_guest_connections = 1;
+        guest_tx.guest_rst_dispatch.ignored_packets = 1;
+        guest_tx.guest_shutdown_dispatch.updated_host_connections = 1;
+        guest_tx.guest_shutdown_dispatch.updated_guest_connections = 1;
+        guest_tx.guest_shutdown_dispatch.closed_host_connections = 1;
+        guest_tx.guest_shutdown_dispatch.closed_guest_connections = 1;
+        guest_tx.guest_shutdown_dispatch.ignored_packets = 1;
+        guest_tx.guest_shutdown_dispatch.queued_resets = 1;
+
+        let lifecycle = super::VirtioVsockConnectionLifecycleDispatch {
+            host_stream_host_connections_closed: 1,
+            host_stream_host_connections_read_failed: 1,
+            host_stream_guest_connections_closed: 1,
+            host_stream_guest_connections_read_failed: 1,
+            host_connection_request_deadlines_expired: 1,
+            host_connection_shutdown_deadlines_expired: 1,
+            guest_connection_request_deadlines_expired: 1,
+            guest_connection_shutdown_deadlines_expired: 1,
+            queued_resets: 1,
+            dropped_resets: 1,
+        };
+        let mut rx = super::VirtioVsockRxQueueDispatch::new();
+        rx.delivered_reset_packets = 1;
+        let result = Ok(super::VirtioVsockDeviceNotificationDispatch::new(
+            Vec::new(),
+            super::VirtioVsockHostRequestDispatch::new(),
+            guest_tx,
+            lifecycle,
+            Some(rx),
+            None,
+        ));
+
+        let outcomes = super::VsockNotificationObservation::from_result(&result)
+            .outcomes()
+            .collect::<Vec<_>>();
+        for expected in [
+            LoggerVsockOutcome::GuestRwHostConnectionForwarded,
+            LoggerVsockOutcome::GuestRwHostConnectionSuppressed,
+            LoggerVsockOutcome::GuestRwHostConnectionMissing,
+            LoggerVsockOutcome::GuestRwGuestConnectionForwarded,
+            LoggerVsockOutcome::GuestRwGuestConnectionSuppressed,
+            LoggerVsockOutcome::GuestRwGuestConnectionMissing,
+            LoggerVsockOutcome::GuestRstHostConnectionClosed,
+            LoggerVsockOutcome::GuestRstGuestConnectionClosed,
+            LoggerVsockOutcome::GuestRstIgnored,
+            LoggerVsockOutcome::GuestShutdownHostConnectionUpdated,
+            LoggerVsockOutcome::GuestShutdownHostConnectionClosed,
+            LoggerVsockOutcome::GuestShutdownGuestConnectionUpdated,
+            LoggerVsockOutcome::GuestShutdownGuestConnectionClosed,
+            LoggerVsockOutcome::GuestShutdownIgnored,
+            LoggerVsockOutcome::HostStreamHostConnectionClosed,
+            LoggerVsockOutcome::HostStreamHostConnectionReadFailed,
+            LoggerVsockOutcome::HostStreamGuestConnectionClosed,
+            LoggerVsockOutcome::HostStreamGuestConnectionReadFailed,
+            LoggerVsockOutcome::HostConnectionRequestDeadlineExpired,
+            LoggerVsockOutcome::HostConnectionShutdownDeadlineExpired,
+            LoggerVsockOutcome::GuestConnectionRequestDeadlineExpired,
+            LoggerVsockOutcome::GuestConnectionShutdownDeadlineExpired,
+            LoggerVsockOutcome::ConnectionResetQueued,
+            LoggerVsockOutcome::ConnectionResetDropped,
+            LoggerVsockOutcome::ConnectionResetDelivered,
+        ] {
+            assert!(
+                outcomes.contains(&expected),
+                "endpoint-specific summary should retain {expected:?}"
+            );
+        }
     }
 
     #[test]
@@ -20593,6 +21297,7 @@ mod tests {
             vec![VIRTIO_VSOCK_RX_QUEUE_INDEX],
             host_request_dispatch,
             guest_tx_control_dispatch,
+            super::VirtioVsockConnectionLifecycleDispatch::default(),
             None,
             None,
         );
@@ -20658,8 +21363,9 @@ mod tests {
         assert_eq!(
             capture.output(),
             "device-kind=vsock operation=guest-connection outcome=dropped\n\
-             device-kind=vsock operation=tx outcome=succeeded\n\
-             device-kind=vsock operation=connection-reset outcome=queued\n"
+             device-kind=vsock operation=guest-rw-guest-connection outcome=missing\n\
+             device-kind=vsock operation=connection-reset outcome=queued\n\
+             device-kind=vsock operation=tx outcome=succeeded\n"
         );
     }
 
@@ -21931,6 +22637,192 @@ mod tests {
     }
 
     #[test]
+    fn guest_response_rejects_handshake_readiness_registration() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
+
+        activate_vsock_handler(&mut handler);
+        let (accepted, mut client, request) =
+            accepted_host_connection_with_request("response-before-host-eof", 4000);
+        let accepted_fd = accepted.stream().as_raw_fd();
+        let key = handler
+            .activation_handler_mut()
+            .insert_accepted_host_connection(accepted, request)
+            .expect("host connection should insert");
+        write_vsock_rx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::writable(
+                TEST_VSOCK_RX_BUFFER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_rx_available_heads(&mut memory, &[0]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+        let request_notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("RX host request should dispatch");
+        assert_eq!(
+            request_notification
+                .rx_queue_dispatch()
+                .expect("RX dispatch summary should be present")
+                .delivered_requests(),
+            1
+        );
+        let pre_response_generation = handler.activation_handler().host_readiness_generation();
+
+        client
+            .shutdown(std::net::Shutdown::Write)
+            .expect("host stream should half-close writes");
+        let response = guest_response_tx_packet(42, key.local_port(), key.peer_port());
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, response.header());
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
+
+        let response_notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("guest response should dispatch before unobserved host EOF");
+
+        assert_eq!(
+            response_notification
+                .guest_response_dispatch()
+                .acknowledged_responses(),
+            1
+        );
+        assert_eq!(
+            response_notification
+                .connection_lifecycle_dispatch
+                .host_stream_host_connections_closed,
+            0,
+            "guest TX must not probe a host stream without a readiness observation"
+        );
+        assert!(handler.activation_handler().has_host_connection(key));
+        assert_host_ok_message(&mut client, key.local_port());
+        let post_response_generation = handler.activation_handler().host_readiness_generation();
+        assert_ne!(post_response_generation, pre_response_generation);
+
+        handler.observe_vsock_host_readiness(
+            &[super::VsockHostReadiness::for_registration(
+                super::VsockHostReadinessRegistration::unclassified(accepted_fd),
+                libc::POLLIN | libc::POLLHUP,
+                post_response_generation,
+            )],
+            false,
+        );
+        let stale_readiness_notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("pre-response host readiness should be discarded");
+        assert_eq!(
+            stale_readiness_notification
+                .connection_lifecycle_dispatch
+                .host_stream_host_connections_closed,
+            0,
+            "a monitor registration from the request phase must not authorize an established-stream read"
+        );
+        assert!(handler.activation_handler().has_host_connection(key));
+
+        let current_generation = handler.activation_handler().host_readiness_generation();
+        handler.observe_vsock_host_readiness(
+            &[super::VsockHostReadiness::for_registration(
+                super::VsockHostReadinessRegistration::host_connection(accepted_fd, key),
+                libc::POLLIN | libc::POLLHUP,
+                current_generation,
+            )],
+            false,
+        );
+        let readiness_notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("observed host EOF should dispatch");
+
+        assert_eq!(
+            readiness_notification
+                .connection_lifecycle_dispatch
+                .host_stream_host_connections_closed,
+            1
+        );
+        assert!(handler.activation_handler().has_host_connection(key));
+    }
+
+    #[test]
+    fn one_host_readiness_does_not_consume_following_eof_after_payload() {
+        let (mut memory, mut handler, mut client, key) =
+            established_host_connection_for_test("one-read-per-readiness", 4000);
+        let payload = b"readiness-owned-payload";
+
+        client
+            .write_all(payload)
+            .expect("host payload should write before half-close");
+        client
+            .shutdown(std::net::Shutdown::Write)
+            .expect("host payload should be followed by EOF");
+        observe_host_connection_readiness(&mut handler, key, libc::POLLIN | libc::POLLHUP);
+
+        let first_readiness = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("first host readiness should queue exactly one payload");
+        assert_eq!(
+            first_readiness
+                .connection_lifecycle_dispatch
+                .host_stream_host_connections_closed,
+            0,
+            "one readiness observation must not authorize a second EOF read"
+        );
+        assert!(handler.activation_handler().has_host_connection(key));
+
+        write_vsock_rx_descriptor(
+            &mut memory,
+            1,
+            TestDescriptor::writable(
+                TEST_VSOCK_RX_SECOND_BUFFER,
+                vsock_packet_len_with_payload(payload),
+                None,
+            ),
+        );
+        append_vsock_rx_available_head(&mut memory, 1, 1, 2);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+        let payload_notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("queued host payload should deliver before EOF");
+        assert_eq!(
+            payload_notification
+                .rx_queue_dispatch()
+                .expect("host payload should produce RX dispatch")
+                .delivered_host_rw_packets(),
+            1
+        );
+        assert_host_rw_payload_in_guest(
+            &memory,
+            TEST_VSOCK_RX_SECOND_BUFFER,
+            42,
+            key.local_port().raw(),
+            key.peer_port(),
+            payload,
+        );
+
+        observe_host_connection_readiness(&mut handler, key, libc::POLLIN | libc::POLLHUP);
+        let second_readiness = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("second host readiness should consume the retained EOF");
+        assert_eq!(
+            second_readiness
+                .connection_lifecycle_dispatch
+                .host_stream_host_connections_closed,
+            1
+        );
+        assert!(handler.activation_handler().has_host_connection(key));
+    }
+
+    #[test]
     fn virtio_vsock_notifications_connect_guest_request_and_deliver_response() {
         let mut memory = vsock_tx_memory();
         let path = unique_socket_path("guest-connect");
@@ -22452,6 +23344,7 @@ mod tests {
         accepted
             .write_all(payload)
             .expect("host payload should write before credit request");
+        observe_guest_connection_readiness(&mut handler, key, libc::POLLIN);
         write_vsock_rx_descriptor(
             &mut memory,
             1,
@@ -22667,6 +23560,18 @@ mod tests {
         assert_eq!(notification.guest_rw_dispatch().rw_packets(), 1);
         assert_eq!(notification.guest_rw_dispatch().forwarded_packets(), 1);
         assert_eq!(
+            notification
+                .guest_rw_dispatch()
+                .forwarded_guest_connection_packets(),
+            1
+        );
+        assert_eq!(
+            notification
+                .guest_rw_dispatch()
+                .forwarded_host_connection_packets(),
+            0
+        );
+        assert_eq!(
             notification.guest_rw_dispatch().forwarded_bytes(),
             payload.len()
         );
@@ -22836,6 +23741,18 @@ mod tests {
         assert_empty_guest_request_dispatch(notification.guest_request_dispatch());
         assert_eq!(notification.guest_rw_dispatch().rw_packets(), 1);
         assert_eq!(notification.guest_rw_dispatch().forwarded_packets(), 1);
+        assert_eq!(
+            notification
+                .guest_rw_dispatch()
+                .forwarded_host_connection_packets(),
+            1
+        );
+        assert_eq!(
+            notification
+                .guest_rw_dispatch()
+                .forwarded_guest_connection_packets(),
+            0
+        );
         assert_eq!(
             notification.guest_rw_dispatch().forwarded_bytes(),
             payload.len()
@@ -23013,7 +23930,11 @@ mod tests {
         let payload = b"payload";
         let packet = guest_rw_tx_packet(42, 52, 4000).header();
         drop(accepted);
-
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN | libc::POLLHUP,
+        );
         write_vsock_tx_packet_with_payload(
             &mut memory,
             1,
@@ -23254,6 +24175,11 @@ mod tests {
         accepted
             .write_all(payload)
             .expect("host payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         write_vsock_rx_descriptor(
             &mut memory,
             1,
@@ -23350,6 +24276,7 @@ mod tests {
         client
             .write_all(payload)
             .expect("host-initiated payload should write");
+        observe_host_connection_readiness(&mut handler, key, libc::POLLIN);
         write_vsock_rx_descriptor(
             &mut memory,
             1,
@@ -23416,6 +24343,11 @@ mod tests {
         accepted
             .write_all(payload)
             .expect("split host payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         write_vsock_rx_descriptor(
             &mut memory,
             1,
@@ -23485,6 +24417,11 @@ mod tests {
         accepted
             .write_all(payload)
             .expect("late-buffer host payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
 
         let empty_notification = handler
             .dispatch_vsock_queue_notifications(&mut memory)
@@ -23561,6 +24498,11 @@ mod tests {
         accepted
             .write_all(payload)
             .expect("retry host payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         write_vsock_rx_descriptor(
             &mut memory,
             1,
@@ -23684,6 +24626,11 @@ mod tests {
         accepted
             .write_all(first_payload)
             .expect("first host payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         let first_empty_notification = handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("first host RW should queue without RX buffers");
@@ -23697,6 +24644,11 @@ mod tests {
         accepted
             .write_all(second_payload)
             .expect("second host payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         let second_empty_notification = handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("second host RW should queue behind the first payload");
@@ -23787,6 +24739,7 @@ mod tests {
         client
             .write_all(first_payload)
             .expect("first host-initiated payload should write");
+        observe_host_connection_readiness(&mut handler, key, libc::POLLIN);
         let first_empty_notification = handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("first host-initiated RW should queue without RX buffers");
@@ -23802,6 +24755,7 @@ mod tests {
         client
             .write_all(second_payload)
             .expect("second host-initiated payload should write");
+        observe_host_connection_readiness(&mut handler, key, libc::POLLIN);
         let second_empty_notification = handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("second host-initiated RW should queue behind the first payload");
@@ -23908,6 +24862,11 @@ mod tests {
             accepted
                 .write_all(payload)
                 .expect("host payload should write into bounded backlog");
+            observe_guest_connection_readiness(
+                &mut handler,
+                VsockGuestConnectionKey::new(52, 4000),
+                libc::POLLIN,
+            );
             let notification = handler
                 .dispatch_vsock_queue_notifications(&mut memory)
                 .expect("host payload should queue while RX buffers are unavailable");
@@ -23932,6 +24891,13 @@ mod tests {
         assert_eq!(read_vsock_rx_used_index(&memory), 1);
 
         for (index, (payload, rx_buffer)) in payloads.iter().copied().zip(rx_buffers).enumerate() {
+            if index == VSOCK_HOST_RW_PENDING_PACKET_LIMIT {
+                observe_guest_connection_readiness(
+                    &mut handler,
+                    VsockGuestConnectionKey::new(52, 4000),
+                    libc::POLLIN,
+                );
+            }
             let descriptor_index =
                 u16::try_from(index + 1).expect("test descriptor index should fit");
             write_vsock_rx_descriptor(
@@ -23985,12 +24951,22 @@ mod tests {
         accepted
             .write_all(first_payload)
             .expect("first retry backlog payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("first retry backlog payload should queue");
         accepted
             .write_all(second_payload)
             .expect("second retry backlog payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("second retry backlog payload should queue");
@@ -24095,16 +25071,31 @@ mod tests {
         accepted
             .write_all(first_payload)
             .expect("first close backlog payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("first close backlog payload should queue");
         accepted
             .write_all(second_payload)
             .expect("second close backlog payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("second close backlog payload should queue");
         drop(accepted);
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN | libc::POLLHUP,
+        );
         let now = Instant::now();
 
         write_vsock_rx_descriptor(
@@ -24279,6 +25270,11 @@ mod tests {
         accepted
             .shutdown(std::net::Shutdown::Write)
             .expect("final host RW stream should close its write half");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN | libc::POLLHUP,
+        );
 
         for (offset, address) in payload_buffers.iter().copied().enumerate() {
             let payload_slice = match offset {
@@ -24316,23 +25312,47 @@ mod tests {
         append_vsock_rx_available_head(&mut memory, 4, 4, 5);
         notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
         let now = Instant::now();
+        let key = VsockGuestConnectionKey::new(52, 4000);
+        let mut delivered_host_rw_packets = 0;
+        let mut delivered_host_rw_bytes = 0;
+        let mut delivered_shutdown_packets = 0;
+        let mut delivered_kinds = Vec::new();
 
-        let notification = handler
-            .dispatch_vsock_queue_notifications_at(&mut memory, now)
-            .expect("final host RW packets and clean shutdown should drain together");
-        let rx = notification
-            .rx_queue_dispatch()
-            .expect("final host work should produce one RX dispatch");
+        // POLLIN remains level-triggered while bytes are buffered. Each exact readiness owns one
+        // backing read, so the three payload chunks and terminal EOF arrive over four monitor
+        // rounds instead of one speculative read batch.
+        for round in 0..4 {
+            observe_guest_connection_readiness(&mut handler, key, libc::POLLIN | libc::POLLHUP);
+            let notification = handler
+                .dispatch_vsock_queue_notifications_at(&mut memory, now)
+                .expect("each exact readiness should drain one final host-stream state");
+            let rx = notification
+                .rx_queue_dispatch()
+                .expect("each final host-stream state should produce one RX dispatch");
+            assert_eq!(rx.processed_buffers(), 1);
+            assert!(rx.needs_queue_interrupt());
+            delivered_host_rw_packets += rx.delivered_host_rw_packets();
+            delivered_host_rw_bytes += rx.delivered_host_rw_bytes();
+            delivered_shutdown_packets += rx.delivered_shutdown_packets();
+            delivered_kinds.extend(
+                rx.deliveries()
+                    .iter()
+                    .map(|delivery| delivery.packet_kind()),
+            );
+            if round < 3 {
+                assert_eq!(rx.delivered_host_rw_packets(), 1);
+                assert_eq!(rx.delivered_shutdown_packets(), 0);
+            } else {
+                assert_eq!(rx.delivered_host_rw_packets(), 0);
+                assert_eq!(rx.delivered_shutdown_packets(), 1);
+            }
+        }
 
-        assert_eq!(rx.processed_buffers(), 4);
-        assert_eq!(rx.delivered_host_rw_packets(), 3);
-        assert_eq!(rx.delivered_host_rw_bytes(), payload.len());
-        assert_eq!(rx.delivered_shutdown_packets(), 1);
+        assert_eq!(delivered_host_rw_packets, 3);
+        assert_eq!(delivered_host_rw_bytes, payload.len());
+        assert_eq!(delivered_shutdown_packets, 1);
         assert_eq!(
-            rx.deliveries()
-                .iter()
-                .map(|delivery| delivery.packet_kind())
-                .collect::<Vec<_>>(),
+            delivered_kinds,
             vec![
                 VirtioVsockRxPacketKind::HostRw,
                 VirtioVsockRxPacketKind::HostRw,
@@ -24340,7 +25360,6 @@ mod tests {
                 VirtioVsockRxPacketKind::ConnectionShutdown,
             ]
         );
-        assert!(rx.needs_queue_interrupt());
         assert_host_rw_payload_in_guest(
             &memory,
             payload_buffers[0],
@@ -24428,6 +25447,11 @@ mod tests {
         accepted
             .write_all(payload)
             .expect("host RW payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
         write_vsock_rx_descriptor(
             &mut memory,
             1,
@@ -24486,6 +25510,11 @@ mod tests {
         let (mut memory, mut handler, accepted) =
             established_guest_connection_for_test("host-rw-eof", 52, 4000);
         drop(accepted);
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN | libc::POLLHUP,
+        );
         let now = Instant::now();
         write_vsock_rx_descriptor(
             &mut memory,
@@ -24502,6 +25531,18 @@ mod tests {
         let notification = handler
             .dispatch_vsock_queue_notifications_at(&mut memory, now)
             .expect("closed host stream should queue guest shutdown");
+        assert_eq!(
+            notification
+                .connection_lifecycle_dispatch
+                .host_stream_guest_connections_closed,
+            1
+        );
+        assert_eq!(
+            notification
+                .connection_lifecycle_dispatch
+                .host_stream_host_connections_closed,
+            0
+        );
 
         let rx = notification
             .rx_queue_dispatch()
@@ -24557,6 +25598,14 @@ mod tests {
         let expiry = handler
             .dispatch_vsock_queue_notifications_at(&mut memory, deadline)
             .expect("connection should reset exactly at shutdown deadline");
+        assert_eq!(
+            expiry
+                .connection_lifecycle_dispatch
+                .guest_connection_shutdown_deadlines_expired,
+            1
+        );
+        assert_eq!(expiry.connection_lifecycle_dispatch.queued_resets, 1);
+        assert_eq!(expiry.connection_lifecycle_dispatch.dropped_resets, 0);
         let expiry_rx = expiry
             .rx_queue_dispatch()
             .expect("deadline reset should dispatch");
@@ -24584,7 +25633,8 @@ mod tests {
         let mut handler = virtio_vsock_mmio_handler_with_host_socket(42, &path);
         let first_request = guest_request_tx_packet(42, 52, 4000).header();
         let second_request = guest_request_tx_packet(42, 53, 4001).header();
-        let payload = b"second-only";
+        let first_payload = b"first-unobserved";
+        let second_payload = b"second-ready";
 
         activate_vsock_handler(&mut handler);
         write_vsock_rx_descriptor(
@@ -24648,16 +25698,24 @@ mod tests {
         assert_eq!(read_vsock_rx_used_index(&memory), 2);
         let mut first_accepted = first_listener.accept();
         let mut second_accepted = second_listener.accept();
+        first_accepted
+            .write_all(first_payload)
+            .expect("first unobserved host payload should write");
         second_accepted
-            .write_all(payload)
+            .write_all(second_payload)
             .expect("second host payload should write");
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(53, 4001),
+            libc::POLLIN,
+        );
 
         write_vsock_rx_descriptor(
             &mut memory,
             2,
             TestDescriptor::writable(
                 TEST_VSOCK_PAYLOAD,
-                vsock_packet_len_with_payload(payload),
+                vsock_packet_len_with_payload(second_payload),
                 None,
             ),
         );
@@ -24672,21 +25730,61 @@ mod tests {
             .rx_queue_dispatch()
             .expect("second host RW should produce RX dispatch");
         assert_eq!(rx.delivered_host_rw_packets(), 1);
-        assert_eq!(rx.delivered_host_rw_bytes(), payload.len());
+        assert_eq!(rx.delivered_host_rw_bytes(), second_payload.len());
         assert_host_rw_packet_header(
             read_vsock_packet_header(&memory, TEST_VSOCK_PAYLOAD),
             42,
             53,
             4001,
-            payload.len(),
+            second_payload.len(),
         );
         assert_eq!(
             read_guest_bytes(
                 &memory,
                 vsock_payload_address_after_header(TEST_VSOCK_PAYLOAD),
-                payload.len(),
+                second_payload.len(),
             ),
-            payload
+            second_payload
+        );
+        assert_eq!(
+            handler
+                .activation_handler()
+                .pending_guest_rw_payload_count(VsockGuestConnectionKey::new(52, 4000)),
+            Some(0),
+            "the unobserved connection must not be prefetched"
+        );
+
+        observe_guest_connection_readiness(
+            &mut handler,
+            VsockGuestConnectionKey::new(52, 4000),
+            libc::POLLIN,
+        );
+        write_vsock_rx_descriptor(
+            &mut memory,
+            3,
+            TestDescriptor::writable(
+                TEST_VSOCK_SECOND_PAYLOAD,
+                vsock_packet_len_with_payload(first_payload),
+                None,
+            ),
+        );
+        append_vsock_rx_available_head(&mut memory, 3, 3, 4);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+        let first_notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("first host RW should deliver after its readiness observation");
+        let first_rx = first_notification
+            .rx_queue_dispatch()
+            .expect("first host RW should produce RX dispatch");
+        assert_eq!(first_rx.delivered_host_rw_packets(), 1);
+        assert_eq!(first_rx.delivered_host_rw_bytes(), first_payload.len());
+        assert_host_rw_payload_in_guest(
+            &memory,
+            TEST_VSOCK_SECOND_PAYLOAD,
+            42,
+            52,
+            4000,
+            first_payload,
         );
         assert_eq!(
             handler
@@ -25635,7 +26733,7 @@ mod tests {
             .expect("host connection should exist");
         assert!(connection.mark_local_closed(now));
         assert!(connection.has_pending_local_shutdown_packet());
-        let (_, _, pending_deadline) = device
+        let (_, _, pending_deadline, _, _) = device
             .host_wakeup()
             .expect("pending local shutdown wakeup should collect");
         assert_eq!(
@@ -25688,7 +26786,7 @@ mod tests {
         assert_eq!(device.pending_guest_reset_packet_count(), 0);
 
         let deadline = delivered_at + Duration::from_secs(2);
-        let (_, _, delivered_deadline) = device
+        let (_, _, delivered_deadline, _, _) = device
             .host_wakeup()
             .expect("delivered local shutdown wakeup should collect");
         assert_eq!(delivered_deadline, Some(deadline));
@@ -25839,12 +26937,18 @@ mod tests {
             .as_raw_fd();
         let metrics = SharedVsockDeviceMetrics::default();
         handler.attach_vsock_metrics(metrics.clone());
+        let generation = handler.activation_handler().host_readiness_generation();
+        let registration = super::VsockHostReadinessRegistration::guest_connection(descriptor, key);
         let readiness = [
-            super::VsockHostReadiness::from_poll_revents(-1, libc::POLLIN),
-            super::VsockHostReadiness::from_poll_revents(descriptor, libc::POLLNVAL),
-            super::VsockHostReadiness::from_poll_revents(descriptor, libc::POLLIN),
-            super::VsockHostReadiness::from_poll_revents(descriptor, libc::POLLOUT),
-            super::VsockHostReadiness::from_poll_revents(descriptor, libc::POLLERR | libc::POLLHUP),
+            super::VsockHostReadiness::from_poll_revents(-1, libc::POLLIN, generation),
+            super::VsockHostReadiness::for_registration(registration, libc::POLLNVAL, generation),
+            super::VsockHostReadiness::for_registration(registration, libc::POLLIN, generation),
+            super::VsockHostReadiness::for_registration(registration, libc::POLLOUT, generation),
+            super::VsockHostReadiness::for_registration(
+                registration,
+                libc::POLLERR | libc::POLLHUP,
+                generation,
+            ),
         ];
 
         handler.observe_vsock_host_readiness(&readiness, true);
@@ -25876,11 +26980,13 @@ mod tests {
             .as_raw_fd();
         let metrics = SharedVsockDeviceMetrics::default();
         handler.attach_vsock_metrics(metrics.clone());
+        let generation = handler.activation_handler().host_readiness_generation();
 
         handler.observe_vsock_host_readiness(
-            &[super::VsockHostReadiness::from_poll_revents(
-                descriptor,
+            &[super::VsockHostReadiness::for_registration(
+                super::VsockHostReadinessRegistration::guest_connection(descriptor, key),
                 libc::POLLOUT,
+                generation,
             )],
             false,
         );
@@ -25896,6 +27002,7 @@ mod tests {
         client
             .shutdown(std::net::Shutdown::Write)
             .expect("host stream should half-close writes");
+        observe_host_connection_readiness(&mut handler, key, libc::POLLIN | libc::POLLHUP);
         write_vsock_rx_descriptor(
             &mut memory,
             1,
@@ -25923,6 +27030,18 @@ mod tests {
         let notification = handler
             .dispatch_vsock_queue_notifications_at(&mut memory, now)
             .expect("same-window host EOF and guest shutdown should dispatch");
+        assert_eq!(
+            notification
+                .connection_lifecycle_dispatch
+                .host_stream_host_connections_closed,
+            1
+        );
+        assert_eq!(
+            notification
+                .connection_lifecycle_dispatch
+                .host_stream_guest_connections_closed,
+            0
+        );
 
         assert_eq!(
             notification
@@ -25957,9 +27076,12 @@ mod tests {
             0
         );
 
-        handler
+        let expiry = handler
             .activation_handler_mut()
             .expire_connections(now + Duration::from_secs(2));
+        assert_eq!(expiry.host_connection_shutdown_deadlines_expired, 1);
+        assert_eq!(expiry.guest_connection_shutdown_deadlines_expired, 0);
+        assert_eq!(expiry.queued_resets, 1);
         assert!(!handler.activation_handler().has_host_connection(key));
         assert_eq!(
             handler
@@ -26359,6 +27481,7 @@ mod tests {
         client
             .write_all(queued_payload)
             .expect("host payload before receive shutdown should write");
+        observe_host_connection_readiness(&mut handler, key, libc::POLLIN);
         let queued = handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("host payload should queue without an RX buffer");
@@ -26431,6 +27554,7 @@ mod tests {
         client
             .write_all(queued_payload)
             .expect("host payload before receive shutdown should write");
+        observe_host_connection_readiness(&mut handler, key, libc::POLLIN);
         let queued = handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("host payload should queue without an RX buffer");
@@ -26537,6 +27661,18 @@ mod tests {
         assert_eq!(rw_notification.guest_rw_dispatch().rw_packets(), 1);
         assert_eq!(rw_notification.guest_rw_dispatch().forwarded_packets(), 0);
         assert_eq!(rw_notification.guest_rw_dispatch().ignored_packets(), 1);
+        assert_eq!(
+            rw_notification
+                .guest_rw_dispatch()
+                .suppressed_host_connection_packets(),
+            1
+        );
+        assert_eq!(
+            rw_notification
+                .guest_rw_dispatch()
+                .suppressed_guest_connection_packets(),
+            0
+        );
         assert_eq!(rw_notification.guest_rw_dispatch().dropped_connections(), 0);
         assert_empty_guest_reset_dispatch(rw_notification.guest_reset_dispatch());
         assert!(rw_notification.rx_queue_dispatch().is_none());
@@ -26804,6 +27940,7 @@ mod tests {
         accepted
             .write_all(queued_payload)
             .expect("host payload before receive shutdown should write");
+        observe_guest_connection_readiness(&mut handler, key, libc::POLLIN);
         let queued = handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("host payload should queue without an RX buffer");
@@ -26877,6 +28014,7 @@ mod tests {
         accepted
             .write_all(queued_payload)
             .expect("host payload before receive shutdown should write");
+        observe_guest_connection_readiness(&mut handler, key, libc::POLLIN);
         let queued = handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("host payload should queue without an RX buffer");
@@ -26984,6 +28122,18 @@ mod tests {
         assert_eq!(rw_notification.guest_rw_dispatch().rw_packets(), 1);
         assert_eq!(rw_notification.guest_rw_dispatch().forwarded_packets(), 0);
         assert_eq!(rw_notification.guest_rw_dispatch().ignored_packets(), 1);
+        assert_eq!(
+            rw_notification
+                .guest_rw_dispatch()
+                .suppressed_guest_connection_packets(),
+            1
+        );
+        assert_eq!(
+            rw_notification
+                .guest_rw_dispatch()
+                .suppressed_host_connection_packets(),
+            0
+        );
         assert_eq!(rw_notification.guest_rw_dispatch().dropped_connections(), 0);
         assert_empty_guest_reset_dispatch(rw_notification.guest_reset_dispatch());
         assert!(rw_notification.rx_queue_dispatch().is_none());
@@ -27619,9 +28769,11 @@ mod tests {
         let mut memory = vsock_tx_memory();
         let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
         let packet = guest_rw_tx_packet(42, 52, 4000).header();
+        let host_packet = guest_rw_tx_packet(42, VSOCK_HOST_LOCAL_PORT_BASE, 4001).header();
 
         activate_vsock_handler(&mut handler);
         write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, packet);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_SECOND_HEADER, host_packet);
         write_vsock_tx_descriptor(
             &mut memory,
             0,
@@ -27631,25 +28783,46 @@ mod tests {
                 None,
             ),
         );
-        write_vsock_tx_available_heads(&mut memory, &[0]);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            1,
+            TestDescriptor::readable(
+                TEST_VSOCK_SECOND_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0, 1]);
         notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
 
         let notification = handler
             .dispatch_vsock_queue_notifications(&mut memory)
             .expect("orphan guest RW should queue RST");
 
-        assert_eq!(notification.guest_rw_dispatch().rw_packets(), 1);
+        assert_eq!(notification.guest_rw_dispatch().rw_packets(), 2);
         assert_eq!(notification.guest_rw_dispatch().forwarded_packets(), 0);
         assert_eq!(notification.guest_rw_dispatch().forwarded_bytes(), 0);
         assert_eq!(notification.guest_rw_dispatch().ignored_packets(), 0);
-        assert_eq!(notification.guest_rw_dispatch().dropped_connections(), 1);
-        assert_eq!(notification.guest_reset_dispatch().reset_candidates(), 1);
-        assert_eq!(notification.guest_reset_dispatch().queued_resets(), 1);
+        assert_eq!(notification.guest_rw_dispatch().dropped_connections(), 2);
+        assert_eq!(
+            notification
+                .guest_rw_dispatch()
+                .missing_guest_connection_packets(),
+            1
+        );
+        assert_eq!(
+            notification
+                .guest_rw_dispatch()
+                .missing_host_connection_packets(),
+            1
+        );
+        assert_eq!(notification.guest_reset_dispatch().reset_candidates(), 2);
+        assert_eq!(notification.guest_reset_dispatch().queued_resets(), 2);
         assert_eq!(
             handler
                 .activation_handler()
                 .pending_guest_reset_packet_count(),
-            1
+            2
         );
         let rx = notification
             .rx_queue_dispatch()
@@ -28182,6 +29355,10 @@ mod tests {
                 .expect("source host connection should remain present")
                 .credit
                 .pending_credit_request_packet = true;
+            device.ready_host_connection_reads.push(key);
+            device
+                .ready_guest_connection_reads
+                .push(VsockGuestConnectionKey::new(52, 4000));
             device
                 .pending_guest_reset_packets
                 .push_back(VirtioVsockPacketHeader::new());
@@ -28200,6 +29377,22 @@ mod tests {
         let (first, first_validation) = handler
             .capture_vsock_state(&config, &memory, reset_attempt)
             .expect("active vsock capture should succeed");
+        assert_eq!(
+            handler
+                .activation_handler()
+                .ready_host_connection_reads
+                .len(),
+            1,
+            "immutable capture must not consume a runtime readiness observation"
+        );
+        assert_eq!(
+            handler
+                .activation_handler()
+                .ready_guest_connection_reads
+                .len(),
+            1,
+            "immutable capture must not consume a runtime readiness observation"
+        );
         let (second, second_validation) = handler
             .capture_vsock_state(&config, &memory, reset_attempt)
             .expect("repeat active vsock capture should succeed");
@@ -28268,6 +29461,18 @@ mod tests {
             0
         );
         assert_eq!(handler.activation_handler().active_connection_count(), 0);
+        assert!(
+            handler
+                .activation_handler()
+                .ready_host_connection_reads
+                .is_empty()
+        );
+        assert!(
+            handler
+                .activation_handler()
+                .ready_guest_connection_reads
+                .is_empty()
+        );
         assert_eq!(
             handler
                 .activation_handler()

--- a/crates/runtime/src/vsock/direct_restore.rs
+++ b/crates/runtime/src/vsock/direct_restore.rs
@@ -579,9 +579,7 @@ fn path_to_cstring(path: &Path) -> io::Result<CString> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_os = "macos")]
-    use std::os::unix::fs::MetadataExt as _;
-    use std::os::unix::fs::{PermissionsExt as _, symlink};
+    use std::os::unix::fs::symlink;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use crate::snapshot::{SnapshotVsockOverride, resolve_snapshot_vsock_selectors};

--- a/crates/vhost-user/src/message.rs
+++ b/crates/vhost-user/src/message.rs
@@ -306,8 +306,10 @@ mod tests {
 
     fn words(bytes: &[u8]) -> Vec<u32> {
         bytes
-            .chunks_exact(4)
-            .map(|chunk| u32::from_ne_bytes(chunk.try_into().expect("word should be exact")))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|chunk| u32::from_ne_bytes(*chunk))
             .collect()
     }
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -883,14 +883,20 @@ The owner thread retains the resolved scope and exact directory anchor. A
 short-lived default-close instance of the already signed worker authenticates
 its parent, receives only its control endpoint at fd5 and the exact private
 namespace anchor at fd6, enters that anchor, binds one fixed role-specific
-staging name, validates the listener, transfers its descriptor, and is killed
-and reaped on every failure. The main worker verifies the namespace inode and
-listener identity, writes one fixed bounded record containing only role, safe
-child, and socket device/inode, and publishes the live vnode exclusively with
-fd-relative `renameatx_np(RENAME_EXCL)` to the grant anchor. Cross-filesystem
-publication, an existing target, symlink or pathname replacement, role/identity
-mismatch, and extra rights fail closed and value-redacted. The binder is always
-reaped before API readiness or VM-start success.
+staging name, validates the listener, and transfers its descriptor. It retains
+the listener until the authenticated parent returns one fixed adoption
+acknowledgment bound to the role and socket device/inode; the parent sends that
+acknowledgment only after validating the received descriptor. This keeps the
+listener externally reachable until `SCM_RIGHTS` externalization completes,
+rather than leaving its last reference only in an in-flight Unix-domain
+message. The main worker then verifies the namespace inode and listener
+identity, writes one fixed bounded record containing only role, safe child, and
+socket device/inode, and publishes the live vnode exclusively with fd-relative
+`renameatx_np(RENAME_EXCL)` to the grant anchor. Cross-filesystem publication,
+an existing target, symlink or pathname replacement, role/identity mismatch,
+malformed acknowledgment, and extra rights fail closed and value-redacted. The
+binder is killed and reaped on every failure and is always reaped before API
+readiness or VM-start success.
 
 The supplied API listener preserves owner-only mode, no-clobber publication,
 readiness timing, and identity-aware cleanup. The supplied vsock main listener
@@ -3222,7 +3228,10 @@ producer snapshot shares the controller's sole worker and the independent
 `logger-rate.entropy.outcome`, `logger-rate.memory-hotplug.outcome`,
 `logger-rate.network.outcome`, `logger-rate.pmem.outcome`,
 `logger-rate.serial.outcome`, `logger-rate.time-identity.outcome`, and
-`logger-rate.vsock.outcome` states.
+`logger-rate.vsock.outcome` states. Vsock local-stream EOF/read failures and
+connection deadlines use the additional bounded
+`logger-rate.vsock.endpoint-outcome` state, so ordinary RX/TX success traffic
+cannot consume the first endpoint-lifecycle evidence budget.
 Normal and native-v2 assembly install the capability before HVF and MMIO/PCI
 publication, and run-loop adapter traits require explicit logger forwarding so
 a wrapper cannot silently substitute an inert capability. Repeating successful

--- a/tools/seccompiler/tests/cli.rs
+++ b/tools/seccompiler/tests/cli.rs
@@ -122,8 +122,10 @@ fn decode_split(path: &Path) -> Vec<u64> {
     let bytes = fs::read(path).expect("split output should be readable");
     assert!(bytes.len().is_multiple_of(size_of::<u64>()));
     bytes
-        .chunks_exact(size_of::<u64>())
-        .map(|chunk| u64::from_le_bytes(chunk.try_into().expect("chunk should be eight bytes")))
+        .as_chunks::<{ size_of::<u64>() }>()
+        .0
+        .iter()
+        .map(|chunk| u64::from_le_bytes(*chunk))
         .collect()
 }
 

--- a/tools/snapshot-tools/tests/cli.rs
+++ b/tools/snapshot-tools/tests/cli.rs
@@ -504,7 +504,9 @@ mod state {
             .collect::<Vec<_>>();
         assert_eq!(digits.len() % 2, 0, "fixture hex should be paired");
         digits
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let text = std::str::from_utf8(pair).expect("fixture digits should be UTF-8");
                 u8::from_str_radix(text, 16).expect("fixture should contain only hex")


### PR DESCRIPTION
## Summary

- bind every established vsock host read to the exact poll registration,
  connection key, and runtime generation, and require every HVF run-loop
  wrapper to forward the observation;
- retain contained API/vsock listeners in the binder until the authenticated
  parent acknowledges validated descriptor adoption by role and inode;
- add fixed value-redacted endpoint lifecycle outcomes, an independent bounded
  endpoint-evidence budget, deterministic runtime regressions, and correct the
  two test-only pathname-authority races.

## Causal evidence

The first reduced defect was an unobserved backing read: guest TX dispatch
probed every established stream, and the packet-I/O run-loop wrapper also
discarded monitor readiness. One retained readiness now authorizes exactly one
read for the exact connection and generation, so payload and following EOF
require distinct level-triggered observations.

The remaining production-only failure was the listener binder exiting after
`sendmsg` but before the parent externalized the `SCM_RIGHTS` descriptor. Under
load, XNU could garbage-collect the message-only last listener reference. The
new fixed acknowledgment keeps the child listener live through validated
adoption and preserves failure-atomic cleanup.

## CI compatibility

Rust 1.98 added the `chunks_exact_to_as_chunks` Clippy lint after the original
implementation review. The current head mechanically adopts fixed-width array
chunks across the workspace without a lint suppression, preserving the prior
complete-chunk and remainder behavior.

## Verification

- `cargo +1.98.0 fmt --all -- --check`
- `git diff --check`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (96 passed)
- capability audit delivery, logger-final, metrics-device-final, and
  metrics-final profiles
- Rust 1.98 workspace/all-target Clippy, complete non-HVF workspace tests,
  1,540 HVF library tests, all six signed-target Clippy commands, and rustdoc
  with warnings denied
- workspace/all-target checks, both Linux-musl cross-target checks, and focused
  runtime logger/vsock, anchored binder, and HVF monitor tests
- direct signed restored-vsock MMIO: 5/5 consecutive passes
- direct signed restored-vsock product PCI: 5/5 consecutive passes
- strict production restored lifecycle: 5/5 consecutive passes, plus the same
  target under eight-worker CPU load and one current-head non-PTY control pass
- older production snapshot continuation: 5/5 consecutive passes
- final full production-bundle group: 77/77 passed
- complete integration-wrapper coverage: every constituent target group passed
  on the final behavioral code; earlier monolithic attempts encountered
  unrelated timing-sensitive HVF/guest/snapshot tests, and each exact failure
  reran clean

## Scope exclusions

No snapshot bytes, API schema, metric fields or meanings, deadlines, retries,
sleeps, timeout extensions, supported-host skips, App Sandbox bypasses, or
payload/EOF relaxations change.

Closes #1922

Parent: #1348
