### PR TITLE
fix: eliminate recurrent malformed production API requests

### DIFF
--- a/compat/firecracker/v1.16.0/host-resource-authority-contract.md
+++ b/compat/firecracker/v1.16.0/host-resource-authority-contract.md
@@ -67,7 +67,7 @@ read-only, write-only, read-write, create-children, and connect-children.
 | `initrd-image` | regular file, read-only | One-time guest initrd load |
 | `drive-backing` | regular file or block device, read-only/read-write | Transactional startup, hotplug, replacement, and restore |
 | `pmem-backing` | regular file, read-only/read-write | Transactional startup, hotplug, replacement, and restore |
-| `api-socket-directory` | directory, create-children | Session-retained bind/publication/cleanup |
+| `api-socket-directory` | directory, create-children | Worker claim, launcher staged bind/publication, record-backed cleanup |
 | `vsock-socket-directory` | directory, create-children | Session-retained listener/publication/connect |
 | `logger-sink` | regular file, write-only | One-time output adoption |
 | `metrics-sink` | regular file, write-only | One-time output adoption |
@@ -90,7 +90,10 @@ file and directory population before one commit exposes authority.
 Contained consumers use opened identities or retained anchored scopes; no
 tagged path string becomes ambient authority. Startup and restore preflight
 complete before mutation. Storage and snapshot transactions return unused
-authority on abort and consume it exactly on commit. API/vsock publication,
+authority on abort and consume it exactly on commit. Ordinary API publication
+uses one authenticated worker request, launcher-owned private staging, a
+durable record before exclusive rename, and one exact listener reply; later
+vsock activation carries the same broker sequence. API/vsock publication,
 vhost-user exact-child connects, retained block control, and pager streams each
 use separate bounded session/sequence protocols rather than a general dynamic
 resource broker.

--- a/crates/bangbang/src/anchored_socket.rs
+++ b/crates/bangbang/src/anchored_socket.rs
@@ -25,7 +25,7 @@ use bangbang_session::{ObjectIdentity, ResourceRole, SocketChild};
 
 use crate::contained_session::{
     ClaimedSocketDirectory, PreparedSocketBrokerEndpoint, PreparedSocketDirectoryClaim,
-    SocketBrokerEndpoint,
+    SocketBrokerAuthority, SocketBrokerEndpoint,
 };
 
 const BINDER_ARGUMENT: &str = "--bangbang-internal-socket-binder-v1";
@@ -416,6 +416,185 @@ pub(crate) fn bind(
         broker.map(SocketBrokerClaim::Committed),
         || false,
     )
+}
+
+/// Requests launcher-side staged publication and adopts one ordinary API listener.
+pub(crate) fn request_api_listener(
+    namespace: WorkerSocketNamespace,
+    claim: ClaimedSocketDirectory,
+    authority: &SocketBrokerAuthority,
+) -> Result<BoundAnchoredSocket, AnchoredSocketError> {
+    if namespace.identity().device != claim.directory.identity().device {
+        return Err(AnchoredSocketError::CrossFilesystem);
+    }
+    let mut broker = authority
+        .prepare_endpoint()
+        .map_err(|_| AnchoredSocketError::Broker)?;
+    let exchanged = exchange_api_publication(&mut broker, &claim.child);
+    let (descriptor, identity) = match exchanged {
+        Ok(published) => published,
+        Err(error) => {
+            broker.invalidate();
+            cleanup_failed_api_publication(&namespace, &claim)?;
+            return Err(error);
+        }
+    };
+    let record = match SocketOwnershipRecord::new(
+        ResourceRole::ApiSocketDirectory,
+        claim.child.clone(),
+        identity,
+    ) {
+        Ok(record) => record,
+        Err(_) => {
+            broker.invalidate();
+            cleanup_failed_api_publication(&namespace, &claim)?;
+            return Err(AnchoredSocketError::Invalid);
+        }
+    };
+    let listener = UnixListener::from(descriptor);
+    // SAFETY: Effective identity calls have no pointer or ownership contract.
+    let expected_owner = unsafe { (libc::geteuid(), libc::getegid()) };
+    let adopted = (|| {
+        if identity.device != claim.directory.identity().device {
+            return Err(AnchoredSocketError::CrossFilesystem);
+        }
+        namespace
+            .require_socket_record(&record)
+            .map_err(|_| AnchoredSocketError::Invalid)?;
+        let child = child_cstring(&claim.child)?;
+        if relative_socket_identity_with_owner(
+            claim.directory.anchor_fd(),
+            &child,
+            Some(expected_owner),
+        )? != identity
+        {
+            return Err(AnchoredSocketError::PathChanged);
+        }
+        validate_brokered_api_listener_descriptor(listener.as_raw_fd())?;
+        if relative_socket_identity_with_owner(
+            claim.directory.anchor_fd(),
+            &child,
+            Some(expected_owner),
+        )? != identity
+        {
+            return Err(AnchoredSocketError::PathChanged);
+        }
+        namespace
+            .require_socket_record(&record)
+            .map_err(|_| AnchoredSocketError::Invalid)
+    })();
+    if let Err(error) = adopted {
+        broker.invalidate();
+        drop(listener);
+        cleanup_failed_api_publication(&namespace, &claim)?;
+        return Err(error);
+    }
+    if broker.restore_after_exchange().is_err() {
+        drop(listener);
+        cleanup_failed_api_publication(&namespace, &claim)?;
+        return Err(AnchoredSocketError::Broker);
+    }
+    Ok(BoundAnchoredSocket {
+        listener,
+        guard: AnchoredSocketGuard {
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            ownership: AnchoredSocketOwnership::Recorded(namespace),
+            #[cfg(not(feature = "elevated-bootstrap-probe"))]
+            namespace,
+            claim,
+            record,
+            expected_owner: Some(expected_owner),
+        },
+        connector: None,
+    })
+}
+
+fn exchange_api_publication(
+    broker: &mut PreparedSocketBrokerEndpoint,
+    child: &SocketChild,
+) -> Result<(OwnedFd, ObjectIdentity), AnchoredSocketError> {
+    let endpoint = broker
+        .endpoint_mut()
+        .map_err(|_| AnchoredSocketError::Broker)?;
+    prepare_connector_endpoint(endpoint)?;
+    wait_for_broker(endpoint, libc::POLLOUT, AnchoredSocketError::Cancelled)?;
+    let sequence = endpoint.next_sequence;
+    let next_sequence = sequence.checked_add(1).ok_or(AnchoredSocketError::Broker)?;
+    send_socket_broker_message(
+        &endpoint.socket,
+        &SocketBrokerMessage::PublishApi {
+            session: endpoint.session,
+            sequence,
+            child: child.clone(),
+        },
+        None,
+    )
+    .map_err(|_| AnchoredSocketError::Broker)?;
+    verify_peer_pid(endpoint.socket.as_raw_fd(), endpoint.launcher_pid)
+        .map_err(|_| AnchoredSocketError::Broker)?;
+    wait_for_broker(endpoint, libc::POLLIN, AnchoredSocketError::Cancelled)?;
+    let response =
+        receive_socket_broker_message(&endpoint.socket).map_err(|_| AnchoredSocketError::Broker)?;
+    verify_peer_pid(endpoint.socket.as_raw_fd(), endpoint.launcher_pid)
+        .map_err(|_| AnchoredSocketError::Broker)?;
+    endpoint.next_sequence = next_sequence;
+    match (response.message, response.descriptor) {
+        (
+            SocketBrokerMessage::ApiPublished {
+                session,
+                sequence: response_sequence,
+                identity,
+            },
+            Some(descriptor),
+        ) if session == endpoint.session && response_sequence == sequence => {
+            Ok((descriptor, identity))
+        }
+        (
+            SocketBrokerMessage::ApiPublishFailed {
+                session,
+                sequence: response_sequence,
+                kind,
+            },
+            None,
+        ) if session == endpoint.session && response_sequence == sequence => {
+            Err(AnchoredSocketError::Io(kind))
+        }
+        _ => Err(AnchoredSocketError::Invalid),
+    }
+}
+
+fn cleanup_failed_api_publication(
+    namespace: &WorkerSocketNamespace,
+    claim: &ClaimedSocketDirectory,
+) -> Result<(), AnchoredSocketError> {
+    let record = namespace
+        .socket_record(ResourceRole::ApiSocketDirectory)
+        .map_err(|_| AnchoredSocketError::Cleanup)?;
+    let Some(record) = record else {
+        let staging = socket_staging_name(ResourceRole::ApiSocketDirectory)
+            .map_err(|_| AnchoredSocketError::Cleanup)?;
+        return cleanup_staged_socket_checked(namespace, staging, None);
+    };
+    if record.child() != &claim.child {
+        return Err(AnchoredSocketError::Cleanup);
+    }
+    // SAFETY: Effective identity calls have no pointer or ownership contract.
+    let expected_owner = unsafe { (libc::geteuid(), libc::getegid()) };
+    match unlink_socket_if_owned_with_owner(
+        claim.directory.anchor_fd(),
+        &claim.child,
+        record.identity(),
+        Some(expected_owner),
+    ) {
+        Ok(()) | Err(AnchoredSocketError::Io(io::ErrorKind::NotFound)) => {}
+        Err(_) => return Err(AnchoredSocketError::Cleanup),
+    }
+    namespace
+        .unlink_staged_socket(&record)
+        .map_err(|_| AnchoredSocketError::Cleanup)?;
+    namespace
+        .clear_socket_record(&record)
+        .map_err(|_| AnchoredSocketError::Cleanup)
 }
 
 /// Adopts the fixed final API listener created by the elevated launcher.
@@ -834,9 +1013,11 @@ fn spawn_connector(
 ) -> Result<AnchoredVsockConnector, AnchoredSocketError> {
     prepare_connector_endpoint(&endpoint)?;
     wait_for_broker(&endpoint, libc::POLLOUT, AnchoredSocketError::Broker)?;
+    let sequence = endpoint.next_sequence;
+    let next_sequence = sequence.checked_add(1).ok_or(AnchoredSocketError::Broker)?;
     let activate = SocketBrokerMessage::Activate {
         session: endpoint.session,
-        sequence: 1,
+        sequence,
         child: claim.child.clone(),
     };
     send_socket_broker_message(&endpoint.socket, &activate, None)
@@ -849,9 +1030,9 @@ fn spawn_connector(
     if !matches!(
         response,
         bangbang_session::macos::socket_broker::ReceivedSocketBrokerMessage {
-            message: SocketBrokerMessage::Ready { session, sequence: 1 },
+            message: SocketBrokerMessage::Ready { session, sequence: response_sequence },
             descriptor: None,
-        } if session == endpoint.session
+        } if session == endpoint.session && response_sequence == sequence
     ) {
         return Err(AnchoredSocketError::Invalid);
     }
@@ -859,13 +1040,14 @@ fn spawn_connector(
         socket,
         session,
         launcher_pid,
+        next_sequence: _,
         wakeup: _,
     } = endpoint;
     Ok(AnchoredVsockConnector {
         socket,
         session,
         launcher_pid,
-        next_sequence: 2,
+        next_sequence,
         healthy: true,
     })
 }
@@ -1234,6 +1416,22 @@ fn validate_listener_descriptor(
 ) -> Result<(), AnchoredSocketError> {
     let staging = socket_staging_name(role).map_err(|_| AnchoredSocketError::Invalid)?;
     validate_listener_descriptor_for_name(descriptor, staging)
+}
+
+fn validate_brokered_api_listener_descriptor(descriptor: RawFd) -> Result<(), AnchoredSocketError> {
+    // SAFETY: F_GETFD and F_GETFL inspect the live received descriptor.
+    let descriptor_flags = unsafe { libc::fcntl(descriptor, libc::F_GETFD) };
+    // SAFETY: F_GETFL inspects the same live received descriptor.
+    let status_flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    if descriptor_flags < 0
+        || status_flags < 0
+        || descriptor_flags & libc::FD_CLOEXEC == 0
+        || status_flags & libc::O_NONBLOCK == 0
+        || socket_int_option(descriptor, libc::SO_ERROR)? != 0
+    {
+        return Err(AnchoredSocketError::Invalid);
+    }
+    validate_listener_descriptor(descriptor, ResourceRole::ApiSocketDirectory)
 }
 
 fn validate_listener_descriptor_for_name(
@@ -2093,10 +2291,199 @@ mod tests {
     use std::os::unix::process::CommandExt as _;
     use std::process::{Command, Stdio};
     use std::rc::Rc;
+    use std::thread;
 
     use bangbang_session::SessionId;
+    use bangbang_session::macos::socket_broker::{
+        receive_socket_broker_message, send_socket_broker_message,
+    };
 
     use super::*;
+
+    fn ordinary_api_fixture() -> (
+        WorkerSocketNamespace,
+        ClaimedSocketDirectory,
+        crate::contained_session::TestVhostDirectory,
+        crate::contained_session::TestVhostDirectory,
+    ) {
+        use crate::contained_session::{
+            TestVhostDirectory, ordinary_api_directory_authority_for_test,
+        };
+
+        let (directories, api_directory) = ordinary_api_directory_authority_for_test();
+        let claim = directories
+            .claim_socket_directory(
+                Path::new("bangbang-grant:api-directory/api.sock"),
+                ResourceRole::ApiSocketDirectory,
+            )
+            .expect("API grant should claim")
+            .expect("API reference should be contained");
+        let namespace_directory = TestVhostDirectory::new();
+        for directory in [namespace_directory.path(), api_directory.path()] {
+            let descriptor = fs::File::open(directory).expect("test directory should open");
+            assert_eq!(
+                // SAFETY: The directory descriptor is live and effective IDs need no pointers.
+                unsafe { libc::fchown(descriptor.as_raw_fd(), libc::geteuid(), libc::getegid(),) },
+                0,
+                "test directory owner and group should install"
+            );
+            fs::set_permissions(directory, fs::Permissions::from_mode(0o700))
+                .expect("test directory mode should restrict");
+        }
+        let namespace = WorkerSocketNamespace::from_directory_for_test(namespace_directory.path())
+            .expect("test namespace should validate");
+        (namespace, claim, namespace_directory, api_directory)
+    }
+
+    fn prepublish_api_listener(
+        namespace: &WorkerSocketNamespace,
+        claim: &ClaimedSocketDirectory,
+    ) -> (UnixListener, ObjectIdentity) {
+        let (listener, identity) = spawn_binder(namespace, ResourceRole::ApiSocketDirectory)
+            .expect("test binder should return an API listener");
+        listener
+            .set_nonblocking(true)
+            .expect("brokered API listener should be nonblocking");
+        let record = SocketOwnershipRecord::new(
+            ResourceRole::ApiSocketDirectory,
+            claim.child.clone(),
+            identity,
+        )
+        .expect("API ownership record should validate");
+        namespace
+            .write_socket_record(&record)
+            .expect("API ownership record should write");
+        let staging = socket_staging_name(ResourceRole::ApiSocketDirectory)
+            .expect("API staging name should resolve");
+        let child = child_cstring(&claim.child).expect("API child should encode");
+        assert_eq!(
+            // SAFETY: Both test-owned anchors and bounded names remain live.
+            unsafe {
+                renameatx_np(
+                    namespace.anchor_fd(),
+                    staging.as_ptr(),
+                    claim.directory.anchor_fd(),
+                    child.as_ptr(),
+                    RENAME_EXCL,
+                )
+            },
+            0,
+            "test listener should publish"
+        );
+        (listener, identity)
+    }
+
+    #[test]
+    fn brokered_api_adoption_restores_the_advanced_endpoint_and_cleans() {
+        use crate::contained_session::socket_broker_authority_for_test;
+
+        let (namespace, claim, namespace_directory, api_directory) = ordinary_api_fixture();
+        let (listener, identity) = prepublish_api_listener(&namespace, &claim);
+        let (authority, launcher, session) = socket_broker_authority_for_test();
+        let retained = authority.clone();
+        let (release, hold) = std::sync::mpsc::channel();
+        let peer = thread::spawn(move || {
+            let received = receive_socket_broker_message(&launcher)
+                .expect("API publication request should receive");
+            assert!(matches!(
+                received,
+                bangbang_session::macos::socket_broker::ReceivedSocketBrokerMessage {
+                    message: SocketBrokerMessage::PublishApi {
+                        session: request_session,
+                        sequence: 1,
+                        ref child,
+                    },
+                    descriptor: None,
+                } if request_session == session && child.as_bytes() == b"api.sock"
+            ));
+            send_socket_broker_message(
+                &launcher,
+                &SocketBrokerMessage::ApiPublished {
+                    session,
+                    sequence: 1,
+                    identity,
+                },
+                Some(listener.as_raw_fd()),
+            )
+            .expect("API publication response should send");
+            hold.recv().expect("broker peer should remain live");
+        });
+
+        let adopted = request_api_listener(namespace, claim, &authority);
+        release.send(()).expect("broker peer should release");
+        peer.join().expect("broker peer should join");
+        let bound = adopted.expect("brokered API listener should adopt");
+        let carried = retained
+            .prepare_endpoint()
+            .expect("successful adoption should restore broker authority");
+        assert_eq!(
+            carried
+                .endpoint()
+                .expect("restored endpoint should remain active")
+                .next_sequence,
+            2
+        );
+        carried
+            .abort()
+            .expect("inspection should restore broker authority");
+        assert!(api_directory.path().join("api.sock").exists());
+        drop(bound);
+        assert!(!api_directory.path().join("api.sock").exists());
+        assert_eq!(
+            fs::read_dir(namespace_directory.path())
+                .expect("namespace should read")
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn brokered_api_failure_and_wrong_sequence_poison_authority_without_residue() {
+        use crate::contained_session::socket_broker_authority_for_test;
+
+        for wrong_sequence in [false, true] {
+            let (namespace, claim, namespace_directory, api_directory) = ordinary_api_fixture();
+            let (authority, launcher, session) = socket_broker_authority_for_test();
+            let retained = authority.clone();
+            let (release, hold) = std::sync::mpsc::channel();
+            let peer = thread::spawn(move || {
+                let received = receive_socket_broker_message(&launcher)
+                    .expect("API publication request should receive");
+                assert_eq!(received.message.sequence(), 1);
+                send_socket_broker_message(
+                    &launcher,
+                    &SocketBrokerMessage::ApiPublishFailed {
+                        session,
+                        sequence: if wrong_sequence { 2 } else { 1 },
+                        kind: io::ErrorKind::NotFound,
+                    },
+                    None,
+                )
+                .expect("API failure response should send");
+                hold.recv().expect("broker peer should remain live");
+            });
+            let failure = request_api_listener(namespace, claim, &authority)
+                .expect_err("API publication failure should reject");
+            release.send(()).expect("broker peer should release");
+            peer.join().expect("broker peer should join");
+            assert_eq!(
+                failure,
+                if wrong_sequence {
+                    AnchoredSocketError::Invalid
+                } else {
+                    AnchoredSocketError::Io(io::ErrorKind::NotFound)
+                }
+            );
+            assert!(retained.prepare_endpoint().is_err());
+            assert!(!api_directory.path().join("api.sock").exists());
+            assert_eq!(
+                fs::read_dir(namespace_directory.path())
+                    .expect("namespace should read")
+                    .count(),
+                0
+            );
+        }
+    }
 
     #[test]
     #[ignore = "private binder subprocess entry point"]
@@ -2490,6 +2877,7 @@ mod tests {
             socket: worker,
             session: SessionId::from_bytes([71; 32]),
             launcher_pid: pid,
+            next_sequence: 1,
             wakeup: Some(Rc::new(wakeup_reader)),
         };
 
@@ -2538,6 +2926,7 @@ mod tests {
             socket: worker,
             session: SessionId::from_bytes([72; 32]),
             launcher_pid: pid,
+            next_sequence: 1,
             wakeup: None,
         };
         launcher

--- a/crates/bangbang/src/contained_session.rs
+++ b/crates/bangbang/src/contained_session.rs
@@ -2427,6 +2427,7 @@ mod platform {
         pub(crate) socket: UnixDatagram,
         pub(crate) session: SessionId,
         pub(crate) launcher_pid: libc::pid_t,
+        pub(crate) next_sequence: u64,
         pub(crate) wakeup: Option<Rc<UnixStream>>,
     }
 
@@ -2458,6 +2459,21 @@ mod platform {
                 return Err(GrantClaimError);
             }
             self.endpoint.as_ref().ok_or(GrantClaimError)
+        }
+
+        pub(crate) fn endpoint_mut(
+            &mut self,
+        ) -> Result<&mut SocketBrokerEndpoint, GrantClaimError> {
+            if !self
+                .authority
+                .state
+                .try_borrow()
+                .map_err(|_| GrantClaimError)?
+                .active
+            {
+                return Err(GrantClaimError);
+            }
+            self.endpoint.as_mut().ok_or(GrantClaimError)
         }
 
         pub(crate) fn commit(mut self) -> Result<SocketBrokerEndpoint, GrantClaimError> {
@@ -2499,6 +2515,19 @@ mod platform {
         pub(crate) fn abort(mut self) -> Result<(), GrantClaimError> {
             self.restore()
         }
+
+        pub(crate) fn restore_after_exchange(mut self) -> Result<(), GrantClaimError> {
+            if self.restore().is_err() {
+                self.authority.invalidate();
+                return Err(GrantClaimError);
+            }
+            Ok(())
+        }
+
+        pub(crate) fn invalidate(mut self) {
+            self.endpoint.take();
+            self.authority.invalidate();
+        }
     }
 
     impl Drop for PreparedSocketBrokerEndpoint {
@@ -2531,6 +2560,7 @@ mod platform {
                 .field("socket", &"<owned>")
                 .field("session", &"<redacted>")
                 .field("launcher_pid", &"<redacted>")
+                .field("next_sequence", &"<redacted>")
                 .field("wakeup", &self.wakeup.as_ref().map(|_| "<borrowed>"))
                 .finish()
         }
@@ -2559,6 +2589,7 @@ mod platform {
                         socket,
                         session,
                         launcher_pid,
+                        next_sequence: 1,
                         wakeup: None,
                     }),
                     active: true,
@@ -5636,8 +5667,9 @@ mod platform {
         TestContainedRestoreAuthority, TestDirectory as TestVhostDirectory,
         contained_restore_authority_for_test, contained_restore_authority_with_grants_for_test,
         empty_grant_authority_for_vhost_test, file_grant_authority_for_test,
-        root_file_grant_authority_for_test, snapshot_file_grant_authority_for_test,
-        snapshot_root_file_grant_authority_for_test, snapshot_storage_grant_authority_for_test,
+        ordinary_api_directory_authority_for_test, root_file_grant_authority_for_test,
+        snapshot_file_grant_authority_for_test, snapshot_root_file_grant_authority_for_test,
+        snapshot_storage_grant_authority_for_test, socket_broker_authority_for_test,
         vhost_directory_authority_for_test, vsock_directory_authority_for_test,
     };
 
@@ -7300,6 +7332,25 @@ mod platform {
             )
         }
 
+        pub(crate) fn ordinary_api_directory_authority_for_test()
+        -> (DirectoryGrantAuthority, TestDirectory) {
+            let (mut registry, directory) =
+                directory_registry("api-directory", ResourceRole::ApiSocketDirectory);
+            (
+                DirectoryGrantAuthority::new(registry.take_directory_registry()),
+                directory,
+            )
+        }
+
+        pub(crate) fn socket_broker_authority_for_test()
+        -> (SocketBrokerAuthority, UnixDatagram, SessionId) {
+            let session = next_restore_session();
+            let (worker, launcher) = UnixDatagram::pair().expect("broker pair should create");
+            // SAFETY: Both broker endpoints belong to this test process.
+            let authority = SocketBrokerAuthority::new(worker, session, unsafe { libc::getpid() });
+            (authority, launcher, session)
+        }
+
         #[cfg(feature = "elevated-bootstrap-probe")]
         pub(crate) fn api_directory_authority_for_test() -> (DirectoryGrantAuthority, TestDirectory)
         {
@@ -7875,6 +7926,33 @@ mod platform {
             assert!(authority.prepare_endpoint().is_err());
             assert!(!format!("{prepared:?}").contains("91"));
             drop(prepared);
+
+            let mut exchanged = authority
+                .prepare_endpoint()
+                .expect("restored endpoint should reserve for an exchange");
+            exchanged
+                .endpoint_mut()
+                .expect("reserved endpoint should remain active")
+                .next_sequence = 7;
+            exchanged
+                .restore_after_exchange()
+                .expect("successful exchange should restore authority");
+            let carried = authority
+                .prepare_endpoint()
+                .expect("restored exchange should remain reservable");
+            assert_eq!(
+                carried
+                    .endpoint()
+                    .expect("carried endpoint should remain active")
+                    .next_sequence,
+                7
+            );
+            let debug = format!("{:?}", carried.endpoint().expect("endpoint"));
+            assert!(debug.contains("<redacted>"));
+            assert!(!debug.contains("next_sequence: 7"));
+            carried
+                .abort()
+                .expect("carried endpoint should restore after inspection");
 
             let committed = authority
                 .prepare_endpoint()
@@ -8650,7 +8728,8 @@ pub(crate) use platform::{
     ContainedSnapshotRestoreDriveRequest, TestContainedRestoreAuthority, TestVhostDirectory,
     contained_restore_authority_for_test, contained_restore_authority_with_grants_for_test,
     empty_grant_authority_for_vhost_test, file_grant_authority_for_test,
-    root_file_grant_authority_for_test, snapshot_file_grant_authority_for_test,
-    snapshot_root_file_grant_authority_for_test, snapshot_storage_grant_authority_for_test,
+    ordinary_api_directory_authority_for_test, root_file_grant_authority_for_test,
+    snapshot_file_grant_authority_for_test, snapshot_root_file_grant_authority_for_test,
+    snapshot_storage_grant_authority_for_test, socket_broker_authority_for_test,
     vhost_directory_authority_for_test, vsock_directory_authority_for_test,
 };

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -43,7 +43,7 @@ mod vsock_restore;
 #[cfg(all(target_os = "macos", feature = "elevated-bootstrap-probe"))]
 use anchored_socket::adopt_elevated_api_listener;
 #[cfg(target_os = "macos")]
-use anchored_socket::bind as bind_anchored_socket;
+use anchored_socket::request_api_listener;
 use api_server::{ApiServer, ApiServerError, config_vmm_action_from_api_request};
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 use bangbang_api::config::{
@@ -530,13 +530,11 @@ fn run(
                                             .socket_namespace()
                                             .map_err(|_| ProcessError::ContainedSession)?
                                             .ok_or(ProcessError::ContainedSession)?;
-                                        bind_anchored_socket(
-                                            namespace,
-                                            claim,
-                                            ResourceRole::ApiSocketDirectory,
-                                            None,
-                                        )
-                                        .map_err(
+                                        let broker = contained
+                                            .as_ref()
+                                            .and_then(ContainedSession::socket_broker_authority)
+                                            .ok_or(ProcessError::ContainedSession)?;
+                                        request_api_listener(namespace, claim, &broker).map_err(
                                             |error| {
                                                 ProcessError::ApiServer(ApiServerError::Anchored(
                                                     error,
@@ -545,15 +543,19 @@ fn run(
                                         )?
                                     };
                                     #[cfg(not(feature = "elevated-bootstrap-probe"))]
-                                    let socket = bind_anchored_socket(
-                                        namespace,
-                                        claim,
-                                        ResourceRole::ApiSocketDirectory,
-                                        None,
-                                    )
-                                    .map_err(|error| {
-                                        ProcessError::ApiServer(ApiServerError::Anchored(error))
-                                    })?;
+                                    let socket = {
+                                        let broker = contained
+                                            .as_ref()
+                                            .and_then(ContainedSession::socket_broker_authority)
+                                            .ok_or(ProcessError::ContainedSession)?;
+                                        request_api_listener(namespace, claim, &broker).map_err(
+                                            |error| {
+                                                ProcessError::ApiServer(ApiServerError::Anchored(
+                                                    error,
+                                                ))
+                                            },
+                                        )?
+                                    };
                                     let (server, guard) =
                                         ApiServer::from_anchored(socket, http_api_max_payload_size);
                                     (Some(guard), server)

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -19,6 +19,7 @@ sha2 = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 bangbang-pager = { path = "../pager" }
+bangbang-session = { path = "../session", features = ["test-support"] }
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 bangbang-hvf = { path = "../hvf" }

--- a/crates/launcher/src/macos/api_listener.rs
+++ b/crates/launcher/src/macos/api_listener.rs
@@ -1,0 +1,758 @@
+//! Launcher-owned staged publication for one ordinary granted API listener.
+
+use std::cell::Cell;
+use std::ffi::{CStr, CString};
+use std::io;
+use std::mem::{MaybeUninit, size_of};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixListener;
+
+use bangbang_session::macos::runtime::{
+    SocketOwnershipRecord, WorkerSocketNamespace, socket_staging_name,
+};
+use bangbang_session::macos::set_cloexec;
+use bangbang_session::{ObjectIdentity, ResourceRole, SocketChild};
+
+use crate::grant_manifest::SocketDirectoryAnchor;
+
+use super::scoped_cwd::{ScopedCwdOperationError, directory_descriptor_identity, with_scoped_cwd};
+
+const LISTEN_BACKLOG: libc::c_int = 128;
+
+/// Value-redacted failure while publishing one ordinary API listener.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApiListenerPublicationError {
+    Io(io::ErrorKind),
+    Invalid,
+    PathExists,
+    PathChanged,
+    Cwd,
+    Record,
+}
+
+impl ApiListenerPublicationError {
+    pub(crate) const fn category(self) -> io::ErrorKind {
+        match self {
+            Self::Io(kind) => kind,
+            Self::PathExists => io::ErrorKind::AlreadyExists,
+            Self::Invalid | Self::PathChanged | Self::Cwd | Self::Record => io::ErrorKind::Other,
+        }
+    }
+}
+
+/// Exact record and listener alias retained until the broker response is sent.
+pub(crate) struct ApiListenerPublication {
+    listener: Option<UnixListener>,
+    record: SocketOwnershipRecord,
+}
+
+impl std::fmt::Debug for ApiListenerPublication {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ApiListenerPublication(<redacted>)")
+    }
+}
+
+impl ApiListenerPublication {
+    pub(crate) fn listener_fd(&self) -> Option<RawFd> {
+        self.listener.as_ref().map(AsRawFd::as_raw_fd)
+    }
+
+    pub(crate) const fn identity(&self) -> ObjectIdentity {
+        self.record.identity()
+    }
+
+    #[cfg(test)]
+    const fn record(&self) -> &SocketOwnershipRecord {
+        &self.record
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_descriptor(descriptor: OwnedFd, identity: ObjectIdentity) -> Self {
+        Self {
+            listener: Some(UnixListener::from(descriptor)),
+            record: SocketOwnershipRecord::new(
+                ResourceRole::ApiSocketDirectory,
+                SocketChild::parse("test-api.sock").expect("test child should validate"),
+                identity,
+            )
+            .expect("test record should validate"),
+        }
+    }
+
+    pub(crate) fn release_listener_alias(&mut self) -> Result<(), ApiListenerPublicationError> {
+        self.listener
+            .take()
+            .map(drop)
+            .ok_or(ApiListenerPublicationError::Invalid)
+    }
+}
+
+/// Publishes one fixed-role API listener through private staging and a durable record.
+pub(crate) fn publish_api_listener(
+    namespace: WorkerSocketNamespace,
+    anchor: SocketDirectoryAnchor,
+    child: SocketChild,
+) -> Result<ApiListenerPublication, ApiListenerPublicationError> {
+    let namespace_identity = ObjectIdentity {
+        device: namespace.identity().device,
+        inode: namespace.identity().inode,
+    };
+    if namespace_identity.device != anchor.identity().device
+        || directory_descriptor_identity(namespace.anchor_fd())
+            .map_err(|_| ApiListenerPublicationError::Invalid)?
+            != namespace_identity
+        || directory_descriptor_identity(anchor.descriptor())
+            .map_err(|_| ApiListenerPublicationError::Invalid)?
+            != anchor.identity()
+    {
+        return Err(ApiListenerPublicationError::Invalid);
+    }
+    // SAFETY: Identity calls have no pointer or ownership contract.
+    let expected_owner = unsafe { (libc::geteuid(), libc::getegid()) };
+    let staging = socket_staging_name(ResourceRole::ApiSocketDirectory)
+        .map_err(|_| ApiListenerPublicationError::Invalid)?;
+    let record_child = child.clone();
+    let child = CString::new(child.as_bytes()).map_err(|_| ApiListenerPublicationError::Invalid)?;
+    ensure_absent(namespace.anchor_fd(), staging)?;
+    ensure_absent(anchor.descriptor(), &child)?;
+
+    let staged_identity = Cell::new(None);
+    let staged = with_scoped_cwd(namespace.anchor_fd(), namespace_identity, || {
+        let result = bind_staging(staging, expected_owner);
+        if let Ok((_, identity)) = &result {
+            staged_identity.set(Some(*identity));
+        }
+        result
+    });
+    let (listener, identity) = match staged {
+        Ok(staged) => staged,
+        Err(ScopedCwdOperationError::Operation(error)) => return Err(error),
+        Err(ScopedCwdOperationError::Boundary(_)) => {
+            if let Some(identity) = staged_identity.get() {
+                cleanup_unrecorded(
+                    namespace.anchor_fd(),
+                    staging,
+                    Some(identity),
+                    expected_owner,
+                );
+            }
+            return Err(ApiListenerPublicationError::Cwd);
+        }
+    };
+    let mut staging_guard = StagingGuard {
+        directory: namespace.anchor_fd(),
+        name: staging,
+        identity,
+        expected_owner,
+        armed: true,
+    };
+    let record =
+        SocketOwnershipRecord::new(ResourceRole::ApiSocketDirectory, record_child, identity)
+            .map_err(|_| ApiListenerPublicationError::Invalid)?;
+    namespace
+        .write_socket_record(&record)
+        .map_err(|_| ApiListenerPublicationError::Record)?;
+    // The durable record now owns rollback. A local or transport failure must
+    // leave it for the worker or post-reap launcher recovery.
+    staging_guard.armed = false;
+
+    // SAFETY: Both validated directory anchors and bounded C strings remain live.
+    if unsafe {
+        libc::renameatx_np(
+            namespace.anchor_fd(),
+            staging.as_ptr(),
+            anchor.descriptor(),
+            child.as_ptr(),
+            libc::RENAME_EXCL,
+        )
+    } != 0
+    {
+        let error = io::Error::last_os_error();
+        return if matches!(
+            error.kind(),
+            io::ErrorKind::AlreadyExists | io::ErrorKind::AddrInUse
+        ) {
+            Err(ApiListenerPublicationError::PathExists)
+        } else {
+            Err(ApiListenerPublicationError::Io(error.kind()))
+        };
+    }
+
+    if socket_identity_at(anchor.descriptor(), &child, expected_owner, Some(0o600))? != identity {
+        return Err(ApiListenerPublicationError::PathChanged);
+    }
+    validate_listener_descriptor(listener.as_raw_fd(), staging)?;
+    namespace
+        .require_socket_record(&record)
+        .map_err(|_| ApiListenerPublicationError::Record)?;
+    Ok(ApiListenerPublication {
+        listener: Some(listener),
+        record,
+    })
+}
+
+fn bind_staging(
+    staging: &CStr,
+    expected_owner: (u32, u32),
+) -> Result<(UnixListener, ObjectIdentity), ApiListenerPublicationError> {
+    ensure_absent(libc::AT_FDCWD, staging)?;
+    // SAFETY: A successful descriptor is immediately wrapped for unique ownership.
+    let descriptor = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+    if descriptor < 0 {
+        return Err(ApiListenerPublicationError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    // SAFETY: The fresh descriptor has no other owner.
+    let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
+    set_cloexec(descriptor.as_raw_fd())
+        .map_err(|error| ApiListenerPublicationError::Io(error.kind()))?;
+    set_nonblocking(descriptor.as_raw_fd())?;
+    let (address, address_length) = relative_address(staging)?;
+    // SAFETY: The descriptor and initialized bounded address remain live.
+    if unsafe {
+        libc::bind(
+            descriptor.as_raw_fd(),
+            (&raw const address).cast(),
+            address_length,
+        )
+    } != 0
+    {
+        let error = io::Error::last_os_error();
+        return if matches!(
+            error.kind(),
+            io::ErrorKind::AlreadyExists | io::ErrorKind::AddrInUse
+        ) {
+            Err(ApiListenerPublicationError::PathExists)
+        } else {
+            Err(ApiListenerPublicationError::Io(error.kind()))
+        };
+    }
+    let identity = match socket_identity_at(libc::AT_FDCWD, staging, expected_owner, None) {
+        Ok(identity) => identity,
+        Err(error) => {
+            cleanup_unrecorded(libc::AT_FDCWD, staging, None, expected_owner);
+            return Err(error);
+        }
+    };
+    let mut guard = StagingGuard {
+        directory: libc::AT_FDCWD,
+        name: staging,
+        identity,
+        expected_owner,
+        armed: true,
+    };
+    // SAFETY: The live relative path names the exact captured socket.
+    if unsafe { libc::chmod(staging.as_ptr(), 0o600) } != 0 {
+        return Err(ApiListenerPublicationError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    if socket_identity_at(libc::AT_FDCWD, staging, expected_owner, Some(0o600))? != identity {
+        return Err(ApiListenerPublicationError::PathChanged);
+    }
+    // SAFETY: The live stream socket is ready to become a listener.
+    if unsafe { libc::listen(descriptor.as_raw_fd(), LISTEN_BACKLOG) } != 0 {
+        return Err(ApiListenerPublicationError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    validate_listener_descriptor(descriptor.as_raw_fd(), staging)?;
+    guard.armed = false;
+    Ok((UnixListener::from(descriptor), identity))
+}
+
+struct StagingGuard<'a> {
+    directory: RawFd,
+    name: &'a CStr,
+    identity: ObjectIdentity,
+    expected_owner: (u32, u32),
+    armed: bool,
+}
+
+impl Drop for StagingGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            cleanup_unrecorded(
+                self.directory,
+                self.name,
+                Some(self.identity),
+                self.expected_owner,
+            );
+        }
+    }
+}
+
+fn cleanup_unrecorded(
+    directory: RawFd,
+    name: &CStr,
+    expected_identity: Option<ObjectIdentity>,
+    expected_owner: (u32, u32),
+) {
+    let Ok(identity) = socket_identity_at(directory, name, expected_owner, None) else {
+        return;
+    };
+    if expected_identity.is_some_and(|expected| expected != identity) {
+        return;
+    }
+    // SAFETY: The retained anchor and bounded name identify the validated socket.
+    let _ = unsafe { libc::unlinkat(directory, name.as_ptr(), 0) };
+}
+
+fn ensure_absent(directory: RawFd, name: &CStr) -> Result<(), ApiListenerPublicationError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: The directory, bounded name, and writable stat storage remain live.
+    if unsafe {
+        libc::fstatat(
+            directory,
+            name.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } == 0
+    {
+        return Err(ApiListenerPublicationError::PathExists);
+    }
+    let error = io::Error::last_os_error();
+    if error.kind() == io::ErrorKind::NotFound {
+        Ok(())
+    } else {
+        Err(ApiListenerPublicationError::Io(error.kind()))
+    }
+}
+
+fn socket_identity_at(
+    directory: RawFd,
+    name: &CStr,
+    expected_owner: (u32, u32),
+    expected_mode: Option<u32>,
+) -> Result<ObjectIdentity, ApiListenerPublicationError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: The retained directory, name, and writable stat storage remain live.
+    if unsafe {
+        libc::fstatat(
+            directory,
+            name.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(ApiListenerPublicationError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    // SAFETY: Successful fstatat initialized the complete structure.
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFSOCK
+        || stat.st_uid != expected_owner.0
+        || stat.st_gid != expected_owner.1
+        || stat.st_nlink != 1
+        || expected_mode.is_some_and(|mode| u32::from(stat.st_mode & 0o7777) != mode)
+    {
+        return Err(ApiListenerPublicationError::PathChanged);
+    }
+    let identity = stat_identity(&stat);
+    if identity.device == 0 || identity.inode == 0 {
+        return Err(ApiListenerPublicationError::Invalid);
+    }
+    Ok(identity)
+}
+
+fn relative_address(
+    name: &CStr,
+) -> Result<(libc::sockaddr_un, libc::socklen_t), ApiListenerPublicationError> {
+    let bytes = name.to_bytes_with_nul();
+    let address = MaybeUninit::<libc::sockaddr_un>::zeroed();
+    // SAFETY: Zeroed sockaddr_un is valid before initialization below.
+    let mut address = unsafe { address.assume_init() };
+    if bytes.len() > address.sun_path.len() {
+        return Err(ApiListenerPublicationError::Invalid);
+    }
+    address.sun_family = libc::sa_family_t::try_from(libc::AF_UNIX)
+        .map_err(|_| ApiListenerPublicationError::Invalid)?;
+    address.sun_len = u8::try_from(
+        std::mem::offset_of!(libc::sockaddr_un, sun_path)
+            .checked_add(bytes.len())
+            .ok_or(ApiListenerPublicationError::Invalid)?,
+    )
+    .map_err(|_| ApiListenerPublicationError::Invalid)?;
+    // SAFETY: The bounded source including NUL fits the destination array.
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            address.sun_path.as_mut_ptr().cast::<u8>(),
+            bytes.len(),
+        );
+    }
+    Ok((address, libc::socklen_t::from(address.sun_len)))
+}
+
+fn set_nonblocking(descriptor: RawFd) -> Result<(), ApiListenerPublicationError> {
+    // SAFETY: F_GETFL inspects the live descriptor.
+    let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    if flags < 0
+        // SAFETY: F_SETFL changes only status flags on the same live descriptor.
+        || unsafe { libc::fcntl(descriptor, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0
+    {
+        return Err(ApiListenerPublicationError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_listener_descriptor(
+    descriptor: RawFd,
+    expected_name: &CStr,
+) -> Result<(), ApiListenerPublicationError> {
+    // SAFETY: F_GETFD/F_GETFL inspect the live descriptor.
+    let descriptor_flags = unsafe { libc::fcntl(descriptor, libc::F_GETFD) };
+    // SAFETY: F_GETFL inspects the same live descriptor.
+    let status_flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    if descriptor_flags < 0
+        || status_flags < 0
+        || descriptor_flags & libc::FD_CLOEXEC == 0
+        || status_flags & libc::O_NONBLOCK == 0
+        || socket_int_option(descriptor, libc::SO_TYPE)? != libc::SOCK_STREAM
+        || socket_int_option(descriptor, libc::SO_ERROR)? != 0
+    {
+        return Err(ApiListenerPublicationError::Invalid);
+    }
+    let mut address = MaybeUninit::<libc::sockaddr_un>::zeroed();
+    let mut length = libc::socklen_t::try_from(size_of::<libc::sockaddr_un>())
+        .map_err(|_| ApiListenerPublicationError::Invalid)?;
+    // SAFETY: Address storage and length are writable for the live listener.
+    if unsafe { libc::getsockname(descriptor, address.as_mut_ptr().cast(), &raw mut length) } != 0 {
+        return Err(ApiListenerPublicationError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    // SAFETY: Successful getsockname initialized the returned address prefix.
+    let address = unsafe { address.assume_init() };
+    let returned = usize::try_from(length).map_err(|_| ApiListenerPublicationError::Invalid)?;
+    let path_length = returned
+        .checked_sub(std::mem::offset_of!(libc::sockaddr_un, sun_path))
+        .ok_or(ApiListenerPublicationError::Invalid)?;
+    if address.sun_family
+        != libc::sa_family_t::try_from(libc::AF_UNIX)
+            .map_err(|_| ApiListenerPublicationError::Invalid)?
+        || path_length != expected_name.to_bytes_with_nul().len()
+        || path_length > address.sun_path.len()
+    {
+        return Err(ApiListenerPublicationError::Invalid);
+    }
+    // SAFETY: Kernel-returned length bounds the path read within address.
+    let path =
+        unsafe { std::slice::from_raw_parts(address.sun_path.as_ptr().cast::<u8>(), path_length) };
+    if path != expected_name.to_bytes_with_nul() {
+        return Err(ApiListenerPublicationError::Invalid);
+    }
+    // SAFETY: Null address arguments probe for an already queued client only.
+    let accepted = unsafe { libc::accept(descriptor, std::ptr::null_mut(), std::ptr::null_mut()) };
+    if accepted >= 0 {
+        // SAFETY: A successful accept returns a uniquely owned descriptor.
+        drop(unsafe { OwnedFd::from_raw_fd(accepted) });
+        return Err(ApiListenerPublicationError::Invalid);
+    }
+    if io::Error::last_os_error().kind() != io::ErrorKind::WouldBlock {
+        return Err(ApiListenerPublicationError::Invalid);
+    }
+    Ok(())
+}
+
+fn socket_int_option(
+    descriptor: RawFd,
+    option: libc::c_int,
+) -> Result<libc::c_int, ApiListenerPublicationError> {
+    let mut value = 0;
+    let mut length = libc::socklen_t::try_from(size_of::<libc::c_int>())
+        .map_err(|_| ApiListenerPublicationError::Invalid)?;
+    // SAFETY: Option storage and length are writable for the live listener.
+    if unsafe {
+        libc::getsockopt(
+            descriptor,
+            libc::SOL_SOCKET,
+            option,
+            (&raw mut value).cast(),
+            &raw mut length,
+        )
+    } != 0
+    {
+        return Err(ApiListenerPublicationError::Io(
+            io::Error::last_os_error().kind(),
+        ));
+    }
+    if usize::try_from(length).ok() != Some(size_of::<libc::c_int>()) {
+        return Err(ApiListenerPublicationError::Invalid);
+    }
+    Ok(value)
+}
+
+fn stat_identity(stat: &libc::stat) -> ObjectIdentity {
+    ObjectIdentity {
+        device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
+        inode: stat.st_ino,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt, symlink};
+    use std::os::unix::net::UnixStream;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDirectories {
+        root: PathBuf,
+        namespace: PathBuf,
+        external: PathBuf,
+    }
+
+    impl TestDirectories {
+        fn create() -> Self {
+            let id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "bangbang-api-publication-{}-{id}",
+                std::process::id()
+            ));
+            let namespace = root.join("namespace");
+            let external = root.join("external");
+            fs::create_dir(&root).expect("test root should create");
+            fs::create_dir(&namespace).expect("namespace should create");
+            fs::create_dir(&external).expect("external directory should create");
+            for directory in [&namespace, &external] {
+                fs::set_permissions(directory, fs::Permissions::from_mode(0o700))
+                    .expect("directory mode should set");
+            }
+            Self {
+                root,
+                namespace,
+                external,
+            }
+        }
+
+        fn namespace(&self) -> WorkerSocketNamespace {
+            WorkerSocketNamespace::from_directory_for_test(&self.namespace)
+                .expect("test namespace should validate")
+        }
+
+        fn anchor(&self) -> (File, SocketDirectoryAnchor) {
+            let directory = File::open(&self.external).expect("external directory should open");
+            let descriptor = directory.as_raw_fd();
+            let identity = directory_descriptor_identity(descriptor)
+                .expect("external identity should inspect");
+            (
+                directory,
+                SocketDirectoryAnchor::for_test(descriptor, identity),
+            )
+        }
+
+        fn final_path(&self, child: &str) -> PathBuf {
+            self.external.join(child)
+        }
+    }
+
+    impl Drop for TestDirectories {
+        fn drop(&mut self) {
+            for directory in [&self.namespace, &self.external] {
+                if let Ok(entries) = fs::read_dir(directory) {
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if path.is_dir() {
+                            let _ = fs::remove_dir(&path);
+                        } else {
+                            let _ = fs::remove_file(&path);
+                        }
+                    }
+                }
+                let _ = fs::remove_dir(directory);
+            }
+            let _ = fs::remove_dir(&self.root);
+        }
+    }
+
+    fn child(value: &str) -> SocketChild {
+        SocketChild::parse(value).expect("test child should parse")
+    }
+
+    fn cleanup_recorded(
+        namespace: &WorkerSocketNamespace,
+        directory: &TestDirectories,
+        record: &SocketOwnershipRecord,
+    ) {
+        let final_path = directory.final_path(
+            std::str::from_utf8(record.child().as_bytes()).expect("child should be UTF-8"),
+        );
+        if final_path.exists() {
+            fs::remove_file(&final_path).expect("recorded socket should remove");
+        }
+        namespace
+            .unlink_staged_socket(record)
+            .expect("staging cleanup should be idempotent");
+        namespace
+            .clear_socket_record(record)
+            .expect("record should clear");
+    }
+
+    #[test]
+    fn staged_listener_publishes_exact_record_and_survives_alias_release() {
+        let directories = TestDirectories::create();
+        let namespace = directories.namespace();
+        let inspection = namespace.try_clone().expect("namespace should duplicate");
+        let (_anchor_file, anchor) = directories.anchor();
+        let mut publication = publish_api_listener(namespace, anchor, child("api.sock"))
+            .expect("API listener should publish");
+        let record = publication.record().clone();
+        assert_eq!(
+            inspection
+                .socket_record(ResourceRole::ApiSocketDirectory)
+                .expect("record should read"),
+            Some(record.clone())
+        );
+        assert_eq!(record.identity(), publication.identity());
+        assert!(directories.final_path("api.sock").exists());
+        assert!(!directories.namespace.join(".api-socket.pending").exists());
+        assert!(
+            fs::symlink_metadata(directories.final_path("api.sock"))
+                .expect("final socket should inspect")
+                .file_type()
+                .is_socket()
+        );
+
+        let client = UnixStream::connect(directories.final_path("api.sock"))
+            .expect("published listener should accept connections");
+        let accepted = publication
+            .listener
+            .as_ref()
+            .expect("launcher alias should remain")
+            .accept()
+            .expect("queued connection should accept")
+            .0;
+        drop((client, accepted));
+        publication
+            .release_listener_alias()
+            .expect("launcher alias should release once");
+        assert!(directories.final_path("api.sock").exists());
+        assert_eq!(
+            publication.release_listener_alias(),
+            Err(ApiListenerPublicationError::Invalid)
+        );
+        cleanup_recorded(&inspection, &directories, &record);
+    }
+
+    #[test]
+    fn final_collisions_and_wrong_anchor_identity_are_preserved() {
+        let directories = TestDirectories::create();
+        let namespace = directories.namespace();
+        let (_anchor_file, anchor) = directories.anchor();
+        let final_path = directories.final_path("api.sock");
+        File::create(&final_path).expect("collision file should create");
+        assert!(matches!(
+            publish_api_listener(namespace, anchor, child("api.sock")),
+            Err(ApiListenerPublicationError::PathExists)
+        ));
+        assert!(final_path.is_file());
+        assert!(!directories.namespace.join(".api-socket.pending").exists());
+
+        fs::remove_file(&final_path).expect("collision file should remove");
+        symlink("missing", &final_path).expect("collision symlink should create");
+        let namespace = directories.namespace();
+        let (_anchor_file, anchor) = directories.anchor();
+        assert!(matches!(
+            publish_api_listener(namespace, anchor, child("api.sock")),
+            Err(ApiListenerPublicationError::PathExists)
+        ));
+        assert!(
+            fs::symlink_metadata(&final_path)
+                .expect("collision symlink should inspect")
+                .file_type()
+                .is_symlink()
+        );
+
+        fs::remove_file(&final_path).expect("collision symlink should remove");
+        let namespace = directories.namespace();
+        let (_anchor_file, anchor) = directories.anchor();
+        let wrong = SocketDirectoryAnchor::for_test(
+            anchor.descriptor(),
+            ObjectIdentity {
+                device: anchor.identity().device,
+                inode: anchor.identity().inode.saturating_add(1),
+            },
+        );
+        assert_eq!(
+            publish_api_listener(namespace, wrong, child("api.sock"))
+                .expect_err("wrong anchor identity should fail"),
+            ApiListenerPublicationError::Invalid
+        );
+        assert!(!final_path.exists());
+    }
+
+    #[test]
+    fn record_collision_cleans_only_unrecorded_staging() {
+        let directories = TestDirectories::create();
+        let namespace = directories.namespace();
+        let inspection = namespace.try_clone().expect("namespace should duplicate");
+        let existing = SocketOwnershipRecord::new(
+            ResourceRole::ApiSocketDirectory,
+            child("existing.sock"),
+            ObjectIdentity {
+                device: 7,
+                inode: 11,
+            },
+        )
+        .expect("fixture record should validate");
+        namespace
+            .write_socket_record(&existing)
+            .expect("fixture record should write");
+        let (_anchor_file, anchor) = directories.anchor();
+        assert_eq!(
+            publish_api_listener(namespace, anchor, child("api.sock"))
+                .expect_err("record collision should fail"),
+            ApiListenerPublicationError::Record
+        );
+        assert!(!directories.namespace.join(".api-socket.pending").exists());
+        assert!(!directories.final_path("api.sock").exists());
+        assert_eq!(
+            inspection
+                .socket_record(ResourceRole::ApiSocketDirectory)
+                .expect("existing record should read"),
+            Some(existing.clone())
+        );
+        inspection
+            .clear_socket_record(&existing)
+            .expect("existing record should clear");
+    }
+
+    #[test]
+    fn debug_and_errors_do_not_expose_names_or_identities() {
+        let error = ApiListenerPublicationError::PathChanged;
+        assert_eq!(error.category(), io::ErrorKind::Other);
+        assert!(!format!("{error:?}").contains("api.sock"));
+        let directories = TestDirectories::create();
+        let namespace = directories.namespace();
+        let inspection = namespace.try_clone().expect("namespace should duplicate");
+        let (_anchor_file, anchor) = directories.anchor();
+        let publication = publish_api_listener(namespace, anchor, child("sensitive.sock"))
+            .expect("API listener should publish");
+        let record = publication.record().clone();
+        let debug = format!("{publication:?}");
+        assert!(!debug.contains("sensitive.sock"));
+        assert!(!debug.contains(&record.identity().inode.to_string()));
+        drop(publication);
+        cleanup_recorded(&inspection, &directories, &record);
+    }
+
+    #[test]
+    fn child_validation_remains_owned_by_the_closed_socket_child_type() {
+        for invalid in ["", ".", "..", "nested/api.sock", "nul\0.sock"] {
+            assert!(SocketChild::parse(invalid).is_err());
+        }
+        assert!(Path::new("api.sock").is_relative());
+    }
+}

--- a/crates/launcher/src/macos/mod.rs
+++ b/crates/launcher/src/macos/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod api_listener;
 pub(crate) mod block_control;
 pub(crate) mod block_device;
 pub(crate) mod code_sign;

--- a/crates/launcher/src/macos/socket_broker.rs
+++ b/crates/launcher/src/macos/socket_broker.rs
@@ -1,11 +1,13 @@
-//! Narrow launcher-side transport facet for granted-vsock guest connections.
+//! Narrow launcher-side transport for granted API publication and vsock connections.
 
 use std::ffi::{CStr, CString};
 use std::io;
 use std::mem::{MaybeUninit, size_of};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixDatagram;
+use std::time::{Duration, Instant};
 
+use bangbang_session::macos::runtime::LauncherNamespace;
 use bangbang_session::macos::socket_broker::{
     SocketBrokerError, SocketBrokerMessage, receive_socket_broker_message,
     send_socket_broker_message,
@@ -16,13 +18,17 @@ use bangbang_session::{LauncherState, ObjectIdentity, ResourceRole, SessionId, S
 use crate::LauncherError;
 use crate::grant_manifest::PreparedGrantBatch;
 
+use super::api_listener::{ApiListenerPublication, publish_api_listener};
+
 const CONNECT_INTERRUPTED_RETRY_LIMIT: usize = 8;
+const API_PUBLICATION_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Session-bound state for the one dormant or active broker endpoint.
 pub(crate) struct LauncherSocketBroker {
     session: SessionId,
     next_sequence: u64,
     state: BrokerState,
+    api: ApiPublicationState,
 }
 
 impl std::fmt::Debug for LauncherSocketBroker {
@@ -32,6 +38,7 @@ impl std::fmt::Debug for LauncherSocketBroker {
             .field("session", &"<redacted>")
             .field("next_sequence", &"<redacted>")
             .field("state", &self.state)
+            .field("api", &self.api)
             .finish()
     }
 }
@@ -43,6 +50,35 @@ enum BrokerState {
     Complete,
 }
 
+enum ApiPublicationState {
+    Available,
+    Pending(PendingApiPublicationReply),
+    Published,
+    Failed,
+}
+
+impl std::fmt::Debug for ApiPublicationState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Available => "Available",
+            Self::Pending(_) => "Pending(<redacted>)",
+            Self::Published => "Published",
+            Self::Failed => "Failed",
+        })
+    }
+}
+
+struct PendingApiPublicationReply {
+    sequence: u64,
+    deadline: Instant,
+    outcome: ApiPublicationOutcome,
+}
+
+enum ApiPublicationOutcome {
+    Published(ApiListenerPublication),
+    Failed(io::ErrorKind),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SocketBrokerDrainStatus {
     /// The authenticated broker remains open for another request.
@@ -51,12 +87,108 @@ pub(crate) enum SocketBrokerDrainStatus {
     Complete,
 }
 
+/// Narrow launcher authority required only by ordinary API publication.
+#[derive(Clone, Copy)]
+pub(crate) struct ApiPublicationContext<'a> {
+    namespace: Option<&'a LauncherNamespace>,
+    grants_acknowledged: bool,
+}
+
+impl<'a> ApiPublicationContext<'a> {
+    pub(crate) const fn new(
+        namespace: Option<&'a LauncherNamespace>,
+        grants_acknowledged: bool,
+    ) -> Self {
+        Self {
+            namespace,
+            grants_acknowledged,
+        }
+    }
+}
+
 impl LauncherSocketBroker {
     pub(crate) const fn new(session: SessionId) -> Self {
         Self {
             session,
             next_sequence: 1,
             state: BrokerState::Dormant,
+            api: ApiPublicationState::Available,
+        }
+    }
+
+    pub(crate) const fn api_readiness_is_valid(&self) -> bool {
+        matches!(
+            self.api,
+            ApiPublicationState::Available | ApiPublicationState::Published
+        )
+    }
+
+    pub(crate) const fn requires_write_event(&self) -> bool {
+        matches!(self.api, ApiPublicationState::Pending(_))
+    }
+
+    pub(crate) const fn deadline(&self) -> Option<Instant> {
+        match &self.api {
+            ApiPublicationState::Pending(pending) => Some(pending.deadline),
+            ApiPublicationState::Available
+            | ApiPublicationState::Published
+            | ApiPublicationState::Failed => None,
+        }
+    }
+
+    pub(crate) fn has_timed_out(&self, now: Instant) -> bool {
+        self.deadline().is_some_and(|deadline| now >= deadline)
+    }
+
+    pub(crate) fn pump(&mut self, socket: &UnixDatagram) -> Result<(), LauncherError> {
+        let ApiPublicationState::Pending(pending) = &self.api else {
+            return Ok(());
+        };
+        let message = match &pending.outcome {
+            ApiPublicationOutcome::Published(publication) => SocketBrokerMessage::ApiPublished {
+                session: self.session,
+                sequence: pending.sequence,
+                identity: publication.identity(),
+            },
+            ApiPublicationOutcome::Failed(kind) => SocketBrokerMessage::ApiPublishFailed {
+                session: self.session,
+                sequence: pending.sequence,
+                kind: *kind,
+            },
+        };
+        let descriptor = match &pending.outcome {
+            ApiPublicationOutcome::Published(publication) => publication.listener_fd(),
+            ApiPublicationOutcome::Failed(_) => None,
+        };
+        match send_socket_broker_message(socket, &message, descriptor) {
+            Ok(()) => {
+                let sent = std::mem::replace(&mut self.api, ApiPublicationState::Failed);
+                match sent {
+                    ApiPublicationState::Pending(PendingApiPublicationReply {
+                        outcome: ApiPublicationOutcome::Published(mut publication),
+                        ..
+                    }) => {
+                        publication
+                            .release_listener_alias()
+                            .map_err(|_| LauncherError::SocketBroker)?;
+                        self.api = ApiPublicationState::Published;
+                    }
+                    ApiPublicationState::Pending(PendingApiPublicationReply {
+                        outcome: ApiPublicationOutcome::Failed(_),
+                        ..
+                    }) => {}
+                    ApiPublicationState::Available
+                    | ApiPublicationState::Published
+                    | ApiPublicationState::Failed => return Err(LauncherError::SocketBroker),
+                }
+                Ok(())
+            }
+            Err(SocketBrokerError::Io(io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock)) => {
+                Ok(())
+            }
+            Err(SocketBrokerError::Io(_) | SocketBrokerError::Invalid) => {
+                Err(LauncherError::SocketBroker)
+            }
         }
     }
 
@@ -67,7 +199,16 @@ impl LauncherSocketBroker {
         lifecycle_state: LauncherState,
         lifecycle_cancelled: bool,
         grants: &PreparedGrantBatch,
+        api_context: ApiPublicationContext<'_>,
     ) -> Result<SocketBrokerDrainStatus, LauncherError> {
+        let ApiPublicationContext {
+            namespace,
+            grants_acknowledged,
+        } = api_context;
+        self.pump(socket)?;
+        if self.requires_write_event() {
+            return Ok(SocketBrokerDrainStatus::Pending);
+        }
         loop {
             let received = match receive_socket_broker_message(socket) {
                 Ok(received) => received,
@@ -90,22 +231,50 @@ impl LauncherSocketBroker {
                 .checked_add(1)
                 .ok_or(LauncherError::SocketBroker)?;
 
-            match (&mut self.state, received.message) {
-                (
-                    BrokerState::Dormant,
-                    SocketBrokerMessage::Activate {
-                        child,
-                        sequence: request_sequence,
-                        ..
-                    },
-                ) if request_sequence == 1
-                    && !lifecycle_cancelled
-                    && matches!(
-                        lifecycle_state,
-                        LauncherState::AwaitStarting
-                            | LauncherState::Starting
-                            | LauncherState::Ready(_)
-                    ) =>
+            match received.message {
+                SocketBrokerMessage::PublishApi { child, .. }
+                    if matches!(self.api, ApiPublicationState::Available)
+                        && matches!(self.state, BrokerState::Dormant)
+                        && grants_acknowledged
+                        && !lifecycle_cancelled
+                        && matches!(
+                            lifecycle_state,
+                            LauncherState::AwaitStarting | LauncherState::Starting
+                        ) =>
+                {
+                    let namespace = namespace
+                        .ok_or(LauncherError::SocketBroker)?
+                        .socket_namespace()
+                        .map_err(|_| LauncherError::SocketBroker)?;
+                    let anchor = grants
+                        .socket_directory_anchor(ResourceRole::ApiSocketDirectory)
+                        .ok_or(LauncherError::SocketBroker)?;
+                    let outcome = match publish_api_listener(namespace, anchor, child) {
+                        Ok(publication) => ApiPublicationOutcome::Published(publication),
+                        Err(error) => ApiPublicationOutcome::Failed(error.category()),
+                    };
+                    self.api = ApiPublicationState::Pending(PendingApiPublicationReply {
+                        sequence,
+                        deadline: Instant::now()
+                            .checked_add(API_PUBLICATION_REPLY_TIMEOUT)
+                            .ok_or(LauncherError::SocketBroker)?,
+                        outcome,
+                    });
+                    self.pump(socket)?;
+                    if self.requires_write_event() {
+                        return Ok(SocketBrokerDrainStatus::Pending);
+                    }
+                }
+                SocketBrokerMessage::Activate { child, .. }
+                    if matches!(self.state, BrokerState::Dormant)
+                        && !matches!(self.api, ApiPublicationState::Failed)
+                        && !lifecycle_cancelled
+                        && matches!(
+                            lifecycle_state,
+                            LauncherState::AwaitStarting
+                                | LauncherState::Starting
+                                | LauncherState::Ready(_)
+                        ) =>
                 {
                     activate_directory(grants)?;
                     self.state = BrokerState::Active(child);
@@ -118,9 +287,12 @@ impl LauncherSocketBroker {
                         None,
                     )?;
                 }
-                (BrokerState::Active(child), SocketBrokerMessage::Connect { port, .. })
-                    if !lifecycle_cancelled =>
+                SocketBrokerMessage::Connect { port, .. }
+                    if matches!(self.state, BrokerState::Active(_)) && !lifecycle_cancelled =>
                 {
+                    let BrokerState::Active(child) = &self.state else {
+                        return Err(LauncherError::SocketBroker);
+                    };
                     match connect_relative_vsock_port(child, port) {
                         Ok(stream) => send(
                             socket,
@@ -146,7 +318,9 @@ impl LauncherSocketBroker {
                         }
                     }
                 }
-                (BrokerState::Active(_), SocketBrokerMessage::Shutdown { .. }) => {
+                SocketBrokerMessage::Shutdown { .. }
+                    if matches!(self.state, BrokerState::Active(_)) =>
+                {
                     self.state = BrokerState::Complete;
                     send(
                         socket,
@@ -497,7 +671,46 @@ mod tests {
         let mut broker = LauncherSocketBroker::new(broker_session);
         // SAFETY: The test process is both authenticated socketpair peers.
         let pid = unsafe { libc::getpid() };
-        broker.drain(&launcher, pid, lifecycle_state, cancelled, &empty_grants())
+        broker.drain(
+            &launcher,
+            pid,
+            lifecycle_state,
+            cancelled,
+            &empty_grants(),
+            ApiPublicationContext::new(None, true),
+        )
+    }
+
+    fn rejected_api_request(
+        lifecycle_state: LauncherState,
+        cancelled: bool,
+        acknowledged: bool,
+    ) -> Result<SocketBrokerDrainStatus, LauncherError> {
+        let (launcher, worker) = UnixDatagram::pair().expect("broker pair should open");
+        launcher
+            .set_nonblocking(true)
+            .expect("launcher endpoint should become nonblocking");
+        send_socket_broker_message(
+            &worker,
+            &SocketBrokerMessage::PublishApi {
+                session: session(),
+                sequence: 1,
+                child: SocketChild::parse("api.sock").expect("child should parse"),
+            },
+            None,
+        )
+        .expect("API request should send");
+        let mut broker = LauncherSocketBroker::new(session());
+        // SAFETY: The test process owns both authenticated peers.
+        let pid = unsafe { libc::getpid() };
+        broker.drain(
+            &launcher,
+            pid,
+            lifecycle_state,
+            cancelled,
+            &empty_grants(),
+            ApiPublicationContext::new(None, acknowledged),
+        )
     }
 
     #[test]
@@ -587,6 +800,156 @@ mod tests {
     }
 
     #[test]
+    fn api_publication_requires_start_authority_ack_namespace_and_anchor() {
+        for result in [
+            rejected_api_request(LauncherState::ReadyToProceed, false, true),
+            rejected_api_request(LauncherState::AwaitStarting, false, false),
+            rejected_api_request(LauncherState::AwaitStarting, true, true),
+            rejected_api_request(LauncherState::AwaitStarting, false, true),
+        ] {
+            assert_eq!(result, Err(LauncherError::SocketBroker));
+        }
+    }
+
+    #[test]
+    fn pending_api_reply_survives_backpressure_and_keeps_one_deadline() {
+        let (launcher, worker) = UnixDatagram::pair().expect("broker pair should open");
+        launcher
+            .set_nonblocking(true)
+            .expect("launcher endpoint should become nonblocking");
+        worker
+            .set_nonblocking(true)
+            .expect("worker endpoint should become nonblocking");
+        let filler = SocketBrokerMessage::Ready {
+            session: session(),
+            sequence: 1,
+        };
+        loop {
+            match send_socket_broker_message(&launcher, &filler, None) {
+                Ok(()) | Err(SocketBrokerError::Io(io::ErrorKind::Interrupted)) => {}
+                Err(SocketBrokerError::Io(io::ErrorKind::WouldBlock)) => break,
+                Err(error) => panic!("filler send should only backpressure: {error:?}"),
+            }
+        }
+
+        let deadline = Instant::now()
+            .checked_add(API_PUBLICATION_REPLY_TIMEOUT)
+            .expect("deadline should fit");
+        let mut broker = LauncherSocketBroker::new(session());
+        assert!(broker.api_readiness_is_valid());
+        broker.api = ApiPublicationState::Pending(PendingApiPublicationReply {
+            sequence: 1,
+            deadline,
+            outcome: ApiPublicationOutcome::Failed(io::ErrorKind::NotFound),
+        });
+        broker
+            .pump(&launcher)
+            .expect("backpressure should retain the reply");
+        assert!(broker.requires_write_event());
+        assert!(!broker.api_readiness_is_valid());
+        assert_eq!(broker.deadline(), Some(deadline));
+        assert!(!broker.has_timed_out(Instant::now()));
+
+        loop {
+            match receive_socket_broker_message(&worker) {
+                Ok(received) => assert_eq!(received.message, filler),
+                Err(SocketBrokerError::Io(io::ErrorKind::Interrupted)) => {}
+                Err(SocketBrokerError::Io(io::ErrorKind::WouldBlock)) => break,
+                Err(error) => panic!("filler drain should remain valid: {error:?}"),
+            }
+        }
+        broker
+            .pump(&launcher)
+            .expect("retained reply should send once writable");
+        assert!(!broker.requires_write_event());
+        assert_eq!(broker.deadline(), None);
+        assert!(matches!(broker.api, ApiPublicationState::Failed));
+        assert!(!broker.api_readiness_is_valid());
+        assert!(matches!(
+            receive_socket_broker_message(&worker),
+            Ok(bangbang_session::macos::socket_broker::ReceivedSocketBrokerMessage {
+                message: SocketBrokerMessage::ApiPublishFailed {
+                    session: response_session,
+                    sequence: 1,
+                    kind: io::ErrorKind::NotFound,
+                },
+                descriptor: None,
+            }) if response_session == session()
+        ));
+
+        loop {
+            match send_socket_broker_message(&launcher, &filler, None) {
+                Ok(()) | Err(SocketBrokerError::Io(io::ErrorKind::Interrupted)) => {}
+                Err(SocketBrokerError::Io(io::ErrorKind::WouldBlock)) => break,
+                Err(error) => panic!("second filler send should only backpressure: {error:?}"),
+            }
+        }
+        let (stream, stream_peer) =
+            std::os::unix::net::UnixStream::pair().expect("test descriptor pair should open");
+        let identity = ObjectIdentity {
+            device: 17,
+            inode: 23,
+        };
+        let publication = ApiListenerPublication::from_test_descriptor(stream.into(), identity);
+        let retained_descriptor = publication
+            .listener_fd()
+            .expect("test publication should retain its alias");
+        broker.api = ApiPublicationState::Pending(PendingApiPublicationReply {
+            sequence: 2,
+            deadline,
+            outcome: ApiPublicationOutcome::Published(publication),
+        });
+        broker
+            .pump(&launcher)
+            .expect("published reply backpressure should retain the alias");
+        assert!(matches!(
+            &broker.api,
+            ApiPublicationState::Pending(PendingApiPublicationReply {
+                outcome: ApiPublicationOutcome::Published(publication),
+                ..
+            }) if publication.listener_fd() == Some(retained_descriptor)
+        ));
+        loop {
+            match receive_socket_broker_message(&worker) {
+                Ok(received) => assert_eq!(received.message, filler),
+                Err(SocketBrokerError::Io(io::ErrorKind::Interrupted)) => {}
+                Err(SocketBrokerError::Io(io::ErrorKind::WouldBlock)) => break,
+                Err(error) => panic!("second filler drain should remain valid: {error:?}"),
+            }
+        }
+        broker
+            .pump(&launcher)
+            .expect("retained published reply should send once writable");
+        assert!(broker.api_readiness_is_valid());
+        assert!(matches!(broker.api, ApiPublicationState::Published));
+        assert!(matches!(
+            receive_socket_broker_message(&worker),
+            Ok(bangbang_session::macos::socket_broker::ReceivedSocketBrokerMessage {
+                message: SocketBrokerMessage::ApiPublished {
+                    session: response_session,
+                    sequence: 2,
+                    identity: response_identity,
+                },
+                descriptor: Some(_),
+            }) if response_session == session() && response_identity == identity
+        ));
+        drop(stream_peer);
+
+        broker.api = ApiPublicationState::Pending(PendingApiPublicationReply {
+            sequence: 3,
+            deadline: Instant::now()
+                .checked_sub(Duration::from_millis(1))
+                .expect("past deadline should fit"),
+            outcome: ApiPublicationOutcome::Failed(io::ErrorKind::Other),
+        });
+        assert!(broker.has_timed_out(Instant::now()));
+        assert!(!format!("{broker:?}").contains("NotFound"));
+
+        broker.api = ApiPublicationState::Published;
+        assert!(broker.api_readiness_is_valid());
+    }
+
+    #[test]
     fn broker_rejects_another_activation_after_completion() {
         let (launcher, worker) = UnixDatagram::pair().expect("broker pair should open");
         launcher
@@ -615,6 +978,7 @@ mod tests {
                 LauncherState::ReadyToProceed,
                 false,
                 &empty_grants(),
+                ApiPublicationContext::new(None, true),
             ),
             Err(LauncherError::SocketBroker)
         );
@@ -649,6 +1013,7 @@ mod tests {
                 LauncherState::ReadyToProceed,
                 true,
                 &empty_grants(),
+                ApiPublicationContext::new(None, true),
             ),
             Ok(SocketBrokerDrainStatus::Complete)
         );

--- a/crates/launcher/src/macos/supervise.rs
+++ b/crates/launcher/src/macos/supervise.rs
@@ -25,7 +25,7 @@ use super::block_control::LauncherBlockControlBroker;
 use super::daemon::{NotifierEvent, SessionNotifier};
 #[cfg(feature = "elevated-bootstrap-probe")]
 use super::elevated_guest::ElevatedGuestSupervisor;
-use super::socket_broker::{LauncherSocketBroker, SocketBrokerDrainStatus};
+use super::socket_broker::{ApiPublicationContext, LauncherSocketBroker, SocketBrokerDrainStatus};
 use super::spawn::OwnedWorker;
 use super::vhost_user_broker::LauncherVhostUserBroker;
 use crate::LauncherError;
@@ -859,6 +859,12 @@ fn wait_session_inner(
             0,
         ),
         event(
+            broker_fd,
+            libc::EVFILT_WRITE,
+            libc::EV_ADD | libc::EV_DISABLE | libc::EV_CLEAR,
+            0,
+        ),
+        event(
             vhost_broker_fd,
             libc::EVFILT_READ,
             libc::EV_ADD | libc::EV_ENABLE | libc::EV_CLEAR,
@@ -904,6 +910,7 @@ fn wait_session_inner(
     let mut grant_send = GrantSendState::new(grants, lifecycle.session());
     let mut broker = LauncherSocketBroker::new(lifecycle.session());
     let mut broker_complete = false;
+    let mut broker_write_enabled = false;
     let mut vhost_broker = LauncherVhostUserBroker::new(lifecycle.session());
     let mut block_control = LauncherBlockControlBroker::new(lifecycle.session());
     #[cfg(feature = "elevated-bootstrap-probe")]
@@ -914,6 +921,7 @@ fn wait_session_inner(
             cancellation_deadline,
             exit_deadline,
             grant_send.deadline(),
+            broker.deadline(),
             notifier_deadline,
             #[cfg(feature = "elevated-bootstrap-probe")]
             guest.as_ref().and_then(ElevatedGuestSupervisor::deadline),
@@ -1031,15 +1039,6 @@ fn wait_session_inner(
             .close()?;
         }
 
-        if observation.readiness.is_some()
-            && let Some(notifier) = notifier.as_deref_mut()
-            && notifier.is_awaiting_ready()
-        {
-            // SAFETY: `getpid` has no pointer or ownership contract.
-            let supervisor_pid = unsafe { libc::getpid() };
-            notifier.notify_ready(supervisor_pid)?;
-        }
-
         if let (Some(notifier_fd), Some(notifier)) = (notifier_fd, notifier.as_deref_mut())
             && events
                 .iter()
@@ -1095,15 +1094,71 @@ fn wait_session_inner(
                 lifecycle.state(),
                 lifecycle.is_cancelled(),
                 grants,
+                ApiPublicationContext::new(
+                    observation.namespace.as_ref(),
+                    grant_send.acknowledged(),
+                ),
             )? == SocketBrokerDrainStatus::Complete
         {
             // Shutdown is the broker's authenticated terminal message. Stop
             // observing the descriptor before the worker closes its peer.
             register_events(
                 kqueue.as_raw_fd(),
-                &[event(broker_fd, libc::EVFILT_READ, libc::EV_DELETE, 0)],
+                &[
+                    event(broker_fd, libc::EVFILT_READ, libc::EV_DELETE, 0),
+                    event(broker_fd, libc::EVFILT_WRITE, libc::EV_DELETE, 0),
+                ],
             )?;
             broker_complete = true;
+            broker_write_enabled = false;
+        }
+
+        if !broker_complete {
+            sync_broker_write_event(
+                kqueue.as_raw_fd(),
+                broker_fd,
+                &mut broker_write_enabled,
+                broker.requires_write_event(),
+            )?;
+            if events.iter().any(|queued| {
+                queued.filter == libc::EVFILT_WRITE
+                    && queued.ident == broker_fd
+                    && queued.flags & libc::EV_ERROR != 0
+            }) {
+                return Err(LauncherError::SocketBroker);
+            }
+            if !child_exited
+                && events.iter().any(|queued| {
+                    queued.filter == libc::EVFILT_WRITE
+                        && queued.ident == broker_fd
+                        && queued.flags & libc::EV_ERROR == 0
+                })
+            {
+                broker.pump(socket_broker)?;
+                sync_broker_write_event(
+                    kqueue.as_raw_fd(),
+                    broker_fd,
+                    &mut broker_write_enabled,
+                    broker.requires_write_event(),
+                )?;
+            }
+        }
+
+        if matches!(
+            observation.readiness,
+            Some(bangbang_session::Readiness::Api)
+        ) && !broker.api_readiness_is_valid()
+        {
+            return Err(LauncherError::SocketBroker);
+        }
+
+        if observation.readiness.is_some()
+            && let Some(notifier) = notifier.as_deref_mut()
+            && notifier.is_awaiting_ready()
+        {
+            // SAFETY: `getpid` has no pointer or ownership contract.
+            let supervisor_pid = unsafe { libc::getpid() };
+            notifier.notify_ready(supervisor_pid)?;
         }
 
         if !child_exited
@@ -1281,6 +1336,9 @@ fn wait_session_inner(
         }
         if grant_send.has_timed_out(Instant::now()) {
             return Err(LauncherError::GrantProtocol);
+        }
+        if broker.has_timed_out(Instant::now()) {
+            return Err(LauncherError::SocketBroker);
         }
         #[cfg(feature = "elevated-bootstrap-probe")]
         if !lifecycle.is_cancelled()
@@ -1706,6 +1764,10 @@ impl GrantSendState {
         self.final_sequence
     }
 
+    const fn acknowledged(&self) -> bool {
+        self.acknowledged
+    }
+
     fn begin(&mut self) -> Result<(), LauncherError> {
         if self.started || self.acknowledged || self.cancelled || self.outbound.is_empty() {
             return Err(LauncherError::GrantProtocol);
@@ -1796,6 +1858,32 @@ fn sync_grant_write_event(
     };
     register_events(kqueue, &[event(grant_fd, libc::EVFILT_WRITE, flag, 0)])?;
     state.event_enabled = should_enable;
+    Ok(())
+}
+
+fn sync_broker_write_event(
+    kqueue: RawFd,
+    broker_fd: usize,
+    enabled: &mut bool,
+    should_enable: bool,
+) -> Result<(), LauncherError> {
+    if should_enable == *enabled {
+        return Ok(());
+    }
+    register_events(
+        kqueue,
+        &[event(
+            broker_fd,
+            libc::EVFILT_WRITE,
+            if should_enable {
+                libc::EV_ENABLE
+            } else {
+                libc::EV_DISABLE
+            },
+            0,
+        )],
+    )?;
+    *enabled = should_enable;
     Ok(())
 }
 

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -8729,7 +8729,7 @@ fn normal_bundle_routes_guest_vsock_through_launcher_broker_without_helpers() {
     let worker = only_worker_pid(&running.child);
     assert!(
         child_pids(worker).is_empty(),
-        "short-lived API binder must be reaped before readiness"
+        "launcher-owned API publication must not leave a worker helper"
     );
 
     assert_http_status(
@@ -14195,6 +14195,92 @@ fn concurrent_sessions_remain_independent_when_one_worker_crashes() {
     assert!(session_entries().is_empty());
     let _ = fs::remove_file(&first.socket);
     assert!(!second.socket.exists());
+}
+
+#[test]
+fn normal_granted_api_listener_preserves_5000_fresh_connections() {
+    let bundle = production_bundle();
+    let fixture = SocketDirectoryGrantFixture::new("api-transport-stress");
+    let mut running =
+        spawn_ready_socket_grant_api_launcher(&bundle, &fixture, "api-transport-stress");
+
+    for request in 0..5_000 {
+        let response = http_get(&running.socket, "/");
+        assert!(
+            response.starts_with("HTTP/1.1 200 "),
+            "fresh production API request {request} failed:\n{response}"
+        );
+    }
+
+    let launcher_pid = i32::try_from(running.child.id()).expect("launcher PID should fit");
+    // SAFETY: `launcher_pid` is the live unreaped launcher owned by this fixture.
+    assert_eq!(unsafe { libc::kill(launcher_pid, libc::SIGTERM) }, 0);
+    assert!(running.wait("API transport stress graceful stop").success());
+    assert!(!running.socket.exists());
+    assert!(session_entries().is_empty());
+}
+
+#[test]
+fn direct_api_remains_independent_of_unused_socket_directory_grants() {
+    let bundle = production_bundle();
+    let fixture = SocketDirectoryGrantFixture::new("direct-api-unused-socket-grants");
+    initialize_worker_container(&bundle);
+    let test_id = NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst);
+    let socket = container_tmp_dir().join(format!(
+        "bb-direct-extra-{:x}-{test_id:x}.sock",
+        std::process::id()
+    ));
+    let mut child = Command::new(launcher(&bundle))
+        .arg(GRANT_MANIFEST_OPTION)
+        .arg(&fixture.devices.manifest)
+        .arg("--")
+        .args(["--api-sock", path_text(&socket)])
+        .args(["--id", &format!("direct-extra-{test_id}")])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0)
+        .spawn()
+        .expect("direct API launcher with extra grants should start");
+    let (ready, stdout_reader) = read_stdout_until_ready(&mut child);
+    let stderr_reader = read_stream(child.stderr.take().expect("stderr should be piped"));
+    if let Err(error) = ready.recv_timeout(PROCESS_TIMEOUT) {
+        kill_child_group(&mut child);
+        let _ = child.wait();
+        let stdout = stdout_reader.join().expect("stdout reader should join");
+        let stderr = stderr_reader.join().expect("stderr reader should join");
+        panic!(
+            "direct API with unused socket grants should become ready: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
+    let mut running = RunningApiLauncher {
+        child,
+        socket,
+        stdout_reader: Some(stdout_reader),
+        stderr_reader: Some(stderr_reader),
+        sensitive: fixture.sensitive_strings(),
+        completed: false,
+    };
+
+    assert_http_status(
+        &http_get(&running.socket, "/"),
+        200,
+        "direct API with unused socket grants",
+    );
+    assert!(
+        !fixture.api_socket().exists(),
+        "unused API grant must not publish a listener"
+    );
+    let worker = only_worker_pid(&running.child);
+    assert!(
+        child_pids(worker).is_empty(),
+        "direct API path must not start a socket binder"
+    );
+    let launcher_pid = i32::try_from(running.child.id()).expect("launcher PID should fit");
+    // SAFETY: `launcher_pid` is the live unreaped launcher owned by this fixture.
+    assert_eq!(unsafe { libc::kill(launcher_pid, libc::SIGTERM) }, 0);
+    assert!(running.wait("direct API with unused grants stop").success());
+    assert!(!running.socket.exists());
+    assert!(session_entries().is_empty());
 }
 
 fn run_graceful_signal_case(signal: i32, name: &str) {

--- a/crates/session/src/macos/runtime.rs
+++ b/crates/session/src/macos/runtime.rs
@@ -313,6 +313,32 @@ impl WorkerSocketNamespace {
         write_socket_record(self.anchor_fd(), record)
     }
 
+    /// Reads one strict socket record for an exact role.
+    pub fn socket_record(
+        &self,
+        role: ResourceRole,
+    ) -> Result<Option<SocketOwnershipRecord>, RuntimeError> {
+        self.require_record_support()?;
+        read_socket_record(self.anchor_fd(), role)
+    }
+
+    /// Requires the current role record to equal the expected value exactly.
+    pub fn require_socket_record(
+        &self,
+        expected: &SocketOwnershipRecord,
+    ) -> Result<(), RuntimeError> {
+        match self.socket_record(expected.role())? {
+            Some(actual) if actual == *expected => Ok(()),
+            Some(_) | None => Err(RuntimeError::InvalidEntry),
+        }
+    }
+
+    /// Removes only the exact fixed staging socket described by a record.
+    pub fn unlink_staged_socket(&self, record: &SocketOwnershipRecord) -> Result<(), RuntimeError> {
+        self.require_record_support()?;
+        unlink_staged_socket(self.anchor_fd(), record)
+    }
+
     /// Removes only the exact current ownership record.
     pub fn clear_socket_record(&self, record: &SocketOwnershipRecord) -> Result<(), RuntimeError> {
         self.require_record_support()?;
@@ -1171,9 +1197,28 @@ impl fmt::Debug for LauncherNamespace {
 }
 
 impl LauncherNamespace {
-    /// Revalidates the exact linked namespace and proves the worker lock remains held.
+    /// Duplicates the live namespace for one bounded socket publication transaction.
+    pub fn socket_namespace(&self) -> Result<WorkerSocketNamespace, RuntimeError> {
+        self.verify_worker_lock_inner()?;
+        Ok(WorkerSocketNamespace {
+            directory: duplicate_fd(self.directory.as_raw_fd())?,
+            identity: self.identity,
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            record_policy: match self.publication {
+                NamespacePublication::Linked => NamespaceRecordPolicy::Linked,
+                NamespacePublication::Retired => NamespaceRecordPolicy::RetiredRecordFree,
+            },
+        })
+    }
+
+    /// Revalidates the exact retained namespace and proves the worker lock remains held.
     #[cfg(feature = "elevated-bootstrap-probe")]
     pub fn verify_worker_lock(&self) -> Result<(), RuntimeError> {
+        self.verify_worker_lock_inner()
+    }
+
+    fn verify_worker_lock_inner(&self) -> Result<(), RuntimeError> {
+        #[cfg(feature = "elevated-bootstrap-probe")]
         match self.publication {
             NamespacePublication::Linked => validate_preopened_namespace(
                 self.root.as_raw_fd(),
@@ -1192,6 +1237,15 @@ impl LauncherNamespace {
                 false,
             )?,
         }
+        #[cfg(not(feature = "elevated-bootstrap-probe"))]
+        validate_preopened_namespace(
+            self.root.as_raw_fd(),
+            self.directory.as_raw_fd(),
+            &self.name,
+            self.identity,
+            self.owner,
+            false,
+        )?;
         if try_lock_exclusive(self.directory.as_raw_fd())? {
             unlock(self.directory.as_raw_fd());
             return Err(RuntimeError::InvalidEntry);
@@ -1958,7 +2012,6 @@ fn validate_directory_owned(
     validate_directory_stat(directory_stat(fd)?, owner)
 }
 
-#[cfg(feature = "elevated-bootstrap-probe")]
 fn validate_linked_directory_owned(
     fd: RawFd,
     owner: DirectoryOwner,
@@ -1970,7 +2023,6 @@ fn validate_linked_directory_owned(
     validate_directory_stat(stat, owner)
 }
 
-#[cfg(feature = "elevated-bootstrap-probe")]
 fn validate_preopened_namespace(
     root: RawFd,
     directory: RawFd,
@@ -2766,6 +2818,18 @@ mod tests {
             Err(RuntimeError::InvalidEntry)
         );
         assert_eq!(
+            namespace.socket_record(ResourceRole::ApiSocketDirectory),
+            Err(RuntimeError::InvalidEntry)
+        );
+        assert_eq!(
+            namespace.require_socket_record(&socket),
+            Err(RuntimeError::InvalidEntry)
+        );
+        assert_eq!(
+            namespace.unlink_staged_socket(&socket),
+            Err(RuntimeError::InvalidEntry)
+        );
+        assert_eq!(
             namespace.clear_socket_record(&socket),
             Err(RuntimeError::InvalidEntry)
         );
@@ -3030,6 +3094,48 @@ mod tests {
     }
 
     #[test]
+    fn worker_socket_namespace_requires_one_exact_record() {
+        let root = TestRoot::new();
+        let namespace = WorkerSocketNamespace::from_directory_for_test(root.path())
+            .expect("test namespace should validate");
+        let record = SocketOwnershipRecord::new(
+            ResourceRole::ApiSocketDirectory,
+            SocketChild::parse("api.sock").expect("child should parse"),
+            ObjectIdentity {
+                device: 101,
+                inode: 103,
+            },
+        )
+        .expect("record should construct");
+        let wrong = SocketOwnershipRecord::new(
+            ResourceRole::ApiSocketDirectory,
+            SocketChild::parse("other.sock").expect("child should parse"),
+            record.identity(),
+        )
+        .expect("wrong record should construct");
+        assert!(
+            namespace
+                .socket_record(ResourceRole::ApiSocketDirectory)
+                .expect("record absence should read")
+                .is_none()
+        );
+        namespace
+            .write_socket_record(&record)
+            .expect("record should write");
+        namespace
+            .require_socket_record(&record)
+            .expect("exact record should match");
+        assert_eq!(
+            namespace.require_socket_record(&wrong),
+            Err(RuntimeError::InvalidEntry)
+        );
+        namespace
+            .clear_socket_record(&record)
+            .expect("exact record should clear");
+        assert!(directory_is_empty(namespace.anchor_fd()).expect("namespace should inspect"));
+    }
+
+    #[test]
     fn snapshot_staging_records_round_trip_redacted_and_clear_exactly() {
         let root = TestRoot::new();
         let directory = open_directory(root.path()).expect("test root should open");
@@ -3286,6 +3392,62 @@ mod tests {
 
         assert_eq!(namespace.cleanup(), Err(RuntimeError::InvalidEntry));
         drop(namespace);
+        assert!(named_path.is_dir(), "replacement must be preserved");
+        assert!(moved_path.is_dir(), "original fd target must be preserved");
+    }
+
+    #[test]
+    fn launcher_socket_namespace_requires_linked_name_and_live_worker_lock() {
+        let root = TestRoot::new();
+        let name = session_name(SessionId::from_bytes([4; 32])).expect("name should derive");
+        let named_path = root.path().join(OsStr::from_bytes(name.as_bytes()));
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&named_path)
+            .expect("namespace should be created");
+        let root_fd = open_directory(root.path()).expect("test root should open");
+        let launcher_directory =
+            openat_directory(root_fd.as_raw_fd(), &name).expect("launcher anchor should open");
+        let identity =
+            validate_directory(launcher_directory.as_raw_fd()).expect("identity should validate");
+        let mut worker_directory = open_directory(&named_path).expect("worker anchor should open");
+        lock_exclusive(worker_directory.as_raw_fd()).expect("worker lock should acquire");
+        let mut namespace = LauncherNamespace {
+            root: root_fd,
+            directory: launcher_directory,
+            name,
+            identity,
+            owner: DirectoryOwner::current_user(),
+            #[cfg(feature = "elevated-bootstrap-probe")]
+            publication: NamespacePublication::Linked,
+            cleaned: false,
+        };
+
+        namespace
+            .socket_namespace()
+            .expect("linked namespace with a worker lock should duplicate");
+        drop(worker_directory);
+        assert!(matches!(
+            namespace.socket_namespace(),
+            Err(RuntimeError::InvalidEntry)
+        ));
+
+        worker_directory = open_directory(&named_path).expect("worker anchor should reopen");
+        lock_exclusive(worker_directory.as_raw_fd()).expect("worker lock should reacquire");
+        let moved_path = root.path().join("moved-live-namespace");
+        fs::rename(&named_path, &moved_path).expect("original namespace should move");
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&named_path)
+            .expect("replacement should be created");
+        assert!(matches!(
+            namespace.socket_namespace(),
+            Err(RuntimeError::InvalidEntry)
+        ));
+
+        drop(worker_directory);
+        assert_eq!(namespace.cleanup(), Err(RuntimeError::InvalidEntry));
+        namespace.cleaned = true;
         assert!(named_path.is_dir(), "replacement must be preserved");
         assert!(moved_path.is_dir(), "original fd target must be preserved");
     }

--- a/crates/session/src/macos/socket_broker.rs
+++ b/crates/session/src/macos/socket_broker.rs
@@ -1,11 +1,12 @@
-//! Closed launcher-worker transport for granted-vsock guest connections.
+//! Closed launcher-worker transport for granted API publication and vsock connections.
 
 use std::fmt;
 use std::io;
+use std::mem::size_of;
 use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::os::unix::net::UnixDatagram;
 
-use crate::{MAX_SOCKET_CHILD_BYTES, SessionId, SocketChild};
+use crate::{MAX_SOCKET_CHILD_BYTES, ObjectIdentity, SessionId, SocketChild};
 
 use super::grant_transport::{GrantTransportError, receive_raw, send_raw};
 
@@ -19,6 +20,9 @@ const KIND_READY: u8 = 4;
 const KIND_CONNECTED: u8 = 5;
 const KIND_FAILED: u8 = 6;
 const KIND_COMPLETE: u8 = 7;
+const KIND_PUBLISH_API: u8 = 8;
+const KIND_API_PUBLISHED: u8 = 9;
+const KIND_API_PUBLISH_FAILED: u8 = 10;
 const STATUS_OK: u8 = 0;
 const STATUS_NOT_FOUND: u8 = 1;
 const STATUS_PERMISSION_DENIED: u8 = 2;
@@ -31,10 +35,22 @@ const PORT_OFFSET: usize = 48;
 const CHILD_LENGTH_OFFSET: usize = 52;
 const CHILD_OFFSET: usize = 56;
 const CHILD_END: usize = CHILD_OFFSET + MAX_SOCKET_CHILD_BYTES;
+const IDENTITY_DEVICE_OFFSET: usize = CHILD_OFFSET;
+const IDENTITY_INODE_OFFSET: usize = IDENTITY_DEVICE_OFFSET + size_of::<u64>();
+const IDENTITY_END: usize = IDENTITY_INODE_OFFSET + size_of::<u64>();
 
 /// One closed session-bound broker message.
 #[derive(Clone, PartialEq, Eq)]
 pub enum SocketBrokerMessage {
+    /// Requests publication of one already-claimed API socket child.
+    PublishApi {
+        /// Exact lifecycle session.
+        session: SessionId,
+        /// Monotonic request sequence.
+        sequence: u64,
+        /// Exact child selected by the worker grant claim.
+        child: SocketChild,
+    },
     /// Fixes the dormant broker to one already-claimed safe child.
     Activate {
         /// Exact lifecycle session.
@@ -94,11 +110,30 @@ pub enum SocketBrokerMessage {
         /// Matching request sequence.
         sequence: u64,
     },
+    /// Returns one published API listener and its exact path identity.
+    ApiPublished {
+        /// Exact lifecycle session.
+        session: SessionId,
+        /// Matching request sequence.
+        sequence: u64,
+        /// Exact final socket device/inode.
+        identity: ObjectIdentity,
+    },
+    /// Reports one bounded API publication failure without path data.
+    ApiPublishFailed {
+        /// Exact lifecycle session.
+        session: SessionId,
+        /// Matching request sequence.
+        sequence: u64,
+        /// Stable redacted failure category.
+        kind: io::ErrorKind,
+    },
 }
 
 impl fmt::Debug for SocketBrokerMessage {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
+            Self::PublishApi { .. } => "PublishApi(<redacted>)",
             Self::Activate { .. } => "Activate(<redacted>)",
             Self::Connect { .. } => "Connect(<redacted>)",
             Self::Shutdown { .. } => "Shutdown(<redacted>)",
@@ -106,6 +141,8 @@ impl fmt::Debug for SocketBrokerMessage {
             Self::Connected { .. } => "Connected(<redacted>)",
             Self::Failed { .. } => "Failed(<redacted>)",
             Self::Complete { .. } => "Complete(<redacted>)",
+            Self::ApiPublished { .. } => "ApiPublished(<redacted>)",
+            Self::ApiPublishFailed { .. } => "ApiPublishFailed(<redacted>)",
         })
     }
 }
@@ -115,13 +152,16 @@ impl SocketBrokerMessage {
     #[must_use]
     pub const fn session(&self) -> SessionId {
         match self {
-            Self::Activate { session, .. }
+            Self::PublishApi { session, .. }
+            | Self::Activate { session, .. }
             | Self::Connect { session, .. }
             | Self::Shutdown { session, .. }
             | Self::Ready { session, .. }
             | Self::Connected { session, .. }
             | Self::Failed { session, .. }
-            | Self::Complete { session, .. } => *session,
+            | Self::Complete { session, .. }
+            | Self::ApiPublished { session, .. }
+            | Self::ApiPublishFailed { session, .. } => *session,
         }
     }
 
@@ -129,18 +169,21 @@ impl SocketBrokerMessage {
     #[must_use]
     pub const fn sequence(&self) -> u64 {
         match self {
-            Self::Activate { sequence, .. }
+            Self::PublishApi { sequence, .. }
+            | Self::Activate { sequence, .. }
             | Self::Connect { sequence, .. }
             | Self::Shutdown { sequence, .. }
             | Self::Ready { sequence, .. }
             | Self::Connected { sequence, .. }
             | Self::Failed { sequence, .. }
-            | Self::Complete { sequence, .. } => *sequence,
+            | Self::Complete { sequence, .. }
+            | Self::ApiPublished { sequence, .. }
+            | Self::ApiPublishFailed { sequence, .. } => *sequence,
         }
     }
 
     const fn descriptor_count(&self) -> u8 {
-        if matches!(self, Self::Connected { .. }) {
+        if matches!(self, Self::Connected { .. } | Self::ApiPublished { .. }) {
             1
         } else {
             0
@@ -178,7 +221,7 @@ impl From<GrantTransportError> for SocketBrokerError {
 pub struct ReceivedSocketBrokerMessage {
     /// Decoded session-bound message.
     pub message: SocketBrokerMessage,
-    /// Descriptor required by `Connected`, if any.
+    /// Descriptor required by `Connected` or `ApiPublished`, if any.
     pub descriptor: Option<OwnedFd>,
 }
 
@@ -242,8 +285,13 @@ fn encode(message: &SocketBrokerMessage) -> Result<[u8; FRAME_BYTES], SocketBrok
     frame[SEQUENCE_OFFSET..PORT_OFFSET].copy_from_slice(&sequence.to_be_bytes());
 
     match message {
-        SocketBrokerMessage::Activate { child, .. } => {
-            frame[5] = KIND_ACTIVATE;
+        SocketBrokerMessage::PublishApi { child, .. }
+        | SocketBrokerMessage::Activate { child, .. } => {
+            frame[5] = if matches!(message, SocketBrokerMessage::PublishApi { .. }) {
+                KIND_PUBLISH_API
+            } else {
+                KIND_ACTIVATE
+            };
             let length =
                 u8::try_from(child.as_bytes().len()).map_err(|_| SocketBrokerError::Invalid)?;
             frame[CHILD_LENGTH_OFFSET] = length;
@@ -271,6 +319,20 @@ fn encode(message: &SocketBrokerMessage) -> Result<[u8; FRAME_BYTES], SocketBrok
             frame[PORT_OFFSET..PORT_OFFSET + 4].copy_from_slice(&port.to_be_bytes());
         }
         SocketBrokerMessage::Complete { .. } => frame[5] = KIND_COMPLETE,
+        SocketBrokerMessage::ApiPublished { identity, .. } => {
+            if identity.device == 0 || identity.inode == 0 {
+                return Err(SocketBrokerError::Invalid);
+            }
+            frame[5] = KIND_API_PUBLISHED;
+            frame[IDENTITY_DEVICE_OFFSET..IDENTITY_INODE_OFFSET]
+                .copy_from_slice(&identity.device.to_be_bytes());
+            frame[IDENTITY_INODE_OFFSET..IDENTITY_END]
+                .copy_from_slice(&identity.inode.to_be_bytes());
+        }
+        SocketBrokerMessage::ApiPublishFailed { kind, .. } => {
+            frame[5] = KIND_API_PUBLISH_FAILED;
+            frame[6] = failure_status(*kind);
+        }
     }
     Ok(frame)
 }
@@ -302,21 +364,19 @@ fn decode(frame: &[u8; FRAME_BYTES]) -> Result<SocketBrokerMessage, SocketBroker
     let child_end = CHILD_OFFSET
         .checked_add(child_length)
         .ok_or(SocketBrokerError::Invalid)?;
-    if session.is_pre_session()
-        || sequence == 0
-        || child_length > MAX_SOCKET_CHILD_BYTES
-        || frame
-            .get(child_end..CHILD_END)
-            .ok_or(SocketBrokerError::Invalid)?
-            .iter()
-            .any(|byte| *byte != 0)
-    {
+    if session.is_pre_session() || sequence == 0 || child_length > MAX_SOCKET_CHILD_BYTES {
         return Err(SocketBrokerError::Invalid);
     }
     let kind = frame[5];
     let status = frame[6];
     let descriptor_count = frame[7];
     let no_child = child_length == 0;
+    let child_padding_zero = frame
+        .get(child_end..CHILD_END)
+        .ok_or(SocketBrokerError::Invalid)?
+        .iter()
+        .all(|byte| *byte == 0);
+    let no_child_bytes = frame[CHILD_OFFSET..CHILD_END].iter().all(|byte| *byte == 0);
     let child = || {
         std::str::from_utf8(
             frame
@@ -328,33 +388,79 @@ fn decode(frame: &[u8; FRAME_BYTES]) -> Result<SocketBrokerMessage, SocketBroker
     };
 
     match (kind, status, descriptor_count, port, no_child) {
-        (KIND_ACTIVATE, STATUS_OK, 0, 0, false) => Ok(SocketBrokerMessage::Activate {
-            session,
-            sequence,
-            child: child()?,
-        }),
-        (KIND_CONNECT, STATUS_OK, 0, _, true) => Ok(SocketBrokerMessage::Connect {
-            session,
-            sequence,
-            port,
-        }),
-        (KIND_SHUTDOWN, STATUS_OK, 0, 0, true) => {
+        (KIND_PUBLISH_API, STATUS_OK, 0, 0, false) if child_padding_zero => {
+            Ok(SocketBrokerMessage::PublishApi {
+                session,
+                sequence,
+                child: child()?,
+            })
+        }
+        (KIND_ACTIVATE, STATUS_OK, 0, 0, false) if child_padding_zero => {
+            Ok(SocketBrokerMessage::Activate {
+                session,
+                sequence,
+                child: child()?,
+            })
+        }
+        (KIND_CONNECT, STATUS_OK, 0, _, true) if no_child_bytes => {
+            Ok(SocketBrokerMessage::Connect {
+                session,
+                sequence,
+                port,
+            })
+        }
+        (KIND_SHUTDOWN, STATUS_OK, 0, 0, true) if no_child_bytes => {
             Ok(SocketBrokerMessage::Shutdown { session, sequence })
         }
-        (KIND_READY, STATUS_OK, 0, 0, true) => Ok(SocketBrokerMessage::Ready { session, sequence }),
-        (KIND_CONNECTED, STATUS_OK, 1, _, true) => Ok(SocketBrokerMessage::Connected {
-            session,
-            sequence,
-            port,
-        }),
-        (KIND_FAILED, status, 0, _, true) => Ok(SocketBrokerMessage::Failed {
+        (KIND_READY, STATUS_OK, 0, 0, true) if no_child_bytes => {
+            Ok(SocketBrokerMessage::Ready { session, sequence })
+        }
+        (KIND_CONNECTED, STATUS_OK, 1, _, true) if no_child_bytes => {
+            Ok(SocketBrokerMessage::Connected {
+                session,
+                sequence,
+                port,
+            })
+        }
+        (KIND_FAILED, status, 0, _, true) if no_child_bytes => Ok(SocketBrokerMessage::Failed {
             session,
             sequence,
             port,
             kind: failure_kind(status)?,
         }),
-        (KIND_COMPLETE, STATUS_OK, 0, 0, true) => {
+        (KIND_COMPLETE, STATUS_OK, 0, 0, true) if no_child_bytes => {
             Ok(SocketBrokerMessage::Complete { session, sequence })
+        }
+        (KIND_API_PUBLISHED, STATUS_OK, 1, 0, true)
+            if frame[IDENTITY_END..CHILD_END].iter().all(|byte| *byte == 0) =>
+        {
+            let identity = ObjectIdentity {
+                device: u64::from_be_bytes(
+                    frame[IDENTITY_DEVICE_OFFSET..IDENTITY_INODE_OFFSET]
+                        .try_into()
+                        .map_err(|_| SocketBrokerError::Invalid)?,
+                ),
+                inode: u64::from_be_bytes(
+                    frame[IDENTITY_INODE_OFFSET..IDENTITY_END]
+                        .try_into()
+                        .map_err(|_| SocketBrokerError::Invalid)?,
+                ),
+            };
+            if identity.device == 0 || identity.inode == 0 {
+                return Err(SocketBrokerError::Invalid);
+            }
+            Ok(SocketBrokerMessage::ApiPublished {
+                session,
+                sequence,
+                identity,
+            })
+        }
+        (KIND_API_PUBLISH_FAILED, status, 0, 0, true) if no_child_bytes => {
+            Ok(SocketBrokerMessage::ApiPublishFailed {
+                session,
+                sequence,
+                kind: failure_kind(status)?,
+            })
         }
         _ => Err(SocketBrokerError::Invalid),
     }
@@ -395,6 +501,11 @@ mod tests {
     fn round_trips_closed_messages_and_one_descriptor() {
         let child = SocketChild::parse("vm.vsock").expect("child should parse");
         let messages = [
+            SocketBrokerMessage::PublishApi {
+                session: session(),
+                sequence: 1,
+                child: child.clone(),
+            },
             SocketBrokerMessage::Activate {
                 session: session(),
                 sequence: 1,
@@ -423,6 +534,11 @@ mod tests {
                 session: session(),
                 sequence: 3,
             },
+            SocketBrokerMessage::ApiPublishFailed {
+                session: session(),
+                sequence: 1,
+                kind: io::ErrorKind::PermissionDenied,
+            },
         ];
         for message in messages {
             let encoded = encode(&message).expect("message should encode");
@@ -441,6 +557,22 @@ mod tests {
         let received =
             receive_socket_broker_message(&receiver).expect("descriptor response should receive");
         assert_eq!(received.message, message);
+        assert!(received.descriptor.is_some());
+
+        let identity = ObjectIdentity {
+            device: 17,
+            inode: 23,
+        };
+        let published = SocketBrokerMessage::ApiPublished {
+            session: session(),
+            sequence: 5,
+            identity,
+        };
+        send_socket_broker_message(&sender, &published, Some(file.as_raw_fd()))
+            .expect("API listener response should send");
+        let received =
+            receive_socket_broker_message(&receiver).expect("API listener response should receive");
+        assert_eq!(received.message, published);
         assert!(received.descriptor.is_some());
     }
 
@@ -473,5 +605,48 @@ mod tests {
             format!("{message:?} {}", SocketBrokerError::Invalid),
             "Connect(<redacted>) private socket broker failure"
         );
+    }
+
+    #[test]
+    fn rejects_api_identity_reserved_bytes_and_wrong_rights() {
+        let identity = ObjectIdentity {
+            device: 17,
+            inode: 23,
+        };
+        let message = SocketBrokerMessage::ApiPublished {
+            session: session(),
+            sequence: 1,
+            identity,
+        };
+        let mut encoded = encode(&message).expect("API response should encode");
+        encoded[IDENTITY_END] = 1;
+        assert_eq!(decode(&encoded), Err(SocketBrokerError::Invalid));
+
+        assert_eq!(
+            encode(&SocketBrokerMessage::ApiPublished {
+                session: session(),
+                sequence: 1,
+                identity: ObjectIdentity {
+                    device: 0,
+                    inode: 23,
+                },
+            }),
+            Err(SocketBrokerError::Invalid)
+        );
+
+        let child = SocketChild::parse("api.sock").expect("API child should parse");
+        let request = SocketBrokerMessage::PublishApi {
+            session: session(),
+            sequence: 1,
+            child,
+        };
+        assert!(matches!(
+            send_socket_broker_message(
+                &UnixDatagram::pair().expect("pair should open").0,
+                &request,
+                Some(libc::STDIN_FILENO)
+            ),
+            Err(SocketBrokerError::Invalid)
+        ));
     }
 }

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -1271,6 +1271,18 @@ endpoints retain and validate only the locked open directory, and the feature
 namespace rejects ownership records. Ordinary foreground and daemon sessions
 remain linked and record-bearing.
 
+#1907 changes only ordinary rootless granted-API publication. The worker still
+claims the exact directory/child, but the authenticated socket broker now asks
+the unsandboxed launcher to bind the fixed private staging listener, durably
+write the ordinary ownership record, exclusively rename into the grant anchor,
+and return exactly one descriptor. The worker validates that record, final
+path, descriptor, peer, session, and sequence before readiness, then restores
+the same broker authority for a possible later vsock activation. A signed
+production regression completes 5,000 fresh HTTP 200 connections and exact
+signal/socket/record/staging/session cleanup. Direct and no-API modes, the
+vsock binder, and the separate feature-only record-free evidence above are
+unchanged.
+
 API and no-API daemons complete for mapped, retained-root/no-drop, and SDK-
 maximum unmapped identities. Every retirement fault, both single-endpoint death
 orders for both workloads, supervisor SIGINT/SIGTERM, worker SIGHUP, same-name
@@ -1355,9 +1367,10 @@ strings. Block and pmem consumers similarly adopt exact repeatable grants with
 access derived from device intent at config-file, API startup, and the existing
 live block replacement seam. Logger, metrics, and serial consume singleton
 write-only grants. API and vsock consume exact singleton directory anchors plus
-one bounded safe child; short-lived binders perform same-filesystem exclusive
-publication, while guest-initiated vsock connections use one fixed port-only
-launcher facet with no guest bytes or outgoing-network entitlement. Snapshot
+one bounded safe child. Ordinary API uses launcher-owned staged
+same-filesystem publication; vsock retains the short-lived binder, while
+guest-initiated connections use one fixed port-only launcher facet with no
+guest bytes or outgoing-network entitlement. Snapshot
 describe/state/memory consumers adopt exact files, and frozen native-v1 load
 may additionally adopt its persisted root; create retains
 repeatable output anchors with bounded children and strict crash-cleanup
@@ -5342,10 +5355,11 @@ identity after pathname replacement, redacted failure-atomic mismatch handling,
 guest block I/O, read-only rejection, pmem read/flush, logger records, initial
 and terminal metrics, guest serial bytes, concurrent output isolation, and live
 block swap. API and vsock consumers now adopt exact singleton directory grants
-plus a bounded safe child, use short-lived signed binders for same-filesystem
-anchored exclusive publication, retain supplied listeners and identity-aware
-cleanup, and keep guest-initiated vsock connects on one fixed session-bound
-launcher port facet without guest payloads or an outgoing-network entitlement.
+plus a bounded safe child. Ordinary API uses launcher-owned staged
+same-filesystem publication; vsock retains its short-lived signed binder. Both
+retain supplied listeners and identity-aware cleanup, and guest-initiated
+vsock connects stay on one fixed session-bound launcher port facet without
+guest payloads or an outgoing-network entitlement.
 Signed normal-bundle proof covers outside-container API clients, real guest- and
 host-initiated vsock traffic, two contained vhost-user children from one
 connect-only directory grant, active CONFIG refresh on the retained stream, no

--- a/docs/review-guidelines.md
+++ b/docs/review-guidelines.md
@@ -214,17 +214,27 @@ For API/vsock directory grants, require the distinct exact
 ASCII component and direct mode preserves identical bytes as a path. Review
 validation-before-claim, exact singleton role/access, owner-thread scope and
 anchor lifetime, no-API non-consumption, API readiness after publication, and
-deferred vsock claim/startup failure atomicity. The transient signed binder must
-use a default-close fd5/fd6 allowlist, authenticate its parent, bind only the
-fixed private staging name, validate and transfer exactly one listener, and be
-killed/reaped before exposure. Publication must require matching filesystems,
-use fd-relative exclusive rename, reject replacement and traversal races, and
-install a strict value-redacted ownership record before the public name exists.
+deferred vsock claim/startup failure atomicity. Ordinary API publication must
+reserve the authenticated broker endpoint, let the launcher bind the fixed
+private staging name outside App Sandbox, install the strict value-redacted
+ownership record before the public name exists, and return exactly one listener
+descriptor only after fd-relative exclusive rename and final revalidation.
+Review `Interrupted`/`WouldBlock` as one retained reply transaction: no second
+bind, record, or rename is allowed, and readiness must require a sent reply.
+The worker must validate record, final path, descriptor, peer, session, and
+sequence before restoring the same broker endpoint at its advanced sequence.
+The transient signed fd5/fd6 binder is retained for vsock only; it must
+authenticate its parent, bind only that role's fixed private staging name,
+validate and transfer exactly one listener, and be killed/reaped before
+VM-start exposure. Both publication paths require matching filesystems and
+must reject replacement and traversal races.
 
 Review the fixed vsock broker separately from general resource brokerage. Its
 initial endpoint is always inherited but dormant; activation must bind exact
-peer PID, lifecycle SessionId, first sequence, retained singleton anchor, cwd
-identity, and the already validated child. Later requests may contain only a
+peer PID, lifecycle SessionId, the carried next sequence, retained singleton
+anchor, cwd identity, and the already validated child. Vsock-only activation is
+sequence one; API-then-vsock activation follows the successful API exchange.
+Later requests may contain only a
 monotonic sequence and `u32` port, producing only relative
 `<SocketChild>_<port>` targets and at most one validated connected AF_UNIX
 stream descriptor. Require closed frame/reserved/status variants, exact rights
@@ -260,9 +270,9 @@ escalation, and concurrent launchers must never share session state or signal,
 reap, or clean each other's workers and namespaces. Absolute handshake
 deadlines must survive fragmented reads and `EINTR`; `Terminal` or EOF must also
 start a bounded owned-process exit grace rather than permitting an indefinite
-wait. Grant sending must remain nonblocking in the same event loop, continue to
-observe signals, lifecycle input, and child exit, and use one absolute
-send-plus-acknowledgment deadline.
+wait. Grant and broker-reply sending must remain nonblocking in the same event
+loop, continue to observe signals, lifecycle input, and child exit, and use
+their absolute send/acknowledgment or publication-reply deadlines.
 
 Authorized socket construction may transiently add only one fixed role-specific
 staging socket. Snapshot construction may transiently add one strict record per

--- a/docs/security.md
+++ b/docs/security.md
@@ -879,34 +879,49 @@ Direct mode continues treating the identical bytes as an ordinary path. Claims
 are singleton, require exact `CreateChildren` role/access, and consume only
 after complete consumer validation. No-API mode never claims the API role.
 
-The owner thread retains the resolved scope and exact directory anchor. A
-short-lived default-close instance of the already signed worker authenticates
-its parent, receives only its control endpoint at fd5 and the exact private
-namespace anchor at fd6, enters that anchor, binds one fixed role-specific
-staging name, validates the listener, and transfers its descriptor. It retains
+The owner thread retains the resolved scope and exact directory anchor. For an
+ordinary granted API socket, the App Sandbox worker claims the safe child and
+uses the existing authenticated descriptor-5 socket broker to send one
+session/sequence-bound `PublishApi` request. The launcher duplicates the live
+validated private namespace, enters it through the serialized cwd boundary,
+binds only the fixed API staging name, applies close-on-exec, nonblocking,
+owner-only listener state, and writes the fixed durable ownership record before
+an fd-relative `renameatx_np(RENAME_EXCL)` into the exact grant anchor. Only
+after final path, record, listener, owner, mode, link, and identity revalidation
+does it send `ApiPublished` with exactly one descriptor. A backpressured reply
+retains the same listener alias, identity, sequence, and absolute deadline; it
+never repeats bind, record creation, or rename. The worker requires that exact
+record and validates the final path and received listener before API readiness,
+then restores the same broker endpoint at its advanced sequence. Direct API
+paths and no-API startup do not use this transaction.
+
+The short-lived default-close instance of the already signed worker remains
+the vsock staging binder. It authenticates its parent, receives only its control
+endpoint at fd5 and the exact private namespace anchor at fd6, binds the fixed
+vsock staging name, validates it, and transfers exactly one listener. It retains
 the listener until the authenticated parent returns one fixed adoption
-acknowledgment bound to the role and socket device/inode; the parent sends that
-acknowledgment only after validating the received descriptor. This keeps the
-listener externally reachable until `SCM_RIGHTS` externalization completes,
+acknowledgment bound to the vsock role and socket device/inode; the parent sends
+that acknowledgment only after validating the received descriptor. This keeps
+the listener externally reachable until `SCM_RIGHTS` externalization completes,
 rather than leaving its last reference only in an in-flight Unix-domain
-message. The main worker then verifies the namespace inode and listener
-identity, writes one fixed bounded record containing only role, safe child, and
-socket device/inode, and publishes the live vnode exclusively with fd-relative
-`renameatx_np(RENAME_EXCL)` to the grant anchor. Cross-filesystem publication,
-an existing target, symlink or pathname replacement, role/identity mismatch,
-malformed acknowledgment, and extra rights fail closed and value-redacted. The
-binder is killed and reaped on every failure and is always reaped before API
-readiness or VM-start success.
+message. The main worker verifies the namespace and listener identity, writes
+the fixed durable ownership record, and exclusively publishes that listener
+before VM-start success. Cross-filesystem publication, an existing target,
+symlink or pathname replacement, role/identity mismatch, malformed
+acknowledgment, and extra rights fail closed and value-redacted. The binder is
+killed and reaped on every failure and is always reaped before VM-start
+success.
 
 The supplied API listener preserves owner-only mode, no-clobber publication,
 readiness timing, and identity-aware cleanup. The supplied vsock main listener
 is retained through the VM lifetime and serves host-initiated Firecracker-style
 connections. For guest-initiated connections, contained vsock consumes the
 fixed descriptor-5 broker endpoint exactly once. `Activate` binds lifecycle
-SessionId, sequence 1, and the validated safe child; the launcher requires the
-retained exact `VsockSocketDirectory` anchor, enters it with `fchdir`, rechecks
-cwd identity, and cannot change the child afterward. Subsequent requests carry
-only a monotonic sequence and `u32` port. The launcher constructs only relative
+SessionId, the next carried sequence (one for vsock-only; two after API
+publication), and the validated safe child; the launcher requires the retained
+exact `VsockSocketDirectory` anchor, enters it with `fchdir`, rechecks cwd
+identity, and cannot change the child afterward. Subsequent requests carry only
+a monotonic sequence and `u32` port. The launcher constructs only relative
 `<SocketChild>_<port>`, validates the target before and after a nonblocking Unix
 connect, and returns at most one validated connected stream descriptor. Closed
 framing, exact rights counts, peer PID, lifecycle state, shutdown, EOF, and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2678,9 +2678,13 @@ may skip execution. On supported Apple Silicon it proves:
   recorded, followed by worker `SIGKILL`; launcher recovery removes an exact
   current-user regular `0600` single-link inode but preserves a same-name
   replacement while clearing the private record and namespace;
-- exact socket-directory references publishing an owner-only API listener into
-  an outside-container granted directory, serving a real client only after
-  readiness, and reaping the short-lived signed binder before exposure;
+- exact socket-directory references having the unsandboxed launcher bind one
+  fixed private staging listener, durably record it, exclusively publish it
+  into an outside-container granted directory, transfer exactly one descriptor
+  through the authenticated broker, and serve clients only after worker
+  adoption and readiness; the strict transport regression opens 5,000 fresh
+  connections, requires HTTP 200 every time, then proves normal signal exit and
+  zero socket/record/staging/session residue;
 - delayed API `PUT /vsock` retaining the directory claim until startup,
   publishing the supplied main listener, and leaving only launcher plus worker
   in steady state with the worker's exact entitlements unchanged;
@@ -2722,8 +2726,13 @@ tests cover every closed record, limit and descriptor declaration, including
 connected-stream source/peer identity and the 255-byte redacted snapshot child
 grammar. Socket
 broker codec tests cover every closed kind, exact fixed frame/reserved fields,
-session/sequence/child/port/status encoding, descriptor declarations,
-truncation, malformed ancillary data, and value-redacted formatting. The
+session/sequence/child/port/status/identity encoding, API publication variants,
+descriptor declarations, truncation, malformed ancillary data, and
+value-redacted formatting. Launcher tests retain one exact API reply and
+deadline across datagram backpressure, enforce grants/lifecycle/namespace
+gates, and reject replay. Worker tests prove exact record/path/fd adoption,
+advanced broker-sequence restoration, failed-exchange poisoning, and
+residue-free bounded failures. The
 separate fixed 256-byte `BBU1` vhost-user broker codec covers exact
 session/sequence/grant/child/status correlation, one-stream rights, retryable
 failures, stale or malformed response rejection, and facet poisoning. Darwin
@@ -2737,8 +2746,8 @@ poisoning and rollback, fragmented bookmark scope, kernel peer acceptance and
 PID rejection, exact namespace naming/root derivation, bounded independent
 directory iteration across repeated checks, stale empty-directory recovery,
 populated-entry preservation, strict socket ownership records, identity-safe
-fixed-staging cleanup, anchored exclusive publication/rollback, binder
-framing/descriptor validation, broker state and relative-target validation, and
+fixed-staging cleanup, launcher-owned API staged publication/alias lifetime,
+vsock binder framing/descriptor validation, broker state and relative-target validation, and
 replacement-safe cleanup. Snapshot registry/runtime tests additionally cover
 non-consuming exact file duplication, validate-all-before-remove state/memory/
 root and output-directory batches, shared/distinct output anchors, strict


### PR DESCRIPTION
## Summary

- move ordinary granted API-listener creation and durable no-clobber publication into the unsandboxed launcher
- pass the exact listener to the App Sandbox worker with `SCM_RIGHTS`, preserving one broker sequence for later vsock operations
- revalidate the live namespace and worker lock at publication time, retain aliases across reply backpressure, and preserve replacement-safe cleanup across both process death orders
- document the resulting authority and review contracts and add permanent signed regressions, including 5,000 fresh API connections

## Scope exclusions

- no new helper process, fixed channel, public CLI/API, or durable record format
- direct `--api-sock`, no-API, elevated, and unused-grant behavior remains independent of granted publication
- platform-impossible Firecracker behavior remains outside this child issue

## Verification

- `cargo +1.98.0 fmt --all -- --check`
- all base and terminal `bangbang-firecracker-capability-audit` validation modes documented in `AGENTS.md`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (96 passed)
- `cargo +1.98.0 check --workspace --all-targets --all-features --locked`
- both documented `aarch64-unknown-linux-musl` package checks
- `cargo +1.98.0 test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo +1.98.0 test -p bangbang-hvf --lib --all-features --locked` (1,540 passed)
- `cargo +1.98.0 clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all six documented Apple integration-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo +1.98.0 doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test production_bundle` (79 passed)
- `scripts/run-integration-tests.sh` without `--allow-unsupported`, including 30 guest-boot, 7 CPU-template-helper, 101 HVF lifecycle, 8 App Sandbox, 79 production-bundle, and 81 executable-HVF tests

Closes #1907

Parent context: #1348
