### PR TITLE
feat: add bounded vmnet provider protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,10 @@ This is a Rust workspace for `bangbang`, a macOS-oriented VMM scaffold intended 
 - `crates/bangbang` -> package `bangbang`: executable VMM process entrypoint.
 - `crates/api` -> package `bangbang-api`: Firecracker-compatible API endpoint names.
 - `crates/runtime` -> package `bangbang-runtime`: backend-neutral VM trait and error type.
+- `crates/session` -> package `bangbang-session`: private launcher/worker
+  lifecycle, grant, and bounded vmnet-provider protocols.
+- `crates/unix-stream` -> package `bangbang-unix-stream`: shared
+  deadline-bounded exact Unix-stream and SCM_RIGHTS transport primitive.
 - `crates/vhost-user` -> package `bangbang-vhost-user`: strict portable
   Firecracker-shaped vhost-user frontend protocol and pipe notifier foundation.
 - `crates/hvf` -> package `bangbang-hvf`: Apple Hypervisor.framework backend skeleton.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
 name = "bangbang-session"
 version = "0.1.0"
 dependencies = [
+ "bangbang-unix-stream",
  "getrandom",
  "libc",
 ]
@@ -244,9 +245,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bangbang-unix-stream"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "bangbang-vhost-user"
 version = "0.1.0"
 dependencies = [
+ "bangbang-unix-stream",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/pager",
     "crates/runtime",
     "crates/session",
+    "crates/unix-stream",
     "crates/vhost-user",
     "crates/bangbang",
     "tools/cpu-template-helper",

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Each detailed subject has one primary document:
 - [Entitlement-free vmnet Feasibility Contract](compat/firecracker/v1.16.0/vmnet-feasibility-contract.md)
   owns the no-Apple-authorization root-direct evidence boundary, exact dropped
   owner and repeated guest-connectivity gates, and the `383/0/2/33` handoff.
+- [Private vmnet Provider Protocol](docs/vmnet-provider-protocol.md) freezes the
+  bounded session/control/data wire, state, packet, deadline, and descriptor
+  ownership contract needed by the no-Apple-authorization split topology. It
+  is portable nonproduction machinery and promotes no capability.
 - [Production vmnet certification runner](docs/testing.md#production-vmnet-certification-foundation)
   owns the private config, retained fixture, guest DHCP/TCP oracle, two-package
   inspection, descriptor-grant assembly, fixed 21-case production matrix, and
@@ -110,7 +114,9 @@ crates/hvf        Hypervisor.framework backend and signed integration tests
 crates/bangbang   VMM process, API server, and startup CLI
 crates/launcher   Production app bundle, nested worker, and supervision
 crates/pager      bangbang-pager-v1 protocol and VMM-side client
-crates/session    Private launcher/worker lifecycle and grant protocols
+crates/session    Private launcher/worker lifecycle, grant, and vmnet-provider protocols
+crates/unix-stream
+                  Shared exact Unix-stream and SCM_RIGHTS transport primitive
 crates/vhost-user Portable vhost-user frontend protocol foundations
 tools/firecracker-capability-audit
                   Checked Firecracker source/capability inventory validator

--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -170,6 +170,12 @@ two-row evidence transition, and
 [`docs/testing.md`](../../../docs/testing.md#entitlement-free-vmnet-feasibility)
 for the canonical commands.
 
+The portable
+[`provider-v1` contract](../../../docs/vmnet-provider-protocol.md) now freezes
+the closed session/control/data wire and descriptor ownership needed by the
+next implementation slices. It intentionally leaves this inventory and both
+`missing-platform-feasible` dispositions unchanged.
+
 ## Guest workflow artifact authority
 
 The guest-workflow audit deliberately separates the pinned Firecracker v1.16.0

--- a/compat/firecracker/v1.16.0/vmnet-feasibility-contract.md
+++ b/compat/firecracker/v1.16.0/vmnet-feasibility-contract.md
@@ -124,6 +124,13 @@ delivery validation requires that authority and the exact `383/0/2/33`
 partition. Global `validate --final` must still fail, and it must identify only
 the same two `missing-platform-feasible` records.
 
+The later portable
+[`provider-v1` contract](../../../docs/vmnet-provider-protocol.md) freezes the
+bounded wire, role state, and descriptor ownership for a future split topology.
+It consumes none of this evidence, calls no vmnet API, and changes neither
+disposition; broker/owner assembly and product certification remain separate
+successor work.
+
 #1930 does not claim any of the following:
 
 - a root direct VMM as production;

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -9,6 +9,7 @@ elevated-bootstrap-probe = []
 test-support = []
 
 [dependencies]
+bangbang-unix-stream = { path = "../unix-stream" }
 getrandom = "0.3"
 libc = "0.2"
 

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -12,6 +12,7 @@ mod grant;
 #[cfg(target_os = "macos")]
 pub mod macos;
 mod state;
+pub mod vmnet_provider;
 
 pub use codec::{
     CancelSignal, Frame, FrameDecoder, MAX_VMNET_ACTIVE_INTERFACES, MAX_VMNET_BRIDGE_NAME_BYTES,

--- a/crates/session/src/vmnet_provider/frame.rs
+++ b/crates/session/src/vmnet_provider/frame.rs
@@ -1,0 +1,2053 @@
+use std::fmt;
+use std::os::unix::net::UnixStream;
+
+use crate::SessionId;
+
+use super::VmnetProviderError;
+
+/// Encoded provider-v1 header size.
+pub const HEADER_BYTES: usize = 80;
+/// Control-channel discriminant.
+pub const CONTROL_CHANNEL: u8 = 1;
+/// Per-interface data-channel discriminant.
+pub const DATA_CHANNEL: u8 = 2;
+/// Tight production authority limit for active system-vmnet interfaces.
+pub const MAX_ACTIVE_INTERFACES: usize = crate::MAX_VMNET_ACTIVE_INTERFACES as usize;
+/// Existing local vmnet packet-count bound for one operation.
+pub const MAX_PACKET_COUNT: usize = 200;
+/// Existing local vmnet aggregate packet-byte bound for one operation.
+pub const MAX_AGGREGATE_PACKET_BYTES: usize = 256 * 1024;
+/// Largest local packet buffer including an enabled 12-byte virtio header.
+pub const MAX_PACKET_BUFFER_BYTES: usize = 65_562 + 12;
+const PACKET_BATCH_METADATA_BYTES: usize = 8 + MAX_PACKET_COUNT * size_of_u32();
+const MAX_BODY_BYTES: usize = 8 + PACKET_BATCH_METADATA_BYTES + MAX_AGGREGATE_PACKET_BYTES;
+/// Largest complete encoded provider frame.
+pub const MAX_FRAME_BYTES: usize = HEADER_BYTES + MAX_BODY_BYTES;
+/// Incremental decoder buffering limit.
+pub const MAX_BUFFERED_FRAME_BYTES: usize = MAX_FRAME_BYTES * 2;
+
+const MAGIC: [u8; 8] = *b"BBVNETP\0";
+const VERSION: u16 = 1;
+const VIRTIO_HEADER_BYTES: usize = 12;
+const MIN_MTU: u16 = 68;
+const MAX_VMNET_PACKET_BYTES: usize = 65_562;
+const BACKEND_INTERFACE_ID_BYTES: usize = 16;
+
+const CONTROL_HELLO: u8 = 1;
+const CONTROL_HELLO_ACK: u8 = 2;
+const CONTROL_START: u8 = 3;
+const CONTROL_STARTED: u8 = 4;
+const CONTROL_START_FAILED: u8 = 5;
+const CONTROL_STOP: u8 = 6;
+const CONTROL_STOPPED: u8 = 7;
+const CONTROL_CANCEL: u8 = 8;
+const CONTROL_CANCELLED: u8 = 9;
+const CONTROL_SHUTDOWN: u8 = 10;
+const CONTROL_SHUTDOWN_ACK: u8 = 11;
+const CONTROL_TERMINAL: u8 = 12;
+
+const DATA_HELLO: u8 = 32;
+const DATA_HELLO_ACK: u8 = 33;
+const DATA_READINESS: u8 = 34;
+const DATA_READ: u8 = 35;
+const DATA_READ_RESULT: u8 = 36;
+const DATA_WRITE: u8 = 37;
+const DATA_WRITE_RESULT: u8 = 38;
+const DATA_OPERATION_FAILED: u8 = 39;
+const DATA_STOP: u8 = 40;
+const DATA_STOPPED: u8 = 41;
+const DATA_SHUTDOWN: u8 = 42;
+const DATA_SHUTDOWN_ACK: u8 = 43;
+const DATA_TERMINAL: u8 = 44;
+
+const REQUEST_MAC_PRESENT: u8 = 1 << 0;
+const REQUEST_MTU_PRESENT: u8 = 1 << 1;
+const REQUEST_FLAGS: u8 = REQUEST_MAC_PRESENT | REQUEST_MTU_PRESENT;
+
+const REALIZED_BACKEND_ID_PRESENT: u16 = 1 << 0;
+const REALIZED_READ_MAX_PRESENT: u16 = 1 << 1;
+const REALIZED_WRITE_MAX_PRESENT: u16 = 1 << 2;
+const REALIZED_DIRECT_AVAILABLE: u16 = 1 << 3;
+const REALIZED_DIRECT_ENABLED: u16 = 1 << 4;
+const REALIZED_FLAGS: u16 = REALIZED_BACKEND_ID_PRESENT
+    | REALIZED_READ_MAX_PRESENT
+    | REALIZED_WRITE_MAX_PRESENT
+    | REALIZED_DIRECT_AVAILABLE
+    | REALIZED_DIRECT_ENABLED;
+
+const fn size_of_u32() -> usize {
+    4
+}
+
+macro_rules! nonzero_identifier {
+    ($name:ident, $inner:ty, $label:literal) => {
+        #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        pub struct $name($inner);
+
+        impl $name {
+            /// Smallest valid wire identity.
+            pub const MIN: Self = Self(1);
+
+            /// Constructs a validated nonzero identity.
+            pub const fn new(value: $inner) -> Result<Self, VmnetProviderError> {
+                if value == 0 {
+                    Err(VmnetProviderError::InvalidConfiguration)
+                } else {
+                    Ok(Self(value))
+                }
+            }
+
+            /// Returns the exact numeric wire value.
+            #[must_use]
+            pub const fn get(self) -> $inner {
+                self.0
+            }
+
+            pub(crate) const fn decode(value: $inner) -> Result<Self, VmnetProviderError> {
+                if value == 0 {
+                    Err(VmnetProviderError::InvalidFrame)
+                } else {
+                    Ok(Self(value))
+                }
+            }
+
+            /// Returns the next nonzero value without wrapping.
+            pub const fn checked_next(self) -> Result<Self, VmnetProviderError> {
+                match self.0.checked_add(1) {
+                    Some(next) => Ok(Self(next)),
+                    None => Err(VmnetProviderError::LimitExceeded),
+                }
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(concat!($label, "(<redacted>)"))
+            }
+        }
+    };
+}
+
+nonzero_identifier!(VmnetInterfaceId, u32, "VmnetInterfaceId");
+nonzero_identifier!(VmnetGeneration, u64, "VmnetGeneration");
+nonzero_identifier!(VmnetSequence, u64, "VmnetSequence");
+nonzero_identifier!(VmnetReadinessEpoch, u64, "VmnetReadinessEpoch");
+
+/// Fixed bootstrap-owned vmnet policy slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum VmnetPolicySlot {
+    /// Host-mode authority.
+    Host = 1,
+    /// Shared-mode authority.
+    Shared = 2,
+    /// First bootstrap-owned bridged selector.
+    Bridge0 = 3,
+    /// Second bootstrap-owned bridged selector.
+    Bridge1 = 4,
+    /// Third bootstrap-owned bridged selector.
+    Bridge2 = 5,
+    /// Fourth bootstrap-owned bridged selector.
+    Bridge3 = 6,
+}
+
+impl VmnetPolicySlot {
+    fn decode(value: u8) -> Result<Self, VmnetProviderError> {
+        match value {
+            1 => Ok(Self::Host),
+            2 => Ok(Self::Shared),
+            3 => Ok(Self::Bridge0),
+            4 => Ok(Self::Bridge1),
+            5 => Ok(Self::Bridge2),
+            6 => Ok(Self::Bridge3),
+            _ => Err(VmnetProviderError::InvalidFrame),
+        }
+    }
+}
+
+/// Optional typed parameters requested for one policy-slot start.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct RequestedVmnetParameters {
+    mac: Option<[u8; 6]>,
+    mtu: Option<u16>,
+}
+
+impl RequestedVmnetParameters {
+    /// Constructs one canonical optional request.
+    pub fn new(mac: Option<[u8; 6]>, mtu: Option<u16>) -> Result<Self, VmnetProviderError> {
+        if mac.is_some_and(|mac| !valid_unicast_mac(mac)) || mtu.is_some_and(|mtu| mtu < MIN_MTU) {
+            return Err(VmnetProviderError::InvalidConfiguration);
+        }
+        Ok(Self { mac, mtu })
+    }
+
+    /// Returns the optional requested guest MAC.
+    #[must_use]
+    pub const fn mac(self) -> Option<[u8; 6]> {
+        self.mac
+    }
+
+    /// Returns the optional requested MTU.
+    #[must_use]
+    pub const fn mtu(self) -> Option<u16> {
+        self.mtu
+    }
+}
+
+impl fmt::Debug for RequestedVmnetParameters {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("RequestedVmnetParameters(<redacted>)")
+    }
+}
+
+/// Validated realized interface parameters returned by a provider owner.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct RealizedVmnetParameters {
+    mac: [u8; 6],
+    effective_mtu: u16,
+    maximum_packet_bytes: u32,
+    backend_interface_id: Option<[u8; BACKEND_INTERFACE_ID_BYTES]>,
+    read_max_packets: Option<u16>,
+    write_max_packets: Option<u16>,
+    direct_virtio_header_available: bool,
+    direct_virtio_header_enabled: bool,
+}
+
+impl RealizedVmnetParameters {
+    /// Constructs one bounded canonical realized parameter set.
+    pub fn new(
+        mac: [u8; 6],
+        effective_mtu: u16,
+        maximum_packet_bytes: u32,
+    ) -> Result<Self, VmnetProviderError> {
+        Self {
+            mac,
+            effective_mtu,
+            maximum_packet_bytes,
+            backend_interface_id: None,
+            read_max_packets: None,
+            write_max_packets: None,
+            direct_virtio_header_available: false,
+            direct_virtio_header_enabled: false,
+        }
+        .validated()
+    }
+
+    /// Adds one optional opaque backend identity.
+    pub fn with_backend_interface_id(
+        mut self,
+        backend_interface_id: Option<[u8; BACKEND_INTERFACE_ID_BYTES]>,
+    ) -> Result<Self, VmnetProviderError> {
+        self.backend_interface_id = backend_interface_id;
+        self.validated()
+    }
+
+    /// Narrows the optional backend read and write batch maxima.
+    pub fn with_batch_limits(
+        mut self,
+        read_max_packets: Option<u16>,
+        write_max_packets: Option<u16>,
+    ) -> Result<Self, VmnetProviderError> {
+        self.read_max_packets = read_max_packets;
+        self.write_max_packets = write_max_packets;
+        self.validated()
+    }
+
+    /// Declares coherent direct-virtio-header availability and selection.
+    pub fn with_direct_virtio_header(
+        mut self,
+        direct_virtio_header_available: bool,
+        direct_virtio_header_enabled: bool,
+    ) -> Result<Self, VmnetProviderError> {
+        self.direct_virtio_header_available = direct_virtio_header_available;
+        self.direct_virtio_header_enabled = direct_virtio_header_enabled;
+        self.validated()
+    }
+
+    fn validated(self) -> Result<Self, VmnetProviderError> {
+        let maximum = usize::try_from(self.maximum_packet_bytes)
+            .map_err(|_| VmnetProviderError::InvalidConfiguration)?;
+        let packet_buffer = maximum
+            .checked_add(if self.direct_virtio_header_enabled {
+                VIRTIO_HEADER_BYTES
+            } else {
+                0
+            })
+            .ok_or(VmnetProviderError::InvalidConfiguration)?;
+        if !valid_unicast_mac(self.mac)
+            || self.effective_mtu < MIN_MTU
+            || maximum == 0
+            || maximum > MAX_VMNET_PACKET_BYTES
+            || packet_buffer > MAX_PACKET_BUFFER_BYTES
+            || self.direct_virtio_header_enabled && !self.direct_virtio_header_available
+            || self
+                .backend_interface_id
+                .is_some_and(|identity| identity == [0; 16])
+        {
+            return Err(VmnetProviderError::InvalidConfiguration);
+        }
+        let derived_max = MAX_PACKET_COUNT.min(MAX_AGGREGATE_PACKET_BYTES / packet_buffer);
+        if derived_max == 0
+            || self
+                .read_max_packets
+                .is_some_and(|value| value == 0 || usize::from(value) > derived_max)
+            || self
+                .write_max_packets
+                .is_some_and(|value| value == 0 || usize::from(value) > derived_max)
+        {
+            return Err(VmnetProviderError::InvalidConfiguration);
+        }
+        Ok(self)
+    }
+
+    /// Returns the realized guest MAC.
+    #[must_use]
+    pub const fn mac(self) -> [u8; 6] {
+        self.mac
+    }
+
+    /// Returns the realized MTU.
+    #[must_use]
+    pub const fn effective_mtu(self) -> u16 {
+        self.effective_mtu
+    }
+
+    /// Returns the backend packet size excluding an optional direct header.
+    #[must_use]
+    pub const fn maximum_packet_bytes(self) -> u32 {
+        self.maximum_packet_bytes
+    }
+
+    /// Returns the optional opaque backend interface identity.
+    #[must_use]
+    pub const fn backend_interface_id(self) -> Option<[u8; BACKEND_INTERFACE_ID_BYTES]> {
+        self.backend_interface_id
+    }
+
+    /// Returns the optional backend read maximum.
+    #[must_use]
+    pub const fn read_max_packets(self) -> Option<u16> {
+        self.read_max_packets
+    }
+
+    /// Returns the optional backend write maximum.
+    #[must_use]
+    pub const fn write_max_packets(self) -> Option<u16> {
+        self.write_max_packets
+    }
+
+    /// Returns whether direct virtio headers are available.
+    #[must_use]
+    pub const fn direct_virtio_header_available(self) -> bool {
+        self.direct_virtio_header_available
+    }
+
+    /// Returns whether direct virtio headers are enabled.
+    #[must_use]
+    pub const fn direct_virtio_header_enabled(self) -> bool {
+        self.direct_virtio_header_enabled
+    }
+
+    /// Returns the exact provider packet-buffer size.
+    #[must_use]
+    pub fn packet_buffer_bytes(self) -> usize {
+        usize::try_from(self.maximum_packet_bytes)
+            .unwrap_or(0)
+            .saturating_add(if self.direct_virtio_header_enabled {
+                VIRTIO_HEADER_BYTES
+            } else {
+                0
+            })
+    }
+
+    /// Returns the effective read batch maximum.
+    #[must_use]
+    pub fn effective_read_max_packets(self) -> u16 {
+        self.read_max_packets
+            .unwrap_or_else(|| self.derived_batch_max())
+    }
+
+    /// Returns the effective write batch maximum.
+    #[must_use]
+    pub fn effective_write_max_packets(self) -> u16 {
+        self.write_max_packets
+            .unwrap_or_else(|| self.derived_batch_max())
+    }
+
+    fn derived_batch_max(self) -> u16 {
+        u16::try_from(
+            MAX_PACKET_COUNT.min(MAX_AGGREGATE_PACKET_BYTES / self.packet_buffer_bytes().max(1)),
+        )
+        .unwrap_or(1)
+    }
+}
+
+impl fmt::Debug for RealizedVmnetParameters {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("RealizedVmnetParameters(<redacted>)")
+    }
+}
+
+fn valid_unicast_mac(mac: [u8; 6]) -> bool {
+    mac != [0; 6] && mac != [0xff; 6] && mac.first().is_some_and(|byte| byte & 1 == 0)
+}
+
+/// Closed provider failure category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum ProviderStatus {
+    /// Policy slot is not authorized.
+    PolicyDenied = 1,
+    /// Active-interface capacity is exhausted.
+    ResourceLimit = 2,
+    /// Platform authorization rejected the operation.
+    NotAuthorized = 3,
+    /// Shared networking service is busy.
+    SharingServiceBusy = 4,
+    /// Typed request was rejected by the backend.
+    InvalidArgument = 5,
+    /// Backend memory allocation failed.
+    MemoryFailure = 6,
+    /// A packet exceeded the backend limit.
+    PacketTooBig = 7,
+    /// Backend buffering is exhausted.
+    BufferExhausted = 8,
+    /// Backend packet count is too large.
+    TooManyPackets = 9,
+    /// Start did not complete.
+    SetupIncomplete = 10,
+    /// A bounded backend operation failed.
+    BackendFailure = 11,
+    /// Cleanup ownership cannot be proved.
+    CleanupUncertain = 12,
+}
+
+impl ProviderStatus {
+    fn decode(value: u16) -> Result<Self, VmnetProviderError> {
+        match value {
+            1 => Ok(Self::PolicyDenied),
+            2 => Ok(Self::ResourceLimit),
+            3 => Ok(Self::NotAuthorized),
+            4 => Ok(Self::SharingServiceBusy),
+            5 => Ok(Self::InvalidArgument),
+            6 => Ok(Self::MemoryFailure),
+            7 => Ok(Self::PacketTooBig),
+            8 => Ok(Self::BufferExhausted),
+            9 => Ok(Self::TooManyPackets),
+            10 => Ok(Self::SetupIncomplete),
+            11 => Ok(Self::BackendFailure),
+            12 => Ok(Self::CleanupUncertain),
+            _ => Err(VmnetProviderError::InvalidFrame),
+        }
+    }
+}
+
+/// Cleanup certainty returned by stop or cancellation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProviderCleanup {
+    /// Every owned interface/resource was retired.
+    Complete = 1,
+    /// Cleanup could not be confirmed.
+    Uncertain = 2,
+}
+
+impl ProviderCleanup {
+    fn decode(value: u8) -> Result<Self, VmnetProviderError> {
+        match value {
+            1 => Ok(Self::Complete),
+            2 => Ok(Self::Uncertain),
+            _ => Err(VmnetProviderError::InvalidFrame),
+        }
+    }
+}
+
+/// Session cancellation category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProviderCancelReason {
+    /// The worker no longer needs the session.
+    Worker = 1,
+    /// The launcher is terminating the session.
+    Launcher = 2,
+}
+
+impl ProviderCancelReason {
+    fn decode(value: u8) -> Result<Self, VmnetProviderError> {
+        match value {
+            1 => Ok(Self::Worker),
+            2 => Ok(Self::Launcher),
+            _ => Err(VmnetProviderError::InvalidFrame),
+        }
+    }
+}
+
+/// Redacted terminal protocol category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProviderTerminalCode {
+    /// Peer input violated the protocol.
+    Protocol = 1,
+    /// A local backend operation failed.
+    Backend = 2,
+    /// Cleanup ownership became uncertain.
+    Cleanup = 3,
+    /// Supervising process requested termination.
+    Supervisor = 4,
+}
+
+impl ProviderTerminalCode {
+    fn decode(value: u8) -> Result<Self, VmnetProviderError> {
+        match value {
+            1 => Ok(Self::Protocol),
+            2 => Ok(Self::Backend),
+            3 => Ok(Self::Cleanup),
+            4 => Ok(Self::Supervisor),
+            _ => Err(VmnetProviderError::InvalidFrame),
+        }
+    }
+}
+
+/// Per-interface backend operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProviderOperation {
+    /// Read one bounded packet batch.
+    Read = 1,
+    /// Write one bounded packet batch.
+    Write = 2,
+}
+
+impl ProviderOperation {
+    fn decode(value: u8) -> Result<Self, VmnetProviderError> {
+        match value {
+            1 => Ok(Self::Read),
+            2 => Ok(Self::Write),
+            _ => Err(VmnetProviderError::InvalidFrame),
+        }
+    }
+}
+
+/// Canonical ordered packet batch.
+#[derive(Clone, PartialEq, Eq)]
+pub struct VmnetPacketBatch {
+    lengths: Vec<u32>,
+    bytes: Vec<u8>,
+}
+
+impl VmnetPacketBatch {
+    /// Constructs a canonical read result; the packet list may be empty.
+    pub fn read(packets: &[&[u8]]) -> Result<Self, VmnetProviderError> {
+        Self::from_packets(packets, true)
+    }
+
+    /// Constructs a canonical nonempty write request.
+    pub fn write(packets: &[&[u8]]) -> Result<Self, VmnetProviderError> {
+        Self::from_packets(packets, false)
+    }
+
+    fn from_packets(packets: &[&[u8]], allow_empty: bool) -> Result<Self, VmnetProviderError> {
+        if (!allow_empty && packets.is_empty()) || packets.len() > MAX_PACKET_COUNT {
+            return Err(VmnetProviderError::InvalidConfiguration);
+        }
+        let aggregate = packets.iter().try_fold(0_usize, |total, packet| {
+            if packet.is_empty() || packet.len() > MAX_PACKET_BUFFER_BYTES {
+                return Err(VmnetProviderError::InvalidConfiguration);
+            }
+            total
+                .checked_add(packet.len())
+                .filter(|total| *total <= MAX_AGGREGATE_PACKET_BYTES)
+                .ok_or(VmnetProviderError::LimitExceeded)
+        })?;
+        let mut lengths = Vec::new();
+        lengths
+            .try_reserve_exact(packets.len())
+            .map_err(|_| VmnetProviderError::LimitExceeded)?;
+        let mut bytes = Vec::new();
+        bytes
+            .try_reserve_exact(aggregate)
+            .map_err(|_| VmnetProviderError::LimitExceeded)?;
+        for packet in packets {
+            lengths
+                .push(u32::try_from(packet.len()).map_err(|_| VmnetProviderError::LimitExceeded)?);
+            bytes.extend_from_slice(packet);
+        }
+        Ok(Self { lengths, bytes })
+    }
+
+    fn from_parts(
+        lengths: Vec<u32>,
+        bytes: Vec<u8>,
+        allow_empty: bool,
+    ) -> Result<Self, VmnetProviderError> {
+        if (!allow_empty && lengths.is_empty()) || lengths.len() > MAX_PACKET_COUNT {
+            return Err(VmnetProviderError::InvalidFrame);
+        }
+        let total = lengths.iter().try_fold(0_usize, |total, length| {
+            let length = usize::try_from(*length).map_err(|_| VmnetProviderError::InvalidFrame)?;
+            if length == 0 || length > MAX_PACKET_BUFFER_BYTES {
+                return Err(VmnetProviderError::InvalidFrame);
+            }
+            total
+                .checked_add(length)
+                .filter(|total| *total <= MAX_AGGREGATE_PACKET_BYTES)
+                .ok_or(VmnetProviderError::LimitExceeded)
+        })?;
+        if total != bytes.len() {
+            return Err(VmnetProviderError::InvalidFrame);
+        }
+        Ok(Self { lengths, bytes })
+    }
+
+    /// Returns the packet count.
+    #[must_use]
+    pub fn packet_count(&self) -> usize {
+        self.lengths.len()
+    }
+
+    /// Returns the aggregate packet byte count.
+    #[must_use]
+    pub fn aggregate_bytes(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Borrows one packet by canonical index.
+    #[must_use]
+    pub fn packet(&self, requested_index: usize) -> Option<&[u8]> {
+        let mut offset = 0_usize;
+        for (index, length) in self.lengths.iter().copied().enumerate() {
+            let length = usize::try_from(length).ok()?;
+            let end = offset.checked_add(length)?;
+            if index == requested_index {
+                return self.bytes.get(offset..end);
+            }
+            offset = end;
+        }
+        None
+    }
+
+    pub(crate) fn fits(&self, maximum_packet_bytes: usize, maximum_packets: usize) -> bool {
+        self.packet_count() <= maximum_packets
+            && self.lengths.iter().copied().all(|length| {
+                usize::try_from(length).is_ok_and(|length| length <= maximum_packet_bytes)
+            })
+    }
+}
+
+impl fmt::Debug for VmnetPacketBatch {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VmnetPacketBatch")
+            .field("packet_count", &self.lengths.len())
+            .field("bytes", &"<redacted>")
+            .finish()
+    }
+}
+
+/// One frame and its atomically associated optional transferred stream.
+///
+/// Constructors are private to the protocol state and transport modules.
+/// Application adapters can inspect a frame but cannot detach a stream before
+/// the matching state transition accepts it.
+pub struct ProviderEnvelope {
+    frame: ProviderFrame,
+    stream: Option<UnixStream>,
+}
+
+impl ProviderEnvelope {
+    pub(crate) const fn frame_only(frame: ProviderFrame) -> Self {
+        Self {
+            frame,
+            stream: None,
+        }
+    }
+
+    pub(crate) const fn with_stream(frame: ProviderFrame, stream: UnixStream) -> Self {
+        Self {
+            frame,
+            stream: Some(stream),
+        }
+    }
+
+    /// Borrows the decoded frame without exposing descriptor ownership.
+    #[must_use]
+    pub const fn frame(&self) -> &ProviderFrame {
+        &self.frame
+    }
+
+    /// Returns whether this envelope owns the sole transferred stream.
+    #[must_use]
+    pub const fn has_stream(&self) -> bool {
+        self.stream.is_some()
+    }
+
+    pub(crate) fn into_parts(self) -> (ProviderFrame, Option<UnixStream>) {
+        (self.frame, self.stream)
+    }
+}
+
+impl fmt::Debug for ProviderEnvelope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderEnvelope")
+            .field("frame", &self.frame)
+            .field("stream", &self.stream.as_ref().map(|_| "<owned>"))
+            .finish()
+    }
+}
+
+/// Closed control-channel message set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ControlMessage {
+    /// Client role and session preamble.
+    Hello,
+    /// Broker acknowledgement.
+    HelloAck,
+    /// Starts one interface using a fixed policy slot.
+    Start {
+        /// Bootstrap-owned selector slot.
+        policy_slot: VmnetPolicySlot,
+        /// Optional typed device request.
+        requested: RequestedVmnetParameters,
+    },
+    /// Returns realized parameters and declares one transferred data stream.
+    Started {
+        /// Validated realized backend parameters.
+        parameters: RealizedVmnetParameters,
+    },
+    /// Returns a typed start failure with no descriptor.
+    StartFailed {
+        /// Redacted failure category.
+        status: ProviderStatus,
+    },
+    /// Requests owner stop and process retirement.
+    Stop,
+    /// Reports broker-side interface retirement.
+    Stopped {
+        /// Cleanup certainty.
+        cleanup: ProviderCleanup,
+    },
+    /// Cancels every pending and active generation.
+    Cancel {
+        /// Stable cancellation source.
+        reason: ProviderCancelReason,
+    },
+    /// Acknowledges session-wide cancellation.
+    Cancelled {
+        /// Aggregate cleanup certainty.
+        cleanup: ProviderCleanup,
+    },
+    /// Requests orderly empty-session shutdown.
+    Shutdown,
+    /// Acknowledges orderly shutdown.
+    ShutdownAck,
+    /// Reports a terminal failure.
+    Terminal {
+        /// Stable terminal category.
+        code: ProviderTerminalCode,
+    },
+}
+
+/// Closed per-interface data-channel message set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataMessage {
+    /// Client repeats the exact transferred-stream binding.
+    Hello,
+    /// Owner acknowledges the exact binding.
+    HelloAck,
+    /// Owner publishes one bounded readiness edge.
+    Readiness {
+        /// Contiguous per-interface readiness epoch.
+        epoch: VmnetReadinessEpoch,
+        /// Bounded backend packet estimate.
+        estimated_packets: u16,
+    },
+    /// Client requests up to a bounded packet count.
+    Read {
+        /// Nonzero requested packet maximum.
+        max_packets: u16,
+    },
+    /// Owner returns a zero-to-requested packet prefix.
+    ReadResult {
+        /// Exact client request sequence.
+        request: VmnetSequence,
+        /// Canonical read batch.
+        packets: VmnetPacketBatch,
+    },
+    /// Client submits one nonempty canonical packet batch.
+    Write {
+        /// Canonical write batch.
+        packets: VmnetPacketBatch,
+    },
+    /// Owner returns the successfully written prefix length.
+    WriteResult {
+        /// Exact client request sequence.
+        request: VmnetSequence,
+        /// Zero-to-requested completed prefix.
+        completed_packets: u16,
+    },
+    /// Owner reports a terminal read/write failure.
+    OperationFailed {
+        /// Exact client request sequence.
+        request: VmnetSequence,
+        /// Failed operation.
+        operation: ProviderOperation,
+        /// Redacted backend category.
+        status: ProviderStatus,
+    },
+    /// Requests callback drain and backend stop.
+    Stop,
+    /// Reports backend stop certainty.
+    Stopped {
+        /// Cleanup certainty.
+        cleanup: ProviderCleanup,
+    },
+    /// Requests closure after a complete stop.
+    Shutdown,
+    /// Acknowledges orderly stream closure.
+    ShutdownAck,
+    /// Reports a terminal per-interface failure.
+    Terminal {
+        /// Stable terminal category.
+        code: ProviderTerminalCode,
+    },
+}
+
+/// Provider frame channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderChannel {
+    /// Session-wide broker control.
+    Control,
+    /// One exact interface generation's packet plane.
+    Data,
+}
+
+impl ProviderChannel {
+    const fn byte(self) -> u8 {
+        match self {
+            Self::Control => CONTROL_CHANNEL,
+            Self::Data => DATA_CHANNEL,
+        }
+    }
+
+    fn decode(value: u8) -> Result<Self, VmnetProviderError> {
+        match value {
+            CONTROL_CHANNEL => Ok(Self::Control),
+            DATA_CHANNEL => Ok(Self::Data),
+            _ => Err(VmnetProviderError::InvalidFrame),
+        }
+    }
+}
+
+/// One decoded provider frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderFrame {
+    session: SessionId,
+    interface: Option<VmnetInterfaceId>,
+    generation: Option<VmnetGeneration>,
+    sequence: VmnetSequence,
+    message: ProviderMessage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ProviderMessage {
+    Control(ControlMessage),
+    Data(DataMessage),
+}
+
+impl ProviderFrame {
+    /// Constructs a shape-checked control frame.
+    pub fn control(
+        session: SessionId,
+        interface: Option<VmnetInterfaceId>,
+        generation: Option<VmnetGeneration>,
+        sequence: VmnetSequence,
+        message: ControlMessage,
+    ) -> Result<Self, VmnetProviderError> {
+        let frame = Self {
+            session,
+            interface,
+            generation,
+            sequence,
+            message: ProviderMessage::Control(message),
+        };
+        frame.validate_shape(false)?;
+        Ok(frame)
+    }
+
+    /// Constructs a shape-checked per-interface data frame.
+    pub fn data(
+        session: SessionId,
+        interface: VmnetInterfaceId,
+        generation: VmnetGeneration,
+        sequence: VmnetSequence,
+        message: DataMessage,
+    ) -> Result<Self, VmnetProviderError> {
+        let frame = Self {
+            session,
+            interface: Some(interface),
+            generation: Some(generation),
+            sequence,
+            message: ProviderMessage::Data(message),
+        };
+        frame.validate_shape(false)?;
+        Ok(frame)
+    }
+
+    /// Returns the bound lifecycle session.
+    #[must_use]
+    pub const fn session(&self) -> SessionId {
+        self.session
+    }
+
+    /// Returns the optional interface scope.
+    #[must_use]
+    pub const fn interface(&self) -> Option<VmnetInterfaceId> {
+        self.interface
+    }
+
+    /// Returns the optional interface generation.
+    #[must_use]
+    pub const fn generation(&self) -> Option<VmnetGeneration> {
+        self.generation
+    }
+
+    /// Returns the exact sender sequence.
+    #[must_use]
+    pub const fn sequence(&self) -> VmnetSequence {
+        self.sequence
+    }
+
+    /// Returns the closed channel.
+    #[must_use]
+    pub const fn channel(&self) -> ProviderChannel {
+        match self.message {
+            ProviderMessage::Control(_) => ProviderChannel::Control,
+            ProviderMessage::Data(_) => ProviderChannel::Data,
+        }
+    }
+
+    /// Borrows the control message when this is a control frame.
+    #[must_use]
+    pub const fn control_message(&self) -> Option<&ControlMessage> {
+        match &self.message {
+            ProviderMessage::Control(message) => Some(message),
+            ProviderMessage::Data(_) => None,
+        }
+    }
+
+    /// Borrows the data message when this is a data frame.
+    #[must_use]
+    pub const fn data_message(&self) -> Option<&DataMessage> {
+        match &self.message {
+            ProviderMessage::Control(_) => None,
+            ProviderMessage::Data(message) => Some(message),
+        }
+    }
+
+    /// Returns the exact descriptor count required by this frame.
+    #[must_use]
+    pub const fn descriptor_count(&self) -> u8 {
+        match self.message {
+            ProviderMessage::Control(ControlMessage::Started { .. }) => 1,
+            _ => 0,
+        }
+    }
+
+    fn validate_shape(&self, wire: bool) -> Result<(), VmnetProviderError> {
+        let invalid = || {
+            if wire {
+                VmnetProviderError::InvalidFrame
+            } else {
+                VmnetProviderError::InvalidConfiguration
+            }
+        };
+        if self.session.is_pre_session() {
+            return Err(invalid());
+        }
+        match &self.message {
+            ProviderMessage::Control(message) => match message {
+                ControlMessage::Start { .. } | ControlMessage::StartFailed { .. } => {
+                    if self.interface.is_none() || self.generation.is_some() {
+                        return Err(invalid());
+                    }
+                }
+                ControlMessage::Started { .. }
+                | ControlMessage::Stop
+                | ControlMessage::Stopped { .. } => {
+                    if self.interface.is_none() || self.generation.is_none() {
+                        return Err(invalid());
+                    }
+                }
+                ControlMessage::Hello
+                | ControlMessage::HelloAck
+                | ControlMessage::Cancel { .. }
+                | ControlMessage::Cancelled { .. }
+                | ControlMessage::Shutdown
+                | ControlMessage::ShutdownAck
+                | ControlMessage::Terminal { .. } => {
+                    if self.interface.is_some() || self.generation.is_some() {
+                        return Err(invalid());
+                    }
+                }
+            },
+            ProviderMessage::Data(message) => {
+                if self.interface.is_none() || self.generation.is_none() {
+                    return Err(invalid());
+                }
+                match message {
+                    DataMessage::Read { max_packets } => {
+                        if *max_packets == 0 || usize::from(*max_packets) > MAX_PACKET_COUNT {
+                            return Err(invalid());
+                        }
+                    }
+                    DataMessage::Readiness {
+                        estimated_packets, ..
+                    } => {
+                        if *estimated_packets == 0
+                            || usize::from(*estimated_packets) > MAX_PACKET_COUNT
+                        {
+                            return Err(invalid());
+                        }
+                    }
+                    DataMessage::Write { packets } if packets.packet_count() == 0 => {
+                        return Err(invalid());
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Shape-checked provider header decoded before body allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderFrameHeader {
+    channel: ProviderChannel,
+    kind: u8,
+    body_len: usize,
+    descriptor_count: u8,
+    session: SessionId,
+    interface: Option<VmnetInterfaceId>,
+    generation: Option<VmnetGeneration>,
+    sequence: VmnetSequence,
+}
+
+impl ProviderFrameHeader {
+    /// Returns the bounded body length.
+    #[must_use]
+    pub const fn body_len(self) -> usize {
+        self.body_len
+    }
+
+    /// Returns the declared descriptor count.
+    #[must_use]
+    pub const fn descriptor_count(self) -> u8 {
+        self.descriptor_count
+    }
+
+    /// Returns the frame channel.
+    #[must_use]
+    pub const fn channel(self) -> ProviderChannel {
+        self.channel
+    }
+}
+
+/// Encodes one complete canonical provider frame.
+pub fn encode_frame(frame: &ProviderFrame) -> Result<Vec<u8>, VmnetProviderError> {
+    frame.validate_shape(false)?;
+    let (kind, body) = encode_message(&frame.message)?;
+    if body.len() > MAX_BODY_BYTES {
+        return Err(VmnetProviderError::LimitExceeded);
+    }
+    let body_len = u32::try_from(body.len()).map_err(|_| VmnetProviderError::LimitExceeded)?;
+    let mut encoded = Vec::new();
+    encoded
+        .try_reserve_exact(HEADER_BYTES + body.len())
+        .map_err(|_| VmnetProviderError::LimitExceeded)?;
+    encoded.extend_from_slice(&MAGIC);
+    encoded.extend_from_slice(&VERSION.to_be_bytes());
+    encoded.push(frame.channel().byte());
+    encoded.push(kind);
+    encoded.extend_from_slice(&body_len.to_be_bytes());
+    encoded.push(frame.descriptor_count());
+    encoded.extend_from_slice(&[0; 7]);
+    encoded.extend_from_slice(frame.session.as_bytes());
+    encoded.extend_from_slice(
+        &frame
+            .interface
+            .map_or(0, VmnetInterfaceId::get)
+            .to_be_bytes(),
+    );
+    encoded.extend_from_slice(&[0; 4]);
+    encoded.extend_from_slice(
+        &frame
+            .generation
+            .map_or(0, VmnetGeneration::get)
+            .to_be_bytes(),
+    );
+    encoded.extend_from_slice(&frame.sequence.get().to_be_bytes());
+    encoded.extend_from_slice(&body);
+    Ok(encoded)
+}
+
+/// Decodes and validates one exact provider header.
+pub fn decode_header(encoded: &[u8]) -> Result<ProviderFrameHeader, VmnetProviderError> {
+    if encoded.len() != HEADER_BYTES
+        || encoded.get(0..8) != Some(MAGIC.as_slice())
+        || read_u16(encoded, 8)? != VERSION
+        || encoded
+            .get(17..24)
+            .is_none_or(|reserved| reserved != [0; 7])
+        || encoded
+            .get(60..64)
+            .is_none_or(|reserved| reserved != [0; 4])
+    {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    let channel = ProviderChannel::decode(read_u8(encoded, 10)?)?;
+    let kind = read_u8(encoded, 11)?;
+    let body_len =
+        usize::try_from(read_u32(encoded, 12)?).map_err(|_| VmnetProviderError::InvalidFrame)?;
+    let descriptor_count = read_u8(encoded, 16)?;
+    let session = SessionId::from_bytes(read_array(encoded, 24)?);
+    if session.is_pre_session() {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    if body_len > MAX_BODY_BYTES {
+        return Err(VmnetProviderError::LimitExceeded);
+    }
+    let raw_interface = read_u32(encoded, 56)?;
+    let raw_generation = read_u64(encoded, 64)?;
+    let interface = (raw_interface != 0)
+        .then(|| VmnetInterfaceId::decode(raw_interface))
+        .transpose()?;
+    let generation = (raw_generation != 0)
+        .then(|| VmnetGeneration::decode(raw_generation))
+        .transpose()?;
+    let sequence = VmnetSequence::decode(read_u64(encoded, 72)?)?;
+    validate_header_shape(
+        channel,
+        kind,
+        body_len,
+        descriptor_count,
+        interface,
+        generation,
+    )?;
+    Ok(ProviderFrameHeader {
+        channel,
+        kind,
+        body_len,
+        descriptor_count,
+        session,
+        interface,
+        generation,
+        sequence,
+    })
+}
+
+/// Decodes one exact complete canonical provider frame.
+pub fn decode_frame(encoded: &[u8]) -> Result<ProviderFrame, VmnetProviderError> {
+    if encoded.len() < HEADER_BYTES {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    let header_bytes = encoded
+        .get(..HEADER_BYTES)
+        .ok_or(VmnetProviderError::InvalidFrame)?;
+    let header = decode_header(header_bytes)?;
+    let total = HEADER_BYTES
+        .checked_add(header.body_len)
+        .ok_or(VmnetProviderError::LimitExceeded)?;
+    if encoded.len() != total {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    let body = encoded
+        .get(HEADER_BYTES..total)
+        .ok_or(VmnetProviderError::InvalidFrame)?;
+    let message = decode_message(header.channel, header.kind, body)?;
+    let frame = ProviderFrame {
+        session: header.session,
+        interface: header.interface,
+        generation: header.generation,
+        sequence: header.sequence,
+        message,
+    };
+    frame.validate_shape(true)?;
+    if frame.descriptor_count() != header.descriptor_count {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    Ok(frame)
+}
+
+fn validate_header_shape(
+    channel: ProviderChannel,
+    kind: u8,
+    body_len: usize,
+    descriptor_count: u8,
+    interface: Option<VmnetInterfaceId>,
+    generation: Option<VmnetGeneration>,
+) -> Result<(), VmnetProviderError> {
+    let (expected_channel, scope, expected_descriptors, minimum, maximum) = kind_shape(kind)?;
+    if channel != expected_channel
+        || descriptor_count != expected_descriptors
+        || body_len < minimum
+        || body_len > maximum
+    {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    let scope_valid = match scope {
+        0 => interface.is_none() && generation.is_none(),
+        1 => interface.is_some() && generation.is_none(),
+        2 => interface.is_some() && generation.is_some(),
+        _ => false,
+    };
+    scope_valid
+        .then_some(())
+        .ok_or(VmnetProviderError::InvalidFrame)
+}
+
+fn kind_shape(kind: u8) -> Result<(ProviderChannel, u8, u8, usize, usize), VmnetProviderError> {
+    let fixed = |channel, scope, descriptors, bytes| (channel, scope, descriptors, bytes, bytes);
+    Ok(match kind {
+        CONTROL_HELLO | CONTROL_HELLO_ACK | CONTROL_SHUTDOWN | CONTROL_SHUTDOWN_ACK => {
+            fixed(ProviderChannel::Control, 0, 0, 0)
+        }
+        CONTROL_START => fixed(ProviderChannel::Control, 1, 0, 16),
+        CONTROL_STARTED => fixed(ProviderChannel::Control, 2, 1, 40),
+        CONTROL_START_FAILED => fixed(ProviderChannel::Control, 1, 0, 8),
+        CONTROL_STOP => fixed(ProviderChannel::Control, 2, 0, 0),
+        CONTROL_STOPPED => fixed(ProviderChannel::Control, 2, 0, 8),
+        CONTROL_CANCEL | CONTROL_CANCELLED | CONTROL_TERMINAL => {
+            fixed(ProviderChannel::Control, 0, 0, 8)
+        }
+        DATA_HELLO | DATA_HELLO_ACK | DATA_STOP | DATA_SHUTDOWN | DATA_SHUTDOWN_ACK => {
+            fixed(ProviderChannel::Data, 2, 0, 0)
+        }
+        DATA_READINESS => fixed(ProviderChannel::Data, 2, 0, 16),
+        DATA_READ => fixed(ProviderChannel::Data, 2, 0, 8),
+        DATA_READ_RESULT => (ProviderChannel::Data, 2, 0, 16, MAX_BODY_BYTES),
+        DATA_WRITE => (ProviderChannel::Data, 2, 0, 8 + 4 + 1, MAX_BODY_BYTES - 8),
+        DATA_WRITE_RESULT | DATA_OPERATION_FAILED => fixed(ProviderChannel::Data, 2, 0, 16),
+        DATA_STOPPED | DATA_TERMINAL => fixed(ProviderChannel::Data, 2, 0, 8),
+        _ => return Err(VmnetProviderError::InvalidFrame),
+    })
+}
+
+fn encode_message(message: &ProviderMessage) -> Result<(u8, Vec<u8>), VmnetProviderError> {
+    let mut body = Vec::new();
+    let kind = match message {
+        ProviderMessage::Control(message) => match message {
+            ControlMessage::Hello => CONTROL_HELLO,
+            ControlMessage::HelloAck => CONTROL_HELLO_ACK,
+            ControlMessage::Start {
+                policy_slot,
+                requested,
+            } => {
+                encode_requested(&mut body, *policy_slot, *requested);
+                CONTROL_START
+            }
+            ControlMessage::Started { parameters } => {
+                encode_realized(&mut body, *parameters);
+                CONTROL_STARTED
+            }
+            ControlMessage::StartFailed { status } => {
+                body.extend_from_slice(&(*status as u16).to_be_bytes());
+                body.extend_from_slice(&[0; 6]);
+                CONTROL_START_FAILED
+            }
+            ControlMessage::Stop => CONTROL_STOP,
+            ControlMessage::Stopped { cleanup } => {
+                body.push(*cleanup as u8);
+                body.extend_from_slice(&[0; 7]);
+                CONTROL_STOPPED
+            }
+            ControlMessage::Cancel { reason } => {
+                body.push(*reason as u8);
+                body.extend_from_slice(&[0; 7]);
+                CONTROL_CANCEL
+            }
+            ControlMessage::Cancelled { cleanup } => {
+                body.push(*cleanup as u8);
+                body.extend_from_slice(&[0; 7]);
+                CONTROL_CANCELLED
+            }
+            ControlMessage::Shutdown => CONTROL_SHUTDOWN,
+            ControlMessage::ShutdownAck => CONTROL_SHUTDOWN_ACK,
+            ControlMessage::Terminal { code } => {
+                body.push(*code as u8);
+                body.extend_from_slice(&[0; 7]);
+                CONTROL_TERMINAL
+            }
+        },
+        ProviderMessage::Data(message) => match message {
+            DataMessage::Hello => DATA_HELLO,
+            DataMessage::HelloAck => DATA_HELLO_ACK,
+            DataMessage::Readiness {
+                epoch,
+                estimated_packets,
+            } => {
+                body.extend_from_slice(&epoch.get().to_be_bytes());
+                body.extend_from_slice(&estimated_packets.to_be_bytes());
+                body.extend_from_slice(&[0; 6]);
+                DATA_READINESS
+            }
+            DataMessage::Read { max_packets } => {
+                body.extend_from_slice(&max_packets.to_be_bytes());
+                body.extend_from_slice(&[0; 6]);
+                DATA_READ
+            }
+            DataMessage::ReadResult { request, packets } => {
+                body.extend_from_slice(&request.get().to_be_bytes());
+                encode_batch(&mut body, packets)?;
+                DATA_READ_RESULT
+            }
+            DataMessage::Write { packets } => {
+                encode_batch(&mut body, packets)?;
+                DATA_WRITE
+            }
+            DataMessage::WriteResult {
+                request,
+                completed_packets,
+            } => {
+                body.extend_from_slice(&request.get().to_be_bytes());
+                body.extend_from_slice(&completed_packets.to_be_bytes());
+                body.extend_from_slice(&[0; 6]);
+                DATA_WRITE_RESULT
+            }
+            DataMessage::OperationFailed {
+                request,
+                operation,
+                status,
+            } => {
+                body.extend_from_slice(&request.get().to_be_bytes());
+                body.push(*operation as u8);
+                body.push(0);
+                body.extend_from_slice(&(*status as u16).to_be_bytes());
+                body.extend_from_slice(&[0; 4]);
+                DATA_OPERATION_FAILED
+            }
+            DataMessage::Stop => DATA_STOP,
+            DataMessage::Stopped { cleanup } => {
+                body.push(*cleanup as u8);
+                body.extend_from_slice(&[0; 7]);
+                DATA_STOPPED
+            }
+            DataMessage::Shutdown => DATA_SHUTDOWN,
+            DataMessage::ShutdownAck => DATA_SHUTDOWN_ACK,
+            DataMessage::Terminal { code } => {
+                body.push(*code as u8);
+                body.extend_from_slice(&[0; 7]);
+                DATA_TERMINAL
+            }
+        },
+    };
+    Ok((kind, body))
+}
+
+fn decode_message(
+    channel: ProviderChannel,
+    kind: u8,
+    body: &[u8],
+) -> Result<ProviderMessage, VmnetProviderError> {
+    let message = match (channel, kind) {
+        (ProviderChannel::Control, CONTROL_HELLO) => {
+            ProviderMessage::Control(ControlMessage::Hello)
+        }
+        (ProviderChannel::Control, CONTROL_HELLO_ACK) => {
+            ProviderMessage::Control(ControlMessage::HelloAck)
+        }
+        (ProviderChannel::Control, CONTROL_START) => {
+            let (policy_slot, requested) = decode_requested(body)?;
+            ProviderMessage::Control(ControlMessage::Start {
+                policy_slot,
+                requested,
+            })
+        }
+        (ProviderChannel::Control, CONTROL_STARTED) => {
+            ProviderMessage::Control(ControlMessage::Started {
+                parameters: decode_realized(body)?,
+            })
+        }
+        (ProviderChannel::Control, CONTROL_START_FAILED) => {
+            require_zero(body, 2, 8)?;
+            ProviderMessage::Control(ControlMessage::StartFailed {
+                status: ProviderStatus::decode(read_u16(body, 0)?)?,
+            })
+        }
+        (ProviderChannel::Control, CONTROL_STOP) => ProviderMessage::Control(ControlMessage::Stop),
+        (ProviderChannel::Control, CONTROL_STOPPED) => {
+            require_zero(body, 1, 8)?;
+            ProviderMessage::Control(ControlMessage::Stopped {
+                cleanup: ProviderCleanup::decode(read_u8(body, 0)?)?,
+            })
+        }
+        (ProviderChannel::Control, CONTROL_CANCEL) => {
+            require_zero(body, 1, 8)?;
+            ProviderMessage::Control(ControlMessage::Cancel {
+                reason: ProviderCancelReason::decode(read_u8(body, 0)?)?,
+            })
+        }
+        (ProviderChannel::Control, CONTROL_CANCELLED) => {
+            require_zero(body, 1, 8)?;
+            ProviderMessage::Control(ControlMessage::Cancelled {
+                cleanup: ProviderCleanup::decode(read_u8(body, 0)?)?,
+            })
+        }
+        (ProviderChannel::Control, CONTROL_SHUTDOWN) => {
+            ProviderMessage::Control(ControlMessage::Shutdown)
+        }
+        (ProviderChannel::Control, CONTROL_SHUTDOWN_ACK) => {
+            ProviderMessage::Control(ControlMessage::ShutdownAck)
+        }
+        (ProviderChannel::Control, CONTROL_TERMINAL) => {
+            require_zero(body, 1, 8)?;
+            ProviderMessage::Control(ControlMessage::Terminal {
+                code: ProviderTerminalCode::decode(read_u8(body, 0)?)?,
+            })
+        }
+        (ProviderChannel::Data, DATA_HELLO) => ProviderMessage::Data(DataMessage::Hello),
+        (ProviderChannel::Data, DATA_HELLO_ACK) => ProviderMessage::Data(DataMessage::HelloAck),
+        (ProviderChannel::Data, DATA_READINESS) => {
+            require_zero(body, 10, 16)?;
+            ProviderMessage::Data(DataMessage::Readiness {
+                epoch: VmnetReadinessEpoch::decode(read_u64(body, 0)?)?,
+                estimated_packets: read_u16(body, 8)?,
+            })
+        }
+        (ProviderChannel::Data, DATA_READ) => {
+            require_zero(body, 2, 8)?;
+            ProviderMessage::Data(DataMessage::Read {
+                max_packets: read_u16(body, 0)?,
+            })
+        }
+        (ProviderChannel::Data, DATA_READ_RESULT) => {
+            ProviderMessage::Data(DataMessage::ReadResult {
+                request: VmnetSequence::decode(read_u64(body, 0)?)?,
+                packets: decode_batch(
+                    body.get(8..).ok_or(VmnetProviderError::InvalidFrame)?,
+                    true,
+                )?,
+            })
+        }
+        (ProviderChannel::Data, DATA_WRITE) => ProviderMessage::Data(DataMessage::Write {
+            packets: decode_batch(body, false)?,
+        }),
+        (ProviderChannel::Data, DATA_WRITE_RESULT) => {
+            require_zero(body, 10, 16)?;
+            ProviderMessage::Data(DataMessage::WriteResult {
+                request: VmnetSequence::decode(read_u64(body, 0)?)?,
+                completed_packets: read_u16(body, 8)?,
+            })
+        }
+        (ProviderChannel::Data, DATA_OPERATION_FAILED) => {
+            if read_u8(body, 9)? != 0 {
+                return Err(VmnetProviderError::InvalidFrame);
+            }
+            require_zero(body, 12, 16)?;
+            ProviderMessage::Data(DataMessage::OperationFailed {
+                request: VmnetSequence::decode(read_u64(body, 0)?)?,
+                operation: ProviderOperation::decode(read_u8(body, 8)?)?,
+                status: ProviderStatus::decode(read_u16(body, 10)?)?,
+            })
+        }
+        (ProviderChannel::Data, DATA_STOP) => ProviderMessage::Data(DataMessage::Stop),
+        (ProviderChannel::Data, DATA_STOPPED) => {
+            require_zero(body, 1, 8)?;
+            ProviderMessage::Data(DataMessage::Stopped {
+                cleanup: ProviderCleanup::decode(read_u8(body, 0)?)?,
+            })
+        }
+        (ProviderChannel::Data, DATA_SHUTDOWN) => ProviderMessage::Data(DataMessage::Shutdown),
+        (ProviderChannel::Data, DATA_SHUTDOWN_ACK) => {
+            ProviderMessage::Data(DataMessage::ShutdownAck)
+        }
+        (ProviderChannel::Data, DATA_TERMINAL) => {
+            require_zero(body, 1, 8)?;
+            ProviderMessage::Data(DataMessage::Terminal {
+                code: ProviderTerminalCode::decode(read_u8(body, 0)?)?,
+            })
+        }
+        _ => return Err(VmnetProviderError::InvalidFrame),
+    };
+    Ok(message)
+}
+
+fn encode_requested(
+    body: &mut Vec<u8>,
+    policy_slot: VmnetPolicySlot,
+    requested: RequestedVmnetParameters,
+) {
+    let flags = (if requested.mac.is_some() {
+        REQUEST_MAC_PRESENT
+    } else {
+        0
+    }) | (if requested.mtu.is_some() {
+        REQUEST_MTU_PRESENT
+    } else {
+        0
+    });
+    body.push(policy_slot as u8);
+    body.push(flags);
+    body.extend_from_slice(&[0; 2]);
+    body.extend_from_slice(&requested.mac.unwrap_or([0; 6]));
+    body.extend_from_slice(&requested.mtu.unwrap_or(0).to_be_bytes());
+    body.extend_from_slice(&[0; 4]);
+}
+
+fn decode_requested(
+    body: &[u8],
+) -> Result<(VmnetPolicySlot, RequestedVmnetParameters), VmnetProviderError> {
+    let flags = read_u8(body, 1)?;
+    if flags & !REQUEST_FLAGS != 0 {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    require_zero(body, 2, 4)?;
+    require_zero(body, 12, 16)?;
+    let raw_mac: [u8; 6] = read_array(body, 4)?;
+    let raw_mtu = read_u16(body, 10)?;
+    if flags & REQUEST_MAC_PRESENT == 0 && raw_mac != [0; 6]
+        || flags & REQUEST_MTU_PRESENT == 0 && raw_mtu != 0
+    {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    let requested = RequestedVmnetParameters::new(
+        (flags & REQUEST_MAC_PRESENT != 0).then_some(raw_mac),
+        (flags & REQUEST_MTU_PRESENT != 0).then_some(raw_mtu),
+    )
+    .map_err(|_| VmnetProviderError::InvalidFrame)?;
+    Ok((VmnetPolicySlot::decode(read_u8(body, 0)?)?, requested))
+}
+
+fn encode_realized(body: &mut Vec<u8>, parameters: RealizedVmnetParameters) {
+    let flags = (if parameters.backend_interface_id.is_some() {
+        REALIZED_BACKEND_ID_PRESENT
+    } else {
+        0
+    }) | (if parameters.read_max_packets.is_some() {
+        REALIZED_READ_MAX_PRESENT
+    } else {
+        0
+    }) | (if parameters.write_max_packets.is_some() {
+        REALIZED_WRITE_MAX_PRESENT
+    } else {
+        0
+    }) | (if parameters.direct_virtio_header_available {
+        REALIZED_DIRECT_AVAILABLE
+    } else {
+        0
+    }) | (if parameters.direct_virtio_header_enabled {
+        REALIZED_DIRECT_ENABLED
+    } else {
+        0
+    });
+    body.extend_from_slice(&flags.to_be_bytes());
+    body.extend_from_slice(&[0; 2]);
+    body.extend_from_slice(&parameters.mac);
+    body.extend_from_slice(&parameters.effective_mtu.to_be_bytes());
+    body.extend_from_slice(&parameters.maximum_packet_bytes.to_be_bytes());
+    body.extend_from_slice(&parameters.backend_interface_id.unwrap_or([0; 16]));
+    body.extend_from_slice(&parameters.read_max_packets.unwrap_or(0).to_be_bytes());
+    body.extend_from_slice(&parameters.write_max_packets.unwrap_or(0).to_be_bytes());
+    body.extend_from_slice(&[0; 4]);
+}
+
+fn decode_realized(body: &[u8]) -> Result<RealizedVmnetParameters, VmnetProviderError> {
+    let flags = read_u16(body, 0)?;
+    if flags & !REALIZED_FLAGS != 0 {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    require_zero(body, 2, 4)?;
+    require_zero(body, 36, 40)?;
+    let backend_id: [u8; 16] = read_array(body, 16)?;
+    let read_max = read_u16(body, 32)?;
+    let write_max = read_u16(body, 34)?;
+    if flags & REALIZED_BACKEND_ID_PRESENT == 0 && backend_id != [0; 16]
+        || flags & REALIZED_READ_MAX_PRESENT == 0 && read_max != 0
+        || flags & REALIZED_WRITE_MAX_PRESENT == 0 && write_max != 0
+    {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    RealizedVmnetParameters {
+        mac: read_array(body, 4)?,
+        effective_mtu: read_u16(body, 10)?,
+        maximum_packet_bytes: read_u32(body, 12)?,
+        backend_interface_id: (flags & REALIZED_BACKEND_ID_PRESENT != 0).then_some(backend_id),
+        read_max_packets: (flags & REALIZED_READ_MAX_PRESENT != 0).then_some(read_max),
+        write_max_packets: (flags & REALIZED_WRITE_MAX_PRESENT != 0).then_some(write_max),
+        direct_virtio_header_available: flags & REALIZED_DIRECT_AVAILABLE != 0,
+        direct_virtio_header_enabled: flags & REALIZED_DIRECT_ENABLED != 0,
+    }
+    .validated()
+    .map_err(|_| VmnetProviderError::InvalidFrame)
+}
+
+fn encode_batch(body: &mut Vec<u8>, batch: &VmnetPacketBatch) -> Result<(), VmnetProviderError> {
+    body.extend_from_slice(
+        &u16::try_from(batch.lengths.len())
+            .map_err(|_| VmnetProviderError::LimitExceeded)?
+            .to_be_bytes(),
+    );
+    body.extend_from_slice(&[0; 2]);
+    body.extend_from_slice(
+        &u32::try_from(batch.bytes.len())
+            .map_err(|_| VmnetProviderError::LimitExceeded)?
+            .to_be_bytes(),
+    );
+    for length in &batch.lengths {
+        body.extend_from_slice(&length.to_be_bytes());
+    }
+    body.extend_from_slice(&batch.bytes);
+    Ok(())
+}
+
+fn decode_batch(body: &[u8], allow_empty: bool) -> Result<VmnetPacketBatch, VmnetProviderError> {
+    if body.len() < 8 || read_u16(body, 2)? != 0 {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    let count = usize::from(read_u16(body, 0)?);
+    let aggregate =
+        usize::try_from(read_u32(body, 4)?).map_err(|_| VmnetProviderError::InvalidFrame)?;
+    if count > MAX_PACKET_COUNT || aggregate > MAX_AGGREGATE_PACKET_BYTES {
+        return Err(VmnetProviderError::LimitExceeded);
+    }
+    let metadata_end = 8_usize
+        .checked_add(
+            count
+                .checked_mul(4)
+                .ok_or(VmnetProviderError::LimitExceeded)?,
+        )
+        .ok_or(VmnetProviderError::LimitExceeded)?;
+    let total = metadata_end
+        .checked_add(aggregate)
+        .ok_or(VmnetProviderError::LimitExceeded)?;
+    if total != body.len() {
+        return Err(VmnetProviderError::InvalidFrame);
+    }
+    let mut lengths = Vec::new();
+    lengths
+        .try_reserve_exact(count)
+        .map_err(|_| VmnetProviderError::LimitExceeded)?;
+    for index in 0..count {
+        let offset = 8_usize
+            .checked_add(
+                index
+                    .checked_mul(4)
+                    .ok_or(VmnetProviderError::LimitExceeded)?,
+            )
+            .ok_or(VmnetProviderError::LimitExceeded)?;
+        lengths.push(read_u32(body, offset)?);
+    }
+    let bytes = body
+        .get(metadata_end..)
+        .ok_or(VmnetProviderError::InvalidFrame)?
+        .to_vec();
+    VmnetPacketBatch::from_parts(lengths, bytes, allow_empty)
+}
+
+fn require_zero(bytes: &[u8], start: usize, end: usize) -> Result<(), VmnetProviderError> {
+    bytes
+        .get(start..end)
+        .filter(|reserved| reserved.iter().all(|byte| *byte == 0))
+        .map(|_| ())
+        .ok_or(VmnetProviderError::InvalidFrame)
+}
+
+fn read_u8(bytes: &[u8], offset: usize) -> Result<u8, VmnetProviderError> {
+    bytes
+        .get(offset)
+        .copied()
+        .ok_or(VmnetProviderError::InvalidFrame)
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16, VmnetProviderError> {
+    Ok(u16::from_be_bytes(read_array(bytes, offset)?))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, VmnetProviderError> {
+    Ok(u32::from_be_bytes(read_array(bytes, offset)?))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, VmnetProviderError> {
+    Ok(u64::from_be_bytes(read_array(bytes, offset)?))
+}
+
+fn read_array<const N: usize>(bytes: &[u8], offset: usize) -> Result<[u8; N], VmnetProviderError> {
+    bytes
+        .get(offset..offset.saturating_add(N))
+        .and_then(|slice| slice.try_into().ok())
+        .ok_or(VmnetProviderError::InvalidFrame)
+}
+
+/// Bounded incremental provider-frame decoder.
+#[derive(Debug, Default)]
+pub struct ProviderFrameDecoder {
+    buffered: Vec<u8>,
+    poisoned: bool,
+}
+
+impl ProviderFrameDecoder {
+    /// Adds bytes and returns every newly complete frame in order.
+    pub fn push(&mut self, bytes: &[u8]) -> Result<Vec<ProviderFrame>, VmnetProviderError> {
+        if self.poisoned {
+            return Err(VmnetProviderError::Poisoned);
+        }
+        let result = self.push_inner(bytes);
+        if result.is_err() {
+            self.buffered.clear();
+            self.poisoned = true;
+        }
+        result
+    }
+
+    fn push_inner(&mut self, bytes: &[u8]) -> Result<Vec<ProviderFrame>, VmnetProviderError> {
+        self.buffered
+            .len()
+            .checked_add(bytes.len())
+            .filter(|required| *required <= MAX_BUFFERED_FRAME_BYTES)
+            .ok_or(VmnetProviderError::LimitExceeded)?;
+        self.buffered
+            .try_reserve(bytes.len())
+            .map_err(|_| VmnetProviderError::LimitExceeded)?;
+        self.buffered.extend_from_slice(bytes);
+        let mut frames = Vec::new();
+        loop {
+            if self.buffered.len() < HEADER_BYTES {
+                break;
+            }
+            let header = decode_header(
+                self.buffered
+                    .get(..HEADER_BYTES)
+                    .ok_or(VmnetProviderError::InvalidFrame)?,
+            )?;
+            let total = HEADER_BYTES
+                .checked_add(header.body_len())
+                .filter(|total| *total <= MAX_FRAME_BYTES)
+                .ok_or(VmnetProviderError::LimitExceeded)?;
+            if self.buffered.len() < total {
+                break;
+            }
+            let frame = decode_frame(
+                self.buffered
+                    .get(..total)
+                    .ok_or(VmnetProviderError::InvalidFrame)?,
+            )?;
+            self.buffered.drain(..total);
+            frames.push(frame);
+        }
+        Ok(frames)
+    }
+
+    /// Returns whether malformed input permanently poisoned the decoder.
+    #[must_use]
+    pub const fn is_poisoned(&self) -> bool {
+        self.poisoned
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session() -> SessionId {
+        SessionId::from_bytes([0x31; 32])
+    }
+
+    fn interface() -> VmnetInterfaceId {
+        VmnetInterfaceId::new(7).expect("interface should validate")
+    }
+
+    fn generation() -> VmnetGeneration {
+        VmnetGeneration::new(9).expect("generation should validate")
+    }
+
+    fn sequence(value: u64) -> VmnetSequence {
+        VmnetSequence::new(value).expect("sequence should validate")
+    }
+
+    fn requested() -> RequestedVmnetParameters {
+        RequestedVmnetParameters::new(Some([2, 1, 2, 3, 4, 5]), Some(1500))
+            .expect("request should validate")
+    }
+
+    fn realized() -> RealizedVmnetParameters {
+        RealizedVmnetParameters::new([2, 6, 7, 8, 9, 10], 1500, 2048)
+            .expect("base parameters should validate")
+            .with_backend_interface_id(Some([4; 16]))
+            .expect("identity should validate")
+            .with_batch_limits(Some(4), Some(5))
+            .expect("batch limits should validate")
+            .with_direct_virtio_header(true, false)
+            .expect("parameters should validate")
+    }
+
+    fn frames() -> Vec<ProviderFrame> {
+        let empty = VmnetPacketBatch::read(&[]).expect("empty read should validate");
+        let packets =
+            VmnetPacketBatch::write(&[&[1, 2], &[3, 4, 5]]).expect("packets should validate");
+        let control = [
+            (None, None, ControlMessage::Hello),
+            (None, None, ControlMessage::HelloAck),
+            (
+                Some(interface()),
+                None,
+                ControlMessage::Start {
+                    policy_slot: VmnetPolicySlot::Shared,
+                    requested: requested(),
+                },
+            ),
+            (
+                Some(interface()),
+                Some(generation()),
+                ControlMessage::Started {
+                    parameters: realized(),
+                },
+            ),
+            (
+                Some(interface()),
+                None,
+                ControlMessage::StartFailed {
+                    status: ProviderStatus::NotAuthorized,
+                },
+            ),
+            (Some(interface()), Some(generation()), ControlMessage::Stop),
+            (
+                Some(interface()),
+                Some(generation()),
+                ControlMessage::Stopped {
+                    cleanup: ProviderCleanup::Complete,
+                },
+            ),
+            (
+                None,
+                None,
+                ControlMessage::Cancel {
+                    reason: ProviderCancelReason::Worker,
+                },
+            ),
+            (
+                None,
+                None,
+                ControlMessage::Cancelled {
+                    cleanup: ProviderCleanup::Complete,
+                },
+            ),
+            (None, None, ControlMessage::Shutdown),
+            (None, None, ControlMessage::ShutdownAck),
+            (
+                None,
+                None,
+                ControlMessage::Terminal {
+                    code: ProviderTerminalCode::Protocol,
+                },
+            ),
+        ];
+        let mut result = Vec::new();
+        for (index, (iface, generation, message)) in control.into_iter().enumerate() {
+            result.push(
+                ProviderFrame::control(
+                    session(),
+                    iface,
+                    generation,
+                    sequence(u64::try_from(index + 1).expect("index should fit")),
+                    message,
+                )
+                .expect("control frame should validate"),
+            );
+        }
+        let data = [
+            DataMessage::Hello,
+            DataMessage::HelloAck,
+            DataMessage::Readiness {
+                epoch: VmnetReadinessEpoch::new(1).expect("epoch should validate"),
+                estimated_packets: 2,
+            },
+            DataMessage::Read { max_packets: 4 },
+            DataMessage::ReadResult {
+                request: sequence(4),
+                packets: empty,
+            },
+            DataMessage::Write {
+                packets: packets.clone(),
+            },
+            DataMessage::WriteResult {
+                request: sequence(6),
+                completed_packets: 1,
+            },
+            DataMessage::OperationFailed {
+                request: sequence(6),
+                operation: ProviderOperation::Write,
+                status: ProviderStatus::BufferExhausted,
+            },
+            DataMessage::Stop,
+            DataMessage::Stopped {
+                cleanup: ProviderCleanup::Complete,
+            },
+            DataMessage::Shutdown,
+            DataMessage::ShutdownAck,
+            DataMessage::Terminal {
+                code: ProviderTerminalCode::Cleanup,
+            },
+        ];
+        for (index, message) in data.into_iter().enumerate() {
+            result.push(
+                ProviderFrame::data(
+                    session(),
+                    interface(),
+                    generation(),
+                    sequence(u64::try_from(index + 20).expect("index should fit")),
+                    message,
+                )
+                .expect("data frame should validate"),
+            );
+        }
+        result
+    }
+
+    #[test]
+    fn every_message_round_trips_and_descriptor_contract_is_exact() {
+        for frame in frames() {
+            let encoded = encode_frame(&frame).expect("frame should encode");
+            assert!(encoded.len() <= MAX_FRAME_BYTES);
+            assert_eq!(decode_frame(&encoded), Ok(frame.clone()));
+            assert_eq!(
+                decode_header(encoded.get(..HEADER_BYTES).expect("header should exist"))
+                    .expect("header should decode")
+                    .descriptor_count(),
+                frame.descriptor_count()
+            );
+        }
+    }
+
+    #[test]
+    fn representative_started_header_is_golden() {
+        let frame = ProviderFrame::control(
+            session(),
+            Some(interface()),
+            Some(generation()),
+            sequence(3),
+            ControlMessage::Started {
+                parameters: realized(),
+            },
+        )
+        .expect("frame should validate");
+        let encoded = encode_frame(&frame).expect("frame should encode");
+        assert_eq!(
+            encoded.get(0..17),
+            Some(
+                &[
+                    b'B',
+                    b'B',
+                    b'V',
+                    b'N',
+                    b'E',
+                    b'T',
+                    b'P',
+                    0,
+                    0,
+                    1,
+                    CONTROL_CHANNEL,
+                    CONTROL_STARTED,
+                    0,
+                    0,
+                    0,
+                    40,
+                    1,
+                ][..]
+            )
+        );
+        assert_eq!(encoded.get(17..24), Some(&[0; 7][..]));
+        assert_eq!(encoded.get(56..60), Some(&7_u32.to_be_bytes()[..]));
+        assert_eq!(encoded.get(64..72), Some(&9_u64.to_be_bytes()[..]));
+        assert_eq!(encoded.get(72..80), Some(&3_u64.to_be_bytes()[..]));
+    }
+
+    #[test]
+    fn decoder_accepts_every_split_and_coalesced_frames() {
+        let selected = frames();
+        let first = encode_frame(selected.first().expect("first frame should exist"))
+            .expect("frame should encode");
+        for split in 0..first.len() {
+            let mut decoder = ProviderFrameDecoder::default();
+            assert!(
+                decoder
+                    .push(first.get(..split).expect("prefix should exist"))
+                    .expect("prefix should decode")
+                    .is_empty()
+            );
+            let decoded = decoder
+                .push(first.get(split..).expect("suffix should exist"))
+                .expect("suffix should decode");
+            assert_eq!(
+                decoded,
+                vec![selected.first().expect("frame should exist").clone()]
+            );
+        }
+        let mut all = Vec::new();
+        for frame in &selected {
+            all.extend_from_slice(&encode_frame(frame).expect("frame should encode"));
+        }
+        let mut decoder = ProviderFrameDecoder::default();
+        assert_eq!(decoder.push(&all), Ok(selected));
+    }
+
+    #[test]
+    fn header_body_and_reserved_corruption_fail_closed() {
+        let frame = frames().remove(2);
+        let encoded = encode_frame(&frame).expect("frame should encode");
+        for offset in [0, 8, 10, 11, 16, 17, 60] {
+            let mut corrupt = encoded.clone();
+            let byte = corrupt.get_mut(offset).expect("offset should exist");
+            *byte ^= 0xff;
+            assert!(decode_frame(&corrupt).is_err(), "offset {offset}");
+        }
+        let mut zero_sequence = encoded.clone();
+        zero_sequence
+            .get_mut(72..80)
+            .expect("sequence range should exist")
+            .fill(0);
+        assert_eq!(
+            decode_frame(&zero_sequence),
+            Err(VmnetProviderError::InvalidFrame)
+        );
+        let mut trailing = encoded.clone();
+        trailing.push(0);
+        assert_eq!(
+            decode_frame(&trailing),
+            Err(VmnetProviderError::InvalidFrame)
+        );
+        for split in 0..encoded.len() {
+            assert!(decode_frame(encoded.get(..split).expect("prefix should exist")).is_err());
+        }
+    }
+
+    #[test]
+    fn packet_and_parameter_bounds_are_checked() {
+        assert!(VmnetPacketBatch::write(&[]).is_err());
+        assert!(VmnetPacketBatch::read(&[]).is_ok());
+        let oversized = vec![0_u8; MAX_PACKET_BUFFER_BYTES + 1];
+        assert!(VmnetPacketBatch::write(&[&oversized]).is_err());
+        let packet = vec![0_u8; MAX_PACKET_BUFFER_BYTES];
+        assert!(VmnetPacketBatch::write(&[&packet, &packet, &packet, &packet]).is_err());
+        assert!(RequestedVmnetParameters::new(Some([1; 6]), None).is_err());
+        assert!(RealizedVmnetParameters::new([2; 6], 1500, 0).is_err());
+        assert!(
+            RealizedVmnetParameters::new([2; 6], 1500, 2048)
+                .expect("base parameters should validate")
+                .with_direct_virtio_header(false, true)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn debug_surfaces_redact_protocol_values_and_packet_bytes() {
+        let frame = frames().remove(2);
+        let debug = format!("{frame:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("1500"));
+        assert_eq!(
+            VmnetProviderError::InvalidFrame.to_string(),
+            "private vmnet provider protocol failure"
+        );
+    }
+}

--- a/crates/session/src/vmnet_provider/mod.rs
+++ b/crates/session/src/vmnet_provider/mod.rs
@@ -1,0 +1,73 @@
+//! Closed, bounded vmnet-provider protocol over already-connected Unix streams.
+//!
+//! The protocol is bound to the private launcher-worker lifecycle session. It
+//! carries fixed policy slots and packet data, but no path, bridge name,
+//! command, credential, process launch, privilege transition, or vmnet object.
+
+mod frame;
+mod state;
+mod transport;
+
+use std::fmt;
+use std::io;
+
+pub use frame::{
+    CONTROL_CHANNEL, ControlMessage, DATA_CHANNEL, DataMessage, HEADER_BYTES,
+    MAX_ACTIVE_INTERFACES, MAX_AGGREGATE_PACKET_BYTES, MAX_BUFFERED_FRAME_BYTES, MAX_FRAME_BYTES,
+    MAX_PACKET_BUFFER_BYTES, MAX_PACKET_COUNT, ProviderCancelReason, ProviderChannel,
+    ProviderCleanup, ProviderEnvelope, ProviderFrame, ProviderFrameDecoder, ProviderFrameHeader,
+    ProviderOperation, ProviderStatus, ProviderTerminalCode, RealizedVmnetParameters,
+    RequestedVmnetParameters, VmnetGeneration, VmnetInterfaceId, VmnetPacketBatch, VmnetPolicySlot,
+    VmnetReadinessEpoch, VmnetSequence, decode_frame, decode_header, encode_frame,
+};
+pub use state::{
+    ControlBrokerEvent, ControlBrokerState, ControlClientEvent, ControlClientState,
+    DataClientEvent, DataClientState, DataOwnerEvent, DataOwnerState, VmnetControlBroker,
+    VmnetControlClient, VmnetDataClient, VmnetDataOwner,
+};
+pub use transport::{MAX_PROVIDER_TIMEOUT, VmnetProviderTransport};
+
+/// Redacted vmnet-provider protocol failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmnetProviderError {
+    /// A local constructor or timeout configuration is invalid.
+    InvalidConfiguration,
+    /// Wire bytes or descriptor shape are malformed or noncanonical.
+    InvalidFrame,
+    /// A fixed count or byte bound was exceeded.
+    LimitExceeded,
+    /// A local role attempted an operation outside its legal lifecycle.
+    InvalidLifecycle,
+    /// A peer frame violated ordering, correlation, identity, or scope.
+    InvalidPeerState,
+    /// A transport has already entered terminal poison state.
+    Poisoned,
+    /// The operation deadline elapsed.
+    Timeout,
+    /// The peer closed before a requested frame began.
+    Disconnected,
+    /// The peer closed after transferring only a frame prefix.
+    UnexpectedEof,
+    /// A local socket operation failed.
+    Io(io::ErrorKind),
+}
+
+impl fmt::Display for VmnetProviderError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("private vmnet provider protocol failure")
+    }
+}
+
+impl std::error::Error for VmnetProviderError {}
+
+impl From<bangbang_unix_stream::UnixStreamTransportError> for VmnetProviderError {
+    fn from(error: bangbang_unix_stream::UnixStreamTransportError) -> Self {
+        match error {
+            bangbang_unix_stream::UnixStreamTransportError::Invalid => Self::InvalidFrame,
+            bangbang_unix_stream::UnixStreamTransportError::Timeout => Self::Timeout,
+            bangbang_unix_stream::UnixStreamTransportError::Disconnected => Self::Disconnected,
+            bangbang_unix_stream::UnixStreamTransportError::UnexpectedEof => Self::UnexpectedEof,
+            bangbang_unix_stream::UnixStreamTransportError::Io(kind) => Self::Io(kind),
+        }
+    }
+}

--- a/crates/session/src/vmnet_provider/state.rs
+++ b/crates/session/src/vmnet_provider/state.rs
@@ -1,0 +1,401 @@
+mod control;
+mod data;
+
+use crate::SessionId;
+
+pub use control::{
+    ControlBrokerEvent, ControlBrokerState, ControlClientEvent, ControlClientState,
+    VmnetControlBroker, VmnetControlClient,
+};
+pub use data::{
+    DataClientEvent, DataClientState, DataOwnerEvent, DataOwnerState, VmnetDataClient,
+    VmnetDataOwner,
+};
+
+use super::{VmnetProviderError, VmnetSequence};
+
+fn require_session(session: SessionId) -> Result<(), VmnetProviderError> {
+    if session.is_pre_session() {
+        Err(VmnetProviderError::InvalidConfiguration)
+    } else {
+        Ok(())
+    }
+}
+
+fn first_sequence() -> VmnetSequence {
+    VmnetSequence::MIN
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+    use std::os::unix::net::UnixStream;
+
+    use super::*;
+    use crate::vmnet_provider::{
+        ControlMessage, DataMessage, ProviderCancelReason, ProviderCleanup, ProviderEnvelope,
+        ProviderFrame, RealizedVmnetParameters, RequestedVmnetParameters, VmnetGeneration,
+        VmnetInterfaceId, VmnetPacketBatch, VmnetPolicySlot, VmnetReadinessEpoch, VmnetSequence,
+    };
+
+    fn session(value: u8) -> SessionId {
+        SessionId::from_bytes([value; 32])
+    }
+
+    fn interface(value: u32) -> VmnetInterfaceId {
+        VmnetInterfaceId::new(value).expect("interface should be nonzero")
+    }
+
+    fn generation(value: u64) -> VmnetGeneration {
+        VmnetGeneration::new(value).expect("generation should be nonzero")
+    }
+
+    fn sequence(value: u64) -> VmnetSequence {
+        VmnetSequence::new(value).expect("sequence should be nonzero")
+    }
+
+    fn realized() -> RealizedVmnetParameters {
+        RealizedVmnetParameters::new([2, 0, 0, 0, 0, 1], 1500, 2048)
+            .expect("base parameters should validate")
+            .with_backend_interface_id(Some([7; 16]))
+            .expect("identity should validate")
+            .with_direct_virtio_header(true, true)
+            .expect("direct header should validate")
+            .with_batch_limits(Some(8), Some(8))
+            .expect("parameters should be valid")
+    }
+
+    fn control_pair() -> (VmnetControlClient, VmnetControlBroker) {
+        let mut client = VmnetControlClient::new(session(1)).expect("client should construct");
+        let mut broker = VmnetControlBroker::new(session(1)).expect("broker should construct");
+        assert!(matches!(
+            broker.receive(client.hello().expect("hello should emit")),
+            Ok(ControlBrokerEvent::Hello)
+        ));
+        assert!(matches!(
+            client.receive(broker.hello_ack().expect("ack should emit")),
+            Ok(ControlClientEvent::Ready)
+        ));
+        (client, broker)
+    }
+
+    fn data_pair() -> (VmnetDataClient, VmnetDataOwner) {
+        let mut client = VmnetDataClient::new(session(2), interface(1), generation(1), realized())
+            .expect("client should construct");
+        let mut owner = VmnetDataOwner::new(session(2), interface(1), generation(1), realized())
+            .expect("owner should construct");
+        assert_eq!(
+            owner.receive(client.hello().expect("hello should emit")),
+            Ok(DataOwnerEvent::Hello)
+        );
+        assert_eq!(
+            client.receive(owner.hello_ack().expect("ack should emit")),
+            Ok(DataClientEvent::Ready)
+        );
+        (client, owner)
+    }
+
+    #[test]
+    fn control_supports_four_interfaces_reuse_and_orderly_shutdown() {
+        let (mut client, mut broker) = control_pair();
+        let requested =
+            RequestedVmnetParameters::new(None, Some(1500)).expect("request should be valid");
+        let mut peers = Vec::new();
+        for value in 1_u32..=4 {
+            let id = interface(value);
+            let request = client
+                .start(id, VmnetPolicySlot::Shared, requested)
+                .expect("start should emit");
+            assert!(matches!(
+                broker.receive(request),
+                Ok(ControlBrokerEvent::Start { interface, .. }) if interface == id
+            ));
+            let (data, peer) = UnixStream::pair().expect("pair should construct");
+            peers.push(peer);
+            let response = broker
+                .started(generation(u64::from(value)), realized(), data)
+                .expect("started should emit");
+            assert!(matches!(
+                client.receive(response),
+                Ok(ControlClientEvent::Started {
+                    interface,
+                    generation: active_generation,
+                    ..
+                }) if interface == id && active_generation == generation(u64::from(value))
+            ));
+        }
+        assert_eq!(client.active_count(), 4);
+        assert_eq!(broker.active_count(), 4);
+        assert!(matches!(
+            client.start(interface(5), VmnetPolicySlot::Host, requested),
+            Err(VmnetProviderError::LimitExceeded)
+        ));
+
+        let first = interface(1);
+        assert!(matches!(
+            broker.receive(client.stop(first).expect("stop should emit")),
+            Ok(ControlBrokerEvent::Stop { interface, .. }) if interface == first
+        ));
+        assert!(matches!(
+            client.receive(
+                broker
+                    .stopped(ProviderCleanup::Complete)
+                    .expect("stopped should emit")
+            ),
+            Ok(ControlClientEvent::Stopped { interface, .. }) if interface == first
+        ));
+
+        let (data, peer) = UnixStream::pair().expect("pair should construct");
+        peers.push(peer);
+        broker
+            .receive(
+                client
+                    .start(first, VmnetPolicySlot::Host, requested)
+                    .expect("reused start should emit"),
+            )
+            .expect("reused start should validate");
+        assert!(matches!(
+            client.receive(
+                broker
+                    .started(generation(5), realized(), data)
+                    .expect("fresh generation should emit")
+            ),
+            Ok(ControlClientEvent::Started { generation: active, .. }) if active == generation(5)
+        ));
+
+        for value in [1_u32, 2, 3, 4] {
+            let id = interface(value);
+            broker
+                .receive(client.stop(id).expect("stop should emit"))
+                .expect("stop should validate");
+            client
+                .receive(
+                    broker
+                        .stopped(ProviderCleanup::Complete)
+                        .expect("stopped should emit"),
+                )
+                .expect("stopped should validate");
+        }
+        assert_eq!(client.active_count(), 0);
+        assert_eq!(broker.active_count(), 0);
+        assert_eq!(
+            broker.receive(client.shutdown().expect("shutdown should emit")),
+            Ok(ControlBrokerEvent::Shutdown)
+        );
+        assert!(matches!(
+            client.receive(broker.shutdown_ack().expect("ack should emit")),
+            Ok(ControlClientEvent::Shutdown)
+        ));
+        assert_eq!(client.state(), ControlClientState::Closed);
+        assert_eq!(broker.state(), ControlBrokerState::Closed);
+        drop(peers);
+    }
+
+    #[test]
+    fn cancellation_accepts_one_raced_start_but_never_exposes_its_stream() {
+        let (mut client, mut broker) = control_pair();
+        let id = interface(1);
+        let requested = RequestedVmnetParameters::new(None, None).expect("request should validate");
+        broker
+            .receive(
+                client
+                    .start(id, VmnetPolicySlot::Host, requested)
+                    .expect("start should emit"),
+            )
+            .expect("start should validate");
+        assert!(matches!(
+            broker.receive(
+                client
+                    .cancel(ProviderCancelReason::Worker)
+                    .expect("cancel should emit")
+            ),
+            Ok(ControlBrokerEvent::Cancel { .. })
+        ));
+        let (data, mut peer) = UnixStream::pair().expect("pair should construct");
+        assert!(matches!(
+            client.receive(
+                broker
+                    .started(generation(1), realized(), data)
+                    .expect("raced result should emit")
+            ),
+            Ok(ControlClientEvent::StartRetiredDuringCancellation { .. })
+        ));
+        let mut byte = [0_u8; 1];
+        assert_eq!(
+            peer.read(&mut byte).expect("retired stream should close"),
+            0
+        );
+        assert!(matches!(
+            client.receive(
+                broker
+                    .cancelled(ProviderCleanup::Complete)
+                    .expect("cancelled should emit")
+            ),
+            Ok(ControlClientEvent::Cancelled)
+        ));
+        assert_eq!(client.active_count(), 0);
+        assert_eq!(client.state(), ControlClientState::Closed);
+    }
+
+    #[test]
+    fn cross_session_control_frame_poison_clears_ownership() {
+        let mut client = VmnetControlClient::new(session(1)).expect("client should construct");
+        client.hello().expect("hello should emit");
+        let wrong = ProviderFrame::control(
+            session(9),
+            None,
+            None,
+            sequence(1),
+            ControlMessage::HelloAck,
+        )
+        .expect("frame should construct");
+        assert!(matches!(
+            client.receive(ProviderEnvelope::frame_only(wrong)),
+            Err(VmnetProviderError::InvalidPeerState)
+        ));
+        assert_eq!(client.state(), ControlClientState::Terminal);
+        assert_eq!(client.active_count(), 0);
+    }
+
+    #[test]
+    fn data_validates_readiness_read_write_prefix_stop_and_shutdown() {
+        let (mut client, mut owner) = data_pair();
+        assert_eq!(
+            client.receive(owner.readiness(2).expect("readiness should emit")),
+            Ok(DataClientEvent::Readiness {
+                epoch: VmnetReadinessEpoch::new(1).expect("epoch should validate"),
+                estimated_packets: 2,
+            })
+        );
+        assert_eq!(
+            owner.receive(client.read(2).expect("read should emit")),
+            Ok(DataOwnerEvent::Read {
+                request: sequence(2),
+                max_packets: 2,
+            })
+        );
+        assert_eq!(
+            client.receive(
+                owner
+                    .readiness(1)
+                    .expect("interleaved readiness should emit")
+            ),
+            Ok(DataClientEvent::Readiness {
+                epoch: VmnetReadinessEpoch::new(2).expect("epoch should validate"),
+                estimated_packets: 1,
+            })
+        );
+        let first = [1_u8, 2, 3];
+        let second = [4_u8, 5];
+        let read_batch = VmnetPacketBatch::read(&[&first, &second]).expect("batch should validate");
+        assert_eq!(
+            client.receive(
+                owner
+                    .read_result(read_batch.clone())
+                    .expect("read result should emit")
+            ),
+            Ok(DataClientEvent::ReadComplete {
+                packets: read_batch,
+            })
+        );
+
+        let write_batch =
+            VmnetPacketBatch::write(&[&first, &second]).expect("write should validate");
+        assert!(matches!(
+            owner.receive(client.write(write_batch).expect("write should emit")),
+            Ok(DataOwnerEvent::Write { request, packets })
+                if request == sequence(3) && packets.packet_count() == 2
+        ));
+        assert!(matches!(
+            owner.write_result(3),
+            Err(VmnetProviderError::LimitExceeded)
+        ));
+        assert_eq!(
+            client.receive(owner.write_result(1).expect("prefix should emit")),
+            Ok(DataClientEvent::WriteComplete {
+                completed_packets: 1,
+            })
+        );
+
+        assert_eq!(
+            owner.receive(client.stop().expect("stop should emit")),
+            Ok(DataOwnerEvent::Stop)
+        );
+        assert_eq!(
+            client.receive(
+                owner
+                    .stopped(ProviderCleanup::Complete)
+                    .expect("stopped should emit")
+            ),
+            Ok(DataClientEvent::Stopped)
+        );
+        assert_eq!(
+            owner.receive(client.shutdown().expect("shutdown should emit")),
+            Ok(DataOwnerEvent::Shutdown)
+        );
+        assert_eq!(
+            client.receive(owner.shutdown_ack().expect("ack should emit")),
+            Ok(DataClientEvent::Shutdown)
+        );
+        assert_eq!(client.state(), DataClientState::Closed);
+        assert_eq!(owner.state(), DataOwnerState::Closed);
+    }
+
+    #[test]
+    fn stale_readiness_and_wrong_scope_poison_data_state() {
+        let (mut client, mut owner) = data_pair();
+        client
+            .receive(owner.readiness(1).expect("readiness should emit"))
+            .expect("readiness should validate");
+        let stale = ProviderFrame::data(
+            session(2),
+            interface(1),
+            generation(1),
+            sequence(3),
+            DataMessage::Readiness {
+                epoch: VmnetReadinessEpoch::new(1).expect("epoch should validate"),
+                estimated_packets: 1,
+            },
+        )
+        .expect("frame should construct");
+        assert_eq!(
+            client.receive(ProviderEnvelope::frame_only(stale)),
+            Err(VmnetProviderError::InvalidPeerState)
+        );
+        assert_eq!(client.state(), DataClientState::Terminal);
+
+        let (mut client, _owner) = data_pair();
+        let wrong = ProviderFrame::data(
+            session(2),
+            interface(2),
+            generation(1),
+            sequence(2),
+            DataMessage::Readiness {
+                epoch: VmnetReadinessEpoch::new(1).expect("epoch should validate"),
+                estimated_packets: 1,
+            },
+        )
+        .expect("frame should construct");
+        assert_eq!(
+            client.receive(ProviderEnvelope::frame_only(wrong)),
+            Err(VmnetProviderError::InvalidPeerState)
+        );
+        assert_eq!(client.state(), DataClientState::Terminal);
+    }
+
+    #[test]
+    fn state_debug_surfaces_are_redacted() {
+        let (client, broker) = control_pair();
+        let (data_client, data_owner) = data_pair();
+        for debug in [
+            format!("{client:?}"),
+            format!("{broker:?}"),
+            format!("{data_client:?}"),
+            format!("{data_owner:?}"),
+        ] {
+            assert!(debug.contains("<redacted>"));
+            assert!(!debug.contains(&session(1).private_hex()));
+            assert!(!debug.contains(&session(2).private_hex()));
+        }
+    }
+}

--- a/crates/session/src/vmnet_provider/state/control.rs
+++ b/crates/session/src/vmnet_provider/state/control.rs
@@ -1,0 +1,942 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::os::unix::net::UnixStream;
+
+use crate::SessionId;
+
+use super::{first_sequence, require_session};
+use crate::vmnet_provider::{
+    ControlMessage, MAX_ACTIVE_INTERFACES, ProviderCancelReason, ProviderCleanup, ProviderEnvelope,
+    ProviderFrame, ProviderStatus, ProviderTerminalCode, RealizedVmnetParameters,
+    RequestedVmnetParameters, VmnetGeneration, VmnetInterfaceId, VmnetPolicySlot,
+    VmnetProviderError, VmnetSequence,
+};
+
+/// Worker-side control lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlClientState {
+    /// No hello has been sent.
+    New,
+    /// The hello acknowledgement is pending.
+    AwaitHelloAck,
+    /// The client may start, stop, cancel, or shut down.
+    Ready,
+    /// One start result is pending.
+    AwaitStart,
+    /// One stop result is pending.
+    AwaitStop,
+    /// Cancellation acknowledgement, and possibly one raced result, is pending.
+    AwaitCancelled,
+    /// Orderly shutdown acknowledgement is pending.
+    AwaitShutdownAck,
+    /// The protocol completed cleanly.
+    Closed,
+    /// A terminal failure permanently poisoned the state.
+    Terminal,
+}
+
+/// Broker-side control lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlBrokerState {
+    /// The client hello is pending.
+    AwaitHello,
+    /// A hello acknowledgement must be emitted.
+    ReadyToAck,
+    /// The broker may accept a new operation.
+    Ready,
+    /// The adapter owns one pending start.
+    StartPending,
+    /// The adapter owns one pending stop.
+    StopPending,
+    /// Cancellation cleanup and acknowledgement are required.
+    ReadyToCancel,
+    /// An orderly shutdown acknowledgement is required.
+    ReadyToShutdown,
+    /// The protocol completed cleanly.
+    Closed,
+    /// A terminal failure permanently poisoned the state.
+    Terminal,
+}
+
+/// Checked event produced by the worker-side control state.
+pub enum ControlClientEvent {
+    /// The broker accepted the session binding.
+    Ready,
+    /// One interface started and owns its transferred data stream.
+    Started {
+        /// Exact interface identity.
+        interface: VmnetInterfaceId,
+        /// Fresh interface generation.
+        generation: VmnetGeneration,
+        /// Validated backend parameters.
+        parameters: RealizedVmnetParameters,
+        /// Atomically accepted data stream.
+        stream: UnixStream,
+    },
+    /// One start failed without creating ownership.
+    StartFailed {
+        /// Exact interface identity.
+        interface: VmnetInterfaceId,
+        /// Stable failure category.
+        status: ProviderStatus,
+    },
+    /// One active generation stopped completely.
+    Stopped {
+        /// Exact interface identity.
+        interface: VmnetInterfaceId,
+        /// Retired generation.
+        generation: VmnetGeneration,
+    },
+    /// A raced start was accepted and its stream retired internally.
+    StartRetiredDuringCancellation {
+        /// Exact interface identity.
+        interface: VmnetInterfaceId,
+        /// Raced generation.
+        generation: VmnetGeneration,
+    },
+    /// A failed start was serialized before cancellation.
+    StartFailedDuringCancellation {
+        /// Exact interface identity.
+        interface: VmnetInterfaceId,
+        /// Stable failure category.
+        status: ProviderStatus,
+    },
+    /// A stop was serialized before cancellation.
+    StoppedDuringCancellation {
+        /// Exact interface identity.
+        interface: VmnetInterfaceId,
+        /// Retired generation.
+        generation: VmnetGeneration,
+    },
+    /// Cancellation retired all session ownership.
+    Cancelled,
+    /// Orderly shutdown completed.
+    Shutdown,
+    /// The peer declared a terminal category.
+    PeerTerminal {
+        /// Stable terminal category.
+        code: ProviderTerminalCode,
+    },
+}
+
+impl fmt::Debug for ControlClientEvent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ready => formatter.write_str("Ready"),
+            Self::Started { .. } => formatter.write_str("Started(<redacted>)"),
+            Self::StartFailed { status, .. } => formatter
+                .debug_struct("StartFailed")
+                .field("interface", &"<redacted>")
+                .field("status", status)
+                .finish(),
+            Self::Stopped { .. } => formatter.write_str("Stopped(<redacted>)"),
+            Self::StartRetiredDuringCancellation { .. } => {
+                formatter.write_str("StartRetiredDuringCancellation(<redacted>)")
+            }
+            Self::StartFailedDuringCancellation { status, .. } => formatter
+                .debug_struct("StartFailedDuringCancellation")
+                .field("interface", &"<redacted>")
+                .field("status", status)
+                .finish(),
+            Self::StoppedDuringCancellation { .. } => {
+                formatter.write_str("StoppedDuringCancellation(<redacted>)")
+            }
+            Self::Cancelled => formatter.write_str("Cancelled"),
+            Self::Shutdown => formatter.write_str("Shutdown"),
+            Self::PeerTerminal { code } => formatter
+                .debug_struct("PeerTerminal")
+                .field("code", code)
+                .finish(),
+        }
+    }
+}
+
+/// Checked event produced by the broker-side control state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlBrokerEvent {
+    /// A session hello was accepted.
+    Hello,
+    /// A typed start requires backend work.
+    Start {
+        /// Exact interface identity.
+        interface: VmnetInterfaceId,
+        /// Bootstrap-owned fixed policy slot.
+        policy_slot: VmnetPolicySlot,
+        /// Validated optional parameters.
+        requested: RequestedVmnetParameters,
+    },
+    /// An exact active generation requires stop and reap.
+    Stop {
+        /// Exact interface identity.
+        interface: VmnetInterfaceId,
+        /// Exact active generation.
+        generation: VmnetGeneration,
+    },
+    /// Session cancellation requires aggregate cleanup.
+    Cancel {
+        /// Stable cancellation source.
+        reason: ProviderCancelReason,
+    },
+    /// Empty-session orderly shutdown was requested.
+    Shutdown,
+    /// The peer declared a terminal category.
+    PeerTerminal {
+        /// Stable terminal category.
+        code: ProviderTerminalCode,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ControlPending {
+    Start(VmnetInterfaceId),
+    Stop(VmnetInterfaceId, VmnetGeneration),
+}
+
+/// Worker-side session-bound vmnet control state machine.
+pub struct VmnetControlClient {
+    session: SessionId,
+    state: ControlClientState,
+    next_local: VmnetSequence,
+    next_peer: VmnetSequence,
+    pending: Option<ControlPending>,
+    active: BTreeMap<VmnetInterfaceId, VmnetGeneration>,
+    last_generation: Option<VmnetGeneration>,
+}
+
+impl VmnetControlClient {
+    /// Constructs a control client for one established lifecycle session.
+    pub fn new(session: SessionId) -> Result<Self, VmnetProviderError> {
+        require_session(session)?;
+        Ok(Self {
+            session,
+            state: ControlClientState::New,
+            next_local: first_sequence(),
+            next_peer: first_sequence(),
+            pending: None,
+            active: BTreeMap::new(),
+            last_generation: None,
+        })
+    }
+
+    /// Returns the current lifecycle without exposing ownership values.
+    #[must_use]
+    pub const fn state(&self) -> ControlClientState {
+        self.state
+    }
+
+    /// Returns the bounded active-interface count.
+    #[must_use]
+    pub fn active_count(&self) -> usize {
+        self.active.len()
+    }
+
+    /// Returns the owned generation for an interface.
+    #[must_use]
+    pub fn active_generation(&self, interface: VmnetInterfaceId) -> Option<VmnetGeneration> {
+        self.active.get(&interface).copied()
+    }
+
+    /// Begins the mandatory control handshake.
+    pub fn hello(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(ControlClientState::New)?;
+        let envelope = self.control(None, None, ControlMessage::Hello)?;
+        self.state = ControlClientState::AwaitHelloAck;
+        Ok(envelope)
+    }
+
+    /// Begins one typed interface start.
+    pub fn start(
+        &mut self,
+        interface: VmnetInterfaceId,
+        policy_slot: VmnetPolicySlot,
+        requested: RequestedVmnetParameters,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(ControlClientState::Ready)?;
+        if self.active.len() >= MAX_ACTIVE_INTERFACES || self.active.contains_key(&interface) {
+            return Err(VmnetProviderError::LimitExceeded);
+        }
+        let envelope = self.control(
+            Some(interface),
+            None,
+            ControlMessage::Start {
+                policy_slot,
+                requested,
+            },
+        )?;
+        self.pending = Some(ControlPending::Start(interface));
+        self.state = ControlClientState::AwaitStart;
+        Ok(envelope)
+    }
+
+    /// Begins exact stop of one active generation.
+    pub fn stop(
+        &mut self,
+        interface: VmnetInterfaceId,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(ControlClientState::Ready)?;
+        let generation = self
+            .active
+            .get(&interface)
+            .copied()
+            .ok_or(VmnetProviderError::InvalidLifecycle)?;
+        let envelope = self.control(Some(interface), Some(generation), ControlMessage::Stop)?;
+        self.pending = Some(ControlPending::Stop(interface, generation));
+        self.state = ControlClientState::AwaitStop;
+        Ok(envelope)
+    }
+
+    /// Cancels every pending and active interface in an established session.
+    pub fn cancel(
+        &mut self,
+        reason: ProviderCancelReason,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if !matches!(
+            self.state,
+            ControlClientState::Ready
+                | ControlClientState::AwaitStart
+                | ControlClientState::AwaitStop
+        ) {
+            return Err(self.local_error());
+        }
+        let envelope = self.control(None, None, ControlMessage::Cancel { reason })?;
+        self.state = ControlClientState::AwaitCancelled;
+        Ok(envelope)
+    }
+
+    /// Begins orderly shutdown after all ownership is retired.
+    pub fn shutdown(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(ControlClientState::Ready)?;
+        if !self.active.is_empty() || self.pending.is_some() {
+            return Err(VmnetProviderError::InvalidLifecycle);
+        }
+        let envelope = self.control(None, None, ControlMessage::Shutdown)?;
+        self.state = ControlClientState::AwaitShutdownAck;
+        Ok(envelope)
+    }
+
+    /// Emits a terminal frame and irreversibly drops local ownership state.
+    pub fn terminal(
+        &mut self,
+        code: ProviderTerminalCode,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if matches!(
+            self.state,
+            ControlClientState::Closed | ControlClientState::Terminal
+        ) {
+            return Err(self.local_error());
+        }
+        let envelope = self.control(None, None, ControlMessage::Terminal { code })?;
+        self.poison();
+        Ok(envelope)
+    }
+
+    /// Consumes one atomically received broker frame and optional stream.
+    pub fn receive(
+        &mut self,
+        envelope: ProviderEnvelope,
+    ) -> Result<ControlClientEvent, VmnetProviderError> {
+        if matches!(
+            self.state,
+            ControlClientState::Closed | ControlClientState::Terminal
+        ) {
+            return Err(self.local_error());
+        }
+        let (frame, stream) = envelope.into_parts();
+        if self.validate_peer(&frame).is_err()
+            || usize::from(frame.descriptor_count()) != usize::from(stream.is_some())
+        {
+            return Err(self.peer_error());
+        }
+        let message = frame.control_message().cloned();
+        let result = (|| match (self.state, message) {
+            (ControlClientState::AwaitHelloAck, Some(ControlMessage::HelloAck)) => {
+                self.state = ControlClientState::Ready;
+                Ok(ControlClientEvent::Ready)
+            }
+            (ControlClientState::AwaitStart, Some(ControlMessage::Started { parameters })) => {
+                let ControlPending::Start(interface) =
+                    self.pending.ok_or(VmnetProviderError::InvalidPeerState)?
+                else {
+                    return Err(self.peer_error());
+                };
+                self.accept_started(&frame, interface)?;
+                let generation = frame
+                    .generation()
+                    .ok_or(VmnetProviderError::InvalidPeerState)?;
+                let stream = stream.ok_or(VmnetProviderError::InvalidPeerState)?;
+                self.active.insert(interface, generation);
+                self.last_generation = Some(generation);
+                self.pending = None;
+                self.state = ControlClientState::Ready;
+                Ok(ControlClientEvent::Started {
+                    interface,
+                    generation,
+                    parameters,
+                    stream,
+                })
+            }
+            (ControlClientState::AwaitStart, Some(ControlMessage::StartFailed { status })) => {
+                let ControlPending::Start(interface) =
+                    self.pending.ok_or(VmnetProviderError::InvalidPeerState)?
+                else {
+                    return Err(self.peer_error());
+                };
+                if frame.interface() != Some(interface) || frame.generation().is_some() {
+                    Err(VmnetProviderError::InvalidPeerState)
+                } else {
+                    self.pending = None;
+                    self.state = ControlClientState::Ready;
+                    Ok(ControlClientEvent::StartFailed { interface, status })
+                }
+            }
+            (ControlClientState::AwaitStop, Some(ControlMessage::Stopped { cleanup })) => {
+                let ControlPending::Stop(interface, generation) =
+                    self.pending.ok_or(VmnetProviderError::InvalidPeerState)?
+                else {
+                    return Err(self.peer_error());
+                };
+                self.accept_stopped(&frame, interface, generation, cleanup)?;
+                self.active.remove(&interface);
+                self.pending = None;
+                self.state = ControlClientState::Ready;
+                Ok(ControlClientEvent::Stopped {
+                    interface,
+                    generation,
+                })
+            }
+            (ControlClientState::AwaitCancelled, Some(message)) => {
+                self.receive_during_cancellation(&frame, stream, message)
+            }
+            (ControlClientState::AwaitShutdownAck, Some(ControlMessage::ShutdownAck)) => {
+                self.state = ControlClientState::Closed;
+                Ok(ControlClientEvent::Shutdown)
+            }
+            (_, Some(ControlMessage::Terminal { code })) => {
+                self.poison();
+                Ok(ControlClientEvent::PeerTerminal { code })
+            }
+            _ => Err(VmnetProviderError::InvalidPeerState),
+        })();
+        if result.is_err() {
+            self.poison();
+        }
+        result
+    }
+}
+
+impl VmnetControlClient {
+    fn receive_during_cancellation(
+        &mut self,
+        frame: &ProviderFrame,
+        stream: Option<UnixStream>,
+        message: ControlMessage,
+    ) -> Result<ControlClientEvent, VmnetProviderError> {
+        match (self.pending, message) {
+            (Some(ControlPending::Start(interface)), ControlMessage::Started { .. }) => {
+                self.accept_started(frame, interface)?;
+                let generation = frame
+                    .generation()
+                    .ok_or(VmnetProviderError::InvalidPeerState)?;
+                let _retired_stream = stream.ok_or(VmnetProviderError::InvalidPeerState)?;
+                self.last_generation = Some(generation);
+                self.pending = None;
+                Ok(ControlClientEvent::StartRetiredDuringCancellation {
+                    interface,
+                    generation,
+                })
+            }
+            (Some(ControlPending::Start(interface)), ControlMessage::StartFailed { status })
+                if frame.interface() == Some(interface) && frame.generation().is_none() =>
+            {
+                self.pending = None;
+                Ok(ControlClientEvent::StartFailedDuringCancellation { interface, status })
+            }
+            (
+                Some(ControlPending::Stop(interface, generation)),
+                ControlMessage::Stopped {
+                    cleanup: ProviderCleanup::Complete,
+                },
+            ) if frame.interface() == Some(interface) && frame.generation() == Some(generation) => {
+                self.active.remove(&interface);
+                self.pending = None;
+                Ok(ControlClientEvent::StoppedDuringCancellation {
+                    interface,
+                    generation,
+                })
+            }
+            (
+                _,
+                ControlMessage::Cancelled {
+                    cleanup: ProviderCleanup::Complete,
+                },
+            ) => {
+                self.pending = None;
+                self.active.clear();
+                self.state = ControlClientState::Closed;
+                Ok(ControlClientEvent::Cancelled)
+            }
+            _ => Err(VmnetProviderError::InvalidPeerState),
+        }
+    }
+
+    fn accept_started(
+        &self,
+        frame: &ProviderFrame,
+        interface: VmnetInterfaceId,
+    ) -> Result<(), VmnetProviderError> {
+        let generation = frame
+            .generation()
+            .ok_or(VmnetProviderError::InvalidPeerState)?;
+        if frame.interface() != Some(interface)
+            || self.active.contains_key(&interface)
+            || self.last_generation.is_some_and(|last| generation <= last)
+        {
+            return Err(VmnetProviderError::InvalidPeerState);
+        }
+        Ok(())
+    }
+
+    fn accept_stopped(
+        &self,
+        frame: &ProviderFrame,
+        interface: VmnetInterfaceId,
+        generation: VmnetGeneration,
+        cleanup: ProviderCleanup,
+    ) -> Result<(), VmnetProviderError> {
+        if frame.interface() != Some(interface)
+            || frame.generation() != Some(generation)
+            || cleanup != ProviderCleanup::Complete
+        {
+            return Err(VmnetProviderError::InvalidPeerState);
+        }
+        Ok(())
+    }
+
+    fn control(
+        &mut self,
+        interface: Option<VmnetInterfaceId>,
+        generation: Option<VmnetGeneration>,
+        message: ControlMessage,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        let sequence = self.take_local_sequence()?;
+        ProviderFrame::control(self.session, interface, generation, sequence, message)
+            .map(ProviderEnvelope::frame_only)
+    }
+
+    fn validate_peer(&mut self, frame: &ProviderFrame) -> Result<(), VmnetProviderError> {
+        if frame.session() != self.session
+            || frame.sequence() != self.next_peer
+            || frame.control_message().is_none()
+        {
+            return Err(VmnetProviderError::InvalidPeerState);
+        }
+        self.next_peer = self.next_peer.checked_next()?;
+        Ok(())
+    }
+
+    fn take_local_sequence(&mut self) -> Result<VmnetSequence, VmnetProviderError> {
+        let current = self.next_local;
+        match self.next_local.checked_next() {
+            Ok(next) => {
+                self.next_local = next;
+                Ok(current)
+            }
+            Err(error) => {
+                self.poison();
+                Err(error)
+            }
+        }
+    }
+
+    fn require_state(&self, expected: ControlClientState) -> Result<(), VmnetProviderError> {
+        if self.state == expected {
+            Ok(())
+        } else {
+            Err(self.local_error())
+        }
+    }
+
+    fn local_error(&self) -> VmnetProviderError {
+        if self.state == ControlClientState::Terminal {
+            VmnetProviderError::Poisoned
+        } else {
+            VmnetProviderError::InvalidLifecycle
+        }
+    }
+
+    fn peer_error(&mut self) -> VmnetProviderError {
+        self.poison();
+        VmnetProviderError::InvalidPeerState
+    }
+
+    fn poison(&mut self) {
+        self.pending = None;
+        self.active.clear();
+        self.state = ControlClientState::Terminal;
+    }
+}
+
+impl fmt::Debug for VmnetControlClient {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VmnetControlClient")
+            .field("session", &"<redacted>")
+            .field("state", &self.state)
+            .field("active_count", &self.active.len())
+            .finish()
+    }
+}
+
+/// Bootstrap-side session-bound vmnet control state machine.
+pub struct VmnetControlBroker {
+    session: SessionId,
+    state: ControlBrokerState,
+    next_local: VmnetSequence,
+    next_peer: VmnetSequence,
+    pending: Option<ControlPending>,
+    active: BTreeMap<VmnetInterfaceId, VmnetGeneration>,
+    last_generation: Option<VmnetGeneration>,
+}
+
+impl VmnetControlBroker {
+    /// Constructs a broker for one established lifecycle session.
+    pub fn new(session: SessionId) -> Result<Self, VmnetProviderError> {
+        require_session(session)?;
+        Ok(Self {
+            session,
+            state: ControlBrokerState::AwaitHello,
+            next_local: first_sequence(),
+            next_peer: first_sequence(),
+            pending: None,
+            active: BTreeMap::new(),
+            last_generation: None,
+        })
+    }
+
+    /// Returns the current lifecycle.
+    #[must_use]
+    pub const fn state(&self) -> ControlBrokerState {
+        self.state
+    }
+
+    /// Returns the bounded active-interface count.
+    #[must_use]
+    pub fn active_count(&self) -> usize {
+        self.active.len()
+    }
+
+    /// Consumes one checked client control frame.
+    pub fn receive(
+        &mut self,
+        envelope: ProviderEnvelope,
+    ) -> Result<ControlBrokerEvent, VmnetProviderError> {
+        if matches!(
+            self.state,
+            ControlBrokerState::Closed | ControlBrokerState::Terminal
+        ) {
+            return Err(self.local_error());
+        }
+        let (frame, stream) = envelope.into_parts();
+        if stream.is_some() || self.validate_peer(&frame).is_err() {
+            return Err(self.peer_error());
+        }
+        let message = frame.control_message().cloned();
+        let result = (|| match (self.state, message) {
+            (ControlBrokerState::AwaitHello, Some(ControlMessage::Hello)) => {
+                self.state = ControlBrokerState::ReadyToAck;
+                Ok(ControlBrokerEvent::Hello)
+            }
+            (
+                ControlBrokerState::Ready,
+                Some(ControlMessage::Start {
+                    policy_slot,
+                    requested,
+                }),
+            ) => {
+                let interface = frame
+                    .interface()
+                    .ok_or(VmnetProviderError::InvalidPeerState)?;
+                if self.active.len() >= MAX_ACTIVE_INTERFACES
+                    || self.active.contains_key(&interface)
+                {
+                    Err(VmnetProviderError::InvalidPeerState)
+                } else {
+                    self.pending = Some(ControlPending::Start(interface));
+                    self.state = ControlBrokerState::StartPending;
+                    Ok(ControlBrokerEvent::Start {
+                        interface,
+                        policy_slot,
+                        requested,
+                    })
+                }
+            }
+            (ControlBrokerState::Ready, Some(ControlMessage::Stop)) => {
+                let interface = frame
+                    .interface()
+                    .ok_or(VmnetProviderError::InvalidPeerState)?;
+                let generation = frame
+                    .generation()
+                    .ok_or(VmnetProviderError::InvalidPeerState)?;
+                if self.active.get(&interface) != Some(&generation) {
+                    Err(VmnetProviderError::InvalidPeerState)
+                } else {
+                    self.pending = Some(ControlPending::Stop(interface, generation));
+                    self.state = ControlBrokerState::StopPending;
+                    Ok(ControlBrokerEvent::Stop {
+                        interface,
+                        generation,
+                    })
+                }
+            }
+            (
+                ControlBrokerState::Ready
+                | ControlBrokerState::StartPending
+                | ControlBrokerState::StopPending,
+                Some(ControlMessage::Cancel { reason }),
+            ) => {
+                self.state = ControlBrokerState::ReadyToCancel;
+                Ok(ControlBrokerEvent::Cancel { reason })
+            }
+            (ControlBrokerState::Ready, Some(ControlMessage::Shutdown))
+                if self.active.is_empty() && self.pending.is_none() =>
+            {
+                self.state = ControlBrokerState::ReadyToShutdown;
+                Ok(ControlBrokerEvent::Shutdown)
+            }
+            (_, Some(ControlMessage::Terminal { code })) => {
+                self.poison();
+                Ok(ControlBrokerEvent::PeerTerminal { code })
+            }
+            _ => Err(VmnetProviderError::InvalidPeerState),
+        })();
+        if result.is_err() {
+            self.poison();
+        }
+        result
+    }
+
+    /// Emits the mandatory hello acknowledgement.
+    pub fn hello_ack(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(ControlBrokerState::ReadyToAck)?;
+        let envelope = self.control(None, None, ControlMessage::HelloAck)?;
+        self.state = ControlBrokerState::Ready;
+        Ok(envelope)
+    }
+
+    /// Commits a fresh start and atomically transfers its data stream.
+    pub fn started(
+        &mut self,
+        generation: VmnetGeneration,
+        parameters: RealizedVmnetParameters,
+        stream: UnixStream,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if !matches!(
+            self.state,
+            ControlBrokerState::StartPending | ControlBrokerState::ReadyToCancel
+        ) {
+            return Err(self.local_error());
+        }
+        let ControlPending::Start(interface) =
+            self.pending.ok_or(VmnetProviderError::InvalidLifecycle)?
+        else {
+            return Err(VmnetProviderError::InvalidLifecycle);
+        };
+        if self.last_generation.is_some_and(|last| generation <= last) {
+            return Err(VmnetProviderError::InvalidConfiguration);
+        }
+        let sequence = self.take_local_sequence()?;
+        let frame = ProviderFrame::control(
+            self.session,
+            Some(interface),
+            Some(generation),
+            sequence,
+            ControlMessage::Started { parameters },
+        )?;
+        self.active.insert(interface, generation);
+        self.last_generation = Some(generation);
+        self.pending = None;
+        if self.state == ControlBrokerState::StartPending {
+            self.state = ControlBrokerState::Ready;
+        }
+        Ok(ProviderEnvelope::with_stream(frame, stream))
+    }
+
+    /// Completes a pending start without creating ownership.
+    pub fn start_failed(
+        &mut self,
+        status: ProviderStatus,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if !matches!(
+            self.state,
+            ControlBrokerState::StartPending | ControlBrokerState::ReadyToCancel
+        ) {
+            return Err(self.local_error());
+        }
+        let ControlPending::Start(interface) =
+            self.pending.ok_or(VmnetProviderError::InvalidLifecycle)?
+        else {
+            return Err(VmnetProviderError::InvalidLifecycle);
+        };
+        let envelope = self.control(
+            Some(interface),
+            None,
+            ControlMessage::StartFailed { status },
+        )?;
+        self.pending = None;
+        if self.state == ControlBrokerState::StartPending {
+            self.state = ControlBrokerState::Ready;
+        }
+        Ok(envelope)
+    }
+
+    /// Completes exact stop and reap of a pending generation.
+    pub fn stopped(
+        &mut self,
+        cleanup: ProviderCleanup,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if !matches!(
+            self.state,
+            ControlBrokerState::StopPending | ControlBrokerState::ReadyToCancel
+        ) {
+            return Err(self.local_error());
+        }
+        let ControlPending::Stop(interface, generation) =
+            self.pending.ok_or(VmnetProviderError::InvalidLifecycle)?
+        else {
+            return Err(VmnetProviderError::InvalidLifecycle);
+        };
+        let envelope = self.control(
+            Some(interface),
+            Some(generation),
+            ControlMessage::Stopped { cleanup },
+        )?;
+        self.pending = None;
+        if cleanup == ProviderCleanup::Complete {
+            self.active.remove(&interface);
+            if self.state == ControlBrokerState::StopPending {
+                self.state = ControlBrokerState::Ready;
+            }
+        } else {
+            self.poison();
+        }
+        Ok(envelope)
+    }
+
+    /// Completes aggregate cancellation, suppressing any still-pending result.
+    pub fn cancelled(
+        &mut self,
+        cleanup: ProviderCleanup,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(ControlBrokerState::ReadyToCancel)?;
+        let envelope = self.control(None, None, ControlMessage::Cancelled { cleanup })?;
+        self.pending = None;
+        self.active.clear();
+        self.state = if cleanup == ProviderCleanup::Complete {
+            ControlBrokerState::Closed
+        } else {
+            ControlBrokerState::Terminal
+        };
+        Ok(envelope)
+    }
+
+    /// Completes empty-session orderly shutdown.
+    pub fn shutdown_ack(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(ControlBrokerState::ReadyToShutdown)?;
+        let envelope = self.control(None, None, ControlMessage::ShutdownAck)?;
+        self.state = ControlBrokerState::Closed;
+        Ok(envelope)
+    }
+
+    /// Emits a terminal frame and irreversibly drops broker ownership state.
+    pub fn terminal(
+        &mut self,
+        code: ProviderTerminalCode,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if matches!(
+            self.state,
+            ControlBrokerState::Closed | ControlBrokerState::Terminal
+        ) {
+            return Err(self.local_error());
+        }
+        let envelope = self.control(None, None, ControlMessage::Terminal { code })?;
+        self.poison();
+        Ok(envelope)
+    }
+}
+
+impl VmnetControlBroker {
+    fn control(
+        &mut self,
+        interface: Option<VmnetInterfaceId>,
+        generation: Option<VmnetGeneration>,
+        message: ControlMessage,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        let sequence = self.take_local_sequence()?;
+        ProviderFrame::control(self.session, interface, generation, sequence, message)
+            .map(ProviderEnvelope::frame_only)
+    }
+
+    fn validate_peer(&mut self, frame: &ProviderFrame) -> Result<(), VmnetProviderError> {
+        if frame.session() != self.session
+            || frame.sequence() != self.next_peer
+            || frame.control_message().is_none()
+            || frame.descriptor_count() != 0
+        {
+            return Err(VmnetProviderError::InvalidPeerState);
+        }
+        self.next_peer = self.next_peer.checked_next()?;
+        Ok(())
+    }
+
+    fn take_local_sequence(&mut self) -> Result<VmnetSequence, VmnetProviderError> {
+        let current = self.next_local;
+        match self.next_local.checked_next() {
+            Ok(next) => {
+                self.next_local = next;
+                Ok(current)
+            }
+            Err(error) => {
+                self.poison();
+                Err(error)
+            }
+        }
+    }
+
+    fn require_state(&self, expected: ControlBrokerState) -> Result<(), VmnetProviderError> {
+        if self.state == expected {
+            Ok(())
+        } else {
+            Err(self.local_error())
+        }
+    }
+
+    fn local_error(&self) -> VmnetProviderError {
+        if self.state == ControlBrokerState::Terminal {
+            VmnetProviderError::Poisoned
+        } else {
+            VmnetProviderError::InvalidLifecycle
+        }
+    }
+
+    fn peer_error(&mut self) -> VmnetProviderError {
+        self.poison();
+        VmnetProviderError::InvalidPeerState
+    }
+
+    fn poison(&mut self) {
+        self.pending = None;
+        self.active.clear();
+        self.state = ControlBrokerState::Terminal;
+    }
+}
+
+impl fmt::Debug for VmnetControlBroker {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VmnetControlBroker")
+            .field("session", &"<redacted>")
+            .field("state", &self.state)
+            .field("active_count", &self.active.len())
+            .finish()
+    }
+}

--- a/crates/session/src/vmnet_provider/state/data.rs
+++ b/crates/session/src/vmnet_provider/state/data.rs
@@ -1,0 +1,835 @@
+use std::fmt;
+
+use crate::SessionId;
+
+use super::{first_sequence, require_session};
+use crate::vmnet_provider::{
+    DataMessage, ProviderCleanup, ProviderEnvelope, ProviderFrame, ProviderOperation,
+    ProviderStatus, ProviderTerminalCode, RealizedVmnetParameters, VmnetGeneration,
+    VmnetInterfaceId, VmnetPacketBatch, VmnetProviderError, VmnetReadinessEpoch, VmnetSequence,
+};
+
+/// Worker-side lifecycle for one transferred data stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataClientState {
+    /// No hello has been sent.
+    New,
+    /// The binding acknowledgement is pending.
+    AwaitHelloAck,
+    /// Packet work or stop may begin.
+    Active,
+    /// One read or write result is pending.
+    AwaitResponse,
+    /// Backend stop completion is pending.
+    AwaitStopped,
+    /// Stop completed; only shutdown remains.
+    Stopped,
+    /// Orderly shutdown acknowledgement is pending.
+    AwaitShutdownAck,
+    /// The protocol completed cleanly.
+    Closed,
+    /// A terminal failure permanently poisoned the state.
+    Terminal,
+}
+
+/// Owner-side lifecycle for one transferred data stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataOwnerState {
+    /// The client binding hello is pending.
+    AwaitHello,
+    /// The binding acknowledgement must be emitted.
+    ReadyToAck,
+    /// Packet requests or stop may arrive.
+    Active,
+    /// One read or write response must be emitted.
+    ReadyToRespond,
+    /// Backend drain and stop are required.
+    ReadyToStop,
+    /// Stop completed; only shutdown remains.
+    Stopped,
+    /// An orderly shutdown acknowledgement is required.
+    ReadyToShutdown,
+    /// The protocol completed cleanly.
+    Closed,
+    /// A terminal failure permanently poisoned the state.
+    Terminal,
+}
+
+/// Checked event produced by the data client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataClientEvent {
+    /// The exact stream binding was acknowledged.
+    Ready,
+    /// One contiguous readiness edge was published.
+    Readiness {
+        /// Exact readiness epoch.
+        epoch: VmnetReadinessEpoch,
+        /// Bounded packet estimate.
+        estimated_packets: u16,
+    },
+    /// A read completed with a zero-to-requested batch.
+    ReadComplete {
+        /// Canonical ordered packet batch.
+        packets: VmnetPacketBatch,
+    },
+    /// A write completed with a zero-to-requested prefix.
+    WriteComplete {
+        /// Exact successfully written prefix count.
+        completed_packets: u16,
+    },
+    /// A correlated backend operation failed terminally.
+    OperationFailed {
+        /// Failed operation.
+        operation: ProviderOperation,
+        /// Stable failure category.
+        status: ProviderStatus,
+    },
+    /// Backend stop completed.
+    Stopped,
+    /// Orderly stream shutdown completed.
+    Shutdown,
+    /// The peer declared a terminal category.
+    PeerTerminal {
+        /// Stable terminal category.
+        code: ProviderTerminalCode,
+    },
+}
+
+/// Checked event produced by the data owner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataOwnerEvent {
+    /// The exact client binding hello was accepted.
+    Hello,
+    /// One bounded read requires backend work.
+    Read {
+        /// Exact request sequence for correlation.
+        request: VmnetSequence,
+        /// Requested packet maximum.
+        max_packets: u16,
+    },
+    /// One bounded write requires backend work.
+    Write {
+        /// Exact request sequence for correlation.
+        request: VmnetSequence,
+        /// Canonical ordered packet batch.
+        packets: VmnetPacketBatch,
+    },
+    /// Callback drain and backend stop are required.
+    Stop,
+    /// Orderly closure was requested after stop.
+    Shutdown,
+    /// The peer declared a terminal category.
+    PeerTerminal {
+        /// Stable terminal category.
+        code: ProviderTerminalCode,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DataPending {
+    Read {
+        request: VmnetSequence,
+        max_packets: u16,
+    },
+    Write {
+        request: VmnetSequence,
+        packet_count: u16,
+    },
+}
+
+/// Worker-side state machine for one exact interface generation.
+pub struct VmnetDataClient {
+    session: SessionId,
+    interface: VmnetInterfaceId,
+    generation: VmnetGeneration,
+    parameters: RealizedVmnetParameters,
+    state: DataClientState,
+    next_local: VmnetSequence,
+    next_peer: VmnetSequence,
+    next_readiness: VmnetReadinessEpoch,
+    readiness_pending: bool,
+    pending: Option<DataPending>,
+}
+
+impl VmnetDataClient {
+    /// Constructs a client bound to the exact transferred-stream scope.
+    pub fn new(
+        session: SessionId,
+        interface: VmnetInterfaceId,
+        generation: VmnetGeneration,
+        parameters: RealizedVmnetParameters,
+    ) -> Result<Self, VmnetProviderError> {
+        require_session(session)?;
+        Ok(Self {
+            session,
+            interface,
+            generation,
+            parameters,
+            state: DataClientState::New,
+            next_local: first_sequence(),
+            next_peer: first_sequence(),
+            next_readiness: first_readiness(),
+            readiness_pending: false,
+            pending: None,
+        })
+    }
+
+    /// Returns the current lifecycle.
+    #[must_use]
+    pub const fn state(&self) -> DataClientState {
+        self.state
+    }
+
+    /// Begins the mandatory exact-binding handshake.
+    pub fn hello(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataClientState::New)?;
+        let frame = self.data(DataMessage::Hello)?;
+        self.state = DataClientState::AwaitHelloAck;
+        Ok(frame)
+    }
+
+    /// Begins one bounded read request.
+    pub fn read(&mut self, max_packets: u16) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataClientState::Active)?;
+        if max_packets == 0 || max_packets > self.parameters.effective_read_max_packets() {
+            return Err(VmnetProviderError::LimitExceeded);
+        }
+        let request = self.next_local;
+        let frame = self.data(DataMessage::Read { max_packets })?;
+        self.pending = Some(DataPending::Read {
+            request,
+            max_packets,
+        });
+        self.readiness_pending = false;
+        self.state = DataClientState::AwaitResponse;
+        Ok(frame)
+    }
+
+    /// Begins one bounded nonempty write request.
+    pub fn write(
+        &mut self,
+        packets: VmnetPacketBatch,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataClientState::Active)?;
+        if !packets.fits(
+            self.parameters.packet_buffer_bytes(),
+            usize::from(self.parameters.effective_write_max_packets()),
+        ) {
+            return Err(VmnetProviderError::LimitExceeded);
+        }
+        let packet_count =
+            u16::try_from(packets.packet_count()).map_err(|_| VmnetProviderError::LimitExceeded)?;
+        let request = self.next_local;
+        let frame = self.data(DataMessage::Write { packets })?;
+        self.pending = Some(DataPending::Write {
+            request,
+            packet_count,
+        });
+        self.state = DataClientState::AwaitResponse;
+        Ok(frame)
+    }
+
+    /// Begins callback drain and backend stop.
+    pub fn stop(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataClientState::Active)?;
+        let frame = self.data(DataMessage::Stop)?;
+        self.readiness_pending = false;
+        self.state = DataClientState::AwaitStopped;
+        Ok(frame)
+    }
+
+    /// Begins orderly closure after complete stop.
+    pub fn shutdown(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataClientState::Stopped)?;
+        let frame = self.data(DataMessage::Shutdown)?;
+        self.state = DataClientState::AwaitShutdownAck;
+        Ok(frame)
+    }
+
+    /// Emits a terminal frame and irreversibly clears pending packet ownership.
+    pub fn terminal(
+        &mut self,
+        code: ProviderTerminalCode,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if matches!(
+            self.state,
+            DataClientState::Closed | DataClientState::Terminal
+        ) {
+            return Err(self.local_error());
+        }
+        let frame = self.data(DataMessage::Terminal { code })?;
+        self.poison();
+        Ok(frame)
+    }
+
+    /// Consumes one checked owner frame.
+    pub fn receive(
+        &mut self,
+        envelope: ProviderEnvelope,
+    ) -> Result<DataClientEvent, VmnetProviderError> {
+        if matches!(
+            self.state,
+            DataClientState::Closed | DataClientState::Terminal
+        ) {
+            return Err(self.local_error());
+        }
+        let (frame, stream) = envelope.into_parts();
+        if stream.is_some() || self.validate_peer(&frame).is_err() {
+            return Err(self.peer_error());
+        }
+        let message = frame.data_message().cloned();
+        let result = (|| match (self.state, message) {
+            (DataClientState::AwaitHelloAck, Some(DataMessage::HelloAck)) => {
+                self.state = DataClientState::Active;
+                Ok(DataClientEvent::Ready)
+            }
+            (
+                DataClientState::Active | DataClientState::AwaitResponse,
+                Some(DataMessage::Readiness {
+                    epoch,
+                    estimated_packets,
+                }),
+            ) => self.accept_readiness(epoch, estimated_packets),
+            (
+                DataClientState::AwaitResponse,
+                Some(DataMessage::ReadResult { request, packets }),
+            ) => {
+                let DataPending::Read {
+                    request: expected,
+                    max_packets,
+                } = self.pending.ok_or(VmnetProviderError::InvalidPeerState)?
+                else {
+                    return Err(self.peer_error());
+                };
+                if request != expected
+                    || packets.packet_count() > usize::from(max_packets)
+                    || !packets.fits(
+                        self.parameters.packet_buffer_bytes(),
+                        usize::from(max_packets),
+                    )
+                {
+                    Err(VmnetProviderError::InvalidPeerState)
+                } else {
+                    self.pending = None;
+                    self.state = DataClientState::Active;
+                    Ok(DataClientEvent::ReadComplete { packets })
+                }
+            }
+            (
+                DataClientState::AwaitResponse,
+                Some(DataMessage::WriteResult {
+                    request,
+                    completed_packets,
+                }),
+            ) => {
+                let DataPending::Write {
+                    request: expected,
+                    packet_count,
+                } = self.pending.ok_or(VmnetProviderError::InvalidPeerState)?
+                else {
+                    return Err(self.peer_error());
+                };
+                if request != expected || completed_packets > packet_count {
+                    Err(VmnetProviderError::InvalidPeerState)
+                } else {
+                    self.pending = None;
+                    self.state = DataClientState::Active;
+                    Ok(DataClientEvent::WriteComplete { completed_packets })
+                }
+            }
+            (
+                DataClientState::AwaitResponse,
+                Some(DataMessage::OperationFailed {
+                    request,
+                    operation,
+                    status,
+                }),
+            ) if self.pending_matches(request, operation) => {
+                self.poison();
+                Ok(DataClientEvent::OperationFailed { operation, status })
+            }
+            (
+                DataClientState::AwaitStopped,
+                Some(DataMessage::Stopped {
+                    cleanup: ProviderCleanup::Complete,
+                }),
+            ) => {
+                self.state = DataClientState::Stopped;
+                Ok(DataClientEvent::Stopped)
+            }
+            (DataClientState::AwaitShutdownAck, Some(DataMessage::ShutdownAck)) => {
+                self.state = DataClientState::Closed;
+                Ok(DataClientEvent::Shutdown)
+            }
+            (_, Some(DataMessage::Terminal { code })) => {
+                self.poison();
+                Ok(DataClientEvent::PeerTerminal { code })
+            }
+            _ => Err(VmnetProviderError::InvalidPeerState),
+        })();
+        if result.is_err() {
+            self.poison();
+        }
+        result
+    }
+}
+
+impl VmnetDataClient {
+    fn accept_readiness(
+        &mut self,
+        epoch: VmnetReadinessEpoch,
+        estimated_packets: u16,
+    ) -> Result<DataClientEvent, VmnetProviderError> {
+        if self.readiness_pending
+            || epoch != self.next_readiness
+            || estimated_packets == 0
+            || estimated_packets > self.parameters.effective_read_max_packets()
+        {
+            return Err(VmnetProviderError::InvalidPeerState);
+        }
+        self.next_readiness = self.next_readiness.checked_next()?;
+        self.readiness_pending = true;
+        Ok(DataClientEvent::Readiness {
+            epoch,
+            estimated_packets,
+        })
+    }
+
+    fn pending_matches(&self, request: VmnetSequence, operation: ProviderOperation) -> bool {
+        matches!(
+            (self.pending, operation),
+            (Some(DataPending::Read { request: expected, .. }), ProviderOperation::Read)
+                | (Some(DataPending::Write { request: expected, .. }), ProviderOperation::Write)
+                    if request == expected
+        )
+    }
+
+    fn data(&mut self, message: DataMessage) -> Result<ProviderEnvelope, VmnetProviderError> {
+        let sequence = self.take_local_sequence()?;
+        ProviderFrame::data(
+            self.session,
+            self.interface,
+            self.generation,
+            sequence,
+            message,
+        )
+        .map(ProviderEnvelope::frame_only)
+    }
+
+    fn validate_peer(&mut self, frame: &ProviderFrame) -> Result<(), VmnetProviderError> {
+        if frame.session() != self.session
+            || frame.interface() != Some(self.interface)
+            || frame.generation() != Some(self.generation)
+            || frame.sequence() != self.next_peer
+            || frame.data_message().is_none()
+            || frame.descriptor_count() != 0
+        {
+            return Err(VmnetProviderError::InvalidPeerState);
+        }
+        self.next_peer = self.next_peer.checked_next()?;
+        Ok(())
+    }
+
+    fn take_local_sequence(&mut self) -> Result<VmnetSequence, VmnetProviderError> {
+        let current = self.next_local;
+        match self.next_local.checked_next() {
+            Ok(next) => {
+                self.next_local = next;
+                Ok(current)
+            }
+            Err(error) => {
+                self.poison();
+                Err(error)
+            }
+        }
+    }
+
+    fn require_state(&self, expected: DataClientState) -> Result<(), VmnetProviderError> {
+        if self.state == expected {
+            Ok(())
+        } else {
+            Err(self.local_error())
+        }
+    }
+
+    fn local_error(&self) -> VmnetProviderError {
+        if self.state == DataClientState::Terminal {
+            VmnetProviderError::Poisoned
+        } else {
+            VmnetProviderError::InvalidLifecycle
+        }
+    }
+
+    fn peer_error(&mut self) -> VmnetProviderError {
+        self.poison();
+        VmnetProviderError::InvalidPeerState
+    }
+
+    fn poison(&mut self) {
+        self.pending = None;
+        self.readiness_pending = false;
+        self.state = DataClientState::Terminal;
+    }
+}
+
+impl fmt::Debug for VmnetDataClient {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VmnetDataClient")
+            .field("binding", &"<redacted>")
+            .field("state", &self.state)
+            .field("pending", &self.pending.as_ref().map(|_| "<owned>"))
+            .finish()
+    }
+}
+
+/// Owner-side state machine for one exact interface generation.
+pub struct VmnetDataOwner {
+    session: SessionId,
+    interface: VmnetInterfaceId,
+    generation: VmnetGeneration,
+    parameters: RealizedVmnetParameters,
+    state: DataOwnerState,
+    next_local: VmnetSequence,
+    next_peer: VmnetSequence,
+    next_readiness: VmnetReadinessEpoch,
+    readiness_outstanding: bool,
+    pending: Option<DataPending>,
+}
+
+impl VmnetDataOwner {
+    /// Constructs an owner bound to the exact transferred-stream scope.
+    pub fn new(
+        session: SessionId,
+        interface: VmnetInterfaceId,
+        generation: VmnetGeneration,
+        parameters: RealizedVmnetParameters,
+    ) -> Result<Self, VmnetProviderError> {
+        require_session(session)?;
+        Ok(Self {
+            session,
+            interface,
+            generation,
+            parameters,
+            state: DataOwnerState::AwaitHello,
+            next_local: first_sequence(),
+            next_peer: first_sequence(),
+            next_readiness: first_readiness(),
+            readiness_outstanding: false,
+            pending: None,
+        })
+    }
+
+    /// Returns the current lifecycle.
+    #[must_use]
+    pub const fn state(&self) -> DataOwnerState {
+        self.state
+    }
+
+    /// Consumes one checked client frame.
+    pub fn receive(
+        &mut self,
+        envelope: ProviderEnvelope,
+    ) -> Result<DataOwnerEvent, VmnetProviderError> {
+        if matches!(
+            self.state,
+            DataOwnerState::Closed | DataOwnerState::Terminal
+        ) {
+            return Err(self.local_error());
+        }
+        let (frame, stream) = envelope.into_parts();
+        if stream.is_some() || self.validate_peer(&frame).is_err() {
+            return Err(self.peer_error());
+        }
+        let message = frame.data_message().cloned();
+        let result = (|| match (self.state, message) {
+            (DataOwnerState::AwaitHello, Some(DataMessage::Hello)) => {
+                self.state = DataOwnerState::ReadyToAck;
+                Ok(DataOwnerEvent::Hello)
+            }
+            (DataOwnerState::Active, Some(DataMessage::Read { max_packets })) => {
+                if max_packets == 0 || max_packets > self.parameters.effective_read_max_packets() {
+                    Err(VmnetProviderError::InvalidPeerState)
+                } else {
+                    let request = frame.sequence();
+                    self.pending = Some(DataPending::Read {
+                        request,
+                        max_packets,
+                    });
+                    self.readiness_outstanding = false;
+                    self.state = DataOwnerState::ReadyToRespond;
+                    Ok(DataOwnerEvent::Read {
+                        request,
+                        max_packets,
+                    })
+                }
+            }
+            (DataOwnerState::Active, Some(DataMessage::Write { packets })) => {
+                if !packets.fits(
+                    self.parameters.packet_buffer_bytes(),
+                    usize::from(self.parameters.effective_write_max_packets()),
+                ) {
+                    Err(VmnetProviderError::InvalidPeerState)
+                } else {
+                    let request = frame.sequence();
+                    let packet_count = u16::try_from(packets.packet_count())
+                        .map_err(|_| VmnetProviderError::InvalidPeerState)?;
+                    self.pending = Some(DataPending::Write {
+                        request,
+                        packet_count,
+                    });
+                    self.state = DataOwnerState::ReadyToRespond;
+                    Ok(DataOwnerEvent::Write { request, packets })
+                }
+            }
+            (DataOwnerState::Active, Some(DataMessage::Stop)) => {
+                self.readiness_outstanding = false;
+                self.state = DataOwnerState::ReadyToStop;
+                Ok(DataOwnerEvent::Stop)
+            }
+            (DataOwnerState::Stopped, Some(DataMessage::Shutdown)) => {
+                self.state = DataOwnerState::ReadyToShutdown;
+                Ok(DataOwnerEvent::Shutdown)
+            }
+            (_, Some(DataMessage::Terminal { code })) => {
+                self.poison();
+                Ok(DataOwnerEvent::PeerTerminal { code })
+            }
+            _ => Err(VmnetProviderError::InvalidPeerState),
+        })();
+        if result.is_err() {
+            self.poison();
+        }
+        result
+    }
+
+    /// Emits the mandatory exact-binding acknowledgement.
+    pub fn hello_ack(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataOwnerState::ReadyToAck)?;
+        let frame = self.data(DataMessage::HelloAck)?;
+        self.state = DataOwnerState::Active;
+        Ok(frame)
+    }
+
+    /// Publishes one coalesced readiness edge.
+    pub fn readiness(
+        &mut self,
+        estimated_packets: u16,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if !matches!(
+            self.state,
+            DataOwnerState::Active | DataOwnerState::ReadyToRespond
+        ) {
+            return Err(self.local_error());
+        }
+        if self.readiness_outstanding
+            || estimated_packets == 0
+            || estimated_packets > self.parameters.effective_read_max_packets()
+        {
+            return Err(VmnetProviderError::LimitExceeded);
+        }
+        let epoch = self.next_readiness;
+        let frame = self.data(DataMessage::Readiness {
+            epoch,
+            estimated_packets,
+        })?;
+        self.next_readiness = self.next_readiness.checked_next()?;
+        self.readiness_outstanding = true;
+        Ok(frame)
+    }
+
+    /// Completes one pending read with a zero-to-requested batch.
+    pub fn read_result(
+        &mut self,
+        packets: VmnetPacketBatch,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataOwnerState::ReadyToRespond)?;
+        let DataPending::Read {
+            request,
+            max_packets,
+        } = self.pending.ok_or(VmnetProviderError::InvalidLifecycle)?
+        else {
+            return Err(VmnetProviderError::InvalidLifecycle);
+        };
+        if packets.packet_count() > usize::from(max_packets)
+            || !packets.fits(
+                self.parameters.packet_buffer_bytes(),
+                usize::from(max_packets),
+            )
+        {
+            return Err(VmnetProviderError::LimitExceeded);
+        }
+        let frame = self.data(DataMessage::ReadResult { request, packets })?;
+        self.pending = None;
+        self.state = DataOwnerState::Active;
+        Ok(frame)
+    }
+
+    /// Completes one pending write with a zero-to-requested prefix.
+    pub fn write_result(
+        &mut self,
+        completed_packets: u16,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataOwnerState::ReadyToRespond)?;
+        let DataPending::Write {
+            request,
+            packet_count,
+        } = self.pending.ok_or(VmnetProviderError::InvalidLifecycle)?
+        else {
+            return Err(VmnetProviderError::InvalidLifecycle);
+        };
+        if completed_packets > packet_count {
+            return Err(VmnetProviderError::LimitExceeded);
+        }
+        let frame = self.data(DataMessage::WriteResult {
+            request,
+            completed_packets,
+        })?;
+        self.pending = None;
+        self.state = DataOwnerState::Active;
+        Ok(frame)
+    }
+
+    /// Reports a correlated terminal backend failure.
+    pub fn operation_failed(
+        &mut self,
+        status: ProviderStatus,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataOwnerState::ReadyToRespond)?;
+        let pending = self.pending.ok_or(VmnetProviderError::InvalidLifecycle)?;
+        let (request, operation) = match pending {
+            DataPending::Read { request, .. } => (request, ProviderOperation::Read),
+            DataPending::Write { request, .. } => (request, ProviderOperation::Write),
+        };
+        let frame = self.data(DataMessage::OperationFailed {
+            request,
+            operation,
+            status,
+        })?;
+        self.poison();
+        Ok(frame)
+    }
+
+    /// Completes callback drain and backend stop.
+    pub fn stopped(
+        &mut self,
+        cleanup: ProviderCleanup,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataOwnerState::ReadyToStop)?;
+        let frame = self.data(DataMessage::Stopped { cleanup })?;
+        self.state = if cleanup == ProviderCleanup::Complete {
+            DataOwnerState::Stopped
+        } else {
+            DataOwnerState::Terminal
+        };
+        Ok(frame)
+    }
+
+    /// Completes orderly stream closure.
+    pub fn shutdown_ack(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        self.require_state(DataOwnerState::ReadyToShutdown)?;
+        let frame = self.data(DataMessage::ShutdownAck)?;
+        self.state = DataOwnerState::Closed;
+        Ok(frame)
+    }
+
+    /// Emits a terminal frame and irreversibly clears pending packet ownership.
+    pub fn terminal(
+        &mut self,
+        code: ProviderTerminalCode,
+    ) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if matches!(
+            self.state,
+            DataOwnerState::Closed | DataOwnerState::Terminal
+        ) {
+            return Err(self.local_error());
+        }
+        let frame = self.data(DataMessage::Terminal { code })?;
+        self.poison();
+        Ok(frame)
+    }
+}
+
+impl VmnetDataOwner {
+    fn data(&mut self, message: DataMessage) -> Result<ProviderEnvelope, VmnetProviderError> {
+        let sequence = self.take_local_sequence()?;
+        ProviderFrame::data(
+            self.session,
+            self.interface,
+            self.generation,
+            sequence,
+            message,
+        )
+        .map(ProviderEnvelope::frame_only)
+    }
+
+    fn validate_peer(&mut self, frame: &ProviderFrame) -> Result<(), VmnetProviderError> {
+        if frame.session() != self.session
+            || frame.interface() != Some(self.interface)
+            || frame.generation() != Some(self.generation)
+            || frame.sequence() != self.next_peer
+            || frame.data_message().is_none()
+            || frame.descriptor_count() != 0
+        {
+            return Err(VmnetProviderError::InvalidPeerState);
+        }
+        self.next_peer = self.next_peer.checked_next()?;
+        Ok(())
+    }
+
+    fn take_local_sequence(&mut self) -> Result<VmnetSequence, VmnetProviderError> {
+        let current = self.next_local;
+        match self.next_local.checked_next() {
+            Ok(next) => {
+                self.next_local = next;
+                Ok(current)
+            }
+            Err(error) => {
+                self.poison();
+                Err(error)
+            }
+        }
+    }
+
+    fn require_state(&self, expected: DataOwnerState) -> Result<(), VmnetProviderError> {
+        if self.state == expected {
+            Ok(())
+        } else {
+            Err(self.local_error())
+        }
+    }
+
+    fn local_error(&self) -> VmnetProviderError {
+        if self.state == DataOwnerState::Terminal {
+            VmnetProviderError::Poisoned
+        } else {
+            VmnetProviderError::InvalidLifecycle
+        }
+    }
+
+    fn peer_error(&mut self) -> VmnetProviderError {
+        self.poison();
+        VmnetProviderError::InvalidPeerState
+    }
+
+    fn poison(&mut self) {
+        self.pending = None;
+        self.readiness_outstanding = false;
+        self.state = DataOwnerState::Terminal;
+    }
+}
+
+impl fmt::Debug for VmnetDataOwner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VmnetDataOwner")
+            .field("binding", &"<redacted>")
+            .field("state", &self.state)
+            .field("pending", &self.pending.as_ref().map(|_| "<owned>"))
+            .finish()
+    }
+}
+
+fn first_readiness() -> VmnetReadinessEpoch {
+    VmnetReadinessEpoch::MIN
+}

--- a/crates/session/src/vmnet_provider/transport.rs
+++ b/crates/session/src/vmnet_provider/transport.rs
@@ -1,0 +1,449 @@
+use std::fmt;
+use std::os::fd::{AsFd, OwnedFd};
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+use bangbang_unix_stream::{UnixStreamTransport, connected_unix_stream};
+
+use super::{
+    HEADER_BYTES, ProviderEnvelope, VmnetProviderError, decode_frame, decode_header, encode_frame,
+};
+
+/// Largest permitted timeout for one complete provider frame.
+pub const MAX_PROVIDER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Descriptor-aware exact-frame transport for the private provider protocol.
+pub struct VmnetProviderTransport {
+    inner: UnixStreamTransport,
+    poisoned: bool,
+}
+
+impl VmnetProviderTransport {
+    /// Adopts one already-connected control or data stream.
+    pub fn new(stream: UnixStream, timeout: Duration) -> Result<Self, VmnetProviderError> {
+        if timeout.is_zero() || timeout > MAX_PROVIDER_TIMEOUT {
+            return Err(VmnetProviderError::InvalidConfiguration);
+        }
+        let inner = UnixStreamTransport::new(stream, timeout).map_err(VmnetProviderError::from)?;
+        Ok(Self {
+            inner,
+            poisoned: false,
+        })
+    }
+
+    /// Returns whether any prior transport failure permanently poisoned the stream.
+    #[must_use]
+    pub const fn is_poisoned(&self) -> bool {
+        self.poisoned
+    }
+
+    /// Sends one complete frame and its exact optional transferred stream.
+    pub fn send(&mut self, envelope: ProviderEnvelope) -> Result<(), VmnetProviderError> {
+        if self.poisoned {
+            return Err(VmnetProviderError::Poisoned);
+        }
+        let result = self.send_inner(envelope);
+        if result.is_err() {
+            self.poison();
+        }
+        result
+    }
+
+    /// Receives one complete frame and atomically adopts its exact optional stream.
+    pub fn receive(&mut self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        if self.poisoned {
+            return Err(VmnetProviderError::Poisoned);
+        }
+        let result = self.receive_inner();
+        if result.is_err() {
+            self.poison();
+        }
+        result
+    }
+
+    fn send_inner(&self, envelope: ProviderEnvelope) -> Result<(), VmnetProviderError> {
+        let (frame, stream) = envelope.into_parts();
+        if usize::from(frame.descriptor_count()) != usize::from(stream.is_some()) {
+            return Err(VmnetProviderError::InvalidFrame);
+        }
+        let encoded = encode_frame(&frame)?;
+        match stream.as_ref() {
+            Some(stream) => {
+                validate_outgoing_stream(stream)?;
+                self.inner
+                    .send(&encoded, &[stream.as_fd()])
+                    .map_err(VmnetProviderError::from)
+            }
+            None => self
+                .inner
+                .send(&encoded, &[])
+                .map_err(VmnetProviderError::from),
+        }
+    }
+
+    fn receive_inner(&self) -> Result<ProviderEnvelope, VmnetProviderError> {
+        let deadline = self.inner.deadline().map_err(VmnetProviderError::from)?;
+        let header_range = self
+            .inner
+            .receive_exact_until(HEADER_BYTES, 1, deadline)
+            .map_err(VmnetProviderError::from)?;
+        let (header_bytes, mut descriptors) = header_range.into_parts();
+        let header = decode_header(&header_bytes)?;
+        if descriptors.len() != usize::from(header.descriptor_count()) {
+            return Err(VmnetProviderError::InvalidFrame);
+        }
+
+        let body_range = self
+            .inner
+            .receive_exact_until(header.body_len(), 0, deadline)
+            .map_err(VmnetProviderError::from)?;
+        let (body, body_descriptors) = body_range.into_parts();
+        if !body_descriptors.is_empty() {
+            return Err(VmnetProviderError::InvalidFrame);
+        }
+
+        let mut encoded = header_bytes;
+        encoded
+            .try_reserve_exact(body.len())
+            .map_err(|_| VmnetProviderError::LimitExceeded)?;
+        encoded.extend_from_slice(&body);
+        let frame = decode_frame(&encoded)?;
+        match descriptors.pop() {
+            Some(descriptor) => connected_unix_stream(descriptor)
+                .map(|stream| ProviderEnvelope::with_stream(frame, stream))
+                .map_err(VmnetProviderError::from),
+            None => Ok(ProviderEnvelope::frame_only(frame)),
+        }
+    }
+
+    fn poison(&mut self) {
+        self.poisoned = true;
+        self.inner.shutdown();
+    }
+}
+
+impl fmt::Debug for VmnetProviderTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VmnetProviderTransport")
+            .field("stream", &"<redacted>")
+            .field("timeout", &"<configured>")
+            .field("poisoned", &self.poisoned)
+            .finish()
+    }
+}
+
+fn validate_outgoing_stream(stream: &UnixStream) -> Result<(), VmnetProviderError> {
+    let duplicate = stream
+        .try_clone()
+        .map(OwnedFd::from)
+        .map_err(|error| VmnetProviderError::Io(error.kind()))?;
+    let validated = connected_unix_stream(duplicate).map_err(VmnetProviderError::from)?;
+    drop(validated);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::os::fd::AsFd;
+    use std::os::unix::net::{UnixDatagram, UnixStream};
+    use std::time::Duration;
+
+    use bangbang_unix_stream::UnixStreamTransport;
+
+    use super::*;
+    use crate::SessionId;
+    use crate::vmnet_provider::{
+        ControlClientEvent, ControlMessage, DataClientEvent, DataOwnerEvent, ProviderFrame,
+        RealizedVmnetParameters, RequestedVmnetParameters, VmnetControlBroker, VmnetControlClient,
+        VmnetDataClient, VmnetDataOwner, VmnetGeneration, VmnetInterfaceId, VmnetPacketBatch,
+        VmnetPolicySlot, VmnetSequence,
+    };
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(1);
+
+    fn session(value: u8) -> SessionId {
+        SessionId::from_bytes([value; 32])
+    }
+
+    fn interface() -> VmnetInterfaceId {
+        VmnetInterfaceId::new(1).expect("interface should validate")
+    }
+
+    fn generation() -> VmnetGeneration {
+        VmnetGeneration::new(1).expect("generation should validate")
+    }
+
+    fn sequence(value: u64) -> VmnetSequence {
+        VmnetSequence::new(value).expect("sequence should validate")
+    }
+
+    fn realized() -> RealizedVmnetParameters {
+        RealizedVmnetParameters::new([2, 0, 0, 0, 0, 1], 1500, 2048)
+            .expect("base parameters should validate")
+            .with_batch_limits(Some(8), Some(8))
+            .expect("parameters should validate")
+    }
+
+    fn hello_frame() -> ProviderFrame {
+        ProviderFrame::control(session(1), None, None, sequence(1), ControlMessage::Hello)
+            .expect("frame should validate")
+    }
+
+    fn started_frame() -> ProviderFrame {
+        ProviderFrame::control(
+            session(1),
+            Some(interface()),
+            Some(generation()),
+            sequence(1),
+            ControlMessage::Started {
+                parameters: realized(),
+            },
+        )
+        .expect("frame should validate")
+    }
+
+    #[test]
+    fn ordinary_and_transferred_stream_frames_round_trip() {
+        let (left, right) = UnixStream::pair().expect("pair should construct");
+        let mut sender = VmnetProviderTransport::new(left, TEST_TIMEOUT).expect("sender");
+        let mut receiver = VmnetProviderTransport::new(right, TEST_TIMEOUT).expect("receiver");
+        sender
+            .send(ProviderEnvelope::frame_only(hello_frame()))
+            .expect("hello should send");
+        let hello = receiver.receive().expect("hello should receive");
+        assert_eq!(hello.frame(), &hello_frame());
+        assert!(!hello.has_stream());
+
+        let (data, mut peer) = UnixStream::pair().expect("data pair should construct");
+        sender
+            .send(ProviderEnvelope::with_stream(started_frame(), data))
+            .expect("started should send");
+        let received = receiver.receive().expect("started should receive");
+        assert_eq!(received.frame(), &started_frame());
+        assert!(received.has_stream());
+        let (_frame, mut stream) = received.into_parts();
+        let mut stream = stream.take().expect("stream should be present");
+        peer.write_all(b"x").expect("peer should write");
+        let mut byte = [0_u8; 1];
+        assert_eq!(stream.read(&mut byte).expect("stream should read"), 1);
+        assert_eq!(byte, *b"x");
+    }
+
+    #[test]
+    fn wrong_and_excess_header_rights_poison_and_close() {
+        let (left, right) = UnixStream::pair().expect("pair should construct");
+        let raw = UnixStreamTransport::new(left, TEST_TIMEOUT).expect("raw sender");
+        let mut receiver = VmnetProviderTransport::new(right, TEST_TIMEOUT).expect("receiver");
+        let encoded = encode_frame(&started_frame()).expect("frame should encode");
+        let (datagram, _peer) = UnixDatagram::pair().expect("datagram pair should construct");
+        raw.send(&encoded, &[datagram.as_fd()])
+            .expect("wrong right should send");
+        assert!(matches!(
+            receiver.receive(),
+            Err(VmnetProviderError::InvalidFrame)
+        ));
+        assert!(receiver.is_poisoned());
+        assert!(matches!(
+            receiver.receive(),
+            Err(VmnetProviderError::Poisoned)
+        ));
+
+        let (left, right) = UnixStream::pair().expect("pair should construct");
+        let raw = UnixStreamTransport::new(left, TEST_TIMEOUT).expect("raw sender");
+        let mut receiver = VmnetProviderTransport::new(right, TEST_TIMEOUT).expect("receiver");
+        let encoded = encode_frame(&hello_frame()).expect("frame should encode");
+        let (first, _first_peer) = UnixDatagram::pair().expect("pair should construct");
+        let (second, _second_peer) = UnixDatagram::pair().expect("pair should construct");
+        raw.send(&encoded, &[first.as_fd(), second.as_fd()])
+            .expect("rights should send");
+        assert!(matches!(
+            receiver.receive(),
+            Err(VmnetProviderError::InvalidFrame)
+        ));
+        assert!(receiver.is_poisoned());
+    }
+
+    #[test]
+    fn descriptor_on_body_is_rejected() {
+        let frame = ProviderFrame::control(
+            session(1),
+            Some(interface()),
+            None,
+            sequence(1),
+            ControlMessage::Start {
+                policy_slot: VmnetPolicySlot::Shared,
+                requested: RequestedVmnetParameters::new(None, None)
+                    .expect("request should validate"),
+            },
+        )
+        .expect("frame should validate");
+        let encoded = encode_frame(&frame).expect("frame should encode");
+        let (header, body) = encoded.split_at(HEADER_BYTES);
+        let (left, right) = UnixStream::pair().expect("pair should construct");
+        let raw = UnixStreamTransport::new(left, TEST_TIMEOUT).expect("raw sender");
+        let mut receiver = VmnetProviderTransport::new(right, TEST_TIMEOUT).expect("receiver");
+        raw.send(header, &[]).expect("header should send");
+        let (datagram, _peer) = UnixDatagram::pair().expect("pair should construct");
+        raw.send(body, &[datagram.as_fd()])
+            .expect("body right should send");
+        assert!(matches!(
+            receiver.receive(),
+            Err(VmnetProviderError::InvalidFrame)
+        ));
+        assert!(receiver.is_poisoned());
+    }
+
+    #[test]
+    fn timeout_clean_eof_and_partial_eof_are_distinct_and_terminal() {
+        let (left, _right) = UnixStream::pair().expect("pair should construct");
+        let mut receiver = VmnetProviderTransport::new(left, Duration::from_millis(20))
+            .expect("receiver should construct");
+        assert!(matches!(
+            receiver.receive(),
+            Err(VmnetProviderError::Timeout)
+        ));
+        assert!(receiver.is_poisoned());
+
+        let (left, right) = UnixStream::pair().expect("pair should construct");
+        let mut receiver = VmnetProviderTransport::new(left, TEST_TIMEOUT).expect("receiver");
+        drop(right);
+        assert!(matches!(
+            receiver.receive(),
+            Err(VmnetProviderError::Disconnected)
+        ));
+
+        let (left, mut right) = UnixStream::pair().expect("pair should construct");
+        let mut receiver = VmnetProviderTransport::new(left, TEST_TIMEOUT).expect("receiver");
+        right.write_all(b"prefix").expect("prefix should write");
+        drop(right);
+        assert!(matches!(
+            receiver.receive(),
+            Err(VmnetProviderError::UnexpectedEof)
+        ));
+        assert!(receiver.is_poisoned());
+    }
+
+    #[test]
+    fn transport_and_state_complete_one_transferred_data_lifecycle() {
+        let (client_socket, broker_socket) = UnixStream::pair().expect("pair should construct");
+        let mut client_transport =
+            VmnetProviderTransport::new(client_socket, TEST_TIMEOUT).expect("client transport");
+        let mut broker_transport =
+            VmnetProviderTransport::new(broker_socket, TEST_TIMEOUT).expect("broker transport");
+        let mut client = VmnetControlClient::new(session(3)).expect("client should construct");
+        let mut broker = VmnetControlBroker::new(session(3)).expect("broker should construct");
+
+        client_transport
+            .send(client.hello().expect("hello should emit"))
+            .expect("hello should send");
+        broker
+            .receive(broker_transport.receive().expect("hello should receive"))
+            .expect("hello should validate");
+        broker_transport
+            .send(broker.hello_ack().expect("ack should emit"))
+            .expect("ack should send");
+        client
+            .receive(client_transport.receive().expect("ack should receive"))
+            .expect("ack should validate");
+
+        client_transport
+            .send(
+                client
+                    .start(
+                        interface(),
+                        VmnetPolicySlot::Host,
+                        RequestedVmnetParameters::new(None, None).expect("request should validate"),
+                    )
+                    .expect("start should emit"),
+            )
+            .expect("start should send");
+        broker
+            .receive(broker_transport.receive().expect("start should receive"))
+            .expect("start should validate");
+        let (owner_stream, client_stream) = UnixStream::pair().expect("data pair should construct");
+        broker_transport
+            .send(
+                broker
+                    .started(generation(), realized(), client_stream)
+                    .expect("started should emit"),
+            )
+            .expect("started should send");
+        let event = client
+            .receive(client_transport.receive().expect("started should receive"))
+            .expect("started should validate");
+        let ControlClientEvent::Started { stream, .. } = event else {
+            panic!("expected started event");
+        };
+
+        let mut data_client_transport =
+            VmnetProviderTransport::new(stream, TEST_TIMEOUT).expect("data client transport");
+        let mut data_owner_transport =
+            VmnetProviderTransport::new(owner_stream, TEST_TIMEOUT).expect("data owner transport");
+        let mut data_client =
+            VmnetDataClient::new(session(3), interface(), generation(), realized())
+                .expect("data client");
+        let mut data_owner = VmnetDataOwner::new(session(3), interface(), generation(), realized())
+            .expect("data owner");
+        data_client_transport
+            .send(data_client.hello().expect("hello should emit"))
+            .expect("hello should send");
+        assert_eq!(
+            data_owner.receive(
+                data_owner_transport
+                    .receive()
+                    .expect("hello should receive")
+            ),
+            Ok(DataOwnerEvent::Hello)
+        );
+        data_owner_transport
+            .send(data_owner.hello_ack().expect("ack should emit"))
+            .expect("ack should send");
+        assert_eq!(
+            data_client.receive(data_client_transport.receive().expect("ack should receive")),
+            Ok(DataClientEvent::Ready)
+        );
+
+        let packet = [1_u8, 2, 3];
+        let batch = VmnetPacketBatch::write(&[&packet]).expect("batch should validate");
+        data_client_transport
+            .send(data_client.write(batch).expect("write should emit"))
+            .expect("write should send");
+        assert!(matches!(
+            data_owner.receive(
+                data_owner_transport
+                    .receive()
+                    .expect("write should receive")
+            ),
+            Ok(DataOwnerEvent::Write { .. })
+        ));
+        data_owner_transport
+            .send(data_owner.write_result(1).expect("result should emit"))
+            .expect("result should send");
+        assert_eq!(
+            data_client.receive(
+                data_client_transport
+                    .receive()
+                    .expect("result should receive")
+            ),
+            Ok(DataClientEvent::WriteComplete {
+                completed_packets: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn configuration_and_debug_are_bounded_and_redacted() {
+        let (left, _right) = UnixStream::pair().expect("pair should construct");
+        assert!(matches!(
+            VmnetProviderTransport::new(left, Duration::from_secs(6)),
+            Err(VmnetProviderError::InvalidConfiguration)
+        ));
+        let (left, _right) = UnixStream::pair().expect("pair should construct");
+        let transport = VmnetProviderTransport::new(left, TEST_TIMEOUT).expect("transport");
+        let debug = format!("{transport:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("1000"));
+    }
+}

--- a/crates/unix-stream/Cargo.toml
+++ b/crates/unix-stream/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
-name = "bangbang-vhost-user"
+name = "bangbang-unix-stream"
 version.workspace = true
 edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-bangbang-unix-stream = { path = "../unix-stream" }
 libc = "0.2"
 
 [lints]

--- a/crates/unix-stream/src/lib.rs
+++ b/crates/unix-stream/src/lib.rs
@@ -1,0 +1,920 @@
+//! Deadline-bounded byte and descriptor transfer over connected Unix streams.
+//!
+//! This crate owns no protocol framing, socket path, listener, process, peer
+//! authorization, or application semantics. Callers provide an already
+//! connected stream and impose their own frame and descriptor contracts.
+
+#[cfg(not(unix))]
+compile_error!("bangbang-unix-stream requires Unix descriptor and socket semantics");
+
+use std::fmt;
+use std::io;
+use std::mem::{MaybeUninit, size_of};
+use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::time::{Duration, Instant};
+
+/// Largest descriptor array accepted by the shared transport primitive.
+pub const MAX_ATTACHED_DESCRIPTORS: usize = 32;
+
+const CONTROL_WORDS: usize = 32;
+
+/// Redacted failure from exact Unix-stream transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnixStreamTransportError {
+    /// The caller or received transport shape is invalid.
+    Invalid,
+    /// The absolute operation deadline elapsed.
+    Timeout,
+    /// The peer closed before any requested byte arrived.
+    Disconnected,
+    /// The peer closed after transferring only a prefix.
+    UnexpectedEof,
+    /// A local socket operation failed.
+    Io(io::ErrorKind),
+}
+
+impl fmt::Display for UnixStreamTransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("private Unix stream transport failure")
+    }
+}
+
+impl std::error::Error for UnixStreamTransportError {}
+
+/// Opaque absolute deadline shared by the pieces of one framed operation.
+#[derive(Clone, Copy)]
+pub struct UnixStreamDeadline(Instant);
+
+impl fmt::Debug for UnixStreamDeadline {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("UnixStreamDeadline(<redacted>)")
+    }
+}
+
+/// Exact received bytes and every descriptor attached within their range.
+pub struct ReceivedBytes {
+    bytes: Vec<u8>,
+    descriptors: Vec<OwnedFd>,
+}
+
+impl ReceivedBytes {
+    /// Borrows the exact received bytes.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the number of owned received descriptors.
+    #[must_use]
+    pub fn descriptor_count(&self) -> usize {
+        self.descriptors.len()
+    }
+
+    /// Separates the exact bytes from their owned received descriptors.
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<u8>, Vec<OwnedFd>) {
+        (self.bytes, self.descriptors)
+    }
+}
+
+impl fmt::Debug for ReceivedBytes {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ReceivedBytes")
+            .field("bytes", &"<redacted>")
+            .field("descriptors", &"<owned>")
+            .finish()
+    }
+}
+
+/// Exact-I/O driver for one already-connected Unix stream.
+pub struct UnixStreamTransport {
+    stream: UnixStream,
+    timeout: Duration,
+}
+
+impl UnixStreamTransport {
+    /// Adopts and configures an already-connected Unix stream.
+    pub fn new(stream: UnixStream, timeout: Duration) -> Result<Self, UnixStreamTransportError> {
+        if timeout.is_zero() {
+            return Err(UnixStreamTransportError::Invalid);
+        }
+        stream
+            .set_nonblocking(true)
+            .map_err(|error| UnixStreamTransportError::Io(error.kind()))?;
+        suppress_socket_sigpipe(stream.as_raw_fd())
+            .map_err(|error| UnixStreamTransportError::Io(error.kind()))?;
+        Ok(Self { stream, timeout })
+    }
+
+    /// Creates one absolute deadline for a complete caller-defined operation.
+    pub fn deadline(&self) -> Result<UnixStreamDeadline, UnixStreamTransportError> {
+        Instant::now()
+            .checked_add(self.timeout)
+            .map(UnixStreamDeadline)
+            .ok_or(UnixStreamTransportError::Invalid)
+    }
+
+    /// Sends one nonempty byte sequence and its borrowed descriptor array.
+    pub fn send(
+        &self,
+        bytes: &[u8],
+        descriptors: &[BorrowedFd<'_>],
+    ) -> Result<(), UnixStreamTransportError> {
+        let deadline = self.deadline()?;
+        self.send_until(bytes, descriptors, deadline)
+    }
+
+    /// Sends under a previously created absolute deadline.
+    pub fn send_until(
+        &self,
+        bytes: &[u8],
+        descriptors: &[BorrowedFd<'_>],
+        deadline: UnixStreamDeadline,
+    ) -> Result<(), UnixStreamTransportError> {
+        if bytes.is_empty() || descriptors.len() > MAX_ATTACHED_DESCRIPTORS {
+            return Err(UnixStreamTransportError::Invalid);
+        }
+        let raw: Vec<RawFd> = descriptors.iter().map(AsRawFd::as_raw_fd).collect();
+        let mut driver = SystemSendDriver;
+        send_all_with_driver(
+            &mut driver,
+            self.stream.as_raw_fd(),
+            bytes,
+            &raw,
+            deadline.0,
+        )
+    }
+
+    /// Receives exactly `expected` bytes and at most `max_descriptors` rights.
+    pub fn receive_exact(
+        &self,
+        expected: usize,
+        max_descriptors: usize,
+    ) -> Result<ReceivedBytes, UnixStreamTransportError> {
+        let deadline = self.deadline()?;
+        self.receive_exact_until(expected, max_descriptors, deadline)
+    }
+
+    /// Receives exact bytes under a previously created absolute deadline.
+    pub fn receive_exact_until(
+        &self,
+        expected: usize,
+        max_descriptors: usize,
+        deadline: UnixStreamDeadline,
+    ) -> Result<ReceivedBytes, UnixStreamTransportError> {
+        if max_descriptors > MAX_ATTACHED_DESCRIPTORS {
+            return Err(UnixStreamTransportError::Invalid);
+        }
+        if expected == 0 {
+            return Ok(ReceivedBytes {
+                bytes: Vec::new(),
+                descriptors: Vec::new(),
+            });
+        }
+
+        let mut bytes = Vec::new();
+        bytes
+            .try_reserve_exact(expected)
+            .map_err(|_| UnixStreamTransportError::Invalid)?;
+        bytes.resize(expected, 0);
+        let mut received = 0_usize;
+        let mut descriptors = Vec::new();
+        while received < expected {
+            wait_ready(self.stream.as_raw_fd(), libc::POLLIN, deadline.0)?;
+            let remaining = bytes
+                .get_mut(received..)
+                .ok_or(UnixStreamTransportError::Invalid)?;
+            match recvmsg_once(self.stream.as_raw_fd(), remaining) {
+                Ok(attempt) => {
+                    descriptors.extend(attempt.descriptors);
+                    if descriptors.len() > max_descriptors {
+                        return Err(UnixStreamTransportError::Invalid);
+                    }
+                    if attempt.bytes == 0 {
+                        return Err(if received == 0 {
+                            UnixStreamTransportError::Disconnected
+                        } else {
+                            UnixStreamTransportError::UnexpectedEof
+                        });
+                    }
+                    received = received
+                        .checked_add(attempt.bytes)
+                        .filter(|count| *count <= expected)
+                        .ok_or(UnixStreamTransportError::Invalid)?;
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
+                    ) => {}
+                Err(error) if error.kind() == io::ErrorKind::InvalidData => {
+                    return Err(UnixStreamTransportError::Invalid);
+                }
+                Err(error) => return Err(UnixStreamTransportError::Io(error.kind())),
+            }
+        }
+        Ok(ReceivedBytes { bytes, descriptors })
+    }
+
+    /// Best-effort terminal shutdown of both stream directions.
+    pub fn shutdown(&self) {
+        let _ignored = self.stream.shutdown(std::net::Shutdown::Both);
+    }
+}
+
+impl fmt::Debug for UnixStreamTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UnixStreamTransport")
+            .field("stream", &"<redacted>")
+            .field("timeout", &"<configured>")
+            .finish()
+    }
+}
+
+/// Validates and converts one received descriptor into a connected Unix stream.
+pub fn connected_unix_stream(descriptor: OwnedFd) -> Result<UnixStream, UnixStreamTransportError> {
+    let raw = descriptor.as_raw_fd();
+    let flags = retry_fcntl(raw, libc::F_GETFD, 0)
+        .map_err(|error| UnixStreamTransportError::Io(error.kind()))?;
+    if flags & libc::FD_CLOEXEC == 0
+        || socket_int_option(raw, libc::SO_TYPE)? != libc::SOCK_STREAM
+        || socket_int_option(raw, libc::SO_ERROR)? != 0
+        || socket_family(raw, false)? != libc::AF_UNIX
+        || socket_family(raw, true)? != libc::AF_UNIX
+    {
+        return Err(UnixStreamTransportError::Invalid);
+    }
+    let stream = UnixStream::from(descriptor);
+    stream
+        .set_nonblocking(true)
+        .map_err(|error| UnixStreamTransportError::Io(error.kind()))?;
+    suppress_socket_sigpipe(stream.as_raw_fd())
+        .map_err(|error| UnixStreamTransportError::Io(error.kind()))?;
+    Ok(stream)
+}
+
+trait SendDriver {
+    fn wait_writable(
+        &mut self,
+        descriptor: RawFd,
+        deadline: Instant,
+    ) -> Result<(), UnixStreamTransportError>;
+
+    fn send_once(
+        &mut self,
+        descriptor: RawFd,
+        bytes: &[u8],
+        descriptors: &[RawFd],
+    ) -> io::Result<usize>;
+}
+
+struct SystemSendDriver;
+
+impl SendDriver for SystemSendDriver {
+    fn wait_writable(
+        &mut self,
+        descriptor: RawFd,
+        deadline: Instant,
+    ) -> Result<(), UnixStreamTransportError> {
+        wait_ready(descriptor, libc::POLLOUT, deadline)
+    }
+
+    fn send_once(
+        &mut self,
+        descriptor: RawFd,
+        bytes: &[u8],
+        descriptors: &[RawFd],
+    ) -> io::Result<usize> {
+        sendmsg_once(descriptor, bytes, descriptors)
+    }
+}
+
+fn send_all_with_driver<D: SendDriver>(
+    driver: &mut D,
+    socket: RawFd,
+    bytes: &[u8],
+    descriptors: &[RawFd],
+    deadline: Instant,
+) -> Result<(), UnixStreamTransportError> {
+    if bytes.is_empty() || descriptors.len() > MAX_ATTACHED_DESCRIPTORS {
+        return Err(UnixStreamTransportError::Invalid);
+    }
+    let mut transferred = 0_usize;
+    while transferred < bytes.len() {
+        driver.wait_writable(socket, deadline)?;
+        let remaining = bytes
+            .get(transferred..)
+            .ok_or(UnixStreamTransportError::Invalid)?;
+        let attached = if transferred == 0 { descriptors } else { &[] };
+        match driver.send_once(socket, remaining, attached) {
+            Ok(0) => return Err(UnixStreamTransportError::Disconnected),
+            Ok(sent) if sent <= remaining.len() => {
+                transferred = transferred
+                    .checked_add(sent)
+                    .ok_or(UnixStreamTransportError::Invalid)?;
+            }
+            Ok(_) => return Err(UnixStreamTransportError::Invalid),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
+                ) => {}
+            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {
+                return Err(UnixStreamTransportError::Disconnected);
+            }
+            Err(error) => return Err(UnixStreamTransportError::Io(error.kind())),
+        }
+    }
+    Ok(())
+}
+
+fn sendmsg_once(socket: RawFd, bytes: &[u8], descriptors: &[RawFd]) -> io::Result<usize> {
+    if bytes.is_empty() || descriptors.len() > MAX_ATTACHED_DESCRIPTORS {
+        return Err(io::Error::from(io::ErrorKind::InvalidInput));
+    }
+    let mut iovec = libc::iovec {
+        iov_base: bytes.as_ptr().cast_mut().cast(),
+        iov_len: bytes.len(),
+    };
+    let mut control = [0_usize; CONTROL_WORDS];
+    // SAFETY: A zeroed msghdr is a valid baseline. Live payload and optional
+    // control pointers are installed before the synchronous call.
+    let mut message: libc::msghdr = unsafe { MaybeUninit::zeroed().assume_init() };
+    message.msg_iov = &raw mut iovec;
+    message.msg_iovlen = 1;
+
+    if !descriptors.is_empty() {
+        let descriptor_bytes = descriptors
+            .len()
+            .checked_mul(size_of::<RawFd>())
+            .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?;
+        let descriptor_bytes_u32 = u32::try_from(descriptor_bytes)
+            .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+        // SAFETY: CMSG_SPACE performs platform layout arithmetic on the bounded
+        // descriptor byte count and dereferences no pointer.
+        let control_space = unsafe { libc::CMSG_SPACE(descriptor_bytes_u32) };
+        let control_bytes = usize::try_from(control_space)
+            .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+        if control_bytes > control.len().saturating_mul(size_of::<usize>()) {
+            return Err(io::Error::from(io::ErrorKind::InvalidInput));
+        }
+        message.msg_control = control.as_mut_ptr().cast();
+        message.msg_controllen = control_bytes
+            .try_into()
+            .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+        // SAFETY: The aligned checked control buffer holds one complete header
+        // and the descriptor array; all pointers remain live for sendmsg.
+        unsafe {
+            let header = libc::CMSG_FIRSTHDR(&raw const message);
+            if header.is_null() {
+                return Err(io::Error::from(io::ErrorKind::InvalidInput));
+            }
+            (*header).cmsg_level = libc::SOL_SOCKET;
+            (*header).cmsg_type = libc::SCM_RIGHTS;
+            (*header).cmsg_len = libc::CMSG_LEN(descriptor_bytes_u32) as _;
+            std::ptr::copy_nonoverlapping(
+                descriptors.as_ptr().cast::<u8>(),
+                libc::CMSG_DATA(header),
+                descriptor_bytes,
+            );
+        }
+    }
+
+    // SAFETY: The msghdr references live readable payload/control buffers and
+    // the caller retains ownership of all attached descriptors.
+    let result = unsafe { libc::sendmsg(socket, &raw const message, send_flags()) };
+    if result < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        usize::try_from(result).map_err(|_| io::Error::from(io::ErrorKind::InvalidData))
+    }
+}
+
+struct ReceiveAttempt {
+    bytes: usize,
+    descriptors: Vec<OwnedFd>,
+}
+
+fn recvmsg_once(socket: RawFd, bytes: &mut [u8]) -> io::Result<ReceiveAttempt> {
+    if bytes.is_empty() {
+        return Err(io::Error::from(io::ErrorKind::InvalidInput));
+    }
+    let mut iovec = libc::iovec {
+        iov_base: bytes.as_mut_ptr().cast(),
+        iov_len: bytes.len(),
+    };
+    let mut control = [0_usize; CONTROL_WORDS];
+    // SAFETY: A zeroed msghdr is a valid baseline and receives only into the
+    // live writable payload and aligned control buffers installed below.
+    let mut message: libc::msghdr = unsafe { MaybeUninit::zeroed().assume_init() };
+    message.msg_iov = &raw mut iovec;
+    message.msg_iovlen = 1;
+    message.msg_control = control.as_mut_ptr().cast();
+    message.msg_controllen = control
+        .len()
+        .saturating_mul(size_of::<usize>())
+        .try_into()
+        .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+
+    // SAFETY: The msghdr points only to live writable buffers. Every returned
+    // descriptor is adopted exactly once by parse_control before return.
+    let result = unsafe { libc::recvmsg(socket, &raw mut message, receive_flags()) };
+    if result < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let received =
+        usize::try_from(result).map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
+    let returned_control = usize::try_from(message.msg_controllen)
+        .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
+    let capacity = control.len().saturating_mul(size_of::<usize>());
+    let descriptors = parse_control(&message, returned_control.min(capacity))?;
+    if received > bytes.len()
+        || returned_control > capacity
+        || message.msg_flags & (libc::MSG_TRUNC | libc::MSG_CTRUNC) != 0
+    {
+        return Err(io::Error::from(io::ErrorKind::InvalidData));
+    }
+    Ok(ReceiveAttempt {
+        bytes: received,
+        descriptors,
+    })
+}
+
+fn parse_control(message: &libc::msghdr, control_bytes: usize) -> io::Result<Vec<OwnedFd>> {
+    if control_bytes == 0 {
+        return Ok(Vec::new());
+    }
+    // SAFETY: CMSG_LEN performs platform layout arithmetic for an empty payload.
+    let header_bytes = usize::try_from(unsafe { libc::CMSG_LEN(0) })
+        .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
+    if control_bytes < header_bytes || message.msg_control.is_null() {
+        return Err(io::Error::from(io::ErrorKind::InvalidData));
+    }
+    let start = message.msg_control.cast::<u8>() as usize;
+    let end = start
+        .checked_add(control_bytes)
+        .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+    let mut descriptors = Vec::new();
+    let mut valid = true;
+    // SAFETY: message describes the live aligned kernel-populated control
+    // buffer. Header and data ranges are checked before each read, and every
+    // nonnegative received descriptor is adopted once.
+    unsafe {
+        let mut header = libc::CMSG_FIRSTHDR(message);
+        while !header.is_null() {
+            let address = header.cast::<u8>() as usize;
+            let remaining = end
+                .checked_sub(address)
+                .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+            if address < start || remaining < header_bytes {
+                valid = false;
+                break;
+            }
+            let declared = usize::try_from((*header).cmsg_len)
+                .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
+            if declared < header_bytes
+                || declared > remaining
+                || (*header).cmsg_level != libc::SOL_SOCKET
+                || (*header).cmsg_type != libc::SCM_RIGHTS
+            {
+                valid = false;
+                break;
+            }
+            let data_bytes = declared.saturating_sub(header_bytes);
+            if data_bytes == 0 || data_bytes % size_of::<RawFd>() != 0 {
+                valid = false;
+                break;
+            }
+            let count = data_bytes / size_of::<RawFd>();
+            if descriptors.len().saturating_add(count) > MAX_ATTACHED_DESCRIPTORS {
+                valid = false;
+            }
+            let data = libc::CMSG_DATA(header);
+            for index in 0..count {
+                let offset = index
+                    .checked_mul(size_of::<RawFd>())
+                    .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+                let raw = std::ptr::read_unaligned(data.add(offset).cast::<RawFd>());
+                if raw < 0 {
+                    valid = false;
+                } else {
+                    descriptors.push(OwnedFd::from_raw_fd(raw));
+                }
+            }
+            let next = libc::CMSG_NXTHDR(message, header);
+            if !next.is_null() && next.cast::<u8>() as usize <= address {
+                valid = false;
+                break;
+            }
+            header = next;
+        }
+    }
+    for descriptor in &descriptors {
+        set_cloexec(descriptor.as_raw_fd())?;
+    }
+    if !valid {
+        return Err(io::Error::from(io::ErrorKind::InvalidData));
+    }
+    Ok(descriptors)
+}
+
+fn wait_ready(
+    descriptor: RawFd,
+    interest: libc::c_short,
+    deadline: Instant,
+) -> Result<(), UnixStreamTransportError> {
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(UnixStreamTransportError::Timeout);
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        let whole_millis = remaining.as_millis();
+        let rounded_millis = if remaining.subsec_nanos().is_multiple_of(1_000_000) {
+            whole_millis
+        } else {
+            whole_millis.saturating_add(1)
+        };
+        let timeout = i32::try_from(rounded_millis).unwrap_or(i32::MAX).max(1);
+        let mut poll_descriptor = libc::pollfd {
+            fd: descriptor,
+            events: interest,
+            revents: 0,
+        };
+        // SAFETY: One initialized writable pollfd remains live for this call.
+        let result = unsafe { libc::poll(&raw mut poll_descriptor, 1, timeout) };
+        if result == 0 {
+            return Err(UnixStreamTransportError::Timeout);
+        }
+        if result < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(UnixStreamTransportError::Io(error.kind()));
+        }
+        if poll_descriptor.revents & interest != 0 {
+            return Ok(());
+        }
+        if poll_descriptor.revents & libc::POLLNVAL != 0 {
+            return Err(UnixStreamTransportError::Io(io::ErrorKind::InvalidInput));
+        }
+        if poll_descriptor.revents & (libc::POLLERR | libc::POLLHUP) != 0 {
+            return Err(UnixStreamTransportError::Disconnected);
+        }
+        return Err(UnixStreamTransportError::Invalid);
+    }
+}
+
+fn socket_int_option(
+    descriptor: RawFd,
+    option: libc::c_int,
+) -> Result<i32, UnixStreamTransportError> {
+    let mut value = 0_i32;
+    let mut length = libc::socklen_t::try_from(size_of::<i32>())
+        .map_err(|_| UnixStreamTransportError::Invalid)?;
+    // SAFETY: value and length are live writable storage for this socket query.
+    let result = unsafe {
+        libc::getsockopt(
+            descriptor,
+            libc::SOL_SOCKET,
+            option,
+            (&raw mut value).cast(),
+            &raw mut length,
+        )
+    };
+    if result != 0 || usize::try_from(length).ok() != Some(size_of::<i32>()) {
+        return Err(if result == 0 {
+            UnixStreamTransportError::Invalid
+        } else {
+            UnixStreamTransportError::Io(io::Error::last_os_error().kind())
+        });
+    }
+    Ok(value)
+}
+
+fn socket_family(descriptor: RawFd, peer: bool) -> Result<libc::c_int, UnixStreamTransportError> {
+    let mut address = MaybeUninit::<libc::sockaddr_storage>::zeroed();
+    let mut length = libc::socklen_t::try_from(size_of::<libc::sockaddr_storage>())
+        .map_err(|_| UnixStreamTransportError::Invalid)?;
+    // SAFETY: address and length provide writable storage for the live socket's
+    // local or peer address. Successful return initializes the family prefix.
+    let result = unsafe {
+        if peer {
+            libc::getpeername(descriptor, address.as_mut_ptr().cast(), &raw mut length)
+        } else {
+            libc::getsockname(descriptor, address.as_mut_ptr().cast(), &raw mut length)
+        }
+    };
+    if result != 0
+        || usize::try_from(length)
+            .ok()
+            .is_none_or(|length| length < size_of::<libc::sa_family_t>())
+    {
+        return Err(if result == 0 {
+            UnixStreamTransportError::Invalid
+        } else {
+            UnixStreamTransportError::Io(io::Error::last_os_error().kind())
+        });
+    }
+    // SAFETY: A successful address query initialized at least the checked family.
+    Ok(i32::from(unsafe { address.assume_init() }.ss_family))
+}
+
+fn set_cloexec(descriptor: RawFd) -> io::Result<()> {
+    let flags = retry_fcntl(descriptor, libc::F_GETFD, 0)?;
+    if flags & libc::FD_CLOEXEC == 0 {
+        retry_fcntl(descriptor, libc::F_SETFD, flags | libc::FD_CLOEXEC)?;
+    }
+    Ok(())
+}
+
+fn retry_fcntl(descriptor: RawFd, command: libc::c_int, argument: libc::c_int) -> io::Result<i32> {
+    loop {
+        // SAFETY: command is F_GETFD or F_SETFD with an integer argument and
+        // the borrowed descriptor remains live for the synchronous call.
+        let result = unsafe { libc::fcntl(descriptor, command, argument) };
+        if result >= 0 {
+            return Ok(result);
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+fn suppress_socket_sigpipe(descriptor: RawFd) -> io::Result<()> {
+    let enabled: libc::c_int = 1;
+    // SAFETY: The option pointer references one initialized integer for this
+    // synchronous setsockopt call on the owned Unix stream descriptor.
+    let result = unsafe {
+        libc::setsockopt(
+            descriptor,
+            libc::SOL_SOCKET,
+            libc::SO_NOSIGPIPE,
+            (&raw const enabled).cast(),
+            size_of::<libc::c_int>()
+                .try_into()
+                .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(target_vendor = "apple"))]
+fn suppress_socket_sigpipe(_descriptor: RawFd) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const fn send_flags() -> libc::c_int {
+    libc::MSG_NOSIGNAL
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+const fn send_flags() -> libc::c_int {
+    0
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const fn receive_flags() -> libc::c_int {
+    libc::MSG_CMSG_CLOEXEC
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+const fn receive_flags() -> libc::c_int {
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::fs::File;
+    use std::io::{Read, Write};
+    use std::os::fd::{AsFd, AsRawFd};
+    use std::os::unix::net::UnixDatagram;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct ScriptDriver {
+        results: VecDeque<io::Result<usize>>,
+        attachments: Vec<usize>,
+    }
+
+    impl SendDriver for ScriptDriver {
+        fn wait_writable(
+            &mut self,
+            _descriptor: RawFd,
+            _deadline: Instant,
+        ) -> Result<(), UnixStreamTransportError> {
+            Ok(())
+        }
+
+        fn send_once(
+            &mut self,
+            _descriptor: RawFd,
+            _bytes: &[u8],
+            descriptors: &[RawFd],
+        ) -> io::Result<usize> {
+            self.attachments.push(descriptors.len());
+            self.results
+                .pop_front()
+                .expect("script should have another result")
+        }
+    }
+
+    #[test]
+    fn descriptors_attach_until_first_positive_send() {
+        let mut driver = ScriptDriver {
+            results: VecDeque::from([
+                Err(io::Error::from(io::ErrorKind::WouldBlock)),
+                Err(io::Error::from(io::ErrorKind::Interrupted)),
+                Ok(3),
+                Ok(5),
+            ]),
+            attachments: Vec::new(),
+        };
+        send_all_with_driver(
+            &mut driver,
+            7,
+            &[1; 8],
+            &[11, 12],
+            Instant::now() + Duration::from_secs(1),
+        )
+        .expect("scripted send should complete");
+        assert_eq!(driver.attachments, vec![2, 2, 2, 0]);
+    }
+
+    #[test]
+    fn zero_and_impossible_send_counts_fail_closed() {
+        for result in [Ok(0), Ok(9)] {
+            let mut driver = ScriptDriver {
+                results: VecDeque::from([result]),
+                attachments: Vec::new(),
+            };
+            assert!(
+                send_all_with_driver(
+                    &mut driver,
+                    7,
+                    &[1; 8],
+                    &[],
+                    Instant::now() + Duration::from_secs(1),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn public_send_rejects_empty_bytes_and_excess_rights_before_io() {
+        let (left, _right) = UnixStream::pair().expect("stream pair should open");
+        let sender = UnixStreamTransport::new(left, Duration::from_secs(1))
+            .expect("transport should initialize");
+        let fixture = File::open("/dev/null").expect("fixture should open");
+        let excessive = [fixture.as_fd(); MAX_ATTACHED_DESCRIPTORS + 1];
+
+        assert_eq!(
+            sender.send(&[], &[]),
+            Err(UnixStreamTransportError::Invalid)
+        );
+        assert_eq!(
+            sender.send(&[1], &excessive),
+            Err(UnixStreamTransportError::Invalid)
+        );
+    }
+
+    #[test]
+    fn exact_bytes_and_ordered_descriptors_round_trip() {
+        let (left, right) = UnixStream::pair().expect("stream pair should open");
+        let sender = UnixStreamTransport::new(left, Duration::from_secs(1))
+            .expect("transport should initialize");
+        let receiver = UnixStreamTransport::new(right, Duration::from_secs(1))
+            .expect("transport should initialize");
+        let first = File::open("/dev/null").expect("fixture should open");
+        let second = File::open("/dev/zero").expect("fixture should open");
+        sender
+            .send(&[1, 2, 3], &[first.as_fd(), second.as_fd()])
+            .expect("message should send");
+        let received = receiver
+            .receive_exact(3, 2)
+            .expect("message should receive");
+        let (bytes, descriptors) = received.into_parts();
+        assert_eq!(bytes, [1, 2, 3]);
+        assert_eq!(descriptors.len(), 2);
+        for descriptor in &descriptors {
+            let flags = retry_fcntl(descriptor.as_raw_fd(), libc::F_GETFD, 0)
+                .expect("descriptor flags should read");
+            assert_ne!(flags & libc::FD_CLOEXEC, 0);
+        }
+    }
+
+    #[test]
+    fn connected_stream_validation_rejects_wrong_socket_classes() {
+        let (left, mut right) = UnixStream::pair().expect("stream pair should open");
+        let duplicate = left.try_clone().expect("stream should clone").into();
+        let mut connected = connected_unix_stream(duplicate).expect("stream should validate");
+        connected.write_all(&[9]).expect("byte should send");
+        let mut byte = [0];
+        right.read_exact(&mut byte).expect("byte should arrive");
+        assert_eq!(byte, [9]);
+
+        let file: OwnedFd = File::open("/dev/null").expect("fixture should open").into();
+        assert!(matches!(
+            connected_unix_stream(file),
+            Err(UnixStreamTransportError::Io(_)) | Err(UnixStreamTransportError::Invalid)
+        ));
+        let (datagram, _peer) = UnixDatagram::pair().expect("datagram pair should open");
+        assert_eq!(
+            connected_unix_stream(datagram.into()).expect_err("datagram should fail"),
+            UnixStreamTransportError::Invalid
+        );
+    }
+
+    #[test]
+    fn timeout_clean_eof_and_partial_eof_are_distinct() {
+        let (left, _right) = UnixStream::pair().expect("stream pair should open");
+        let timeout = UnixStreamTransport::new(left, Duration::from_millis(10))
+            .expect("transport should initialize");
+        assert!(matches!(
+            timeout.receive_exact(1, 0),
+            Err(UnixStreamTransportError::Timeout)
+        ));
+
+        let (left, right) = UnixStream::pair().expect("stream pair should open");
+        let receiver = UnixStreamTransport::new(left, Duration::from_secs(1))
+            .expect("transport should initialize");
+        drop(right);
+        assert!(matches!(
+            receiver.receive_exact(2, 0),
+            Err(UnixStreamTransportError::Disconnected)
+        ));
+
+        let (left, mut right) = UnixStream::pair().expect("stream pair should open");
+        let receiver = UnixStreamTransport::new(left, Duration::from_secs(1))
+            .expect("transport should initialize");
+        right.write_all(&[1]).expect("prefix should send");
+        drop(right);
+        assert!(matches!(
+            receiver.receive_exact(2, 0),
+            Err(UnixStreamTransportError::UnexpectedEof)
+        ));
+    }
+
+    #[test]
+    fn impossible_receive_allocation_fails_before_io() {
+        let (left, _right) = UnixStream::pair().expect("stream pair should open");
+        let receiver = UnixStreamTransport::new(left, Duration::from_secs(1))
+            .expect("transport should initialize");
+        assert!(matches!(
+            receiver.receive_exact(usize::MAX, 0),
+            Err(UnixStreamTransportError::Invalid)
+        ));
+    }
+
+    #[test]
+    fn descriptor_limit_rejection_closes_the_received_alias() {
+        let (left, right) = UnixStream::pair().expect("stream pair should open");
+        let sender = UnixStreamTransport::new(left, Duration::from_secs(1))
+            .expect("transport should initialize");
+        let receiver = UnixStreamTransport::new(right, Duration::from_secs(1))
+            .expect("transport should initialize");
+        let (transferred, mut probe) = UnixStream::pair().expect("descriptor pair should open");
+        sender
+            .send(&[1], &[transferred.as_fd()])
+            .expect("descriptor should send");
+        drop(transferred);
+        assert!(matches!(
+            receiver.receive_exact(1, 0),
+            Err(UnixStreamTransportError::Invalid)
+        ));
+        probe
+            .set_nonblocking(true)
+            .expect("probe should become nonblocking");
+        let mut byte = [0];
+        assert_eq!(probe.read(&mut byte).expect("probe should read EOF"), 0);
+    }
+
+    #[test]
+    fn debug_and_errors_are_value_redacted() {
+        let (left, _right) = UnixStream::pair().expect("stream pair should open");
+        let transport = UnixStreamTransport::new(left, Duration::from_millis(37))
+            .expect("transport should initialize");
+        let debug = format!("{transport:?}");
+        assert!(!debug.contains("37"));
+        assert!(!debug.contains("fd"));
+        assert_eq!(
+            UnixStreamTransportError::Timeout.to_string(),
+            "private Unix stream transport failure"
+        );
+    }
+}

--- a/crates/vhost-user/src/frontend.rs
+++ b/crates/vhost-user/src/frontend.rs
@@ -813,7 +813,7 @@ mod tests {
     use crate::notifier::{
         CallDrainOutcome, KickSignalOutcome, create_call_notifier, create_kick_notifier,
     };
-    use crate::transport::{recvmsg_once, sendmsg_once};
+    use bangbang_unix_stream::{MAX_ATTACHED_DESCRIPTORS, UnixStreamTransport};
 
     use super::*;
 
@@ -824,27 +824,25 @@ mod tests {
     }
 
     fn receive_peer_request(stream: &mut UnixStream) -> PeerRequest {
-        let mut header_bytes = [0_u8; HEADER_BYTES];
-        let mut header_received = 0_usize;
-        let mut descriptors = Vec::new();
-        while header_received < HEADER_BYTES {
-            let attempt = recvmsg_once(stream.as_raw_fd(), &mut header_bytes[header_received..])
-                .expect("request header should receive");
-            assert_ne!(attempt.bytes, 0, "request header must not reach EOF");
-            header_received += attempt.bytes;
-            descriptors.extend(attempt.descriptors);
-        }
+        let transport = UnixStreamTransport::new(
+            stream.try_clone().expect("peer stream should clone"),
+            Duration::from_secs(1),
+        )
+        .expect("peer transport should initialize");
+        let header_bytes = transport
+            .receive_exact(HEADER_BYTES, MAX_ATTACHED_DESCRIPTORS)
+            .expect("request header should receive");
+        let (header_bytes, mut descriptors) = header_bytes.into_parts();
         let header = Header::decode(&header_bytes).expect("request header should decode");
         assert!(!header.is_reply);
-        let mut body = vec![0_u8; header.body_size];
-        let mut body_received = 0_usize;
-        while body_received < body.len() {
-            let attempt = recvmsg_once(stream.as_raw_fd(), &mut body[body_received..])
-                .expect("request body should receive");
-            assert_ne!(attempt.bytes, 0, "request body must not reach EOF");
-            body_received += attempt.bytes;
-            descriptors.extend(attempt.descriptors);
-        }
+        let body = transport
+            .receive_exact(
+                header.body_size,
+                MAX_ATTACHED_DESCRIPTORS.saturating_sub(descriptors.len()),
+            )
+            .expect("request body should receive");
+        let (body, body_descriptors) = body.into_parts();
+        descriptors.extend(body_descriptors);
         PeerRequest {
             header,
             body,
@@ -867,7 +865,13 @@ mod tests {
 
     fn send_peer_reply(stream: &mut UnixStream, request: Request, body: &[u8]) {
         let encoded = reply_frame(request, body).expect("reply should encode");
-        stream.write_all(&encoded).expect("reply should send");
+        UnixStreamTransport::new(
+            stream.try_clone().expect("peer stream should clone"),
+            Duration::from_secs(1),
+        )
+        .expect("peer transport should initialize")
+        .send(&encoded, &[])
+        .expect("reply should send");
     }
 
     fn send_peer_reply_with_fd(
@@ -877,13 +881,13 @@ mod tests {
         descriptor: BorrowedFd<'_>,
     ) {
         let encoded = reply_frame(request, body).expect("reply should encode");
-        let sent = sendmsg_once(stream.as_raw_fd(), &encoded, &[descriptor.as_raw_fd()])
-            .expect("descriptor reply should send");
-        if sent < encoded.len() {
-            stream
-                .write_all(&encoded[sent..])
-                .expect("reply remainder should send");
-        }
+        UnixStreamTransport::new(
+            stream.try_clone().expect("peer stream should clone"),
+            Duration::from_secs(1),
+        )
+        .expect("peer transport should initialize")
+        .send(&encoded, &[descriptor])
+        .expect("descriptor reply should send");
     }
 
     fn send_peer_reply_with_fds(
@@ -893,14 +897,13 @@ mod tests {
         descriptors: &[BorrowedFd<'_>],
     ) {
         let encoded = reply_frame(request, body).expect("reply should encode");
-        let raw: Vec<_> = descriptors.iter().map(AsRawFd::as_raw_fd).collect();
-        let sent =
-            sendmsg_once(stream.as_raw_fd(), &encoded, &raw).expect("descriptor reply should send");
-        if sent < encoded.len() {
-            stream
-                .write_all(&encoded[sent..])
-                .expect("reply remainder should send");
-        }
+        UnixStreamTransport::new(
+            stream.try_clone().expect("peer stream should clone"),
+            Duration::from_secs(1),
+        )
+        .expect("peer transport should initialize")
+        .send(&encoded, descriptors)
+        .expect("descriptor reply should send");
     }
 
     fn acknowledge_if_requested(stream: &mut UnixStream, request: &PeerRequest) {
@@ -1281,7 +1284,7 @@ mod tests {
             UnixStream::pair().expect("stream pair should open");
         let mut writers = Vec::new();
         let mut readers = Vec::new();
-        for _ in 0..(MAX_ATTACHED_FDS + 1) {
+        for _ in 0..MAX_ATTACHED_FDS {
             let (writer, reader) = create_kick_notifier().expect("pipe should open");
             writers.push(writer);
             readers.push(reader);

--- a/crates/vhost-user/src/transport.rs
+++ b/crates/vhost-user/src/transport.rs
@@ -1,16 +1,15 @@
-//! Deadline-bounded Unix stream and SCM_RIGHTS framing.
+//! Vhost-user framing over the shared deadline-bounded Unix stream transport.
 
 use std::fmt;
 use std::io;
-use std::mem::{MaybeUninit, size_of};
-use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use std::os::fd::BorrowedFd;
 use std::os::unix::net::UnixStream;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use bangbang_unix_stream::{UnixStreamTransport, UnixStreamTransportError};
 
 use crate::error::VhostUserError;
-use crate::message::{HEADER_BYTES, Header, MAX_ATTACHED_FDS, Request, frame};
-
-const CONTROL_WORDS: usize = 32;
+use crate::message::{HEADER_BYTES, Header, Request, frame};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TransportError {
@@ -18,6 +17,19 @@ pub(crate) enum TransportError {
     Timeout,
     Disconnected,
     Io(io::ErrorKind),
+}
+
+impl From<UnixStreamTransportError> for TransportError {
+    fn from(error: UnixStreamTransportError) -> Self {
+        match error {
+            UnixStreamTransportError::Invalid => Self::Invalid,
+            UnixStreamTransportError::Timeout => Self::Timeout,
+            UnixStreamTransportError::Disconnected | UnixStreamTransportError::UnexpectedEof => {
+                Self::Disconnected
+            }
+            UnixStreamTransportError::Io(kind) => Self::Io(kind),
+        }
+    }
 }
 
 impl From<TransportError> for VhostUserError {
@@ -32,28 +44,25 @@ impl From<TransportError> for VhostUserError {
 }
 
 pub(crate) struct Transport {
-    stream: UnixStream,
-    timeout: Duration,
+    inner: UnixStreamTransport,
 }
 
 impl fmt::Debug for Transport {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("Transport")
-            .field("stream", &"redacted")
-            .field("timeout", &self.timeout)
+            .field("stream", &"<redacted>")
+            .field("timeout", &"<configured>")
             .finish()
     }
 }
 
 impl Transport {
     pub(crate) fn new(stream: UnixStream, timeout: Duration) -> Result<Self, VhostUserError> {
-        stream
-            .set_nonblocking(true)
-            .map_err(|error| VhostUserError::Io(error.kind()))?;
-        suppress_socket_sigpipe(stream.as_raw_fd())
-            .map_err(|error| VhostUserError::Io(error.kind()))?;
-        Ok(Self { stream, timeout })
+        let inner = UnixStreamTransport::new(stream, timeout)
+            .map_err(TransportError::from)
+            .map_err(VhostUserError::from)?;
+        Ok(Self { inner })
     }
 
     pub(crate) fn send(
@@ -64,16 +73,7 @@ impl Transport {
         need_reply: bool,
     ) -> Result<(), TransportError> {
         let encoded = frame(request, body, need_reply).map_err(|_| TransportError::Invalid)?;
-        let raw_descriptors: Vec<RawFd> = descriptors.iter().map(AsRawFd::as_raw_fd).collect();
-        let deadline = self.deadline()?;
-        let mut driver = SystemSendDriver;
-        send_frame_with_driver(
-            &mut driver,
-            self.stream.as_raw_fd(),
-            &encoded,
-            &raw_descriptors,
-            deadline,
-        )
+        self.inner.send(&encoded, descriptors).map_err(Into::into)
     }
 
     pub(crate) fn request_reply(
@@ -83,598 +83,42 @@ impl Transport {
         descriptors: &[BorrowedFd<'_>],
         need_reply: bool,
     ) -> Result<Vec<u8>, TransportError> {
-        let deadline = self.deadline()?;
+        let deadline = self.inner.deadline().map_err(TransportError::from)?;
         let encoded = frame(request, body, need_reply).map_err(|_| TransportError::Invalid)?;
-        let raw_descriptors: Vec<RawFd> = descriptors.iter().map(AsRawFd::as_raw_fd).collect();
-        let mut driver = SystemSendDriver;
-        send_frame_with_driver(
-            &mut driver,
-            self.stream.as_raw_fd(),
-            &encoded,
-            &raw_descriptors,
-            deadline,
-        )?;
+        self.inner
+            .send_until(&encoded, descriptors, deadline)
+            .map_err(TransportError::from)?;
         self.receive_reply(request, deadline)
     }
 
     pub(crate) fn shutdown(&self) {
-        let _ignored = self.stream.shutdown(std::net::Shutdown::Both);
-    }
-
-    fn deadline(&self) -> Result<Instant, TransportError> {
-        Instant::now()
-            .checked_add(self.timeout)
-            .ok_or(TransportError::Invalid)
+        self.inner.shutdown();
     }
 
     fn receive_reply(
         &self,
         expected_request: Request,
-        deadline: Instant,
+        deadline: bangbang_unix_stream::UnixStreamDeadline,
     ) -> Result<Vec<u8>, TransportError> {
-        let header_bytes = receive_exact(self.stream.as_raw_fd(), HEADER_BYTES, deadline)?;
-        let header = Header::decode(&header_bytes).map_err(|_| TransportError::Invalid)?;
+        let header = self
+            .inner
+            .receive_exact_until(HEADER_BYTES, 0, deadline)
+            .map_err(TransportError::from)?;
+        let header = Header::decode(header.bytes()).map_err(|_| TransportError::Invalid)?;
         if !header.is_reply || header.need_reply || header.request != expected_request {
             return Err(TransportError::Invalid);
         }
-        receive_exact(self.stream.as_raw_fd(), header.body_size, deadline)
+        let body = self
+            .inner
+            .receive_exact_until(header.body_size, 0, deadline)
+            .map_err(TransportError::from)?;
+        Ok(body.into_parts().0)
     }
-}
-
-trait SendDriver {
-    fn wait_writable(&mut self, descriptor: RawFd, deadline: Instant)
-    -> Result<(), TransportError>;
-
-    fn send_once(
-        &mut self,
-        descriptor: RawFd,
-        bytes: &[u8],
-        descriptors: &[RawFd],
-    ) -> io::Result<usize>;
-}
-
-struct SystemSendDriver;
-
-impl SendDriver for SystemSendDriver {
-    fn wait_writable(
-        &mut self,
-        descriptor: RawFd,
-        deadline: Instant,
-    ) -> Result<(), TransportError> {
-        wait_ready(descriptor, libc::POLLOUT, deadline)
-    }
-
-    fn send_once(
-        &mut self,
-        descriptor: RawFd,
-        bytes: &[u8],
-        descriptors: &[RawFd],
-    ) -> io::Result<usize> {
-        sendmsg_once(descriptor, bytes, descriptors)
-    }
-}
-
-fn send_frame_with_driver<D: SendDriver>(
-    driver: &mut D,
-    socket: RawFd,
-    frame: &[u8],
-    descriptors: &[RawFd],
-    deadline: Instant,
-) -> Result<(), TransportError> {
-    if frame.is_empty() || descriptors.len() > MAX_ATTACHED_FDS {
-        return Err(TransportError::Invalid);
-    }
-    let mut transferred = 0_usize;
-    while transferred < frame.len() {
-        driver.wait_writable(socket, deadline)?;
-        let remaining = frame.get(transferred..).ok_or(TransportError::Invalid)?;
-        let attached = if transferred == 0 { descriptors } else { &[] };
-        match driver.send_once(socket, remaining, attached) {
-            Ok(0) => return Err(TransportError::Disconnected),
-            Ok(sent) if sent <= remaining.len() => {
-                transferred = transferred
-                    .checked_add(sent)
-                    .ok_or(TransportError::Invalid)?;
-            }
-            Ok(_) => return Err(TransportError::Invalid),
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
-                ) => {}
-            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => {
-                return Err(TransportError::Disconnected);
-            }
-            Err(error) => return Err(TransportError::Io(error.kind())),
-        }
-    }
-    Ok(())
-}
-
-fn receive_exact(
-    socket: RawFd,
-    expected: usize,
-    deadline: Instant,
-) -> Result<Vec<u8>, TransportError> {
-    let mut bytes = vec![0_u8; expected];
-    let mut received = 0_usize;
-    while received < expected {
-        wait_ready(socket, libc::POLLIN, deadline)?;
-        let remaining = bytes.get_mut(received..).ok_or(TransportError::Invalid)?;
-        match recvmsg_once(socket, remaining) {
-            Ok(attempt) => {
-                if !attempt.descriptors.is_empty() {
-                    return Err(TransportError::Invalid);
-                }
-                if attempt.bytes == 0 {
-                    return Err(TransportError::Disconnected);
-                }
-                received = received
-                    .checked_add(attempt.bytes)
-                    .ok_or(TransportError::Invalid)?;
-            }
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
-                ) => {}
-            Err(error) if error.kind() == io::ErrorKind::InvalidData => {
-                return Err(TransportError::Invalid);
-            }
-            Err(error) => return Err(TransportError::Io(error.kind())),
-        }
-    }
-    Ok(bytes)
-}
-
-fn wait_ready(
-    descriptor: RawFd,
-    interest: libc::c_short,
-    deadline: Instant,
-) -> Result<(), TransportError> {
-    loop {
-        let now = Instant::now();
-        if now >= deadline {
-            return Err(TransportError::Timeout);
-        }
-        let remaining = deadline.saturating_duration_since(now);
-        let whole_millis = remaining.as_millis();
-        let rounded_millis = if remaining.subsec_nanos().is_multiple_of(1_000_000) {
-            whole_millis
-        } else {
-            whole_millis.saturating_add(1)
-        };
-        let timeout = i32::try_from(rounded_millis).unwrap_or(i32::MAX).max(1);
-        let mut poll_descriptor = libc::pollfd {
-            fd: descriptor,
-            events: interest,
-            revents: 0,
-        };
-        // SAFETY: `poll_descriptor` is one initialized writable entry and does
-        // not escape this synchronous call.
-        let result = unsafe { libc::poll(&raw mut poll_descriptor, 1, timeout) };
-        if result == 0 {
-            return Err(TransportError::Timeout);
-        }
-        if result < 0 {
-            let error = io::Error::last_os_error();
-            if error.kind() == io::ErrorKind::Interrupted {
-                continue;
-            }
-            return Err(TransportError::Io(error.kind()));
-        }
-        if poll_descriptor.revents & interest != 0 {
-            return Ok(());
-        }
-        if poll_descriptor.revents & libc::POLLNVAL != 0 {
-            return Err(TransportError::Io(io::ErrorKind::InvalidInput));
-        }
-        if poll_descriptor.revents & (libc::POLLERR | libc::POLLHUP) != 0 {
-            return Err(TransportError::Disconnected);
-        }
-        return Err(TransportError::Invalid);
-    }
-}
-
-pub(crate) fn sendmsg_once(
-    socket: RawFd,
-    bytes: &[u8],
-    descriptors: &[RawFd],
-) -> io::Result<usize> {
-    if bytes.is_empty() {
-        return Err(io::Error::from(io::ErrorKind::InvalidInput));
-    }
-    let mut iovec = libc::iovec {
-        iov_base: bytes.as_ptr().cast_mut().cast(),
-        iov_len: bytes.len(),
-    };
-    let mut control = [0_usize; CONTROL_WORDS];
-    // SAFETY: An all-zero msghdr is a valid empty header. Live iovec and
-    // optional control pointers are installed below before the call.
-    let mut message: libc::msghdr = unsafe { MaybeUninit::zeroed().assume_init() };
-    message.msg_iov = &raw mut iovec;
-    message.msg_iovlen = 1;
-
-    if !descriptors.is_empty() {
-        let descriptor_bytes = descriptors
-            .len()
-            .checked_mul(size_of::<RawFd>())
-            .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?;
-        let descriptor_bytes_u32 = u32::try_from(descriptor_bytes)
-            .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
-        // SAFETY: CMSG_SPACE performs checked platform layout arithmetic on
-        // the bounded descriptor payload length and dereferences no pointer.
-        let control_space = unsafe { libc::CMSG_SPACE(descriptor_bytes_u32) };
-        let control_bytes = usize::try_from(control_space)
-            .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
-        if control_bytes > control.len().saturating_mul(size_of::<usize>()) {
-            return Err(io::Error::from(io::ErrorKind::InvalidInput));
-        }
-        message.msg_control = control.as_mut_ptr().cast();
-        message.msg_controllen = control_bytes
-            .try_into()
-            .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
-        // SAFETY: The checked aligned control buffer is large enough for one
-        // cmsghdr and the complete descriptor array. No pointer escapes.
-        unsafe {
-            let header = libc::CMSG_FIRSTHDR(&raw const message);
-            if header.is_null() {
-                return Err(io::Error::from(io::ErrorKind::InvalidInput));
-            }
-            (*header).cmsg_level = libc::SOL_SOCKET;
-            (*header).cmsg_type = libc::SCM_RIGHTS;
-            (*header).cmsg_len = libc::CMSG_LEN(descriptor_bytes_u32) as _;
-            std::ptr::copy_nonoverlapping(
-                descriptors.as_ptr().cast::<u8>(),
-                libc::CMSG_DATA(header),
-                descriptor_bytes,
-            );
-        }
-    }
-
-    // SAFETY: The msghdr points only to live readable buffers for this
-    // synchronous call. Attached descriptors remain borrowed by the caller.
-    let result = unsafe { libc::sendmsg(socket, &raw const message, send_flags()) };
-    if result < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        usize::try_from(result).map_err(|_| io::Error::from(io::ErrorKind::InvalidData))
-    }
-}
-
-pub(crate) struct ReceiveAttempt {
-    pub(crate) bytes: usize,
-    pub(crate) descriptors: Vec<OwnedFd>,
-}
-
-pub(crate) fn recvmsg_once(socket: RawFd, bytes: &mut [u8]) -> io::Result<ReceiveAttempt> {
-    if bytes.is_empty() {
-        return Ok(ReceiveAttempt {
-            bytes: 0,
-            descriptors: Vec::new(),
-        });
-    }
-    let mut iovec = libc::iovec {
-        iov_base: bytes.as_mut_ptr().cast(),
-        iov_len: bytes.len(),
-    };
-    let mut control = [0_usize; CONTROL_WORDS];
-    // SAFETY: An all-zero msghdr is valid and receives live writable payload
-    // and aligned control buffers below.
-    let mut message: libc::msghdr = unsafe { MaybeUninit::zeroed().assume_init() };
-    message.msg_iov = &raw mut iovec;
-    message.msg_iovlen = 1;
-    message.msg_control = control.as_mut_ptr().cast();
-    message.msg_controllen = control
-        .len()
-        .saturating_mul(size_of::<usize>())
-        .try_into()
-        .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
-
-    // SAFETY: The msghdr points only to live writable buffers for this
-    // synchronous call. Any returned descriptor is adopted below.
-    let result = unsafe { libc::recvmsg(socket, &raw mut message, 0) };
-    if result < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    let received =
-        usize::try_from(result).map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
-    let returned_control = usize::try_from(message.msg_controllen)
-        .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
-    let control_capacity = control.len().saturating_mul(size_of::<usize>());
-    let descriptors = parse_control(&message, returned_control.min(control_capacity))?;
-    if received > bytes.len()
-        || returned_control > control_capacity
-        || message.msg_flags & (libc::MSG_TRUNC | libc::MSG_CTRUNC) != 0
-    {
-        return Err(io::Error::from(io::ErrorKind::InvalidData));
-    }
-    Ok(ReceiveAttempt {
-        bytes: received,
-        descriptors,
-    })
-}
-
-fn parse_control(message: &libc::msghdr, control_bytes: usize) -> io::Result<Vec<OwnedFd>> {
-    if control_bytes == 0 {
-        return Ok(Vec::new());
-    }
-    // SAFETY: CMSG_LEN performs platform layout arithmetic for an empty data
-    // payload and dereferences no pointer.
-    let empty_header_len = unsafe { libc::CMSG_LEN(0) };
-    let header_bytes = usize::try_from(empty_header_len)
-        .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
-    if control_bytes < header_bytes || message.msg_control.is_null() {
-        return Err(io::Error::from(io::ErrorKind::InvalidData));
-    }
-    let start = message.msg_control.cast::<u8>() as usize;
-    let end = start
-        .checked_add(control_bytes)
-        .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
-    let mut descriptors = Vec::new();
-    let mut valid = true;
-    // SAFETY: `message` describes the live aligned control buffer returned by
-    // recvmsg. Every header/data range is checked against its returned bounds
-    // before being read, and each received descriptor is adopted once.
-    unsafe {
-        let mut header = libc::CMSG_FIRSTHDR(message);
-        while !header.is_null() {
-            let address = header.cast::<u8>() as usize;
-            let remaining = end
-                .checked_sub(address)
-                .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
-            if address < start || remaining < header_bytes {
-                valid = false;
-                break;
-            }
-            let declared = usize::try_from((*header).cmsg_len)
-                .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
-            if declared < header_bytes
-                || declared > remaining
-                || (*header).cmsg_level != libc::SOL_SOCKET
-                || (*header).cmsg_type != libc::SCM_RIGHTS
-            {
-                valid = false;
-                break;
-            }
-            let data_bytes = declared.saturating_sub(header_bytes);
-            if data_bytes == 0 || data_bytes % size_of::<RawFd>() != 0 {
-                valid = false;
-                break;
-            }
-            let count = data_bytes / size_of::<RawFd>();
-            if descriptors.len().saturating_add(count) > MAX_ATTACHED_FDS {
-                valid = false;
-            }
-            let data = libc::CMSG_DATA(header);
-            for index in 0..count {
-                let offset = index
-                    .checked_mul(size_of::<RawFd>())
-                    .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
-                let raw = std::ptr::read_unaligned(data.add(offset).cast::<RawFd>());
-                if raw < 0 {
-                    valid = false;
-                    continue;
-                }
-                descriptors.push(OwnedFd::from_raw_fd(raw));
-            }
-            let next = libc::CMSG_NXTHDR(message, header);
-            if !next.is_null() && next.cast::<u8>() as usize <= address {
-                valid = false;
-                break;
-            }
-            header = next;
-        }
-    }
-    let mut cloexec_error = None;
-    for descriptor in &descriptors {
-        if let Err(error) = set_cloexec(descriptor.as_raw_fd())
-            && cloexec_error.is_none()
-        {
-            cloexec_error = Some(error);
-        }
-    }
-    if let Some(error) = cloexec_error {
-        return Err(error);
-    }
-    if descriptors.is_empty() || !valid {
-        return Err(io::Error::from(io::ErrorKind::InvalidData));
-    }
-    Ok(descriptors)
-}
-
-fn set_cloexec(descriptor: RawFd) -> io::Result<()> {
-    let flags = retry_fcntl(descriptor, libc::F_GETFD, 0)?;
-    if flags & libc::FD_CLOEXEC == 0 {
-        retry_fcntl(descriptor, libc::F_SETFD, flags | libc::FD_CLOEXEC)?;
-    }
-    Ok(())
-}
-
-fn retry_fcntl(descriptor: RawFd, command: libc::c_int, argument: libc::c_int) -> io::Result<i32> {
-    loop {
-        // SAFETY: The command is either F_GETFD or F_SETFD with an integer
-        // argument and the borrowed descriptor remains live for the call.
-        let result = unsafe { libc::fcntl(descriptor, command, argument) };
-        if result >= 0 {
-            return Ok(result);
-        }
-        let error = io::Error::last_os_error();
-        if error.kind() != io::ErrorKind::Interrupted {
-            return Err(error);
-        }
-    }
-}
-
-#[cfg(target_vendor = "apple")]
-fn suppress_socket_sigpipe(descriptor: RawFd) -> io::Result<()> {
-    let enabled: libc::c_int = 1;
-    // SAFETY: The option pointer references one initialized integer for this
-    // synchronous setsockopt call on the owned Unix stream descriptor.
-    let result = unsafe {
-        libc::setsockopt(
-            descriptor,
-            libc::SOL_SOCKET,
-            libc::SO_NOSIGPIPE,
-            (&raw const enabled).cast(),
-            size_of::<libc::c_int>()
-                .try_into()
-                .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?,
-        )
-    };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-#[cfg(not(target_vendor = "apple"))]
-fn suppress_socket_sigpipe(_descriptor: RawFd) -> io::Result<()> {
-    Ok(())
-}
-
-#[cfg(any(target_os = "linux", target_os = "android"))]
-const fn send_flags() -> libc::c_int {
-    libc::MSG_NOSIGNAL
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
-const fn send_flags() -> libc::c_int {
-    0
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
-    use std::fs::File;
-    use std::os::fd::AsFd;
-
     use super::*;
-
-    #[derive(Debug)]
-    struct ScriptDriver {
-        results: VecDeque<io::Result<usize>>,
-        attachments: Vec<usize>,
-    }
-
-    impl SendDriver for ScriptDriver {
-        fn wait_writable(
-            &mut self,
-            _descriptor: RawFd,
-            _deadline: Instant,
-        ) -> Result<(), TransportError> {
-            Ok(())
-        }
-
-        fn send_once(
-            &mut self,
-            _descriptor: RawFd,
-            _bytes: &[u8],
-            descriptors: &[RawFd],
-        ) -> io::Result<usize> {
-            self.attachments.push(descriptors.len());
-            self.results
-                .pop_front()
-                .expect("script should have another result")
-        }
-    }
-
-    #[test]
-    fn descriptors_are_attached_only_until_first_positive_send() {
-        let mut driver = ScriptDriver {
-            results: VecDeque::from([
-                Err(io::Error::from(io::ErrorKind::WouldBlock)),
-                Err(io::Error::from(io::ErrorKind::Interrupted)),
-                Ok(3),
-                Ok(5),
-            ]),
-            attachments: Vec::new(),
-        };
-        send_frame_with_driver(
-            &mut driver,
-            7,
-            &[1; 8],
-            &[11, 12],
-            Instant::now() + Duration::from_secs(1),
-        )
-        .expect("scripted send should complete");
-        assert_eq!(driver.attachments, vec![2, 2, 2, 0]);
-    }
-
-    #[test]
-    fn zero_and_impossible_send_counts_fail_closed() {
-        for result in [Ok(0), Ok(9)] {
-            let mut driver = ScriptDriver {
-                results: VecDeque::from([result]),
-                attachments: Vec::new(),
-            };
-            assert!(
-                send_frame_with_driver(
-                    &mut driver,
-                    7,
-                    &[1; 8],
-                    &[],
-                    Instant::now() + Duration::from_secs(1),
-                )
-                .is_err()
-            );
-        }
-    }
-
-    #[test]
-    fn real_stream_transfers_ordered_close_on_exec_descriptors() {
-        let (sender, receiver) = UnixStream::pair().expect("stream pair should open");
-        let transport =
-            Transport::new(sender, Duration::from_secs(1)).expect("transport should initialize");
-        let first = File::open("/dev/null").expect("fixture should open");
-        let second = File::open("/dev/zero").expect("fixture should open");
-        transport
-            .send(
-                Request::SetMemoryTable,
-                &[1, 2, 3],
-                &[first.as_fd(), second.as_fd()],
-                false,
-            )
-            .expect("message should send");
-
-        let mut payload = [0_u8; 64];
-        let received =
-            recvmsg_once(receiver.as_raw_fd(), &mut payload).expect("message should receive");
-        assert_eq!(received.bytes, HEADER_BYTES + 3);
-        assert_eq!(received.descriptors.len(), 2);
-        let mut descriptors = received.descriptors.into_iter();
-        let first_received = descriptors.next().expect("first descriptor should arrive");
-        let second_received = descriptors.next().expect("second descriptor should arrive");
-        assert!(descriptors.next().is_none());
-        for descriptor in [&first_received, &second_received] {
-            let flags = retry_fcntl(descriptor.as_raw_fd(), libc::F_GETFD, 0)
-                .expect("descriptor flags should read");
-            assert_ne!(flags & libc::FD_CLOEXEC, 0);
-        }
-        let mut byte = [7_u8; 1];
-        // SAFETY: The first received descriptor is the live /dev/null entry and
-        // the one-byte buffer is writable.
-        let null_read = unsafe {
-            libc::read(
-                first_received.as_raw_fd(),
-                byte.as_mut_ptr().cast(),
-                byte.len(),
-            )
-        };
-        assert_eq!(null_read, 0);
-        // SAFETY: The second received descriptor is the live /dev/zero entry
-        // and the same one-byte buffer is writable.
-        let zero_read = unsafe {
-            libc::read(
-                second_received.as_raw_fd(),
-                byte.as_mut_ptr().cast(),
-                byte.len(),
-            )
-        };
-        assert_eq!(zero_read, 1);
-        assert_eq!(byte, [0]);
-    }
 
     #[test]
     fn disconnected_socket_is_a_typed_failure() {

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -4,6 +4,11 @@ This document describes bangbang's intended Firecracker compatibility scope. It
 is a planning reference for future API, VMM, and backend work; it does not mean
 the current scaffold implements all listed API behavior.
 
+The portable [private vmnet provider protocol](vmnet-provider-protocol.md)
+freezes the bounded control/data and descriptor contract for the remaining
+network handoff. It adds no broker process, vmnet call, sandbox adapter,
+production assembly, Apple authorization, or positive compatibility evidence.
+
 The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`

--- a/docs/security.md
+++ b/docs/security.md
@@ -3935,6 +3935,29 @@ terminal platform/architecture, operator-owned, implementation-specific, or
 external outcomes. It adds no runtime path, host mutation, credential, or
 deployment claim; only #1378's two positive vmnet records remain nonterminal.
 
+## Private vmnet provider boundary
+
+The portable [`provider-v1` contract](vmnet-provider-protocol.md) freezes a
+future least-authority split without claiming the split is assembled. Worker
+input can select only six bootstrap-owned slots and bounded typed parameters;
+it cannot carry a path, bridge name, command, credential, PID, framework value,
+or arbitrary string. Every frame is bound to the private lifecycle session and
+an exact nonwrapping sequence. Per-interface packet streams additionally bind
+the interface and generation.
+
+Only a fully validated `Started` transition can expose one transferred,
+connected, close-on-exec Unix stream. The transport adopts rights immediately,
+forbids them outside the header range of that message, and closes them on every
+malformed, stale, cross-scope, timeout, EOF, or poisoned path. Cancellation
+consumes and retires a raced stream internally. Errors and diagnostics remain
+categorical and redact descriptor, peer, session, and packet values.
+
+This boundary is not authority by itself. A later production implementation
+must separately prove the minimal root broker, irreversible dropped owner,
+sandbox grant and adapter, crash reclamation, bundle/signature split, and real
+guest connectivity. The current protocol executes none of those operations and
+needs no Apple authorization.
+
 ## Current Non-Goals
 
 The current scaffold does not implement:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2963,6 +2963,31 @@ It does not support a root-direct production VMM or implement #1378's minimal
 provider/broker, privilege-dropped service owner, sandbox remote provider,
 crash reclamation, or concurrent production topology.
 
+### Private vmnet provider protocol
+
+The portable `provider-v1` foundation is tested without root, vmnet, a bundle,
+or Apple credentials. `bangbang-unix-stream` owns exact partial I/O,
+one-deadline operations, close-on-exec rights adoption, connected-stream
+typing, and cleanup on malformed ancillary data. `bangbang-session` owns the
+80-byte frame, fixed policy slots, four-interface control lifecycle,
+cancellation race, per-generation packet state, and atomic frame/stream
+envelope. The vhost-user frontend consumes the same low-level transport.
+
+```sh
+cargo test -p bangbang-unix-stream --all-features --locked
+cargo test -p bangbang-session --all-features --locked
+cargo test -p bangbang-vhost-user --all-features --locked
+```
+
+Tests include every message kind and split point, malformed and over-limit
+frames, exact sequence/scope poisoning, generation reuse, a raced transferred
+stream that is retired without exposure, readiness/read/write correlation,
+partial write completion, wrong/excess/body-attached descriptors, clean and
+partial EOF, timeout, and a real combined control-to-data socket lifecycle. See
+the [protocol contract](vmnet-provider-protocol.md). This layer adds no broker
+binary, vmnet call, worker adapter or grant, privilege transition, packaging,
+sudo path, positive product evidence, or capability promotion.
+
 The signed `hvf_lifecycle` native-v1 composite case builds the accepted one-
 vCPU/read-only-root session and gives the production generalized publisher two
 absent final paths. Its producer captures the complete non-memory state and

--- a/docs/vmnet-provider-protocol.md
+++ b/docs/vmnet-provider-protocol.md
@@ -1,0 +1,142 @@
+# Private vmnet Provider Protocol
+
+The `bangbang-session` crate defines a closed `provider-v1` control and packet
+protocol for a future split vmnet topology. It is portable protocol machinery,
+not a production network path: this revision starts no broker or owner process,
+calls no vmnet API, grants no worker resource, changes no bundle, and requires
+neither root nor Apple authorization.
+
+The intended later topology keeps framework authority outside the sandboxed
+worker. A bootstrap-owned broker starts a narrowly scoped interface owner; the
+worker receives only a session-bound packet stream. Later adapters must still
+prove the privilege drop, sandbox grant, crash reclamation, process assembly,
+and real guest connectivity before this becomes supported production behavior.
+
+## Components
+
+- `bangbang-unix-stream` owns deadline-bounded exact byte transfer and
+  `SCM_RIGHTS` adoption for already-connected Unix streams. It owns no listener,
+  path, process, peer authorization, or application framing.
+- `bangbang_session::vmnet_provider` owns identities, policy slots, frame
+  encoding, role-specific state, packet bounds, and descriptor correlation.
+- `VmnetProviderTransport` composes both layers. A transport failure shuts down
+  the stream and poisons that transport permanently.
+
+The same shared Unix-stream primitive backs the existing portable vhost-user
+frontend without changing its public protocol.
+
+## Fixed wire contract
+
+Every integer is network byte order. Every session, interface, generation, and
+sender sequence is checked before a state transition. Reserved bytes must be
+zero.
+
+| Bytes | Field | Rule |
+| --- | --- | --- |
+| `0..8` | magic | `BBVNETP\0` |
+| `8..10` | version | exactly `1` |
+| `10` | channel | control `1`, data `2` |
+| `11` | kind | closed message discriminant |
+| `12..16` | body length | kind-specific and globally bounded |
+| `16` | descriptor count | `1` only for control `Started`; otherwise `0` |
+| `17..24` | reserved | all zero |
+| `24..56` | lifecycle session | nonzero exact 32-byte identity |
+| `56..60` | interface | kind-specific nonzero scope or zero |
+| `60..64` | reserved | all zero |
+| `64..72` | generation | kind-specific nonzero scope or zero |
+| `72..80` | sender sequence | nonzero, contiguous, and nonwrapping |
+
+Only six bootstrap-owned policy slots cross the control channel: `host`,
+`shared`, and bridge slots zero through three. No pathname, bridge name, raw
+selector, command, credential, PID, framework error, or arbitrary string can
+be encoded.
+
+## Bounds
+
+| Resource | Maximum |
+| --- | ---: |
+| Active interfaces per session | 4 |
+| Packets in one operation | 200 |
+| Aggregate packet bytes | 256 KiB |
+| One packet buffer | 65,574 bytes, including an enabled 12-byte virtio header |
+| Provider frame buffering | two maximum frames |
+| Complete frame deadline | 5 seconds |
+| Shared transport descriptors | 32; provider frames use at most 1 |
+
+Realized backend parameters further narrow the packet and read/write batch
+limits. Read results may be empty. Writes must be nonempty, preserve packet
+order, and acknowledge only a zero-to-requested completed prefix.
+
+## Control lifecycle
+
+The client and broker exchange `Hello`/`HelloAck` before work. Only one start or
+stop operation may be pending, while up to four successfully started interface
+generations remain active independently. `Started` must introduce a fresh
+generation and is the only frame allowed to carry a connected close-on-exec
+Unix stream. `StartFailed` creates no ownership. `Stopped(Complete)` retires the
+exact active generation; uncertain cleanup is terminal.
+
+Orderly `Shutdown` is legal only after all pending and active ownership is
+empty. Duplicate, skipped, reordered, cross-session, cross-interface,
+cross-generation, wrong-role, over-capacity, or post-terminal input clears
+tracked ownership and poisons the receiving state.
+
+Cancellation has one explicit pending-operation race. After sequenced `Cancel`,
+the broker may either suppress the pending result and send `Cancelled`, or send
+the already committed exact result before `Cancelled`. The client accepts at
+most that one result. A raced `Started` stream is consumed and retired inside
+the state transition and is never exposed to the application. Nothing may
+follow `Cancelled`.
+
+## Data lifecycle
+
+Each transferred stream repeats its exact session, interface, and generation in
+`Hello`/`HelloAck`. The client may then keep one synchronous read or write
+request outstanding. The owner may publish contiguous nonzero readiness epochs
+before or during a request, but the state retains at most one unconsumed edge.
+
+Every result or failure echoes the exact request sequence. Returned packets
+must fit the realized per-packet and per-batch limits; write completion is an
+ordered prefix, not permission to retry or reorder the suffix. Operation
+failure is terminal. `Stop` disables readiness and packet work,
+`Stopped(Complete)` permits only `Shutdown`, and uncertain cleanup poisons the
+stream.
+
+## Descriptor and failure ownership
+
+Transport receive reads the 80-byte header first under one absolute deadline,
+adopts every delivered right immediately, validates the bounded body length,
+then reads the exact body under the same deadline with rights forbidden. The
+single legal `Started` right must arrive within the header byte range and must
+be a connected `AF_UNIX` stream with `FD_CLOEXEC`, `SOCK_STREAM`, and zero
+`SO_ERROR`.
+
+The transport returns one owned envelope containing the decoded frame and its
+optional stream. State consumes the whole envelope; callers cannot detach a
+right before its transition validates. Malformed ancillary data, wrong or
+excess rights, wrong placement or type, timeout, clean disconnect, partial EOF,
+half-close, and local I/O failure close pending rights, shut down the transport,
+and poison it. Public errors and `Debug` output expose only fixed categories and
+counts, never descriptor numbers, peer identities, packet bytes, or session
+values.
+
+## Verification and current status
+
+The portable tests cover every message kind and split point, golden framing,
+reserved/limit corruption, four-interface ownership, generation reuse,
+cancellation races, readiness and request correlation, partial write
+completion, cross-scope poisoning, real descriptor transfer, misplaced/wrong/
+excess rights, timeout and EOF classes, and a combined control-to-data
+lifecycle. Run them without elevation:
+
+```sh
+cargo test -p bangbang-unix-stream --all-features --locked
+cargo test -p bangbang-session --all-features --locked
+cargo test -p bangbang-vhost-user --all-features --locked
+```
+
+This protocol deliberately changes no capability disposition. The checked
+inventory remains `383 implemented / 0 audit-required / 2
+missing-platform-feasible / 33 proven-platform-impossible`; the two retained
+rows are `corpus:network-setup` and
+`semantic.network:virtio-net-vmnet-policy-and-connectivity`.


### PR DESCRIPTION
## Summary

- add a shared, deadline-bounded Unix stream and SCM_RIGHTS transport primitive
- add the fixed provider-v1 codec plus control/data state machines under `bangbang-session`
- refactor vhost-user to consume the shared transport without changing its protocol
- document the portable no-Apple-authorization boundary and retain the exact capability ledger

## Scope exclusions

This PR adds no broker or owner process, vmnet call, root/sudo path, sandbox
grant/adapter, production bundle change, Apple-authorized artifact, real network
evidence, or capability promotion. `capabilities.json` remains byte-identical at
`383 implemented / 0 audit-required / 2 missing-platform-feasible / 33
proven-platform-impossible`.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bangbang-unix-stream --all-features --locked` (9 passed)
- `cargo test -p bangbang-session --all-features --locked` (150 passed)
- `cargo test -p bangbang-vhost-user --all-features --locked` (25 passed)
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked` (1540 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- documented launcher and CPU-template-helper Linux-musl checks
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (158 passed)
- `scripts/run-integration-tests.sh --test app_sandbox` (101 signed HVF and 8 sandbox process cases passed)
- delivery and `--wave8-final` capability audits
- global `--final` fails only on the two retained #1378 network rows

Closes #1932
