### PR TITLE
test: add staged elevated vmnet guest oracle

### DIFF
--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -211,6 +211,12 @@ static no-std entitlement-free guest oracle used only by #1930. Neither recipe
 aliases historical sidecars; v111 is feasibility evidence and does not itself
 implement either #1378 capability.
 
+`rootfs-ext4-direct-boot-v112` retains the v111 one-shot oracle and adds
+#1942's staged coordinator and authenticated 4096-byte barrier protocol. It is
+used only for exact-root startup/runtime/restore foundation evidence, does not
+replace either public workflow profile, and leaves the inventory at
+`383/0/2/33`.
+
 Runtime sidecars stay under the ignored cache root and never count as checked
 inventory or terminal workflow evidence.
 

--- a/compat/firecracker/v1.16.0/guest-workflow-audit.json
+++ b/compat/firecracker/v1.16.0/guest-workflow-audit.json
@@ -172,6 +172,47 @@
         ],
         "filesystem_check": "e2fsck -fn"
       }
+    },
+    {
+      "id": "rootfs-ext4-direct-boot-v112",
+      "source_artifact": "rootfs",
+      "variant": "direct-boot-v112",
+      "filename_template": "ubuntu-24.04-{size}-direct-boot-v112.ext4",
+      "default_size": "512M",
+      "minimum_size_bytes": 1024,
+      "classification": "recipe-deterministic",
+      "output_class": "verified-repairable-cache",
+      "tool_roles": [
+        "unsquashfs",
+        "mkfs.ext4",
+        "e2fsck"
+      ],
+      "tracked_inputs": [
+        "compat/firecracker/v1.16.0/guest-workflow-audit.json",
+        "scripts/fetch-firecracker-rootfs.sh",
+        "scripts/guest/arm64-id-register-report.rs",
+        "scripts/guest/elevated_vmnet_certification.rs",
+        "scripts/guest/specification-benchmark.rs",
+        "scripts/guest/staged_vmnet_certification.py",
+        "scripts/guest_artifact_policy.py"
+      ],
+      "sidecar": {
+        "schema_version": 1,
+        "suffix": ".bangbang.json",
+        "fields": [
+          "schema_version",
+          "source_sha256",
+          "source_size_bytes",
+          "requested_size_bytes",
+          "variant",
+          "recipe_sha256",
+          "tool_versions",
+          "output_sha256",
+          "output_size_bytes",
+          "filesystem_check"
+        ],
+        "filesystem_check": "e2fsck -fn"
+      }
     }
   ],
   "output_classes": [

--- a/compat/firecracker/v1.16.0/guest-workflow-contract.md
+++ b/compat/firecracker/v1.16.0/guest-workflow-contract.md
@@ -82,6 +82,13 @@ oracle instead and has its own exact sidecar identity. Both selectors are inert
 in the public networkless workflow profiles; v111 is owned by #1930's separate
 root-direct feasibility gate, not by this terminal public workflow.
 
+The further distinct `direct-boot-v112` identity retains the v111 static
+one-shot oracle and adds the staged Python coordinator used by #1942. Its
+authenticated fixed-sector barrier separates startup removal/re-addition,
+networkless runtime insertion/removal, and source-to-destination snapshot
+continuation. It remains nonfinal root-direct evidence and changes neither
+public guest-workflow profile nor capability disposition.
+
 ## API and no-API evidence
 
 API mode starts an unconfigured signed process on an owner-only Unix socket,

--- a/compat/firecracker/v1.16.0/vmnet-feasibility-audit.json
+++ b/compat/firecracker/v1.16.0/vmnet-feasibility-audit.json
@@ -164,7 +164,7 @@
         {
           "kind": "local",
           "path": "scripts/run-elevated-vmnet-evidence.sh",
-          "anchor": "guest=passed repeat=passed cleanup=passed"
+          "anchor": "guest=passed repeat=passed startup=passed runtime=passed restore=passed cleanup=passed"
         },
         {
           "kind": "local",

--- a/compat/firecracker/v1.16.0/vmnet-feasibility-contract.md
+++ b/compat/firecracker/v1.16.0/vmnet-feasibility-contract.md
@@ -47,9 +47,9 @@ It fetches and verifies the pinned kernel/rootfs, builds the static aarch64
 guest oracle and exact Rust harnesses, builds and ad-hoc signs the direct
 Hypervisor-entitled Bangbang executable, and builds the separately ad-hoc-signed
 entitlement-free `bangbang-vmnet-provider`. It validates the closed artifact
-shape and runs both ordinary-user negative controls. The v111 rootfs recipe is
-a distinct identity; v110 and the optional Apple-authorized production
-certifier retain their existing meaning and digest.
+shape and runs both ordinary-user negative controls. The v111 and staged v112
+rootfs recipes are distinct identities; v110 and the optional Apple-authorized
+production certifier retain their existing meaning and digest.
 
 The run wrapper requires that its caller already holds exact root authority:
 
@@ -71,6 +71,10 @@ runner copies that immutable shape into one private root-owned stage. Under a
 closed environment it invokes only four distinct positive prebuilt test names:
 provider data lifecycle, provider cancellation, direct dropped owner, and direct
 guest. The provider data and guest names each run twice for clean-repeat proof.
+It then runs the closed v112 staged host driver for startup, runtime, and
+restore. These successor scenarios remain root-direct foundation evidence; they
+do not change the historical #1930 transition or make root execution a product
+topology.
 
 ## Exact evidence result
 
@@ -83,13 +87,14 @@ checked workflow requires all of the following categorical outcomes:
 | Minimal provider broker/owner | A root-owned, single-link, non-writable provider image starts one suspended exact-image owner through default-close descriptors. The owner starts shared vmnet while root, irreversibly drops and re-attests the configured ordinary uid/gid, then completes provider-v1 Hello/readiness/read/write/stop/shutdown, correlated control Stop/reap, control cancellation, and clean repeat without residue. The provider carries no entitlement. |
 | Dropped owner | A separate exact-root process starts the real Rust `SystemVmnetInterfaceBackend`, validates bounded realized parameters, clears supplementary groups, irreversibly changes real/effective uid and gid, proves it cannot regain root, then completes callback enable, fixed 60-byte experimental-frame write, bounded read, stop, and residue checks. |
 | Direct guest | The public Unix HTTP API configures the exact kernel, read-only v111 rootfs, read-only schema-v2 control sector, serial sink, and one `vmnet:shared` interface. A real HVF guest validates DHCP offer/request/ack, derives the host endpoint only from the accepted DHCP router, and completes an exact nonce-bound request and response. |
+| Staged direct guest | The v112 guest and fixed 4096-byte authenticated barrier separately prove startup removal/re-addition with two TCP generations, networkless runtime insertion/removal with live traffic, and Full snapshot source termination plus fresh destination `vmnet:shared` override and post-restore traffic. Guest PCI rescan/removal precedes host API cleanup. |
 | Repeat and cleanup | The guest gate succeeds twice in separate VMM processes. Each process stops normally, and every harness-owned API socket, process group, temporary file, listener, and interface owner is gone. |
 
 The successful fixed output is:
 
 ```text
 platform: macos=<version> sdk=<version> arch=arm64 hvf=supported root=exact apple-vmnet=absent
-bangbang elevated vmnet proof: denial=passed provider=passed provider-cancel=passed provider-repeat=passed dropped-owner=passed guest=passed repeat=passed cleanup=passed
+bangbang elevated vmnet proof: denial=passed provider=passed provider-cancel=passed provider-repeat=passed dropped-owner=passed guest=passed repeat=passed startup=passed runtime=passed restore=passed cleanup=passed
 ```
 
 Tracked evidence and normal output never contain artifact paths, account names,
@@ -119,6 +124,19 @@ The v111 oracle does not accept a host address from the control sector. The TCP
 address is the router from the accepted DHCP lease, so the host cannot substitute
 an unrelated endpoint after lease validation.
 
+`direct-boot-v112` retains that exact one-shot helper and adds
+`/bangbang-staged-vmnet-certification`. The coordinator accepts only one
+4096-byte `/dev/vdc` barrier with a versioned header and fixed command/status
+sectors. Every record binds role, scenario, sequence, nonce, digest, and zeroed
+reserved bytes. It permits exactly the startup, runtime, or restore transition
+graph selected before boot, performs the manual PCI rescan/removal required by
+the product contract, invokes the v111 helper once per required interface
+generation, and reports fixed failure kinds through the authenticated status
+sector. The host-side driver uses only bounded Unix HTTP and a modern File
+snapshot memory backend; restore supplies an explicit network override so the
+destination must acquire fresh backend authority. Serial remains a bounded
+failure-only auxiliary channel and may be empty.
+
 ## Inventory handoff and nonclaims
 
 The checked `vmnet-feasibility-audit.json` pins the source identity, two public
@@ -139,7 +157,9 @@ outer, transfers the inherited provider authority, and proves the foreground
 and provider-owned daemon topology with repeated real provider I/O, signals,
 and cleanup. Neither successor changes a disposition. A real guest through the
 production provider and the complete lifecycle/concurrency certification remain
-separate work.
+separate work. #1942 subsequently adds the three staged root-direct oracle
+scenarios described above, still without capability promotion or parent
+closure.
 
 At its delivery boundary, #1930 itself did not claim any of the following;
 later provider and topology slices do not retroactively change that evidence

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -5462,6 +5462,15 @@ and cleanup. Neither slice changes either disposition. A real guest through the
 production provider, the complete concurrent production certification, and the
 optional Apple-authorized matrix remain #1378 work.
 
+#1942 adds `direct-boot-v112` as a nonfinal root-direct oracle foundation. It
+retains the v111 DHCP/router-derived nonce-TCP helper and adds an authenticated
+barrier that separately proves startup removal/re-addition, networkless runtime
+hotplug, and cross-process Full snapshot restore with a fresh destination
+network override. The guest performs manual PCI rescan/removal and each scenario
+ends with exact API and process cleanup. This evidence uses no Apple
+authorization and leaves both rows `missing-platform-feasible`; production
+provider handoff and the canonical matrix remain later slices.
+
 ## Validation Expectations
 
 Every future compatibility change should choose validation appropriate to its

--- a/docs/macos-guest-workflow.md
+++ b/docs/macos-guest-workflow.md
@@ -167,6 +167,14 @@ the v110 Python oracle and requires its own sidecar and filename. It is not a
 public guest-workflow mode and does not make root-direct VMM execution a
 supported deployment topology.
 
+`direct-boot-v112` extends only that entitlement-free evidence path. It keeps
+the v111 one-shot DHCP/router-derived TCP oracle byte-for-contract and adds a
+mode-`0555` staged coordinator. A separate writable 4096-byte barrier drive
+binds startup, runtime-hotplug, and cross-process restore transitions to one
+scenario and nonce. The guest performs the required PCI rescan/removal while
+the host retains public API ownership. V112 is likewise not a public workflow
+mode or a production topology.
+
 ## Troubleshooting
 
 - `the macOS guest workflow requires Apple Silicon`: run on Darwin arm64; cross

--- a/docs/security.md
+++ b/docs/security.md
@@ -1385,6 +1385,19 @@ accepted router, completes one nonce-bound TCP exchange, and reverses guest
 network state. Every process, socket, listener, file, and owner created by the
 harness must be absent after each bounded case.
 
+#1942 adds a separate v112 root-direct foundation without changing authority.
+Its coordinator accepts one fixed 4096-byte block barrier whose header,
+commands, and statuses are versioned, scenario-bound, sequence-bound,
+nonce-bound, SHA-256 checked, and reserved-zero closed. The guest performs
+manual PCI rescan/removal; the host performs the public network PUT/DELETE
+operations. Startup requires two distinct live TCP generations, while runtime
+requires one only after insertion. Restore
+captures only after first-generation traffic, terminates the source process,
+uses an explicit destination network override, and requires second-generation
+traffic before cleanup. Neither live vmnet ownership nor a provider stream is
+serialized. Failure statuses are categorical, and empty serial output is
+allowed because the authenticated block barrier is the success authority.
+
 This authority is deliberately evidence-only. Running the VMM as root is not a
 supported production topology; root is not treated as the restricted Apple
 entitlement; and no password, authorization token, account name, path,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2925,7 +2925,8 @@ scripts/prepare-elevated-vmnet-evidence.sh \
 
 The prepared package includes the exact ad-hoc Hypervisor-signed VMM and its
 test target, the entitlement-free `bangbang-vmnet-provider` and provider test
-target, pinned kernel, sidecar-verified `direct-boot-v111` rootfs, and manifest.
+target, pinned kernel, sidecar-verified `direct-boot-v111` and
+`direct-boot-v112` rootfs images, staged host/guest coordinators, and manifest.
 Preparation proves both ordinary-user denial paths. The provider carries no
 entitlement; the VMM carries only the Hypervisor entitlement. Preparation never
 requests Apple credentials or elevation.
@@ -2953,10 +2954,20 @@ deadline and must leave no harness-owned process, socket, file, listener, or
 interface residue. Output is fixed categorical text and excludes paths,
 identities, PIDs, interface names, addresses, packets, nonces, and raw errors.
 
+The v112 phase then runs three exact root-direct scenarios through the same
+closed package. Startup proves traffic on the initial interface, guest-observed
+PCI removal, public-API deletion/re-addition, a second DHCP/TCP generation, and
+cleanup. Runtime boots without a network and proves public-API insertion,
+traffic, guest removal, API deletion, and cleanup. Restore captures only at the
+guest barrier, terminates the source, loads through an explicit fresh
+`vmnet:shared` override, proves destination traffic, and removes the final
+interface. The nonce-bound barrier records are authoritative; serial output is
+bounded and rejected if it contains a fixed failure marker, but may be empty.
+
 The exact success suffix is:
 
 ```text
-bangbang elevated vmnet proof: denial=passed provider=passed provider-cancel=passed provider-repeat=passed dropped-owner=passed guest=passed repeat=passed cleanup=passed
+bangbang elevated vmnet proof: denial=passed provider=passed provider-cancel=passed provider-repeat=passed dropped-owner=passed guest=passed repeat=passed startup=passed runtime=passed restore=passed cleanup=passed
 ```
 
 Portable policy and tamper coverage plus the checked audit run unprivileged:

--- a/scripts/elevated_vmnet_evidence.py
+++ b/scripts/elevated_vmnet_evidence.py
@@ -29,7 +29,15 @@ FILES = (
         0o444,
         64 * 1024,
     ),
+    ("ubuntu-24.04-512M-direct-boot-v112.ext4", 0o444, 2 * 1024 * 1024 * 1024),
+    (
+        "ubuntu-24.04-512M-direct-boot-v112.ext4.bangbang.json",
+        0o444,
+        64 * 1024,
+    ),
     ("elevated-vmnet-evidence.py", 0o444, 256 * 1024),
+    ("staged-vmnet-evidence.py", 0o444, 256 * 1024),
+    ("staged-vmnet-certification.py", 0o444, 256 * 1024),
 )
 
 
@@ -168,27 +176,22 @@ def _record(root: Path, owner: int, name: str, mode: int, maximum: int) -> dict[
     }
 
 
-def _validate_sidecar(root: Path, records: list[dict[str, object]]) -> None:
-    sidecar, _raw = _load_json(
-        root / "ubuntu-24.04-512M-direct-boot-v111.ext4.bangbang.json",
-        64 * 1024,
-    )
-    rootfs = next(
-        (
-            record
-            for record in records
-            if record.get("name") == "ubuntu-24.04-512M-direct-boot-v111.ext4"
-        ),
-        None,
-    )
-    if (
-        rootfs is None
-        or sidecar.get("schema_version") != 1
-        or sidecar.get("variant") != "direct-boot-v111"
-        or sidecar.get("output_sha256") != rootfs["sha256"]
-        or sidecar.get("output_size_bytes") != rootfs["size_bytes"]
-    ):
-        _fail("sidecar")
+def _validate_sidecars(root: Path, records: list[dict[str, object]]) -> None:
+    for variant in ("direct-boot-v111", "direct-boot-v112"):
+        filename = f"ubuntu-24.04-512M-{variant}.ext4"
+        sidecar, _raw = _load_json(root / f"{filename}.bangbang.json", 64 * 1024)
+        rootfs = next(
+            (record for record in records if record.get("name") == filename),
+            None,
+        )
+        if (
+            rootfs is None
+            or sidecar.get("schema_version") != 1
+            or sidecar.get("variant") != variant
+            or sidecar.get("output_sha256") != rootfs["sha256"]
+            or sidecar.get("output_size_bytes") != rootfs["size_bytes"]
+        ):
+            _fail("sidecar")
 
 
 def create_manifest(root: Path, owner: int) -> None:
@@ -197,7 +200,7 @@ def create_manifest(root: Path, owner: int) -> None:
         _fail("collision")
     _file(root / LOG_NAME, owner, 0o600, 1024 * 1024, allow_empty=True)
     records = [_record(root, owner, *specification) for specification in FILES]
-    _validate_sidecar(root, records)
+    _validate_sidecars(root, records)
     document = {
         "files": records,
         "kind": KIND,
@@ -264,7 +267,7 @@ def verify_manifest(root: Path, owner: int) -> None:
         if record != actual:
             _fail("artifact")
         actual_records.append(actual)
-    _validate_sidecar(root, actual_records)
+    _validate_sidecars(root, actual_records)
 
 
 def _owner(value: str) -> int:

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -20,7 +20,8 @@ Options:
                    guest oracle when requested by boot args. Only valid with
                    --format ext4.
   --direct-boot-variant VARIANT
-                   Select direct-boot-v110 or direct-boot-v111. Defaults to
+                   Select direct-boot-v110, direct-boot-v111, or
+                   direct-boot-v112. Defaults to
                    direct-boot-v110 and is valid only with --direct-boot-init.
   -h, --help       Show this help.
 
@@ -142,7 +143,7 @@ if [[ "$direct_boot_init" != true && "$direct_boot_variant_set" == true ]]; then
   exit 2
 fi
 case "$direct_boot_variant" in
-  direct-boot-v110 | direct-boot-v111)
+  direct-boot-v110 | direct-boot-v111 | direct-boot-v112)
     ;;
   *)
     echo "unsupported direct-boot variant: $direct_boot_variant" >&2
@@ -328,11 +329,18 @@ install_static_arm64_guest_helpers() {
     "${repo_root}/scripts/guest/specification-benchmark.rs" \
     "${extract_dir}/bangbang-specification-benchmark" \
     "arm64 specification benchmark workload"
-  if [[ "$populate_variant" == direct-boot-v111 ]]; then
+  if [[ "$populate_variant" == direct-boot-v111 || "$populate_variant" == direct-boot-v112 ]]; then
     build_static_arm64_guest_helper \
       "${repo_root}/scripts/guest/elevated_vmnet_certification.rs" \
       "${extract_dir}/bangbang-elevated-vmnet-certification" \
       "elevated vmnet certification guest helper"
+  fi
+  if [[ "$populate_variant" == direct-boot-v112 ]]; then
+    install_checked_python_helper \
+      "${repo_root}/scripts/guest/staged_vmnet_certification.py" \
+      "${extract_dir}/bangbang-staged-vmnet-certification" \
+      0555 \
+      "staged vmnet certification guest coordinator"
   fi
 }
 
@@ -382,7 +390,7 @@ install_production_vmnet_certification_helper() {
         0555 \
         "production vmnet certification guest helper"
       ;;
-    direct-boot-v111)
+    direct-boot-v111 | direct-boot-v112)
       ;;
     *)
       echo "checked direct-rootfs variant is missing or invalid" >&2
@@ -5356,6 +5364,12 @@ elif cmdline_has bangbang.vsock-host-connect=1; then
   fetch_host_vsock_marker
 elif cmdline_has bangbang.vsock-host-multistream=1; then
   fetch_multi_host_vsock_marker
+elif cmdline_has bangbang.staged-vmnet-certification=1; then
+  if [ -x /bangbang-staged-vmnet-certification ]; then
+    /bangbang-staged-vmnet-certification || true
+  else
+    emit_line BANGBANG_STAGED_VMNET_FAIL_INTERNAL
+  fi
 elif cmdline_has bangbang.elevated-vmnet-certification=1; then
   if [ -x /bangbang-elevated-vmnet-certification ]; then
     /bangbang-elevated-vmnet-certification || true
@@ -5383,7 +5397,7 @@ EOF
 
 if [[ -n "$internal_populate_dir" ]]; then
   case "$populate_variant" in
-    direct-boot-v110 | direct-boot-v111)
+    direct-boot-v110 | direct-boot-v111 | direct-boot-v112)
       ;;
     *)
       echo "internal rootfs population requires an exact checked variant" >&2

--- a/scripts/guest/staged_vmnet_certification.py
+++ b/scripts/guest/staged_vmnet_certification.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""Closed guest-side barriers for staged elevated-vmnet certification.
+
+The coordinator owns no DHCP or traffic semantics.  It observes only the
+presence of one non-loopback interface, exchanges authenticated fixed-sector
+barriers on /dev/vdc, and invokes the checked one-shot v111 DHCP/TCP oracle for
+each generation that must prove live traffic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import Callable, NoReturn, Optional, Protocol
+
+
+CONTROL_PATH = Path("/dev/vdc")
+ONE_SHOT_ORACLE = Path("/bangbang-elevated-vmnet-certification")
+NETWORK_DIRECTORY = Path("/sys/class/net")
+PCI_RESCAN_PATH = Path("/sys/bus/pci/rescan")
+PCI_DEVICES_ROOT = Path("/sys/devices")
+HEADER_MAGIC = b"BBSTGVM1"
+RECORD_MAGIC = b"BBSTREC1"
+VERSION = 1
+SECTOR_BYTES = 512
+CONTROL_BYTES = 4096
+PREFIX_BYTES = 64
+DIGEST_BYTES = 32
+HEADER_OFFSET = 0
+COMMAND_OFFSET = SECTOR_BYTES
+STATUS_OFFSET = SECTOR_BYTES * 2
+ROLE_COMMAND = 1
+ROLE_STATUS = 2
+COMMAND_PROCEED = 1
+FAILURE_KINDS = {
+    "control": 240,
+    "io": 241,
+    "topology": 242,
+    "timeout": 243,
+    "process": 244,
+    "traffic": 245,
+    "internal": 246,
+}
+FAILURE_CATEGORIES = {kind: category for category, kind in FAILURE_KINDS.items()}
+INTERFACE_TIMEOUT_SECONDS = 60.0
+COMMAND_TIMEOUT_SECONDS = 120.0
+TRAFFIC_TIMEOUT_SECONDS = 90.0
+POLL_SECONDS = 0.02
+FIXED_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "PATH": "/usr/sbin:/usr/bin:/sbin:/bin"}
+INTERFACE_NAME = re.compile(r"[A-Za-z0-9_.-]{1,15}\Z")
+
+
+class Scenario(IntEnum):
+    STARTUP = 1
+    RUNTIME = 2
+    RESTORE = 3
+
+    @property
+    def cycles(self) -> int:
+        return 1 if self is Scenario.RUNTIME else 2
+
+
+class Status(IntEnum):
+    INITIAL_PRESENT = 1
+    INITIAL_ABSENT = 2
+    PRESENT = 3
+    TRAFFIC_ONE = 4
+    ABSENT = 5
+    TRAFFIC_TWO = 6
+    CAPTURE_READY = 7
+    COMPLETE = 8
+    FAILED = 9
+
+    @property
+    def label(self) -> str:
+        return self.name.casefold().replace("_", "-")
+
+
+STATUS_GRAPHS = {
+    Scenario.STARTUP: (
+        Status.INITIAL_PRESENT,
+        Status.TRAFFIC_ONE,
+        Status.ABSENT,
+        Status.PRESENT,
+        Status.TRAFFIC_TWO,
+        Status.ABSENT,
+        Status.COMPLETE,
+    ),
+    Scenario.RUNTIME: (
+        Status.INITIAL_ABSENT,
+        Status.PRESENT,
+        Status.TRAFFIC_ONE,
+        Status.ABSENT,
+        Status.COMPLETE,
+    ),
+    Scenario.RESTORE: (
+        Status.INITIAL_PRESENT,
+        Status.CAPTURE_READY,
+        Status.PRESENT,
+        Status.TRAFFIC_TWO,
+        Status.ABSENT,
+        Status.COMPLETE,
+    ),
+}
+COMMAND_COUNTS = {
+    Scenario.STARTUP: 5,
+    Scenario.RUNTIME: 3,
+    Scenario.RESTORE: 4,
+}
+
+
+class CoordinatorError(RuntimeError):
+    """One value-free staged guest failure."""
+
+    def __init__(self, category: str) -> None:
+        if not isinstance(category, str) or re.fullmatch(r"[a-z][a-z-]{0,31}", category) is None:
+            category = "internal"
+        super().__init__(category)
+        self.category = category
+
+
+@dataclass(frozen=True)
+class Header:
+    scenario: Scenario
+    cycles: int
+    nonce: bytes
+
+
+@dataclass(frozen=True)
+class Record:
+    role: int
+    scenario: Scenario
+    kind: int
+    sequence: int
+    nonce: bytes
+
+
+def _digest(prefix: bytes) -> bytes:
+    if len(prefix) != PREFIX_BYTES:
+        raise CoordinatorError("control")
+    return hashlib.sha256(prefix).digest()
+
+
+def encode_header(scenario: Scenario, nonce: bytes) -> bytes:
+    if not isinstance(scenario, Scenario) or not isinstance(nonce, bytes) or len(nonce) != 32 or not any(nonce):
+        raise CoordinatorError("control")
+    value = bytearray(SECTOR_BYTES)
+    value[:8] = HEADER_MAGIC
+    value[8:10] = VERSION.to_bytes(2, "big")
+    value[10] = scenario
+    value[11] = scenario.cycles
+    value[16:48] = nonce
+    value[PREFIX_BYTES : PREFIX_BYTES + DIGEST_BYTES] = _digest(bytes(value[:PREFIX_BYTES]))
+    return bytes(value)
+
+
+def decode_header(value: bytes) -> Header:
+    if not isinstance(value, bytes) or len(value) != SECTOR_BYTES:
+        raise CoordinatorError("control")
+    try:
+        scenario = Scenario(value[10])
+    except (IndexError, ValueError) as error:
+        raise CoordinatorError("control") from error
+    nonce = value[16:48]
+    if (
+        value[:8] != HEADER_MAGIC
+        or int.from_bytes(value[8:10], "big") != VERSION
+        or value[11] != scenario.cycles
+        or any(value[12:16])
+        or len(nonce) != 32
+        or not any(nonce)
+        or any(value[48:PREFIX_BYTES])
+        or value[PREFIX_BYTES : PREFIX_BYTES + DIGEST_BYTES] != _digest(value[:PREFIX_BYTES])
+        or any(value[PREFIX_BYTES + DIGEST_BYTES :])
+    ):
+        raise CoordinatorError("control")
+    return Header(scenario, scenario.cycles, nonce)
+
+
+def decode_initial_control(value: bytes) -> Header:
+    if not isinstance(value, bytes) or len(value) != CONTROL_BYTES or any(value[SECTOR_BYTES:]):
+        raise CoordinatorError("control")
+    return decode_header(value[:SECTOR_BYTES])
+
+
+def encode_record(
+    role: int,
+    scenario: Scenario,
+    kind: int,
+    sequence: int,
+    nonce: bytes,
+) -> bytes:
+    if (
+        role not in (ROLE_COMMAND, ROLE_STATUS)
+        or not isinstance(scenario, Scenario)
+        or isinstance(kind, bool)
+        or not isinstance(kind, int)
+        or not 1 <= kind <= 255
+        or isinstance(sequence, bool)
+        or not isinstance(sequence, int)
+        or not 1 <= sequence <= 0xFFFF_FFFF_FFFF_FFFF
+        or not isinstance(nonce, bytes)
+        or len(nonce) != 32
+        or not any(nonce)
+    ):
+        raise CoordinatorError("control")
+    value = bytearray(SECTOR_BYTES)
+    value[:8] = RECORD_MAGIC
+    value[8:10] = VERSION.to_bytes(2, "big")
+    value[10] = role
+    value[11] = scenario
+    value[12] = kind
+    value[16:24] = sequence.to_bytes(8, "big")
+    value[24:56] = nonce
+    value[PREFIX_BYTES : PREFIX_BYTES + DIGEST_BYTES] = _digest(bytes(value[:PREFIX_BYTES]))
+    return bytes(value)
+
+
+def decode_record(value: bytes, *, allow_empty: bool = False) -> Optional[Record]:
+    if not isinstance(value, bytes) or len(value) != SECTOR_BYTES:
+        raise CoordinatorError("control")
+    if not any(value):
+        if allow_empty:
+            return None
+        raise CoordinatorError("control")
+    try:
+        scenario = Scenario(value[11])
+    except (IndexError, ValueError) as error:
+        raise CoordinatorError("control") from error
+    role = value[10]
+    kind = value[12]
+    sequence = int.from_bytes(value[16:24], "big")
+    nonce = value[24:56]
+    if (
+        value[:8] != RECORD_MAGIC
+        or int.from_bytes(value[8:10], "big") != VERSION
+        or role not in (ROLE_COMMAND, ROLE_STATUS)
+        or kind == 0
+        or sequence == 0
+        or len(nonce) != 32
+        or not any(nonce)
+        or any(value[13:16])
+        or any(value[56:PREFIX_BYTES])
+        or value[PREFIX_BYTES : PREFIX_BYTES + DIGEST_BYTES] != _digest(value[:PREFIX_BYTES])
+        or any(value[PREFIX_BYTES + DIGEST_BYTES :])
+    ):
+        raise CoordinatorError("control")
+    return Record(role, scenario, kind, sequence, nonce)
+
+
+class Barrier(Protocol):
+    def status(self, sequence: int, kind: Status) -> None: ...
+
+    def proceed(self, sequence: int) -> None: ...
+
+
+class BlockBarrier:
+    def __init__(self, device: int, header: Header) -> None:
+        self.device = device
+        self.header = header
+        self._previous_command: Optional[Record] = None
+        self._previous_status_sequence = 0
+        self._terminal = False
+        self._closed = False
+
+    @classmethod
+    def open(cls, path: Path = CONTROL_PATH) -> BlockBarrier:
+        flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = -1
+        try:
+            descriptor = os.open(path, flags)
+            metadata = os.fstat(descriptor)
+            control_bytes = os.pread(descriptor, CONTROL_BYTES + 1, HEADER_OFFSET)
+        except OSError as error:
+            try:
+                os.close(descriptor)
+            except (OSError, UnboundLocalError):
+                pass
+            raise CoordinatorError("io") from error
+        if not stat.S_ISBLK(metadata.st_mode):
+            os.close(descriptor)
+            raise CoordinatorError("control")
+        try:
+            header = decode_initial_control(control_bytes)
+        except BaseException:
+            os.close(descriptor)
+            raise
+        os.close(descriptor)
+        return cls(metadata.st_rdev, header)
+
+    def _open(self) -> int:
+        if self._closed:
+            raise CoordinatorError("io")
+        flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(CONTROL_PATH, flags)
+            metadata = os.fstat(descriptor)
+        except OSError as error:
+            try:
+                os.close(descriptor)
+            except (OSError, UnboundLocalError):
+                pass
+            raise CoordinatorError("io") from error
+        if not stat.S_ISBLK(metadata.st_mode) or metadata.st_rdev != self.device:
+            os.close(descriptor)
+            raise CoordinatorError("control")
+        return descriptor
+
+    def close(self) -> None:
+        self._closed = True
+
+    def _read_command(self) -> Optional[Record]:
+        descriptor = self._open()
+        try:
+            value = os.pread(descriptor, SECTOR_BYTES, COMMAND_OFFSET)
+        except OSError as error:
+            raise CoordinatorError("io") from error
+        finally:
+            os.close(descriptor)
+        return decode_record(value, allow_empty=True)
+
+    def status(self, sequence: int, kind: Status) -> None:
+        graph = STATUS_GRAPHS[self.header.scenario]
+        if (
+            self._terminal
+            or not isinstance(kind, Status)
+            or sequence != self._previous_status_sequence + 1
+            or sequence > len(graph)
+            or kind is not graph[sequence - 1]
+            or (
+                kind is Status.COMPLETE
+                and (
+                    self._previous_command is None
+                    or self._previous_command.sequence
+                    != COMMAND_COUNTS[self.header.scenario]
+                )
+            )
+        ):
+            raise CoordinatorError("control")
+        value = encode_record(
+            ROLE_STATUS,
+            self.header.scenario,
+            int(kind),
+            sequence,
+            self.header.nonce,
+        )
+        descriptor = self._open()
+        try:
+            written = os.pwrite(descriptor, value, STATUS_OFFSET)
+            os.fsync(descriptor)
+        except OSError as error:
+            raise CoordinatorError("io") from error
+        finally:
+            os.close(descriptor)
+        if written != len(value):
+            raise CoordinatorError("io")
+        self._previous_status_sequence = sequence
+        self._terminal = kind is Status.COMPLETE
+        _emit(f"BANGBANG_STAGED_VMNET_STATUS_{kind.name}")
+
+    def failure(self, category: str) -> None:
+        kind = FAILURE_KINDS.get(category, FAILURE_KINDS["internal"])
+        value = encode_record(
+            ROLE_STATUS,
+            self.header.scenario,
+            kind,
+            0xFFFF_FFFF_FFFF_FFFF,
+            self.header.nonce,
+        )
+        descriptor = self._open()
+        try:
+            written = os.pwrite(descriptor, value, STATUS_OFFSET)
+            os.fsync(descriptor)
+        except OSError as error:
+            raise CoordinatorError("io") from error
+        finally:
+            os.close(descriptor)
+        if written != len(value):
+            raise CoordinatorError("io")
+
+    def proceed(self, sequence: int) -> None:
+        expected = 1 if self._previous_command is None else self._previous_command.sequence + 1
+        if (
+            self._terminal
+            or sequence != expected
+            or sequence > COMMAND_COUNTS[self.header.scenario]
+        ):
+            raise CoordinatorError("control")
+        deadline = time.monotonic() + COMMAND_TIMEOUT_SECONDS
+        while True:
+            record = self._read_command()
+            if record is not None:
+                if record == self._previous_command:
+                    pass
+                elif (
+                    record.role == ROLE_COMMAND
+                    and record.scenario is self.header.scenario
+                    and record.kind == COMMAND_PROCEED
+                    and record.sequence == sequence
+                    and record.nonce == self.header.nonce
+                ):
+                    self._previous_command = record
+                    return
+                else:
+                    raise CoordinatorError("control")
+            if time.monotonic() >= deadline:
+                raise CoordinatorError("timeout")
+            time.sleep(POLL_SECONDS)
+
+    def __enter__(self) -> BlockBarrier:
+        return self
+
+    def __exit__(self, *_exception: object) -> None:
+        self.close()
+
+
+def _interface_count(directory: Path = NETWORK_DIRECTORY) -> int:
+    try:
+        names = sorted(entry.name for entry in os.scandir(directory) if entry.name != "lo")
+    except OSError as error:
+        raise CoordinatorError("topology") from error
+    if any(INTERFACE_NAME.fullmatch(name) is None for name in names) or len(names) > 1:
+        raise CoordinatorError("topology")
+    return len(names)
+
+
+def _rescan(path: Path = PCI_RESCAN_PATH) -> None:
+    try:
+        with path.open("wb", buffering=0) as destination:
+            if destination.write(b"1\n") != 2:
+                raise CoordinatorError("topology")
+    except CoordinatorError:
+        raise
+    except OSError as error:
+        raise CoordinatorError("topology") from error
+
+
+def _network_pci_remove_path(directory: Path = NETWORK_DIRECTORY) -> Path:
+    try:
+        interfaces = [entry.name for entry in os.scandir(directory) if entry.name != "lo"]
+    except OSError as error:
+        raise CoordinatorError("topology") from error
+    if len(interfaces) != 1 or INTERFACE_NAME.fullmatch(interfaces[0]) is None:
+        raise CoordinatorError("topology")
+    try:
+        current = (directory / interfaces[0] / "device").resolve(strict=True)
+        devices_root = PCI_DEVICES_ROOT.resolve(strict=True)
+    except OSError as error:
+        raise CoordinatorError("topology") from error
+    if current != devices_root and devices_root not in current.parents:
+        raise CoordinatorError("topology")
+    while current != devices_root:
+        remove = current / "remove"
+        try:
+            vendor = (current / "vendor").read_text(encoding="ascii").strip()
+            device = (current / "device").read_text(encoding="ascii").strip()
+        except OSError:
+            pass
+        else:
+            if vendor == "0x1af4" and device == "0x1041" and remove.exists():
+                return remove
+        current = current.parent
+    raise CoordinatorError("topology")
+
+
+def _remove_interface() -> None:
+    path = _network_pci_remove_path()
+    try:
+        with path.open("wb", buffering=0) as destination:
+            if destination.write(b"1\n") != 2:
+                raise CoordinatorError("topology")
+    except CoordinatorError:
+        raise
+    except OSError as error:
+        raise CoordinatorError("topology") from error
+
+
+def _wait_interface(
+    present: bool,
+    interface_count: Callable[[], int],
+    rescan: Callable[[], None],
+    *,
+    timeout: float = INTERFACE_TIMEOUT_SECONDS,
+) -> None:
+    deadline = time.monotonic() + timeout
+    expected = 1 if present else 0
+    while True:
+        observed = interface_count()
+        if observed not in (0, 1):
+            raise CoordinatorError("topology")
+        if observed == expected:
+            return
+        if present:
+            rescan()
+        if time.monotonic() >= deadline:
+            raise CoordinatorError("timeout")
+        time.sleep(POLL_SECONDS)
+
+
+def _run_traffic(oracle: Path = ONE_SHOT_ORACLE) -> None:
+    if not oracle.is_absolute():
+        raise CoordinatorError("process")
+    try:
+        metadata = os.lstat(oracle)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_mode & 0o111 == 0
+            or metadata.st_mode & 0o022
+        ):
+            raise CoordinatorError("process")
+        outcome = subprocess.run(
+            (os.fspath(oracle),),
+            check=False,
+            cwd="/",
+            env=FIXED_ENVIRONMENT,
+            stdin=subprocess.DEVNULL,
+            timeout=TRAFFIC_TIMEOUT_SECONDS,
+        )
+    except CoordinatorError:
+        raise
+    except (OSError, subprocess.SubprocessError) as error:
+        raise CoordinatorError("process") from error
+    if outcome.returncode != 0:
+        raise CoordinatorError("traffic")
+
+
+def _emit(value: str) -> None:
+    try:
+        sys.stdout.write(value + "\n")
+        sys.stdout.flush()
+    except (OSError, UnicodeError) as error:
+        raise CoordinatorError("io") from error
+
+
+def run_scenario(
+    header: Header,
+    barrier: Barrier,
+    *,
+    interface_count: Callable[[], int] = _interface_count,
+    rescan: Callable[[], None] = _rescan,
+    remove_interface: Callable[[], None] = _remove_interface,
+    traffic: Callable[[], None] = _run_traffic,
+) -> None:
+    if (
+        not isinstance(header, Header)
+        or not isinstance(header.scenario, Scenario)
+        or header.cycles != header.scenario.cycles
+        or not isinstance(header.nonce, bytes)
+        or len(header.nonce) != 32
+        or not any(header.nonce)
+    ):
+        raise CoordinatorError("control")
+    status_sequence = 0
+
+    def publish(kind: Status) -> None:
+        nonlocal status_sequence
+        status_sequence += 1
+        barrier.status(status_sequence, kind)
+
+    scenario = header.scenario
+    if scenario is Scenario.STARTUP:
+        _wait_interface(True, interface_count, rescan)
+        publish(Status.INITIAL_PRESENT)
+        barrier.proceed(1)
+        traffic()
+        publish(Status.TRAFFIC_ONE)
+        barrier.proceed(2)
+        remove_interface()
+        _wait_interface(False, interface_count, rescan)
+        publish(Status.ABSENT)
+        barrier.proceed(3)
+        _wait_interface(True, interface_count, rescan)
+        publish(Status.PRESENT)
+        traffic()
+        publish(Status.TRAFFIC_TWO)
+        barrier.proceed(4)
+        remove_interface()
+        _wait_interface(False, interface_count, rescan)
+        publish(Status.ABSENT)
+        barrier.proceed(5)
+        _wait_interface(False, interface_count, rescan)
+        publish(Status.COMPLETE)
+        return
+    if scenario is Scenario.RUNTIME:
+        _wait_interface(False, interface_count, rescan)
+        publish(Status.INITIAL_ABSENT)
+        barrier.proceed(1)
+        _wait_interface(True, interface_count, rescan)
+        publish(Status.PRESENT)
+        traffic()
+        publish(Status.TRAFFIC_ONE)
+        barrier.proceed(2)
+        remove_interface()
+        _wait_interface(False, interface_count, rescan)
+        publish(Status.ABSENT)
+        barrier.proceed(3)
+        _wait_interface(False, interface_count, rescan)
+        publish(Status.COMPLETE)
+        return
+    if scenario is Scenario.RESTORE:
+        _wait_interface(True, interface_count, rescan)
+        publish(Status.INITIAL_PRESENT)
+        barrier.proceed(1)
+        traffic()
+        publish(Status.CAPTURE_READY)
+        barrier.proceed(2)
+        _wait_interface(True, interface_count, rescan)
+        publish(Status.PRESENT)
+        traffic()
+        publish(Status.TRAFFIC_TWO)
+        barrier.proceed(3)
+        remove_interface()
+        _wait_interface(False, interface_count, rescan)
+        publish(Status.ABSENT)
+        barrier.proceed(4)
+        _wait_interface(False, interface_count, rescan)
+        publish(Status.COMPLETE)
+        return
+    raise CoordinatorError("control")
+
+
+def _fail(error: CoordinatorError, barrier: Optional[BlockBarrier]) -> NoReturn:
+    if barrier is not None:
+        try:
+            barrier.failure(error.category)
+        except BaseException:
+            pass
+    try:
+        _emit(f"BANGBANG_STAGED_VMNET_FAIL_{error.category.upper().replace('-', '_')}")
+    except CoordinatorError:
+        pass
+    raise SystemExit(1)
+
+
+def main() -> int:
+    barrier: Optional[BlockBarrier] = None
+    try:
+        _emit("BANGBANG_STAGED_VMNET_BEGIN")
+        barrier = BlockBarrier.open()
+        run_scenario(barrier.header, barrier)
+        _emit("BANGBANG_STAGED_VMNET_OK")
+        barrier.close()
+        return 0
+    except CoordinatorError as error:
+        _fail(error, barrier)
+    except BaseException as error:
+        internal = CoordinatorError("internal")
+        internal.__cause__ = error
+        _fail(internal, barrier)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/guest/staged_vmnet_certification.py
+++ b/scripts/guest/staged_vmnet_certification.py
@@ -77,7 +77,6 @@ class Status(IntEnum):
     TRAFFIC_TWO = 6
     CAPTURE_READY = 7
     COMPLETE = 8
-    FAILED = 9
 
     @property
     def label(self) -> str:
@@ -267,7 +266,7 @@ class BlockBarrier:
         self.device = device
         self.header = header
         self._previous_command: Optional[Record] = None
-        self._previous_status_sequence = 0
+        self._previous_status: Optional[Record] = None
         self._terminal = False
         self._closed = False
 
@@ -329,10 +328,13 @@ class BlockBarrier:
 
     def status(self, sequence: int, kind: Status) -> None:
         graph = STATUS_GRAPHS[self.header.scenario]
+        expected_sequence = (
+            1 if self._previous_status is None else self._previous_status.sequence + 1
+        )
         if (
             self._terminal
             or not isinstance(kind, Status)
-            or sequence != self._previous_status_sequence + 1
+            or sequence != expected_sequence
             or sequence > len(graph)
             or kind is not graph[sequence - 1]
             or (
@@ -354,6 +356,12 @@ class BlockBarrier:
         )
         descriptor = self._open()
         try:
+            current = decode_record(
+                os.pread(descriptor, SECTOR_BYTES, STATUS_OFFSET),
+                allow_empty=True,
+            )
+            if current != self._previous_status:
+                raise CoordinatorError("control")
             written = os.pwrite(descriptor, value, STATUS_OFFSET)
             os.fsync(descriptor)
         except OSError as error:
@@ -362,7 +370,13 @@ class BlockBarrier:
             os.close(descriptor)
         if written != len(value):
             raise CoordinatorError("io")
-        self._previous_status_sequence = sequence
+        self._previous_status = Record(
+            ROLE_STATUS,
+            self.header.scenario,
+            int(kind),
+            sequence,
+            self.header.nonce,
+        )
         self._terminal = kind is Status.COMPLETE
         _emit(f"BANGBANG_STAGED_VMNET_STATUS_{kind.name}")
 

--- a/scripts/guest_artifact_policy.py
+++ b/scripts/guest_artifact_policy.py
@@ -385,6 +385,7 @@ def load_manifest(path: Path = MANIFEST_PATH) -> GuestWorkflowManifest:
         "rootfs-ext4",
         "rootfs-ext4-direct-boot-v110",
         "rootfs-ext4-direct-boot-v111",
+        "rootfs-ext4-direct-boot-v112",
     )
     for index, value in enumerate(recipe_items):
         item = _require_object(
@@ -1308,6 +1309,7 @@ def prepare_ext4(
         "normal": "rootfs-ext4",
         "direct-boot-v110": "rootfs-ext4-direct-boot-v110",
         "direct-boot-v111": "rootfs-ext4-direct-boot-v111",
+        "direct-boot-v112": "rootfs-ext4-direct-boot-v112",
     }
     recipe_id = recipe_ids.get(variant)
     if recipe_id is None or recipe_id not in policy.recipes:
@@ -1356,7 +1358,7 @@ def prepare_ext4(
             )
             if result.returncode != 0:
                 raise ArtifactPolicyError("build", "unsquashfs failed while preparing ext4 rootfs")
-            if variant in ("direct-boot-v110", "direct-boot-v111"):
+            if variant in ("direct-boot-v110", "direct-boot-v111", "direct-boot-v112"):
                 environment = dict(os.environ)
                 environment[DIRECT_POPULATE_ENV] = "1"
                 environment[DIRECT_POPULATE_VARIANT_ENV] = variant
@@ -1414,7 +1416,7 @@ def _parse_args(arguments: Optional[Sequence[str]] = None) -> argparse.Namespace
     ext4_parser.add_argument(
         "--variant",
         required=True,
-        choices=("normal", "direct-boot-v110", "direct-boot-v111"),
+        choices=("normal", "direct-boot-v110", "direct-boot-v111", "direct-boot-v112"),
     )
 
     publish_parser = subparsers.add_parser("publish", help="Publish a fixed caller-owned output class.")

--- a/scripts/prepare-elevated-vmnet-evidence.sh
+++ b/scripts/prepare-elevated-vmnet-evidence.sh
@@ -96,7 +96,7 @@ kernel="$(scripts/fetch-firecracker-kernel.sh 2>>"$log")" || {
   echo "bangbang elevated vmnet prepare: kernel failed" >&2
   exit 1
 }
-rootfs="$(scripts/fetch-firecracker-rootfs.sh \
+rootfs_v111="$(scripts/fetch-firecracker-rootfs.sh \
   --format ext4 \
   --ext4-size 512M \
   --direct-boot-init \
@@ -105,11 +105,24 @@ rootfs="$(scripts/fetch-firecracker-rootfs.sh \
   echo "bangbang elevated vmnet prepare: rootfs failed" >&2
   exit 1
 }
-sidecar="${rootfs}.bangbang.json"
+rootfs_v112="$(scripts/fetch-firecracker-rootfs.sh \
+  --format ext4 \
+  --ext4-size 512M \
+  --direct-boot-init \
+  --direct-boot-variant direct-boot-v112 \
+  2>>"$log")" || {
+  echo "bangbang elevated vmnet prepare: staged rootfs failed" >&2
+  exit 1
+}
+sidecar_v111="${rootfs_v111}.bangbang.json"
+sidecar_v112="${rootfs_v112}.bangbang.json"
 if [[ ! -f "$kernel" || -L "$kernel" \
-  || ! -f "$rootfs" || -L "$rootfs" \
-  || ! -f "$sidecar" || -L "$sidecar" \
-  || "$(/usr/bin/basename "$rootfs")" != "ubuntu-24.04-512M-direct-boot-v111.ext4" ]]; then
+  || ! -f "$rootfs_v111" || -L "$rootfs_v111" \
+  || ! -f "$sidecar_v111" || -L "$sidecar_v111" \
+  || ! -f "$rootfs_v112" || -L "$rootfs_v112" \
+  || ! -f "$sidecar_v112" || -L "$sidecar_v112" \
+  || "$(/usr/bin/basename "$rootfs_v111")" != "ubuntu-24.04-512M-direct-boot-v111.ext4" \
+  || "$(/usr/bin/basename "$rootfs_v112")" != "ubuntu-24.04-512M-direct-boot-v112.ext4" ]]; then
   echo "bangbang elevated vmnet prepare: artifact failed" >&2
   exit 1
 fi
@@ -255,9 +268,13 @@ fi
 /usr/bin/codesign --verify --strict "$stage/elevated-vmnet-provider-e2e" >>"$log" 2>&1
 
 /bin/cp -p -- "$kernel" "$stage/vmlinux-6.1.155"
-/bin/cp -p -- "$rootfs" "$stage/ubuntu-24.04-512M-direct-boot-v111.ext4"
-/bin/cp -p -- "$sidecar" "$stage/ubuntu-24.04-512M-direct-boot-v111.ext4.bangbang.json"
+/bin/cp -p -- "$rootfs_v111" "$stage/ubuntu-24.04-512M-direct-boot-v111.ext4"
+/bin/cp -p -- "$sidecar_v111" "$stage/ubuntu-24.04-512M-direct-boot-v111.ext4.bangbang.json"
+/bin/cp -p -- "$rootfs_v112" "$stage/ubuntu-24.04-512M-direct-boot-v112.ext4"
+/bin/cp -p -- "$sidecar_v112" "$stage/ubuntu-24.04-512M-direct-boot-v112.ext4.bangbang.json"
 /bin/cp -p -- scripts/elevated_vmnet_evidence.py "$stage/elevated-vmnet-evidence.py"
+/bin/cp -p -- scripts/staged_vmnet_evidence.py "$stage/staged-vmnet-evidence.py"
+/bin/cp -p -- scripts/guest/staged_vmnet_certification.py "$stage/staged-vmnet-certification.py"
 /bin/chmod 0555 \
   "$stage/bangbang" \
   "$stage/elevated-vmnet-e2e" \
@@ -267,7 +284,11 @@ fi
   "$stage/vmlinux-6.1.155" \
   "$stage/ubuntu-24.04-512M-direct-boot-v111.ext4" \
   "$stage/ubuntu-24.04-512M-direct-boot-v111.ext4.bangbang.json" \
-  "$stage/elevated-vmnet-evidence.py"
+  "$stage/ubuntu-24.04-512M-direct-boot-v112.ext4" \
+  "$stage/ubuntu-24.04-512M-direct-boot-v112.ext4.bangbang.json" \
+  "$stage/elevated-vmnet-evidence.py" \
+  "$stage/staged-vmnet-evidence.py" \
+  "$stage/staged-vmnet-certification.py"
 
 entitlements="$stage/entitlements.plist"
 /usr/bin/codesign --display --entitlements - --xml "$stage/bangbang" >"$entitlements" 2>>"$log" || {

--- a/scripts/run-elevated-vmnet-evidence.sh
+++ b/scripts/run-elevated-vmnet-evidence.sh
@@ -259,6 +259,7 @@ run_staged_case() {
   /usr/bin/env -i \
     LANG=C \
     LC_ALL=C \
+    PYTHONDONTWRITEBYTECODE=1 \
     TMPDIR="$stage/runs" \
     BANGBANG_ELEVATED_VMNET_BANGBANG="$stage/bangbang" \
     BANGBANG_ELEVATED_VMNET_KERNEL="$stage/vmlinux-6.1.155" \
@@ -329,6 +330,12 @@ for scenario in startup runtime restore; do
     exit 1
   fi
 done
+
+final_count="$(/usr/bin/find -x "$stage" -mindepth 1 -maxdepth 1 -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+if [[ "$final_count" != "$((${#names[@]} + 1))" ]]; then
+  echo "bangbang elevated vmnet proof: final package residue" >&2
+  exit 1
+fi
 
 os_version="$(/usr/bin/sw_vers -productVersion)"
 sdk_version="$(/usr/bin/xcrun --sdk macosx --show-sdk-version)"

--- a/scripts/run-elevated-vmnet-evidence.sh
+++ b/scripts/run-elevated-vmnet-evidence.sh
@@ -118,7 +118,11 @@ names=(
   vmlinux-6.1.155
   ubuntu-24.04-512M-direct-boot-v111.ext4
   ubuntu-24.04-512M-direct-boot-v111.ext4.bangbang.json
+  ubuntu-24.04-512M-direct-boot-v112.ext4
+  ubuntu-24.04-512M-direct-boot-v112.ext4.bangbang.json
   elevated-vmnet-evidence.py
+  staged-vmnet-evidence.py
+  staged-vmnet-certification.py
   manifest.json
   prepare.log
 )
@@ -171,7 +175,11 @@ done
   "$stage/vmlinux-6.1.155" \
   "$stage/ubuntu-24.04-512M-direct-boot-v111.ext4" \
   "$stage/ubuntu-24.04-512M-direct-boot-v111.ext4.bangbang.json" \
+  "$stage/ubuntu-24.04-512M-direct-boot-v112.ext4" \
+  "$stage/ubuntu-24.04-512M-direct-boot-v112.ext4.bangbang.json" \
   "$stage/elevated-vmnet-evidence.py" \
+  "$stage/staged-vmnet-evidence.py" \
+  "$stage/staged-vmnet-certification.py" \
   "$stage/manifest.json"
 /bin/chmod 0600 "$stage/prepare.log"
 if ! /usr/bin/python3 "$stage/elevated-vmnet-evidence.py" verify \
@@ -246,6 +254,21 @@ run_provider_case() {
       >/dev/null 2>&1
 }
 
+run_staged_case() {
+  local scenario="$1"
+  /usr/bin/env -i \
+    LANG=C \
+    LC_ALL=C \
+    TMPDIR="$stage/runs" \
+    BANGBANG_ELEVATED_VMNET_BANGBANG="$stage/bangbang" \
+    BANGBANG_ELEVATED_VMNET_KERNEL="$stage/vmlinux-6.1.155" \
+    BANGBANG_STAGED_VMNET_ROOTFS="$stage/ubuntu-24.04-512M-direct-boot-v112.ext4" \
+    BANGBANG_STAGED_VMNET_ROOTFS_SIDECAR="$stage/ubuntu-24.04-512M-direct-boot-v112.ext4.bangbang.json" \
+    /usr/bin/python3 "$stage/staged-vmnet-evidence.py" \
+      --scenario "$scenario" \
+      >/dev/null 2>&1
+}
+
 if ! run_provider_case macos_arm64::dropped_provider_serves_data_lifecycle; then
   echo "bangbang elevated vmnet proof: provider data failed" >&2
   exit 1
@@ -296,7 +319,18 @@ if [[ -n "$(/usr/bin/find -x "$stage/runs" -mindepth 1 -print -quit)" ]]; then
   exit 1
 fi
 
+for scenario in startup runtime restore; do
+  if ! run_staged_case "$scenario"; then
+    echo "bangbang elevated vmnet proof: staged $scenario failed" >&2
+    exit 1
+  fi
+  if [[ -n "$(/usr/bin/find -x "$stage/runs" -mindepth 1 -print -quit)" ]]; then
+    echo "bangbang elevated vmnet proof: staged $scenario residue" >&2
+    exit 1
+  fi
+done
+
 os_version="$(/usr/bin/sw_vers -productVersion)"
 sdk_version="$(/usr/bin/xcrun --sdk macosx --show-sdk-version)"
 echo "platform: macos=$os_version sdk=$sdk_version arch=arm64 hvf=supported root=exact apple-vmnet=absent"
-echo "bangbang elevated vmnet proof: denial=passed provider=passed provider-cancel=passed provider-repeat=passed dropped-owner=passed guest=passed repeat=passed cleanup=passed"
+echo "bangbang elevated vmnet proof: denial=passed provider=passed provider-cancel=passed provider-repeat=passed dropped-owner=passed guest=passed repeat=passed startup=passed runtime=passed restore=passed cleanup=passed"

--- a/scripts/staged_vmnet_evidence.py
+++ b/scripts/staged_vmnet_evidence.py
@@ -335,13 +335,26 @@ def _http(
         raise EvidenceError("api")
     response = bytearray()
     client: Optional[socket.socket] = None
+    deadline = time.monotonic() + REQUEST_SECONDS
+
+    def set_remaining_timeout() -> None:
+        if client is None:
+            raise EvidenceError("api")
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise EvidenceError("api")
+        client.settimeout(remaining)
+
     try:
         client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        client.settimeout(REQUEST_SECONDS)
+        set_remaining_timeout()
         client.connect(os.fspath(product.socket_path))
+        set_remaining_timeout()
         client.sendall(request)
+        set_remaining_timeout()
         client.shutdown(socket.SHUT_WR)
         while True:
+            set_remaining_timeout()
             chunk = client.recv(4096)
             if not chunk:
                 break
@@ -369,6 +382,15 @@ def _parse_http_response(response: bytes) -> tuple[int, bytes]:
         status = int(parts[1])
     except (IndexError, UnicodeDecodeError, ValueError) as error:
         raise EvidenceError("api") from error
+    if (
+        len(parts) != 3
+        or parts[0] != "HTTP/1.1"
+        or len(parts[1]) != 3
+        or not 100 <= status <= 599
+        or any(b":" not in line for line in lines[1:])
+        or any(line.lower().startswith(b"transfer-encoding:") for line in lines[1:])
+    ):
+        raise EvidenceError("api")
     lengths = [line[16:] for line in lines[1:] if line.lower().startswith(b"content-length: ")]
     if len(lengths) != 1 or not lengths[0].isdigit() or int(lengths[0]) != len(payload):
         raise EvidenceError("api")
@@ -446,24 +468,52 @@ class Barrier:
             sequence,
             self.nonce,
         )
+        descriptor = -1
         try:
-            descriptor = os.open(self.path, os.O_RDWR | getattr(os, "O_CLOEXEC", 0))
+            descriptor = os.open(
+                self.path,
+                os.O_RDWR
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+            )
+            metadata = os.fstat(descriptor)
+            current = protocol.decode_record(
+                os.pread(descriptor, protocol.SECTOR_BYTES, protocol.COMMAND_OFFSET),
+                allow_empty=True,
+            )
+            expected = None
+            if self.previous_command_sequence != 0:
+                expected = protocol.Record(
+                    protocol.ROLE_COMMAND,
+                    self.scenario,
+                    protocol.COMMAND_PROCEED,
+                    self.previous_command_sequence,
+                    self.nonce,
+                )
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or metadata.st_uid != os.getuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+                or metadata.st_size != protocol.CONTROL_BYTES
+                or current != expected
+            ):
+                raise EvidenceError("control")
             if os.pwrite(descriptor, value, protocol.COMMAND_OFFSET) != len(value):
                 raise EvidenceError("control")
             os.fsync(descriptor)
-            os.close(descriptor)
+        except protocol.CoordinatorError as error:
+            raise EvidenceError("control") from error
         except EvidenceError:
-            try:
-                os.close(descriptor)
-            except (OSError, UnboundLocalError):
-                pass
             raise
         except OSError as error:
-            try:
-                os.close(descriptor)
-            except (OSError, UnboundLocalError):
-                pass
             raise EvidenceError("control") from error
+        finally:
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError as error:
+                    raise EvidenceError("control") from error
         self.previous_command_sequence = sequence
 
     def wait(self, product: Product, sequence: int, kind: Any) -> None:
@@ -509,16 +559,10 @@ class Barrier:
                     and record.scenario is self.scenario
                     and record.nonce == self.nonce
                     and record.kind in protocol.FAILURE_CATEGORIES
+                    and record.sequence == 0xFFFF_FFFF_FFFF_FFFF
                 ):
                     category = protocol.FAILURE_CATEGORIES[record.kind]
                     raise EvidenceError(f"guest-staged-{category}")
-                elif (
-                    record.role == protocol.ROLE_STATUS
-                    and record.scenario is self.scenario
-                    and record.kind == int(protocol.Status.FAILED)
-                    and record.nonce == self.nonce
-                ):
-                    raise EvidenceError("guest")
                 elif (
                     record.role == protocol.ROLE_STATUS
                     and record.scenario is self.scenario
@@ -618,11 +662,11 @@ class Fixture:
         self.expected = expected
         self.cancelled = threading.Event()
         self.result: Optional[EvidenceError] = None
+        self.deadline = time.monotonic() + FIXTURE_SECONDS
         self.thread = threading.Thread(target=self._run, name="staged-vmnet-fixture", daemon=True)
         self.thread.start()
 
     def _run(self) -> None:
-        deadline = time.monotonic() + FIXTURE_SECONDS
         valid = 0
         attempts = 0
         try:
@@ -632,7 +676,7 @@ class Fixture:
                 try:
                     connection, _address = self.listener.accept()
                 except socket.timeout:
-                    if time.monotonic() >= deadline:
+                    if time.monotonic() >= self.deadline:
                         raise EvidenceError("fixture-timeout")
                     continue
                 attempts += 1
@@ -640,13 +684,20 @@ class Fixture:
                     connection.close()
                     raise EvidenceError("fixture")
                 with connection:
-                    connection.settimeout(5)
                     request = bytearray()
                     while len(request) < TCP_RECORD_BYTES:
+                        remaining = self.deadline - time.monotonic()
+                        if remaining <= 0:
+                            raise EvidenceError("fixture-timeout")
+                        connection.settimeout(min(5.0, remaining))
                         chunk = connection.recv(TCP_RECORD_BYTES - len(request))
                         if not chunk:
                             break
                         request.extend(chunk)
+                    remaining = self.deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise EvidenceError("fixture-timeout")
+                    connection.settimeout(min(5.0, remaining))
                     trailing = connection.recv(1)
                     if (
                         len(request) != TCP_RECORD_BYTES
@@ -656,6 +707,10 @@ class Fixture:
                     ):
                         continue
                     response = TCP_RESPONSE_MAGIC + self.nonce
+                    remaining = self.deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise EvidenceError("fixture-timeout")
+                    connection.settimeout(min(5.0, remaining))
                     connection.sendall(response)
                     connection.shutdown(socket.SHUT_WR)
                     valid += 1
@@ -665,7 +720,7 @@ class Fixture:
             self.listener.close()
 
     def finish(self) -> None:
-        self.thread.join(timeout=FIXTURE_SECONDS)
+        self.thread.join(timeout=max(0.0, self.deadline - time.monotonic()))
         if self.thread.is_alive():
             raise EvidenceError("fixture-timeout")
         if self.result is not None:

--- a/scripts/staged_vmnet_evidence.py
+++ b/scripts/staged_vmnet_evidence.py
@@ -1,0 +1,995 @@
+#!/usr/bin/env python3
+"""Run one fixed staged direct-vmnet guest scenario under exact root."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import platform
+import secrets
+import signal
+import socket
+import stat
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, NoReturn, Optional, Sequence
+
+
+MAX_HTTP_BYTES = 64 * 1024
+MAX_SERIAL_BYTES = 256 * 1024
+MAX_PATH_BYTES = 4096
+STARTUP_SECONDS = 20.0
+REQUEST_SECONDS = 15.0
+GUEST_SECONDS = 120.0
+FIXTURE_SECONDS = 180.0
+CLEANUP_SECONDS = 20.0
+POLL_SECONDS = 0.02
+FIXED_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C"}
+BOOT_ARGS = (
+    "console=ttyS0 reboot=k panic=1 quiet loglevel=1 "
+    "init=/bangbang-direct-rootfs-init bangbang.staged-vmnet-certification=1"
+)
+KERNEL_NAME = "vmlinux-6.1.155"
+ROOTFS_NAME = "ubuntu-24.04-512M-direct-boot-v112.ext4"
+SIDECAR_NAME = ROOTFS_NAME + ".bangbang.json"
+BANGBANG_NAME = "bangbang"
+API_SOCKET_NAME = "api.sock"
+SERIAL_NAME = "serial.out"
+ONE_SHOT_CONTROL_NAME = "traffic-control.bin"
+BARRIER_NAME = "barrier.bin"
+SNAPSHOT_STATE_NAME = "snapshot.state"
+SNAPSHOT_MEMORY_NAME = "snapshot.memory"
+TCP_REQUEST_MAGIC = b"BBVREQ1\0"
+TCP_RESPONSE_MAGIC = b"BBVRES1\0"
+TCP_RECORD_BYTES = 40
+FAILURE_MARKERS = (
+    b"BANGBANG_STAGED_VMNET_FAIL_",
+    b"BANGBANG_ELEVATED_VMNET_CERTIFICATION_FAIL_",
+)
+
+
+class EvidenceError(RuntimeError):
+    """One value-free staged evidence failure."""
+
+    def __init__(self, category: str) -> None:
+        if not isinstance(category, str) or not category.replace("-", "").islower():
+            category = "internal"
+        super().__init__(category)
+        self.category = category
+
+
+class ClosedArgumentParser(argparse.ArgumentParser):
+    def error(self, _message: str) -> NoReturn:
+        raise EvidenceError("invocation")
+
+
+def _load_protocol() -> Any:
+    source_root = Path(__file__).resolve().parent
+    candidates = (
+        source_root / "staged-vmnet-certification.py",
+        source_root / "guest/staged_vmnet_certification.py",
+    )
+    matches = [path for path in candidates if path.is_file() and not path.is_symlink()]
+    if len(matches) != 1:
+        raise EvidenceError("protocol")
+    spec = importlib.util.spec_from_file_location("bangbang_staged_vmnet_protocol", matches[0])
+    if spec is None or spec.loader is None:
+        raise EvidenceError("protocol")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException as error:
+        raise EvidenceError("protocol") from error
+    return module
+
+
+protocol = _load_protocol()
+
+
+@dataclass(frozen=True)
+class Artifacts:
+    bangbang: Path
+    kernel: Path
+    rootfs: Path
+
+
+def _environment_path(name: str, filename: str, maximum: int) -> Path:
+    raw = os.environ.get(name)
+    if raw is None:
+        raise EvidenceError("artifact")
+    path = Path(raw)
+    if not path.is_absolute() or path.name != filename or len(os.fsencode(path)) > MAX_PATH_BYTES:
+        raise EvidenceError("artifact")
+    try:
+        metadata = os.lstat(path)
+    except OSError as error:
+        raise EvidenceError("artifact") from error
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_nlink != 1
+        or metadata.st_size <= 0
+        or metadata.st_size > maximum
+        or metadata.st_mode & 0o022
+    ):
+        raise EvidenceError("artifact")
+    return path
+
+
+def _artifacts() -> Artifacts:
+    bangbang = _environment_path(
+        "BANGBANG_ELEVATED_VMNET_BANGBANG", BANGBANG_NAME, 512 * 1024 * 1024
+    )
+    kernel = _environment_path(
+        "BANGBANG_ELEVATED_VMNET_KERNEL", KERNEL_NAME, 256 * 1024 * 1024
+    )
+    rootfs = _environment_path(
+        "BANGBANG_STAGED_VMNET_ROOTFS", ROOTFS_NAME, 2 * 1024 * 1024 * 1024
+    )
+    sidecar = _environment_path(
+        "BANGBANG_STAGED_VMNET_ROOTFS_SIDECAR", SIDECAR_NAME, 64 * 1024
+    )
+    try:
+        document = json.loads(sidecar.read_bytes())
+    except (OSError, UnicodeDecodeError, ValueError) as error:
+        raise EvidenceError("artifact") from error
+    if (
+        not isinstance(document, dict)
+        or document.get("schema_version") != 1
+        or document.get("variant") != "direct-boot-v112"
+        or document.get("output_size_bytes") != os.lstat(rootfs).st_size
+        or not isinstance(document.get("output_sha256"), str)
+        or len(document["output_sha256"]) != 64
+        or any(byte not in "0123456789abcdef" for byte in document["output_sha256"])
+    ):
+        raise EvidenceError("artifact")
+    try:
+        outcome = subprocess.run(
+            ("/usr/bin/codesign", "--verify", "--strict", os.fspath(bangbang)),
+            check=False,
+            cwd="/",
+            env=FIXED_ENVIRONMENT,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise EvidenceError("artifact") from error
+    if outcome.returncode != 0:
+        raise EvidenceError("artifact")
+    return Artifacts(bangbang, kernel, rootfs)
+
+
+def _require_platform() -> None:
+    if (os.getuid(), os.geteuid(), os.getgid(), os.getegid()) != (0, 0, 0, 0):
+        raise EvidenceError("authority")
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        raise EvidenceError("platform")
+    try:
+        outcome = subprocess.run(
+            ("/usr/sbin/sysctl", "-n", "kern.hv_support"),
+            check=False,
+            cwd="/",
+            env=FIXED_ENVIRONMENT,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise EvidenceError("platform") from error
+    if outcome.returncode != 0 or outcome.stdout.strip() != b"1":
+        raise EvidenceError("platform")
+
+
+class RunRoot:
+    def __init__(self) -> None:
+        parent = Path(os.environ.get("TMPDIR", ""))
+        if not parent.is_absolute() or not parent.is_dir() or parent.is_symlink():
+            raise EvidenceError("artifact")
+        try:
+            self.path = Path(tempfile.mkdtemp(prefix="staged-vmnet.", dir=parent))
+            os.chmod(self.path, 0o700)
+        except OSError as error:
+            raise EvidenceError("artifact") from error
+
+    def child(self, name: str) -> Path:
+        return self.path / name
+
+    def cleanup(self) -> None:
+        try:
+            import shutil
+
+            shutil.rmtree(self.path)
+        except FileNotFoundError:
+            return
+        except OSError as error:
+            raise EvidenceError("cleanup") from error
+        if os.path.lexists(self.path):
+            raise EvidenceError("cleanup")
+
+
+class Product:
+    def __init__(self, binary: Path, socket_path: Path, instance: str) -> None:
+        if len(os.fsencode(socket_path)) >= 104:
+            raise EvidenceError("artifact")
+        try:
+            self.process = subprocess.Popen(
+                (
+                    os.fspath(binary),
+                    "--enable-pci",
+                    "--api-sock",
+                    os.fspath(socket_path),
+                    "--id",
+                    instance,
+                ),
+                cwd="/",
+                env=FIXED_ENVIRONMENT,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except OSError as error:
+            raise EvidenceError("process") from error
+        self.socket_path = socket_path
+        self.closed = False
+        deadline = time.monotonic() + STARTUP_SECONDS
+        while True:
+            if self.process.poll() is not None:
+                raise EvidenceError("process")
+            client: Optional[socket.socket] = None
+            try:
+                client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                client.settimeout(0.1)
+                client.connect(os.fspath(socket_path))
+                client.close()
+                break
+            except OSError:
+                if client is not None:
+                    client.close()
+            if time.monotonic() >= deadline:
+                self.kill()
+                raise EvidenceError("process")
+            time.sleep(POLL_SECONDS)
+
+    def running(self) -> bool:
+        return self.process.poll() is None
+
+    def terminate(self) -> None:
+        if self.closed:
+            return
+        self._stop(signal.SIGTERM)
+        if self.process.returncode != 0:
+            raise EvidenceError("cleanup")
+        self._finish()
+
+    def kill(self) -> None:
+        if self.closed:
+            return
+        self._stop(signal.SIGKILL)
+        self._finish(remove_stale_socket=True)
+
+    def _stop(self, number: int) -> None:
+        if self.process.poll() is None:
+            try:
+                os.killpg(self.process.pid, number)
+            except ProcessLookupError:
+                pass
+            except OSError as error:
+                raise EvidenceError("cleanup") from error
+        try:
+            self.process.wait(timeout=CLEANUP_SECONDS)
+        except subprocess.TimeoutExpired:
+            if number != signal.SIGKILL:
+                self._stop(signal.SIGKILL)
+                return
+            raise EvidenceError("cleanup")
+
+    def _finish(self, *, remove_stale_socket: bool = False) -> None:
+        if remove_stale_socket and os.path.lexists(self.socket_path):
+            try:
+                metadata = os.lstat(self.socket_path)
+                if not stat.S_ISSOCK(metadata.st_mode) or metadata.st_uid != os.getuid():
+                    raise EvidenceError("cleanup")
+                os.unlink(self.socket_path)
+            except EvidenceError:
+                raise
+            except OSError as error:
+                raise EvidenceError("cleanup") from error
+        deadline = time.monotonic() + CLEANUP_SECONDS
+        while os.path.lexists(self.socket_path) and time.monotonic() < deadline:
+            time.sleep(POLL_SECONDS)
+        if os.path.lexists(self.socket_path):
+            raise EvidenceError("cleanup")
+        self.closed = True
+
+
+def _http(
+    product: Product,
+    method: str,
+    path: str,
+    body: Optional[dict[str, object]] = None,
+) -> tuple[int, bytes]:
+    if not product.running() or method not in ("PUT", "PATCH", "DELETE"):
+        raise EvidenceError("api")
+    body_bytes = b"" if body is None else json.dumps(body, separators=(",", ":")).encode("ascii")
+    headers = [
+        f"{method} {path} HTTP/1.1",
+        "Host: localhost",
+        "Connection: close",
+    ]
+    if body is not None:
+        headers.extend(("Content-Type: application/json", f"Content-Length: {len(body_bytes)}"))
+    request = ("\r\n".join(headers) + "\r\n\r\n").encode("ascii") + body_bytes
+    if len(request) > MAX_HTTP_BYTES:
+        raise EvidenceError("api")
+    response = bytearray()
+    client: Optional[socket.socket] = None
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(REQUEST_SECONDS)
+        client.connect(os.fspath(product.socket_path))
+        client.sendall(request)
+        client.shutdown(socket.SHUT_WR)
+        while True:
+            chunk = client.recv(4096)
+            if not chunk:
+                break
+            response.extend(chunk)
+            if len(response) > MAX_HTTP_BYTES:
+                raise EvidenceError("api")
+    except (OSError, socket.timeout) as error:
+        raise EvidenceError("api") from error
+    finally:
+        if client is not None:
+            try:
+                client.close()
+            except OSError as error:
+                raise EvidenceError("api") from error
+    return _parse_http_response(bytes(response))
+
+
+def _parse_http_response(response: bytes) -> tuple[int, bytes]:
+    head, separator, payload = response.partition(b"\r\n\r\n")
+    lines = head.split(b"\r\n")
+    if not separator or not lines:
+        raise EvidenceError("api")
+    try:
+        parts = lines[0].decode("ascii").split(" ", 2)
+        status = int(parts[1])
+    except (IndexError, UnicodeDecodeError, ValueError) as error:
+        raise EvidenceError("api") from error
+    lengths = [line[16:] for line in lines[1:] if line.lower().startswith(b"content-length: ")]
+    if len(lengths) != 1 or not lengths[0].isdigit() or int(lengths[0]) != len(payload):
+        raise EvidenceError("api")
+    return status, payload
+
+
+def _no_content(response: tuple[int, bytes], category: str = "api") -> None:
+    if response != (204, b""):
+        raise EvidenceError(category)
+
+
+def _create_file(path: Path, contents: bytes, *, size: Optional[int] = None) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(path, flags, 0o600)
+        if contents:
+            if os.write(descriptor, contents) != len(contents):
+                raise EvidenceError("control")
+        if size is not None:
+            os.ftruncate(descriptor, size)
+        os.fsync(descriptor)
+        os.close(descriptor)
+    except EvidenceError:
+        try:
+            os.close(descriptor)
+        except (OSError, UnboundLocalError):
+            pass
+        raise
+    except OSError as error:
+        try:
+            os.close(descriptor)
+        except (OSError, UnboundLocalError):
+            pass
+        raise EvidenceError("control") from error
+
+
+def _traffic_control(port: int, nonce: bytes) -> bytes:
+    if not 1 <= port <= 65535 or len(nonce) != 32 or not any(nonce):
+        raise EvidenceError("control")
+    value = bytearray(512)
+    value[:8] = b"BBEVNET2"
+    value[8:10] = (2).to_bytes(2, "big")
+    value[10] = 1
+    value[11] = 1
+    value[16:18] = port.to_bytes(2, "big")
+    value[18:50] = nonce
+    import hashlib
+
+    value[64:96] = hashlib.sha256(value[:64]).digest()
+    return bytes(value)
+
+
+class Barrier:
+    def __init__(self, path: Path, scenario: Any, nonce: bytes) -> None:
+        self.path = path
+        self.scenario = scenario
+        self.nonce = nonce
+        header = protocol.encode_header(scenario, nonce)
+        _create_file(path, header, size=protocol.CONTROL_BYTES)
+        self.previous_status: Optional[Any] = None
+        self.previous_command_sequence = 0
+        self.terminal = False
+
+    def command(self, sequence: int) -> None:
+        if (
+            self.terminal
+            or sequence != self.previous_command_sequence + 1
+            or sequence > protocol.COMMAND_COUNTS[self.scenario]
+        ):
+            raise EvidenceError("control")
+        value = protocol.encode_record(
+            protocol.ROLE_COMMAND,
+            self.scenario,
+            protocol.COMMAND_PROCEED,
+            sequence,
+            self.nonce,
+        )
+        try:
+            descriptor = os.open(self.path, os.O_RDWR | getattr(os, "O_CLOEXEC", 0))
+            if os.pwrite(descriptor, value, protocol.COMMAND_OFFSET) != len(value):
+                raise EvidenceError("control")
+            os.fsync(descriptor)
+            os.close(descriptor)
+        except EvidenceError:
+            try:
+                os.close(descriptor)
+            except (OSError, UnboundLocalError):
+                pass
+            raise
+        except OSError as error:
+            try:
+                os.close(descriptor)
+            except (OSError, UnboundLocalError):
+                pass
+            raise EvidenceError("control") from error
+        self.previous_command_sequence = sequence
+
+    def wait(self, product: Product, sequence: int, kind: Any) -> None:
+        expected = 1 if self.previous_status is None else self.previous_status.sequence + 1
+        graph = protocol.STATUS_GRAPHS[self.scenario]
+        if (
+            self.terminal
+            or not isinstance(kind, protocol.Status)
+            or sequence != expected
+            or sequence > len(graph)
+            or kind is not graph[sequence - 1]
+        ):
+            raise EvidenceError("control")
+        deadline = time.monotonic() + GUEST_SECONDS
+        while True:
+            if not product.running():
+                raise EvidenceError("process")
+            descriptor = -1
+            try:
+                descriptor = os.open(
+                    self.path,
+                    os.O_RDONLY
+                    | getattr(os, "O_CLOEXEC", 0)
+                    | getattr(os, "O_NOFOLLOW", 0),
+                )
+                value = os.pread(descriptor, protocol.SECTOR_BYTES, protocol.STATUS_OFFSET)
+                record = protocol.decode_record(value, allow_empty=True)
+            except protocol.CoordinatorError as error:
+                raise EvidenceError("control") from error
+            except OSError as error:
+                raise EvidenceError("control") from error
+            finally:
+                if descriptor >= 0:
+                    try:
+                        os.close(descriptor)
+                    except OSError as error:
+                        raise EvidenceError("control") from error
+            if record is not None:
+                if record == self.previous_status:
+                    pass
+                elif (
+                    record.role == protocol.ROLE_STATUS
+                    and record.scenario is self.scenario
+                    and record.nonce == self.nonce
+                    and record.kind in protocol.FAILURE_CATEGORIES
+                ):
+                    category = protocol.FAILURE_CATEGORIES[record.kind]
+                    raise EvidenceError(f"guest-staged-{category}")
+                elif (
+                    record.role == protocol.ROLE_STATUS
+                    and record.scenario is self.scenario
+                    and record.kind == int(protocol.Status.FAILED)
+                    and record.nonce == self.nonce
+                ):
+                    raise EvidenceError("guest")
+                elif (
+                    record.role == protocol.ROLE_STATUS
+                    and record.scenario is self.scenario
+                    and record.kind == int(kind)
+                    and record.sequence == sequence
+                    and record.nonce == self.nonce
+                ):
+                    self.previous_status = record
+                    self.terminal = kind is protocol.Status.COMPLETE
+                    return
+                else:
+                    raise EvidenceError("protocol")
+            if time.monotonic() >= deadline:
+                label = kind.label if isinstance(kind, protocol.Status) else "status"
+                raise EvidenceError(f"guest-{label}-timeout")
+            time.sleep(POLL_SECONDS)
+
+    def assert_terminal(self) -> None:
+        if (
+            not self.terminal
+            or self.previous_status is None
+            or self.previous_status.kind != int(protocol.Status.COMPLETE)
+            or self.previous_status.sequence
+            != len(protocol.STATUS_GRAPHS[self.scenario])
+            or self.previous_command_sequence != protocol.COMMAND_COUNTS[self.scenario]
+        ):
+            raise EvidenceError("control")
+        descriptor = -1
+        try:
+            descriptor = os.open(
+                self.path,
+                os.O_RDONLY
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+            )
+            metadata = os.fstat(descriptor)
+            value = os.pread(descriptor, protocol.CONTROL_BYTES + 1, 0)
+        except OSError as error:
+            raise EvidenceError("control") from error
+        finally:
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError as error:
+                    raise EvidenceError("control") from error
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_uid != os.getuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+            or metadata.st_size != protocol.CONTROL_BYTES
+            or len(value) != protocol.CONTROL_BYTES
+            or any(value[protocol.STATUS_OFFSET + protocol.SECTOR_BYTES :])
+        ):
+            raise EvidenceError("control")
+        try:
+            header = protocol.decode_header(value[: protocol.SECTOR_BYTES])
+            command = protocol.decode_record(
+                value[
+                    protocol.COMMAND_OFFSET : protocol.COMMAND_OFFSET
+                    + protocol.SECTOR_BYTES
+                ]
+            )
+            status = protocol.decode_record(
+                value[
+                    protocol.STATUS_OFFSET : protocol.STATUS_OFFSET
+                    + protocol.SECTOR_BYTES
+                ]
+            )
+        except protocol.CoordinatorError as error:
+            raise EvidenceError("control") from error
+        expected_command = protocol.Record(
+            protocol.ROLE_COMMAND,
+            self.scenario,
+            protocol.COMMAND_PROCEED,
+            self.previous_command_sequence,
+            self.nonce,
+        )
+        if (
+            header
+            != protocol.Header(self.scenario, self.scenario.cycles, self.nonce)
+            or command != expected_command
+            or status != self.previous_status
+        ):
+            raise EvidenceError("control")
+
+
+class Fixture:
+    def __init__(self, nonce: bytes, expected: int) -> None:
+        self.listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.listener.bind(("0.0.0.0", 0))
+        self.listener.listen(16)
+        self.listener.settimeout(0.1)
+        self.port = self.listener.getsockname()[1]
+        self.nonce = nonce
+        self.expected = expected
+        self.cancelled = threading.Event()
+        self.result: Optional[EvidenceError] = None
+        self.thread = threading.Thread(target=self._run, name="staged-vmnet-fixture", daemon=True)
+        self.thread.start()
+
+    def _run(self) -> None:
+        deadline = time.monotonic() + FIXTURE_SECONDS
+        valid = 0
+        attempts = 0
+        try:
+            while valid < self.expected:
+                if self.cancelled.is_set():
+                    raise EvidenceError("fixture")
+                try:
+                    connection, _address = self.listener.accept()
+                except socket.timeout:
+                    if time.monotonic() >= deadline:
+                        raise EvidenceError("fixture-timeout")
+                    continue
+                attempts += 1
+                if attempts > 16:
+                    connection.close()
+                    raise EvidenceError("fixture")
+                with connection:
+                    connection.settimeout(5)
+                    request = bytearray()
+                    while len(request) < TCP_RECORD_BYTES:
+                        chunk = connection.recv(TCP_RECORD_BYTES - len(request))
+                        if not chunk:
+                            break
+                        request.extend(chunk)
+                    trailing = connection.recv(1)
+                    if (
+                        len(request) != TCP_RECORD_BYTES
+                        or request[:8] != TCP_REQUEST_MAGIC
+                        or request[8:] != self.nonce
+                        or trailing
+                    ):
+                        continue
+                    response = TCP_RESPONSE_MAGIC + self.nonce
+                    connection.sendall(response)
+                    connection.shutdown(socket.SHUT_WR)
+                    valid += 1
+        except (EvidenceError, OSError) as error:
+            self.result = error if isinstance(error, EvidenceError) else EvidenceError("fixture")
+        finally:
+            self.listener.close()
+
+    def finish(self) -> None:
+        self.thread.join(timeout=FIXTURE_SECONDS)
+        if self.thread.is_alive():
+            raise EvidenceError("fixture-timeout")
+        if self.result is not None:
+            raise self.result
+
+    def abort(self) -> None:
+        self.cancelled.set()
+        self.listener.close()
+        self.thread.join(timeout=5)
+
+
+def _configure(
+    product: Product,
+    artifacts: Artifacts,
+    root: RunRoot,
+    traffic_control: Path,
+    barrier: Path,
+    *,
+    startup_network: bool,
+) -> None:
+    for path, body, category in (
+        ("/machine-config", {"vcpu_count": 1, "mem_size_mib": 256}, "api-machine"),
+        (
+            "/boot-source",
+            {"kernel_image_path": os.fspath(artifacts.kernel), "boot_args": BOOT_ARGS},
+            "api-boot",
+        ),
+        (
+            "/drives/rootfs",
+            {
+                "drive_id": "rootfs",
+                "path_on_host": os.fspath(artifacts.rootfs),
+                "is_root_device": True,
+                "is_read_only": True,
+            },
+            "api-rootfs",
+        ),
+        (
+            "/drives/traffic",
+            {
+                "drive_id": "traffic",
+                "path_on_host": os.fspath(traffic_control),
+                "is_root_device": False,
+                "is_read_only": True,
+            },
+            "api-traffic",
+        ),
+        (
+            "/drives/barrier",
+            {
+                "drive_id": "barrier",
+                "path_on_host": os.fspath(barrier),
+                "is_root_device": False,
+                "is_read_only": False,
+                "cache_type": "Writeback",
+            },
+            "api-barrier",
+        ),
+        (
+            "/serial",
+            {"serial_out_path": os.fspath(root.child(SERIAL_NAME))},
+            "api-serial",
+        ),
+    ):
+        _no_content(_http(product, "PUT", path, body), category)
+    if startup_network:
+        _network_put(product)
+    _no_content(
+        _http(product, "PUT", "/actions", {"action_type": "InstanceStart"}),
+        "api-start",
+    )
+
+
+def _network_put(product: Product) -> None:
+    _no_content(
+        _http(
+            product,
+            "PUT",
+            "/network-interfaces/eth0",
+            {"iface_id": "eth0", "host_dev_name": "vmnet:shared"},
+        ),
+        "api-network-put",
+    )
+
+
+def _network_delete(product: Product) -> None:
+    _no_content(
+        _http(product, "DELETE", "/network-interfaces/eth0"),
+        "api-network-delete",
+    )
+
+
+def _check_serial(path: Path) -> None:
+    try:
+        metadata = os.lstat(path)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > MAX_SERIAL_BYTES:
+            raise EvidenceError("guest")
+        contents = path.read_bytes().replace(b"\r", b"")
+    except OSError as error:
+        raise EvidenceError("guest") from error
+    if any(marker in contents for marker in FAILURE_MARKERS):
+        raise EvidenceError("guest")
+
+
+def _serial_failure(path: Path) -> Optional[EvidenceError]:
+    categories = (
+        (b"BANGBANG_STAGED_VMNET_FAIL_CONTROL\n", "guest-staged-control"),
+        (b"BANGBANG_STAGED_VMNET_FAIL_IO\n", "guest-staged-io"),
+        (b"BANGBANG_STAGED_VMNET_FAIL_TOPOLOGY\n", "guest-staged-topology"),
+        (b"BANGBANG_STAGED_VMNET_FAIL_TIMEOUT\n", "guest-staged-timeout"),
+        (b"BANGBANG_STAGED_VMNET_FAIL_PROCESS\n", "guest-staged-process"),
+        (b"BANGBANG_STAGED_VMNET_FAIL_TRAFFIC\n", "guest-staged-traffic"),
+        (b"BANGBANG_STAGED_VMNET_FAIL_INTERNAL\n", "guest-staged-internal"),
+        (b"BANGBANG_ELEVATED_VMNET_CERTIFICATION_FAIL_CONTROL\n", "guest-control"),
+        (b"BANGBANG_ELEVATED_VMNET_CERTIFICATION_FAIL_INTERFACE\n", "guest-interface"),
+        (b"BANGBANG_ELEVATED_VMNET_CERTIFICATION_FAIL_DHCP\n", "guest-dhcp"),
+        (b"BANGBANG_ELEVATED_VMNET_CERTIFICATION_FAIL_CONFIGURE\n", "guest-configure"),
+        (b"BANGBANG_ELEVATED_VMNET_CERTIFICATION_FAIL_TCP\n", "guest-tcp"),
+        (b"BANGBANG_ELEVATED_VMNET_CERTIFICATION_FAIL_CLEANUP\n", "guest-cleanup"),
+        (b"BANGBANG_ELEVATED_VMNET_CERTIFICATION_FAIL_INTERNAL\n", "guest-internal"),
+    )
+    deadline = time.monotonic() + 1.0
+    while True:
+        try:
+            metadata = os.lstat(path)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > MAX_SERIAL_BYTES:
+                return None
+            contents = path.read_bytes().replace(b"\r", b"")
+        except OSError:
+            return None
+        for marker, category in categories:
+            if marker in contents:
+                return EvidenceError(category)
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(POLL_SECONDS)
+
+
+def _run_startup(driver: Product, barrier: Barrier) -> None:
+    barrier.wait(driver, 1, protocol.Status.INITIAL_PRESENT)
+    barrier.command(1)
+    barrier.wait(driver, 2, protocol.Status.TRAFFIC_ONE)
+    barrier.command(2)
+    barrier.wait(driver, 3, protocol.Status.ABSENT)
+    _network_delete(driver)
+    _network_put(driver)
+    barrier.command(3)
+    barrier.wait(driver, 4, protocol.Status.PRESENT)
+    barrier.wait(driver, 5, protocol.Status.TRAFFIC_TWO)
+    barrier.command(4)
+    barrier.wait(driver, 6, protocol.Status.ABSENT)
+    _network_delete(driver)
+    barrier.command(5)
+    barrier.wait(driver, 7, protocol.Status.COMPLETE)
+
+
+def _run_runtime(driver: Product, barrier: Barrier) -> None:
+    barrier.wait(driver, 1, protocol.Status.INITIAL_ABSENT)
+    _network_put(driver)
+    barrier.command(1)
+    barrier.wait(driver, 2, protocol.Status.PRESENT)
+    barrier.wait(driver, 3, protocol.Status.TRAFFIC_ONE)
+    barrier.command(2)
+    barrier.wait(driver, 4, protocol.Status.ABSENT)
+    _network_delete(driver)
+    barrier.command(3)
+    barrier.wait(driver, 5, protocol.Status.COMPLETE)
+
+
+def _run_restore(
+    source: Product,
+    barrier: Barrier,
+    artifacts: Artifacts,
+    root: RunRoot,
+) -> Product:
+    barrier.wait(source, 1, protocol.Status.INITIAL_PRESENT)
+    barrier.command(1)
+    barrier.wait(source, 2, protocol.Status.CAPTURE_READY)
+    _no_content(_http(source, "PATCH", "/vm", {"state": "Paused"}), "api-pause")
+    state = root.child(SNAPSHOT_STATE_NAME)
+    memory = root.child(SNAPSHOT_MEMORY_NAME)
+    _no_content(
+        _http(
+            source,
+            "PUT",
+            "/snapshot/create",
+            {
+                "snapshot_type": "Full",
+                "snapshot_path": os.fspath(state),
+                "mem_file_path": os.fspath(memory),
+            },
+        ),
+        "api-snapshot-create",
+    )
+    source.terminate()
+    destination = Product(artifacts.bangbang, root.child("restore-api.sock"), "staged-restore-destination")
+    try:
+        _no_content(
+            _http(
+                destination,
+                "PUT",
+                "/snapshot/load",
+                {
+                    "snapshot_path": os.fspath(state),
+                    "mem_backend": {
+                        "backend_path": os.fspath(memory),
+                        "backend_type": "File",
+                    },
+                    "network_overrides": [
+                        {"iface_id": "eth0", "host_dev_name": "vmnet:shared"}
+                    ],
+                    "resume_vm": True,
+                },
+            ),
+            "api-snapshot-load",
+        )
+        barrier.command(2)
+        barrier.wait(destination, 3, protocol.Status.PRESENT)
+        barrier.wait(destination, 4, protocol.Status.TRAFFIC_TWO)
+        barrier.command(3)
+        barrier.wait(destination, 5, protocol.Status.ABSENT)
+        _network_delete(destination)
+        barrier.command(4)
+        barrier.wait(destination, 6, protocol.Status.COMPLETE)
+        return destination
+    except BaseException:
+        destination.kill()
+        raise
+
+
+def run(scenario_name: str) -> None:
+    _require_platform()
+    artifacts = _artifacts()
+    scenarios = {
+        "startup": protocol.Scenario.STARTUP,
+        "runtime": protocol.Scenario.RUNTIME,
+        "restore": protocol.Scenario.RESTORE,
+    }
+    scenario = scenarios.get(scenario_name)
+    if scenario is None:
+        raise EvidenceError("invocation")
+    root = RunRoot()
+    source: Optional[Product] = None
+    destination: Optional[Product] = None
+    fixture: Optional[Fixture] = None
+    first_error: Optional[EvidenceError] = None
+    cleanup_error: Optional[EvidenceError] = None
+    try:
+        _create_file(root.child(SERIAL_NAME), b"")
+        nonce = secrets.token_bytes(32)
+        if len(nonce) != 32 or not any(nonce):
+            raise EvidenceError("control")
+        fixture = Fixture(nonce, scenario.cycles)
+        traffic_control = root.child(ONE_SHOT_CONTROL_NAME)
+        _create_file(traffic_control, _traffic_control(fixture.port, nonce))
+        barrier = Barrier(root.child(BARRIER_NAME), scenario, nonce)
+        source = Product(artifacts.bangbang, root.child(API_SOCKET_NAME), f"staged-{scenario_name}-source")
+        _configure(
+            source,
+            artifacts,
+            root,
+            traffic_control,
+            barrier.path,
+            startup_network=scenario is not protocol.Scenario.RUNTIME,
+        )
+        if scenario is protocol.Scenario.STARTUP:
+            _run_startup(source, barrier)
+        elif scenario is protocol.Scenario.RUNTIME:
+            _run_runtime(source, barrier)
+        else:
+            destination = _run_restore(source, barrier, artifacts, root)
+            source = None
+        fixture.finish()
+        fixture = None
+        active = destination if destination is not None else source
+        if active is None:
+            raise EvidenceError("internal")
+        active.terminate()
+        if active is destination:
+            destination = None
+        else:
+            source = None
+        barrier.assert_terminal()
+        _check_serial(root.child(SERIAL_NAME))
+    except EvidenceError as error:
+        first_error = _serial_failure(root.child(SERIAL_NAME)) or error
+    except BaseException as error:
+        first_error = EvidenceError("internal")
+        first_error.__cause__ = error
+    finally:
+        if fixture is not None:
+            fixture.abort()
+        for product in (destination, source):
+            if product is not None:
+                try:
+                    product.kill()
+                except EvidenceError as error:
+                    cleanup_error = cleanup_error or error
+        try:
+            root.cleanup()
+        except EvidenceError as error:
+            cleanup_error = cleanup_error or error
+    if cleanup_error is not None:
+        raise cleanup_error
+    if first_error is not None:
+        raise first_error
+
+
+def _parse(arguments: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = ClosedArgumentParser(allow_abbrev=False)
+    parser.add_argument("--scenario", choices=("startup", "runtime", "restore"), required=True)
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Optional[Sequence[str]] = None) -> int:
+    try:
+        options = _parse(arguments)
+        run(options.scenario)
+    except EvidenceError as error:
+        print(f"bangbang staged vmnet proof: failed category={error.category}", file=sys.stderr)
+        return 1
+    print(f"bangbang staged vmnet proof: scenario={options.scenario} traffic=passed cleanup=passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_elevated_vmnet_evidence.py
+++ b/scripts/tests/test_elevated_vmnet_evidence.py
@@ -182,6 +182,8 @@ class ElevatedVmnetEvidenceTests(unittest.TestCase):
         self.assertEqual(runner.count("elevated_direct_guest_uses_shared_vmnet"), 2)
         self.assertIn('for scenario in startup runtime restore', runner)
         self.assertIn('run_staged_case "$scenario"', runner)
+        self.assertIn("PYTHONDONTWRITEBYTECODE=1", runner)
+        self.assertIn('final_count="$(/usr/bin/find -x "$stage"', runner)
         self.assertNotIn("sudo", runner.lower())
         self.assertNotIn("SUDO_", runner)
         self.assertNotIn("dscacheutil", runner)

--- a/scripts/tests/test_elevated_vmnet_evidence.py
+++ b/scripts/tests/test_elevated_vmnet_evidence.py
@@ -42,32 +42,37 @@ def prepared_package(root: Path) -> None:
         "elevated-vmnet-provider-e2e": b"provider-harness",
         "vmlinux-6.1.155": b"kernel",
         "ubuntu-24.04-512M-direct-boot-v111.ext4": b"rootfs",
+        "ubuntu-24.04-512M-direct-boot-v112.ext4": b"staged-rootfs",
         "elevated-vmnet-evidence.py": b"helper",
+        "staged-vmnet-evidence.py": b"staged-helper",
+        "staged-vmnet-certification.py": b"staged-protocol",
     }
     for name, payload in payloads.items():
         path = root / name
         path.write_bytes(payload)
         mode = next(mode for candidate, mode, _maximum in evidence.FILES if candidate == name)
         path.chmod(mode)
-    rootfs = payloads["ubuntu-24.04-512M-direct-boot-v111.ext4"]
-    sidecar = root / "ubuntu-24.04-512M-direct-boot-v111.ext4.bangbang.json"
-    sidecar.write_bytes(
-        canonical(
-            {
-                "filesystem_check": "e2fsck -fn",
-                "output_sha256": hashlib.sha256(rootfs).hexdigest(),
-                "output_size_bytes": len(rootfs),
-                "recipe_sha256": "1" * 64,
-                "requested_size_bytes": len(rootfs),
-                "schema_version": 1,
-                "source_sha256": "2" * 64,
-                "source_size_bytes": len(rootfs),
-                "tool_versions": {},
-                "variant": "direct-boot-v111",
-            }
+    for variant in ("direct-boot-v111", "direct-boot-v112"):
+        name = f"ubuntu-24.04-512M-{variant}.ext4"
+        rootfs = payloads[name]
+        sidecar = root / f"{name}.bangbang.json"
+        sidecar.write_bytes(
+            canonical(
+                {
+                    "filesystem_check": "e2fsck -fn",
+                    "output_sha256": hashlib.sha256(rootfs).hexdigest(),
+                    "output_size_bytes": len(rootfs),
+                    "recipe_sha256": "1" * 64,
+                    "requested_size_bytes": len(rootfs),
+                    "schema_version": 1,
+                    "source_sha256": "2" * 64,
+                    "source_size_bytes": len(rootfs),
+                    "tool_versions": {},
+                    "variant": variant,
+                }
+            )
         )
-    )
-    sidecar.chmod(0o444)
+        sidecar.chmod(0o444)
     log = root / evidence.LOG_NAME
     log.write_bytes(b"")
     log.chmod(0o600)
@@ -114,18 +119,19 @@ class ElevatedVmnetEvidenceTests(unittest.TestCase):
                 with self.assertRaises(evidence.EvidenceError):
                     evidence.verify_manifest(root, os.getuid())
 
-    def test_verifier_rejects_stale_v110_sidecar(self) -> None:
-        with tempfile.TemporaryDirectory() as raw_temp:
-            root = Path(raw_temp)
-            prepared_package(root)
-            sidecar = root / "ubuntu-24.04-512M-direct-boot-v111.ext4.bangbang.json"
-            value = json.loads(sidecar.read_bytes())
-            value["variant"] = "direct-boot-v110"
-            sidecar.chmod(0o644)
-            sidecar.write_bytes(canonical(value))
-            sidecar.chmod(0o444)
-            with self.assertRaisesRegex(evidence.EvidenceError, "sidecar"):
-                evidence.create_manifest(root, os.getuid())
+    def test_verifier_rejects_stale_sidecars(self) -> None:
+        for variant in ("direct-boot-v111", "direct-boot-v112"):
+            with self.subTest(variant=variant), tempfile.TemporaryDirectory() as raw_temp:
+                root = Path(raw_temp)
+                prepared_package(root)
+                sidecar = root / f"ubuntu-24.04-512M-{variant}.ext4.bangbang.json"
+                value = json.loads(sidecar.read_bytes())
+                value["variant"] = "direct-boot-v110"
+                sidecar.chmod(0o644)
+                sidecar.write_bytes(canonical(value))
+                sidecar.chmod(0o444)
+                with self.assertRaisesRegex(evidence.EvidenceError, "sidecar"):
+                    evidence.create_manifest(root, os.getuid())
 
     def test_verifier_rejects_noncanonical_duplicate_and_unknown_manifest(self) -> None:
         for mutation in ("noncanonical", "duplicate", "unknown"):
@@ -160,6 +166,9 @@ class ElevatedVmnetEvidenceTests(unittest.TestCase):
         prepare = PREPARE_PATH.read_text(encoding="utf-8")
         runner = RUN_PATH.read_text(encoding="utf-8")
         self.assertIn("direct-boot-v111", prepare)
+        self.assertIn("direct-boot-v112", prepare)
+        self.assertIn("staged_vmnet_evidence.py", prepare)
+        self.assertIn("staged_vmnet_certification.py", prepare)
         self.assertIn("ordinary_user_vmnet_start_is_denied", prepare)
         self.assertIn("ordinary denial residue", prepare)
         self.assertIn("cargo test", prepare)
@@ -171,11 +180,13 @@ class ElevatedVmnetEvidenceTests(unittest.TestCase):
         self.assertIn("control_cancellation_reaps_dropped_provider", runner)
         self.assertEqual(runner.count("dropped_provider_serves_data_lifecycle"), 2)
         self.assertEqual(runner.count("elevated_direct_guest_uses_shared_vmnet"), 2)
+        self.assertIn('for scenario in startup runtime restore', runner)
+        self.assertIn('run_staged_case "$scenario"', runner)
         self.assertNotIn("sudo", runner.lower())
         self.assertNotIn("SUDO_", runner)
         self.assertNotIn("dscacheutil", runner)
         self.assertNotIn("ps ", runner)
-        self.assertEqual(runner.count('find -x "$stage/runs"'), 6)
+        self.assertEqual(runner.count('find -x "$stage/runs"'), 7)
 
     def test_guest_oracle_protocol_failures_are_portable(self) -> None:
         compiler = os.environ.get("RUSTC") or shutil.which("rustc")

--- a/scripts/tests/test_guest_artifact_policy.py
+++ b/scripts/tests/test_guest_artifact_policy.py
@@ -75,6 +75,7 @@ class GuestArtifactPolicyTests(unittest.TestCase):
                 "rootfs-ext4",
                 "rootfs-ext4-direct-boot-v110",
                 "rootfs-ext4-direct-boot-v111",
+                "rootfs-ext4-direct-boot-v112",
             ],
         )
 
@@ -114,6 +115,10 @@ class GuestArtifactPolicyTests(unittest.TestCase):
             ["prepare-ext4", "--variant", "direct-boot-v111", "--size", "512M"]
         )
         self.assertEqual(parsed.variant, "direct-boot-v111")
+        parsed = policy._parse_args(
+            ["prepare-ext4", "--variant", "direct-boot-v112", "--size", "512M"]
+        )
+        self.assertEqual(parsed.variant, "direct-boot-v112")
         with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit) as caught:
             policy._parse_args(["prepare-ext4", "--variant", "custom", "--size", "1G"])
         self.assertEqual(caught.exception.code, 2)

--- a/scripts/tests/test_specification_workload.py
+++ b/scripts/tests/test_specification_workload.py
@@ -308,6 +308,63 @@ else:
             self.assertIn("-D", v111_normalized[2])
             self.assertIn("warnings", v111_normalized[2])
 
+            v112_root = temp / "rootfs-v112"
+            v112_root.mkdir()
+            v112_log = temp / "rustc-v112.jsonl"
+            v112_environment = dict(environment)
+            v112_environment["BANGBANG_GUEST_POLICY_VARIANT"] = "direct-boot-v112"
+            v112_environment["FAKE_RUST_LOG"] = os.fspath(v112_log)
+            v112_result = subprocess.run(
+                (
+                    os.fspath(REPOSITORY_ROOT / "scripts/fetch-firecracker-rootfs.sh"),
+                    "--internal-populate-direct",
+                    os.fspath(v112_root),
+                ),
+                env=v112_environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(v112_result.returncode, 0, v112_result.stderr)
+            v112_oracle = v112_root / "bangbang-elevated-vmnet-certification"
+            v112_coordinator = v112_root / "bangbang-staged-vmnet-certification"
+            self.assertTrue(v112_oracle.is_file())
+            self.assertTrue(v112_coordinator.is_file())
+            self.assertEqual(stat.S_IMODE(v112_oracle.stat().st_mode), 0o755)
+            self.assertEqual(stat.S_IMODE(v112_coordinator.stat().st_mode), 0o555)
+            self.assertEqual(
+                v112_coordinator.read_bytes(),
+                (
+                    REPOSITORY_ROOT
+                    / "scripts/guest/staged_vmnet_certification.py"
+                ).read_bytes(),
+            )
+            v112_init = (v112_root / "bangbang-direct-rootfs-init").read_text(
+                encoding="utf-8"
+            )
+            self.assertEqual(
+                v112_init.count("cmdline_has bangbang.staged-vmnet-certification=1"),
+                1,
+            )
+            v112_invocations = [
+                json.loads(line)
+                for line in v112_log.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(
+                [Path(arguments[0]).name for arguments in v112_invocations],
+                [
+                    "arm64-id-register-report.rs",
+                    "specification-benchmark.rs",
+                    "elevated_vmnet_certification.rs",
+                ],
+            )
+            v112_normalized: list[list[str]] = []
+            for arguments in v112_invocations:
+                output_index = arguments.index("-o")
+                v112_normalized.append(
+                    ["<source>", *arguments[1:output_index], "-o", "<output>"]
+                )
+            self.assertEqual(v112_normalized, [normalized[0]] * 3)
+
             for mode, expected_error in (
                 ("missing-target", "Rust target aarch64-unknown-linux-musl is required"),
                 ("missing-linker", "does not provide rust-lld"),
@@ -387,6 +444,23 @@ else:
                 "scripts/guest/arm64-id-register-report.rs",
                 "scripts/guest/elevated_vmnet_certification.rs",
                 "scripts/guest/specification-benchmark.rs",
+                "scripts/guest_artifact_policy.py",
+            ],
+        )
+        v112 = next(
+            recipe
+            for recipe in manifest["ext4_recipes"]
+            if recipe["id"] == "rootfs-ext4-direct-boot-v112"
+        )
+        self.assertEqual(
+            v112["tracked_inputs"],
+            [
+                "compat/firecracker/v1.16.0/guest-workflow-audit.json",
+                "scripts/fetch-firecracker-rootfs.sh",
+                "scripts/guest/arm64-id-register-report.rs",
+                "scripts/guest/elevated_vmnet_certification.rs",
+                "scripts/guest/specification-benchmark.rs",
+                "scripts/guest/staged_vmnet_certification.py",
                 "scripts/guest_artifact_policy.py",
             ],
         )

--- a/scripts/tests/test_staged_vmnet_evidence.py
+++ b/scripts/tests/test_staged_vmnet_evidence.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPOSITORY_ROOT / "scripts/staged_vmnet_evidence.py"
+SPEC = importlib.util.spec_from_file_location("staged_vmnet_evidence", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:  # pragma: no cover - import contract
+    raise RuntimeError("failed to load staged vmnet evidence module")
+evidence = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = evidence
+SPEC.loader.exec_module(evidence)
+
+
+class FakeProduct:
+    def running(self) -> bool:
+        return True
+
+
+class FakeRestoreProduct:
+    def __init__(self) -> None:
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+class FakeRoot:
+    def child(self, name: str) -> Path:
+        return Path("/private/run") / name
+
+
+class FakeBarrier:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, int, object | None]] = []
+
+    def wait(self, _product: object, sequence: int, kind: object) -> None:
+        self.events.append(("wait", sequence, kind))
+
+    def command(self, sequence: int) -> None:
+        self.events.append(("command", sequence, None))
+
+
+class StagedVmnetEvidenceTests(unittest.TestCase):
+    def test_http_response_parser_requires_exact_content_length(self) -> None:
+        self.assertEqual(
+            evidence._parse_http_response(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n"),
+            (204, b""),
+        )
+        for response in (
+            b"HTTP/1.1 204 No Content\r\nContent-Length: 1\r\n\r\n",
+            b"HTTP/1.1 204 No Content\r\n\r\n",
+        ):
+            with self.assertRaisesRegex(evidence.EvidenceError, "api"):
+                evidence._parse_http_response(response)
+
+    def test_cli_and_public_failure_are_value_redacted(self) -> None:
+        parsed = evidence._parse(["--scenario", "restore"])
+        self.assertEqual(parsed.scenario, "restore")
+        for arguments in ([], ["--scenario", "unknown"], ["--scenario", "startup", "extra"]):
+            with self.subTest(arguments=arguments):
+                with contextlib.redirect_stderr(io.StringIO()), self.assertRaisesRegex(
+                    evidence.EvidenceError, "invocation"
+                ):
+                    evidence._parse(arguments)
+        stderr = io.StringIO()
+        with mock.patch.object(
+            evidence, "run", side_effect=evidence.EvidenceError("guest-timeout")
+        ), contextlib.redirect_stderr(stderr):
+            self.assertEqual(evidence.main(["--scenario", "runtime"]), 1)
+        self.assertEqual(
+            stderr.getvalue(),
+            "bangbang staged vmnet proof: failed category=guest-timeout\n",
+        )
+
+    def test_one_shot_control_is_exact_nonce_and_digest_bound(self) -> None:
+        nonce = bytes(range(1, 33))
+        control = evidence._traffic_control(8080, nonce)
+        self.assertEqual(len(control), 512)
+        self.assertEqual(control[:8], b"BBEVNET2")
+        self.assertEqual(control[8:10], (2).to_bytes(2, "big"))
+        self.assertEqual(control[16:18], (8080).to_bytes(2, "big"))
+        self.assertEqual(control[18:50], nonce)
+        import hashlib
+
+        self.assertEqual(control[64:96], hashlib.sha256(control[:64]).digest())
+        self.assertFalse(any(control[96:]))
+        for port, invalid_nonce in ((0, nonce), (65536, nonce), (8080, bytes(32))):
+            with self.assertRaisesRegex(evidence.EvidenceError, "control"):
+                evidence._traffic_control(port, invalid_nonce)
+
+    def test_host_barrier_rejects_skipped_and_post_terminal_operations(self) -> None:
+        nonce = bytes(range(1, 33))
+        with tempfile.TemporaryDirectory() as raw_temp:
+            barrier = evidence.Barrier(
+                Path(raw_temp) / "barrier.bin",
+                evidence.protocol.Scenario.RUNTIME,
+                nonce,
+            )
+            with self.assertRaisesRegex(evidence.EvidenceError, "control"):
+                barrier.command(2)
+            barrier.command(1)
+            with self.assertRaisesRegex(evidence.EvidenceError, "control"):
+                barrier.command(1)
+            barrier.command(2)
+            barrier.command(3)
+            for sequence, status in enumerate(
+                evidence.protocol.STATUS_GRAPHS[evidence.protocol.Scenario.RUNTIME],
+                start=1,
+            ):
+                record = evidence.protocol.encode_record(
+                    evidence.protocol.ROLE_STATUS,
+                    evidence.protocol.Scenario.RUNTIME,
+                    int(status),
+                    sequence,
+                    nonce,
+                )
+                with barrier.path.open("r+b", buffering=0) as destination:
+                    destination.seek(evidence.protocol.STATUS_OFFSET)
+                    destination.write(record)
+                barrier.wait(FakeProduct(), sequence, status)
+            barrier.assert_terminal()
+            with self.assertRaisesRegex(evidence.EvidenceError, "control"):
+                barrier.command(4)
+            with self.assertRaisesRegex(evidence.EvidenceError, "control"):
+                barrier.wait(FakeProduct(), 6, evidence.protocol.Status.ABSENT)
+
+            with barrier.path.open("r+b", buffering=0) as destination:
+                destination.seek(evidence.protocol.CONTROL_BYTES - 1)
+                destination.write(b"\1")
+            with self.assertRaisesRegex(evidence.EvidenceError, "control"):
+                barrier.assert_terminal()
+
+    def test_host_barrier_surfaces_authenticated_guest_failure(self) -> None:
+        nonce = bytes(range(1, 33))
+        with tempfile.TemporaryDirectory() as raw_temp:
+            barrier = evidence.Barrier(
+                Path(raw_temp) / "barrier.bin",
+                evidence.protocol.Scenario.STARTUP,
+                nonce,
+            )
+            failure = evidence.protocol.encode_record(
+                evidence.protocol.ROLE_STATUS,
+                evidence.protocol.Scenario.STARTUP,
+                evidence.protocol.FAILURE_KINDS["traffic"],
+                0xFFFF_FFFF_FFFF_FFFF,
+                nonce,
+            )
+            with barrier.path.open("r+b", buffering=0) as destination:
+                destination.seek(evidence.protocol.STATUS_OFFSET)
+                destination.write(failure)
+            with self.assertRaisesRegex(evidence.EvidenceError, "guest-staged-traffic"):
+                barrier.wait(FakeProduct(), 1, evidence.protocol.Status.INITIAL_PRESENT)
+
+    def test_startup_dispatch_orders_two_network_generations(self) -> None:
+        barrier = FakeBarrier()
+        network: list[str] = []
+        with mock.patch.object(evidence, "_network_put", side_effect=lambda _p: network.append("put")), mock.patch.object(
+            evidence, "_network_delete", side_effect=lambda _p: network.append("delete")
+        ):
+            evidence._run_startup(FakeProduct(), barrier)
+        self.assertEqual(network, ["delete", "put", "delete"])
+        self.assertEqual(
+            barrier.events,
+            [
+                ("wait", 1, evidence.protocol.Status.INITIAL_PRESENT),
+                ("command", 1, None),
+                ("wait", 2, evidence.protocol.Status.TRAFFIC_ONE),
+                ("command", 2, None),
+                ("wait", 3, evidence.protocol.Status.ABSENT),
+                ("command", 3, None),
+                ("wait", 4, evidence.protocol.Status.PRESENT),
+                ("wait", 5, evidence.protocol.Status.TRAFFIC_TWO),
+                ("command", 4, None),
+                ("wait", 6, evidence.protocol.Status.ABSENT),
+                ("command", 5, None),
+                ("wait", 7, evidence.protocol.Status.COMPLETE),
+            ],
+        )
+
+    def test_runtime_dispatch_boots_absent_and_removes_after_traffic(self) -> None:
+        barrier = FakeBarrier()
+        network: list[str] = []
+        with mock.patch.object(evidence, "_network_put", side_effect=lambda _p: network.append("put")), mock.patch.object(
+            evidence, "_network_delete", side_effect=lambda _p: network.append("delete")
+        ):
+            evidence._run_runtime(FakeProduct(), barrier)
+        self.assertEqual(network, ["put", "delete"])
+        self.assertEqual(
+            barrier.events,
+            [
+                ("wait", 1, evidence.protocol.Status.INITIAL_ABSENT),
+                ("command", 1, None),
+                ("wait", 2, evidence.protocol.Status.PRESENT),
+                ("wait", 3, evidence.protocol.Status.TRAFFIC_ONE),
+                ("command", 2, None),
+                ("wait", 4, evidence.protocol.Status.ABSENT),
+                ("command", 3, None),
+                ("wait", 5, evidence.protocol.Status.COMPLETE),
+            ],
+        )
+
+    def test_restore_dispatch_uses_fresh_network_override_and_file_backend(self) -> None:
+        source = FakeRestoreProduct()
+        destination = FakeRestoreProduct()
+        barrier = FakeBarrier()
+        exchanges: list[tuple[object, str, str, object]] = []
+
+        def exchange(product: object, method: str, path: str, body: object = None):
+            exchanges.append((product, method, path, body))
+            return 204, b""
+
+        artifacts = SimpleNamespace(bangbang=Path("/bangbang"))
+        with mock.patch.object(evidence, "Product", return_value=destination), mock.patch.object(
+            evidence, "_http", side_effect=exchange
+        ):
+            restored = evidence._run_restore(source, barrier, artifacts, FakeRoot())
+        self.assertIs(restored, destination)
+        self.assertTrue(source.terminated)
+        load = next(body for _product, _method, path, body in exchanges if path == "/snapshot/load")
+        self.assertNotIn("mem_file_path", load)
+        self.assertEqual(load["mem_backend"]["backend_type"], "File")
+        self.assertEqual(
+            load["network_overrides"],
+            [{"iface_id": "eth0", "host_dev_name": "vmnet:shared"}],
+        )
+        self.assertEqual(
+            barrier.events,
+            [
+                ("wait", 1, evidence.protocol.Status.INITIAL_PRESENT),
+                ("command", 1, None),
+                ("wait", 2, evidence.protocol.Status.CAPTURE_READY),
+                ("command", 2, None),
+                ("wait", 3, evidence.protocol.Status.PRESENT),
+                ("wait", 4, evidence.protocol.Status.TRAFFIC_TWO),
+                ("command", 3, None),
+                ("wait", 5, evidence.protocol.Status.ABSENT),
+                ("command", 4, None),
+                ("wait", 6, evidence.protocol.Status.COMPLETE),
+            ],
+        )
+
+    def test_empty_serial_is_allowed_but_failure_marker_is_not(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            path = Path(raw_temp) / "serial.out"
+            path.write_bytes(b"")
+            evidence._check_serial(path)
+            path.write_bytes(b"BANGBANG_STAGED_VMNET_FAIL_TRAFFIC\r\n")
+            with self.assertRaisesRegex(evidence.EvidenceError, "guest"):
+                evidence._check_serial(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_staged_vmnet_evidence.py
+++ b/scripts/tests/test_staged_vmnet_evidence.py
@@ -63,6 +63,9 @@ class StagedVmnetEvidenceTests(unittest.TestCase):
         for response in (
             b"HTTP/1.1 204 No Content\r\nContent-Length: 1\r\n\r\n",
             b"HTTP/1.1 204 No Content\r\n\r\n",
+            b"HTTP/1.0 204 No Content\r\nContent-Length: 0\r\n\r\n",
+            b"HTTP/1.1 999 Unknown\r\nContent-Length: 0\r\n\r\n",
+            b"HTTP/1.1 204 No Content\r\nTransfer-Encoding: chunked\r\nContent-Length: 0\r\n\r\n",
         ):
             with self.assertRaisesRegex(evidence.EvidenceError, "api"):
                 evidence._parse_http_response(response)
@@ -144,6 +147,25 @@ class StagedVmnetEvidenceTests(unittest.TestCase):
             with self.assertRaisesRegex(evidence.EvidenceError, "control"):
                 barrier.assert_terminal()
 
+        with tempfile.TemporaryDirectory() as raw_temp:
+            barrier = evidence.Barrier(
+                Path(raw_temp) / "barrier.bin",
+                evidence.protocol.Scenario.RUNTIME,
+                nonce,
+            )
+            tampered = evidence.protocol.encode_record(
+                evidence.protocol.ROLE_COMMAND,
+                evidence.protocol.Scenario.RUNTIME,
+                evidence.protocol.COMMAND_PROCEED,
+                2,
+                nonce,
+            )
+            with barrier.path.open("r+b", buffering=0) as destination:
+                destination.seek(evidence.protocol.COMMAND_OFFSET)
+                destination.write(tampered)
+            with self.assertRaisesRegex(evidence.EvidenceError, "control"):
+                barrier.command(1)
+
     def test_host_barrier_surfaces_authenticated_guest_failure(self) -> None:
         nonce = bytes(range(1, 33))
         with tempfile.TemporaryDirectory() as raw_temp:
@@ -163,6 +185,32 @@ class StagedVmnetEvidenceTests(unittest.TestCase):
                 destination.seek(evidence.protocol.STATUS_OFFSET)
                 destination.write(failure)
             with self.assertRaisesRegex(evidence.EvidenceError, "guest-staged-traffic"):
+                barrier.wait(FakeProduct(), 1, evidence.protocol.Status.INITIAL_PRESENT)
+
+            uncategorized = evidence.protocol.encode_record(
+                evidence.protocol.ROLE_STATUS,
+                evidence.protocol.Scenario.STARTUP,
+                9,
+                1,
+                nonce,
+            )
+            with barrier.path.open("r+b", buffering=0) as destination:
+                destination.seek(evidence.protocol.STATUS_OFFSET)
+                destination.write(uncategorized)
+            with self.assertRaisesRegex(evidence.EvidenceError, "protocol"):
+                barrier.wait(FakeProduct(), 1, evidence.protocol.Status.INITIAL_PRESENT)
+
+            wrong_sequence = evidence.protocol.encode_record(
+                evidence.protocol.ROLE_STATUS,
+                evidence.protocol.Scenario.STARTUP,
+                evidence.protocol.FAILURE_KINDS["traffic"],
+                1,
+                nonce,
+            )
+            with barrier.path.open("r+b", buffering=0) as destination:
+                destination.seek(evidence.protocol.STATUS_OFFSET)
+                destination.write(wrong_sequence)
+            with self.assertRaisesRegex(evidence.EvidenceError, "protocol"):
                 barrier.wait(FakeProduct(), 1, evidence.protocol.Status.INITIAL_PRESENT)
 
     def test_startup_dispatch_orders_two_network_generations(self) -> None:

--- a/scripts/tests/test_staged_vmnet_guest.py
+++ b/scripts/tests/test_staged_vmnet_guest.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPOSITORY_ROOT / "scripts/guest/staged_vmnet_certification.py"
+SPEC = importlib.util.spec_from_file_location("staged_vmnet_certification", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:  # pragma: no cover - import contract
+    raise RuntimeError("failed to load staged vmnet guest module")
+staged = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = staged
+SPEC.loader.exec_module(staged)
+
+
+class FakeBarrier:
+    def __init__(self) -> None:
+        self.statuses: list[tuple[int, staged.Status]] = []
+        self.commands: list[int] = []
+
+    def status(self, sequence: int, kind: staged.Status) -> None:
+        self.statuses.append((sequence, kind))
+
+    def proceed(self, sequence: int) -> None:
+        self.commands.append(sequence)
+
+
+def changing_counts(values: list[int]):
+    pending = list(values)
+
+    def read() -> int:
+        if len(pending) > 1:
+            return pending.pop(0)
+        return pending[0]
+
+    return read
+
+
+class StagedVmnetProtocolTests(unittest.TestCase):
+    NONCE = bytes(range(1, 33))
+
+    def test_headers_are_exact_and_scenario_bound(self) -> None:
+        for scenario in staged.Scenario:
+            encoded = staged.encode_header(scenario, self.NONCE)
+            self.assertEqual(len(encoded), staged.SECTOR_BYTES)
+            self.assertEqual(
+                staged.decode_header(encoded),
+                staged.Header(scenario, scenario.cycles, self.NONCE),
+            )
+
+        valid = staged.encode_header(staged.Scenario.STARTUP, self.NONCE)
+        for index in (0, 8, 10, 11, 12, 16, 48, 64, 96, 511):
+            with self.subTest(index=index):
+                changed = bytearray(valid)
+                changed[index] ^= 1
+                with self.assertRaisesRegex(staged.CoordinatorError, "control"):
+                    staged.decode_header(bytes(changed))
+
+        for invalid in (b"", bytes(staged.SECTOR_BYTES), valid[:-1]):
+            with self.assertRaisesRegex(staged.CoordinatorError, "control"):
+                staged.decode_header(invalid)
+
+        control = valid + bytes(staged.CONTROL_BYTES - staged.SECTOR_BYTES)
+        self.assertEqual(
+            staged.decode_initial_control(control),
+            staged.Header(staged.Scenario.STARTUP, 2, self.NONCE),
+        )
+        for index in (staged.SECTOR_BYTES, staged.STATUS_OFFSET, staged.CONTROL_BYTES - 1):
+            with self.subTest(index=index):
+                changed = bytearray(control)
+                changed[index] = 1
+                with self.assertRaisesRegex(staged.CoordinatorError, "control"):
+                    staged.decode_initial_control(bytes(changed))
+        for invalid in (control[:-1], control + b"\0"):
+            with self.assertRaisesRegex(staged.CoordinatorError, "control"):
+                staged.decode_initial_control(invalid)
+
+    def test_records_are_exact_role_sequence_and_nonce_bound(self) -> None:
+        valid = staged.encode_record(
+            staged.ROLE_COMMAND,
+            staged.Scenario.RESTORE,
+            staged.COMMAND_PROCEED,
+            7,
+            self.NONCE,
+        )
+        self.assertEqual(
+            staged.decode_record(valid),
+            staged.Record(
+                staged.ROLE_COMMAND,
+                staged.Scenario.RESTORE,
+                staged.COMMAND_PROCEED,
+                7,
+                self.NONCE,
+            ),
+        )
+        self.assertIsNone(staged.decode_record(bytes(staged.SECTOR_BYTES), allow_empty=True))
+        for index in (0, 8, 10, 11, 12, 13, 16, 24, 56, 64, 96, 511):
+            with self.subTest(index=index):
+                changed = bytearray(valid)
+                changed[index] ^= 1
+                with self.assertRaisesRegex(staged.CoordinatorError, "control"):
+                    staged.decode_record(bytes(changed))
+
+        for role, kind, sequence, nonce in (
+            (0, 1, 1, self.NONCE),
+            (3, 1, 1, self.NONCE),
+            (staged.ROLE_COMMAND, 0, 1, self.NONCE),
+            (staged.ROLE_COMMAND, 1, 0, self.NONCE),
+            (staged.ROLE_COMMAND, 1, 1, bytes(32)),
+        ):
+            with self.assertRaisesRegex(staged.CoordinatorError, "control"):
+                staged.encode_record(role, staged.Scenario.STARTUP, kind, sequence, nonce)
+
+        self.assertEqual(
+            set(staged.FAILURE_CATEGORIES.values()),
+            {"control", "io", "topology", "timeout", "process", "traffic", "internal"},
+        )
+        self.assertEqual(len(staged.FAILURE_KINDS), len(set(staged.FAILURE_KINDS.values())))
+
+    def test_command_reader_rejects_skips_cross_scenario_and_timeout(self) -> None:
+        header = staged.Header(staged.Scenario.STARTUP, 2, self.NONCE)
+        first = staged.Record(
+            staged.ROLE_COMMAND,
+            staged.Scenario.STARTUP,
+            staged.COMMAND_PROCEED,
+            1,
+            self.NONCE,
+        )
+        second = staged.Record(
+            staged.ROLE_COMMAND,
+            staged.Scenario.STARTUP,
+            staged.COMMAND_PROCEED,
+            2,
+            self.NONCE,
+        )
+        barrier = staged.BlockBarrier(1, header)
+        pending = iter((first, first, second))
+        barrier._read_command = lambda: next(pending)
+        with mock.patch.object(staged.time, "sleep"):
+            barrier.proceed(1)
+            barrier.proceed(2)
+
+        for invalid in (
+            staged.Record(
+                staged.ROLE_COMMAND,
+                staged.Scenario.STARTUP,
+                staged.COMMAND_PROCEED,
+                2,
+                self.NONCE,
+            ),
+            staged.Record(
+                staged.ROLE_COMMAND,
+                staged.Scenario.RESTORE,
+                staged.COMMAND_PROCEED,
+                1,
+                self.NONCE,
+            ),
+            staged.Record(
+                staged.ROLE_STATUS,
+                staged.Scenario.STARTUP,
+                staged.COMMAND_PROCEED,
+                1,
+                self.NONCE,
+            ),
+        ):
+            with self.subTest(invalid=invalid):
+                barrier = staged.BlockBarrier(1, header)
+                barrier._read_command = lambda invalid=invalid: invalid
+                with self.assertRaisesRegex(staged.CoordinatorError, "control"):
+                    barrier.proceed(1)
+
+        barrier = staged.BlockBarrier(1, header)
+        barrier._read_command = lambda: None
+        with mock.patch.object(staged, "COMMAND_TIMEOUT_SECONDS", 0.0):
+            with self.assertRaisesRegex(staged.CoordinatorError, "timeout"):
+                barrier.proceed(1)
+
+    def test_state_machine_rejects_noncanonical_header(self) -> None:
+        with self.assertRaisesRegex(staged.CoordinatorError, "control"):
+            staged.run_scenario(
+                staged.Header(staged.Scenario.RUNTIME, 2, self.NONCE),
+                FakeBarrier(),
+            )
+
+    def test_startup_state_machine_requires_two_distinct_traffic_cycles(self) -> None:
+        barrier = FakeBarrier()
+        traffic: list[str] = []
+        staged.run_scenario(
+            staged.Header(staged.Scenario.STARTUP, 2, self.NONCE),
+            barrier,
+            interface_count=changing_counts([1, 0, 1, 0]),
+            rescan=lambda: None,
+            remove_interface=lambda: None,
+            traffic=lambda: traffic.append("traffic"),
+        )
+        self.assertEqual(traffic, ["traffic", "traffic"])
+        self.assertEqual(barrier.commands, [1, 2, 3, 4, 5])
+        self.assertEqual(
+            [kind for _sequence, kind in barrier.statuses],
+            [
+                staged.Status.INITIAL_PRESENT,
+                staged.Status.TRAFFIC_ONE,
+                staged.Status.ABSENT,
+                staged.Status.PRESENT,
+                staged.Status.TRAFFIC_TWO,
+                staged.Status.ABSENT,
+                staged.Status.COMPLETE,
+            ],
+        )
+        self.assertEqual(
+            [sequence for sequence, _kind in barrier.statuses],
+            list(range(1, 8)),
+        )
+
+    def test_runtime_state_machine_starts_absent_and_finishes_absent(self) -> None:
+        barrier = FakeBarrier()
+        traffic: list[str] = []
+        staged.run_scenario(
+            staged.Header(staged.Scenario.RUNTIME, 1, self.NONCE),
+            barrier,
+            interface_count=changing_counts([0, 1, 0]),
+            rescan=lambda: None,
+            remove_interface=lambda: None,
+            traffic=lambda: traffic.append("traffic"),
+        )
+        self.assertEqual(traffic, ["traffic"])
+        self.assertEqual(barrier.commands, [1, 2, 3])
+        self.assertEqual(
+            [kind for _sequence, kind in barrier.statuses],
+            [
+                staged.Status.INITIAL_ABSENT,
+                staged.Status.PRESENT,
+                staged.Status.TRAFFIC_ONE,
+                staged.Status.ABSENT,
+                staged.Status.COMPLETE,
+            ],
+        )
+
+    def test_restore_barrier_separates_source_and_destination_traffic(self) -> None:
+        barrier = FakeBarrier()
+        traffic: list[str] = []
+        staged.run_scenario(
+            staged.Header(staged.Scenario.RESTORE, 2, self.NONCE),
+            barrier,
+            interface_count=changing_counts([1, 1, 0]),
+            rescan=lambda: None,
+            remove_interface=lambda: None,
+            traffic=lambda: traffic.append(f"cycle-{len(traffic) + 1}"),
+        )
+        self.assertEqual(traffic, ["cycle-1", "cycle-2"])
+        self.assertEqual(barrier.commands, [1, 2, 3, 4])
+        self.assertEqual(
+            [kind for _sequence, kind in barrier.statuses],
+            [
+                staged.Status.INITIAL_PRESENT,
+                staged.Status.CAPTURE_READY,
+                staged.Status.PRESENT,
+                staged.Status.TRAFFIC_TWO,
+                staged.Status.ABSENT,
+                staged.Status.COMPLETE,
+            ],
+        )
+
+    def test_wrong_interface_cardinality_and_traffic_failure_are_terminal(self) -> None:
+        barrier = FakeBarrier()
+        with self.assertRaisesRegex(staged.CoordinatorError, "topology"):
+            staged.run_scenario(
+                staged.Header(staged.Scenario.STARTUP, 2, self.NONCE),
+                barrier,
+                interface_count=lambda: 2,
+                rescan=lambda: None,
+                remove_interface=lambda: None,
+                traffic=lambda: None,
+            )
+
+        class TrafficFailure(staged.CoordinatorError):
+            pass
+
+        def fail() -> None:
+            raise TrafficFailure("traffic")
+
+        with self.assertRaisesRegex(staged.CoordinatorError, "traffic"):
+            staged.run_scenario(
+                staged.Header(staged.Scenario.RUNTIME, 1, self.NONCE),
+                FakeBarrier(),
+                interface_count=changing_counts([0, 1]),
+                rescan=lambda: None,
+                remove_interface=lambda: None,
+                traffic=fail,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/firecracker-capability-audit/src/guest_workflow_audit_validate.rs
+++ b/tools/firecracker-capability-audit/src/guest_workflow_audit_validate.rs
@@ -19,10 +19,11 @@ pub const GUEST_WORKFLOW_AUDIT_PATH: &str = "compat/firecracker/v1.16.0/guest-wo
 /// Exact ordered artifact identities owned by the authority.
 pub const GUEST_ARTIFACT_IDS: [&str; 2] = ["kernel", "rootfs"];
 /// Exact ordered ext4 recipe identities owned by the authority.
-pub const GUEST_EXT4_RECIPE_IDS: [&str; 3] = [
+pub const GUEST_EXT4_RECIPE_IDS: [&str; 4] = [
     "rootfs-ext4",
     "rootfs-ext4-direct-boot-v110",
     "rootfs-ext4-direct-boot-v111",
+    "rootfs-ext4-direct-boot-v112",
 ];
 /// Exact ordered planned workflow identities reserved for the completion slice.
 pub const GUEST_WORKFLOW_PROFILE_IDS: [&str; 2] =
@@ -301,6 +302,20 @@ fn validate_ext4_recipes(audit: &GuestWorkflowAudit, errors: &mut Vec<String>) {
                     "scripts/guest/arm64-id-register-report.rs",
                     "scripts/guest/elevated_vmnet_certification.rs",
                     "scripts/guest/specification-benchmark.rs",
+                    "scripts/guest_artifact_policy.py",
+                ],
+            ),
+            3 => (
+                "direct-boot-v112",
+                "ubuntu-24.04-{size}-direct-boot-v112.ext4",
+                "512M",
+                &[
+                    GUEST_WORKFLOW_AUDIT_PATH,
+                    "scripts/fetch-firecracker-rootfs.sh",
+                    "scripts/guest/arm64-id-register-report.rs",
+                    "scripts/guest/elevated_vmnet_certification.rs",
+                    "scripts/guest/specification-benchmark.rs",
+                    "scripts/guest/staged_vmnet_certification.py",
                     "scripts/guest_artifact_policy.py",
                 ],
             ),
@@ -724,7 +739,9 @@ fn validate_source_tokens(repository_root: &Path, errors: &mut Vec<String>) {
             &[
                 "direct-boot-v110",
                 "direct-boot-v111",
+                "direct-boot-v112",
                 "elevated_vmnet_certification.rs",
+                "staged_vmnet_certification.py",
                 "guest_artifact_policy.py",
             ][..],
         ),

--- a/tools/firecracker-capability-audit/src/vmnet_feasibility_audit_validate.rs
+++ b/tools/firecracker-capability-audit/src/vmnet_feasibility_audit_validate.rs
@@ -132,7 +132,7 @@ const EVIDENCE: [EvidenceSpec; 3] = [
         validation: &[
             (
                 "scripts/run-elevated-vmnet-evidence.sh",
-                "guest=passed repeat=passed cleanup=passed",
+                "guest=passed repeat=passed startup=passed runtime=passed restore=passed cleanup=passed",
             ),
             (
                 "compat/firecracker/v1.16.0/vmnet-feasibility-contract.md",


### PR DESCRIPTION
## Summary

- add the distinct direct-boot-v112 guest recipe and closed authenticated staged barrier protocol
- prove root-direct startup re-add, networkless runtime insertion, and fresh-destination Full restore with the existing DHCP/TCP oracle
- extend the immutable no-Apple elevated evidence package, hostile tests, validators, and documentation without promoting either remaining capability

## Scope exclusions

- no production launcher/provider handoff or canonical v2 result
- no Apple signing identity, provisioning profile, or private entitlement
- no capability disposition change; inventory remains 383/0/2/33

## Verification

- python3 -m unittest discover -s scripts/tests -p test_*.py (179 passed)
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked (1540 passed)
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps --locked
- cargo run -p bangbang-firecracker-capability-audit --locked -- validate
- global final reports only the two expected missing-platform-feasible rows
- exact-root Apple Silicon/HVF immutable-package proof passed all denial/provider/guest/startup/runtime/restore/cleanup gates with ad-hoc signing and apple-vmnet absent

One prior identical-package attempt stopped at the unchanged first v111 guest gate; the immediate same-package rerun passed the full matrix. No retry or skip was added.

Closes #1942