### PR TITLE
test: add least-privileged elevated certification handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ only ad-hoc signing, publishes no certification result, and leaves the exact
 `383/0/2/33` inventory unchanged. TERM exercises exact group shutdown. KILL
 targets only the root provider first, preserving the ordinary launcher/worker
 long enough for authenticated parent-loss cleanup before bounded group
-escalation; success also requires the production-session baseline to be
-unchanged.
+escalation; success also requires the descriptor-anchored production-session
+namespace to be empty before and after the probes.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Each detailed subject has one primary document:
 - [Entitlement-free vmnet Feasibility Contract](compat/firecracker/v1.16.0/vmnet-feasibility-contract.md)
   owns the no-Apple-authorization root-direct evidence boundary, exact dropped
   owner and repeated guest-connectivity gates, and the `383/0/2/33` handoff.
+- [Elevated Certification Handoff Contract](compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md)
+  owns the immutable normal-bundle package, one-shot root guardian/supervisor,
+  irreversibly ordinary controller, descriptor-only provider lifecycle, and
+  reciprocal cleanup boundary used by the final certification slice.
 - [Private vmnet Provider Protocol](docs/vmnet-provider-protocol.md) freezes the
   bounded session/control/data wire, state, packet, deadline, and descriptor
   ownership contract and documents the minimal root broker plus irreversibly
@@ -243,6 +247,26 @@ stores, forwards, or logs a password, and the runner itself never invokes
 `sudo`. This gate certifies product assembly and supervision without an Apple
 developer identity or vmnet provisioning profile; the full real-guest
 certification remains separate.
+
+The least-privileged successor prepares the normal networkless production
+bundle and gives an irreversibly ordinary controller only fixed provider
+lifecycle operations:
+
+```sh
+scripts/prepare-elevated-vmnet-handoff.sh \
+  --output /absolute/absent/bangbang-elevated-vmnet-handoff
+sudo -- scripts/run-elevated-vmnet-handoff.sh \
+  --prepared /absolute/absent/bangbang-elevated-vmnet-handoff \
+  --target-uid TARGET_UID \
+  --target-gid TARGET_GID
+```
+
+The repository entries never obtain elevation themselves. The externally
+authorized root side accepts only the immutable package and numeric target
+ids; it cannot select a product image, environment, working directory,
+fixture, result, account, profile, interface, or socket. This foundation uses
+only ad-hoc signing, publishes no certification result, and leaves the exact
+`383/0/2/33` inventory unchanged.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,11 @@ authorized root side accepts only the immutable package and numeric target
 ids; it cannot select a product image, environment, working directory,
 fixture, result, account, profile, interface, or socket. This foundation uses
 only ad-hoc signing, publishes no certification result, and leaves the exact
-`383/0/2/33` inventory unchanged.
+`383/0/2/33` inventory unchanged. TERM exercises exact group shutdown. KILL
+targets only the root provider first, preserving the ordinary launcher/worker
+long enough for authenticated parent-loss cleanup before bounded group
+escalation; success also requires the production-session baseline to be
+unchanged.
 
 ## Development
 

--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -199,8 +199,9 @@ the ordinary package owner. Reciprocal guardian/supervisor cleanup covers
 either single root-actor loss. TERM targets the exact owned group; KILL first
 targets only the root provider and preserves ordinary parent-loss cleanup
 before bounded group escalation. Both require exact group absence and
-restoration of the production-session baseline. The fixed probes require no
-Apple authorization. The canonical matrix and verdict remain #1944.
+an empty descriptor-anchored production-session namespace before and after the
+probe set. The fixed probes require no Apple authorization. The canonical
+matrix and verdict remain #1944.
 
 ## Guest workflow artifact authority
 

--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -167,7 +167,10 @@ for its one-row transition, the
 one-row transition, and
 the [vmnet feasibility contract](vmnet-feasibility-contract.md) for the
 two-row evidence transition, and
-[`docs/testing.md`](../../../docs/testing.md#entitlement-free-vmnet-feasibility)
+the [elevated certification handoff contract](elevated-certification-handoff-contract.md)
+for the immutable normal-bundle, dropped-controller, fixed-provider lifecycle,
+and reciprocal cleanup boundary, and
+[`docs/testing.md`](../../../docs/testing.md#least-privileged-elevated-certification-handoff)
 for the canonical commands.
 
 The [`provider-v1` contract](../../../docs/vmnet-provider-protocol.md) freezes
@@ -186,6 +189,15 @@ convergence, provider-owned daemon handoff, and cleanup. Real
 guest-through-provider lifecycle/concurrency certification remains the next
 slice; the inventory and both `missing-platform-feasible` dispositions stay
 unchanged.
+
+#1943 adds the one-shot least-privileged certification bridge without changing
+the provider product ABI or inventory. The normal ad-hoc/networkless bundle is
+bound to clean source in an immutable package. Exact root stages only that
+package and retains a closed descriptor protocol, while all future private
+certification work runs only after the controller has irreversibly dropped to
+the ordinary package owner. Reciprocal guardian/supervisor cleanup covers
+either single root-actor loss, and fixed completion/TERM/KILL product probes
+require no Apple authorization. The canonical matrix and verdict remain #1944.
 
 ## Guest workflow artifact authority
 

--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -196,8 +196,11 @@ bound to clean source in an immutable package. Exact root stages only that
 package and retains a closed descriptor protocol, while all future private
 certification work runs only after the controller has irreversibly dropped to
 the ordinary package owner. Reciprocal guardian/supervisor cleanup covers
-either single root-actor loss, and fixed completion/TERM/KILL product probes
-require no Apple authorization. The canonical matrix and verdict remain #1944.
+either single root-actor loss. TERM targets the exact owned group; KILL first
+targets only the root provider and preserves ordinary parent-loss cleanup
+before bounded group escalation. Both require exact group absence and
+restoration of the production-session baseline. The fixed probes require no
+Apple authorization. The canonical matrix and verdict remain #1944.
 
 ## Guest workflow artifact authority
 

--- a/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
+++ b/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
@@ -133,7 +133,10 @@ contract deliberately excludes.
 The #1943 real gate uses the normal bundle for two clean version completions and
 two live ordinary API-process cases, one terminated and one killed. Fixed
 private API-grant material is created only inside the dropped controller and is
-removed before finish. Public output is categorical and contains no private
+removed before finish. The contained worker `--version` path emits the existing
+`NoApi` readiness after its authenticated bootstrap and grant acceptance so the
+launcher/provider observe ready before its successful terminal; direct version
+behavior is unchanged. Public output is categorical and contains no private
 path, id, PID, session, arguments, interface, address, packet, nonce, or raw
 tool/process value.
 

--- a/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
+++ b/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
@@ -128,6 +128,12 @@ eventually removed. Simultaneous destruction of both root actors is an external
 administrator/kernel event and would require a persistent service, which this
 contract deliberately excludes.
 
+The requested KILL case may leave the ordinary private API socket name after
+the complete provider group is reaped. The controller may unlink only that
+exact expected socket after revalidating its type, target uid/gid, and mode.
+TERM residue, any extra entry, and every ownership/mode mismatch are terminal;
+this deterministic owned-name step is not fallback process cleanup.
+
 ## Fixed probes and handoff
 
 The #1943 real gate uses the normal bundle for two clean version completions and

--- a/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
+++ b/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
@@ -1,0 +1,146 @@
+# Elevated Certification Handoff Contract
+
+## Scope and inventory position
+
+This contract owns #1943, foundation child 2 of #1941 under #1348. It supplies
+the least-privileged process-control bridge between an ordinary future
+production-vmnet certification controller and the caller-authorized exact-root
+provider bootstrap. It does not execute the canonical guest matrix, publish a
+result, promote a capability, or replace the direct #1930/#1942 evidence.
+
+The live inventory remains exactly `383 implemented / 0 audit-required / 2
+missing-platform-feasible / 33 proven-platform-impossible`. The retained rows
+are `corpus:network-setup` and
+`semantic.network:virtio-net-vmnet-policy-and-connectivity`.
+
+## Ordinary immutable preparation
+
+Preparation requires Darwin arm64, an ordinary uid/gid, a clean Git index,
+worktree, and untracked-file set, and an absolute absent destination named
+`bangbang-elevated-vmnet-handoff`. It records the exact HEAD commit and tree,
+builds `Bangbang.app` through the normal production bundle command with its
+default ad-hoc identity and networkless worker profile, and independently
+checks:
+
+- the fixed outer/provider/worker paths and identifiers;
+- Hardened Runtime on all three signed objects;
+- empty outer and provider entitlements;
+- exactly App Sandbox plus Hypervisor worker entitlements;
+- no embedded provisioning profile; and
+- no test-feature product or Apple-authorized input.
+
+The canonical manifest binds the source, four fixed implementation files, and
+every relative bundle directory/file name, kind, mode, size, and SHA-256. All
+regular nodes are single-link and mode `0444` or `0555`; all directories are
+nonwritable. Links, special files, hard links, writable nodes, unknown residue,
+source drift, replacement, and a pre-existing output fail. Publication uses
+`renamex_np(RENAME_EXCL)` and never replaces a destination.
+
+## Root invocation authority
+
+The public root entry accepts only the prepared absolute package and canonical
+nonzero u32 target uid/gid. It closes stdin. It does not invoke an authorization
+frontend or accept/discover an executable, alternate bundle, environment, cwd,
+fixture, result, account, credential, profile, interface, or socket.
+
+Caller authorization of the fixed repository entry is the trust decision.
+Implementation hashes prove that package/source and the authorized entry are
+coherent and reject a stale package; a program digest checked by the same
+authorized program is not claimed as authentication against modified code.
+
+Root validates the target-owned package, copies it without following links into
+a fresh `/private/var/tmp` root stage, normalizes root ownership and immutable
+modes, revalidates source and staged manifests, repeats every signature and
+entitlement check, then changes only the outer stage to traversal mode. The
+staged `bangbang-vmnet-provider` is the only root product image that can be
+spawned.
+
+## Guardian, supervisor, and controller
+
+The one-shot root entry divides into a guardian and protocol supervisor with
+reciprocal liveness. The supervisor forks exactly one controller. Before any
+controller loader or future private input is parsed, the child:
+
+1. redirects stdin/stdout/stderr to `/dev/null` and closes unrelated fds;
+2. clears supplementary groups;
+3. calls `setgid(target)` and then `setuid(target)`;
+4. attests real/effective/saved uid and gid, empty groups, parent, executable,
+   and process birth identity; and
+5. proves attempts to restore uid 0, gid 0, and a root group all fail without
+   changing that identity.
+
+The supervisor independently attests the same dropped child before sending a
+welcome. Only the controller may later load private config, fixture, API/HVF,
+guest-matrix, or result code.
+
+## Fixed descriptor protocol
+
+The controller and supervisor use a connected `AF_UNIX/SOCK_DGRAM` socketpair.
+Both ends set and read back `SO_SNDBUF` and `SO_RCVBUF` at no less than 8192
+bytes before traffic; target macOS defaults are insufficient for one atomic
+record. Every record is exactly 4096 bytes:
+
+- 96-byte big-endian prefix with magic/version, role/kind, descriptor count,
+  sequence, request correlation, 32-byte random session, handle/value, payload
+  length, and zero reserved bytes;
+- 32-byte SHA-256 of the prefix plus live payload;
+- a bounded payload; and
+- an all-zero unused tail.
+
+Per-role sequences start at one and advance exactly. Responses bind one request
+sequence. Replay, skip, reordering, wrong role/session/correlation, unknown
+kind/handle, malformed length/digest/reserved/tail, truncation, ancillary
+truncation, and post-terminal traffic fail the session.
+
+The graph contains only welcome/ready, spawn/spawned, poll, bounded wait,
+running/exited, TERM, KILL, close/closed, finish/finished, and categorical
+failure. Controller requests carry no descriptors. Spawn success alone carries
+exactly two distinct read-only pipe descriptors; wrong, duplicate, excess,
+mixed, non-pipe, writable, or truncated descriptors are closed and rejected.
+
+The spawn payload is a bounded byte-preserved argument vector. Root validates
+only its structure and never emits or semantically interprets it. Root prepends
+the exact staged provider, `--bootstrap-v1`, and target ids, and fixes `/` cwd,
+`LANG/LC_ALL=C`, null stdin, closed unrelated descriptors, and a fresh process
+group. The provider itself pins its sibling outer/worker and preserves its
+drop-before-broad-parse contract.
+
+## Lifecycle and cleanup
+
+Each process handle supports poll, bounded wait, exact process-group TERM/KILL,
+and close. Output pumps start immediately, retain only a bounded prefix, and
+make overflow, reader failure, or stuck EOF terminal. Partial pipe creation,
+partial spawn, response-transfer failure, timeout, protocol failure, controller
+loss, and normal close retire and reap every owned group.
+
+On success the supervisor sends `complete` but stays alive. The guardian then
+proves the controller and every exact staged provider/launcher/worker image
+absent using only `pid/ppid/state/comm`, removes the stage, and sends `ack`.
+Only then may the supervisor exit successfully. Supervisor loss makes the
+guardian the cleanup owner; guardian loss makes the supervisor the cleanup
+owner. Forced cleanup or identity/absence uncertainty fails even if residue is
+eventually removed. Simultaneous destruction of both root actors is an external
+administrator/kernel event and would require a persistent service, which this
+contract deliberately excludes.
+
+## Fixed probes and handoff
+
+The #1943 real gate uses the normal bundle for two clean version completions and
+two live ordinary API-process cases, one terminated and one killed. Fixed
+private API-grant material is created only inside the dropped controller and is
+removed before finish. Public output is categorical and contains no private
+path, id, PID, session, arguments, interface, address, packet, nonce, or raw
+tool/process value.
+
+Portable tests own canonical package/tamper behavior, every record region,
+argument bounds, configured datagram plus rights transfer, sequence/replay/
+cross-session rejection, descriptor confusion, credential order and
+irreversibility, partial spawn closure, output overflow, reciprocal loss, and
+cleanup acknowledgment. The target gate requires caller-arranged exact root
+and ad-hoc signing only; it has no unsupported-success or Apple-authorization
+fallback.
+
+#1944 may import the ordinary `ControllerProxy`/`RemoteProviderProcess` seam and
+adapt the canonical process factory after drop. It alone owns private plan
+parsing, guest/provider concurrency, canonical result publication, capability
+promotion, and parent completion.

--- a/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
+++ b/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
@@ -39,9 +39,12 @@ source drift, replacement, and a pre-existing output fail. Publication uses
 ## Root invocation authority
 
 The public root entry accepts only the prepared absolute package and canonical
-nonzero u32 target uid/gid. It closes stdin. It does not invoke an authorization
-frontend or accept/discover an executable, alternate bundle, environment, cwd,
-fixture, result, account, credential, profile, interface, or socket.
+nonzero u32 target uid/gid. It closes stdin. Root does not invoke an
+authorization frontend or accept/discover an executable, alternate bundle,
+environment, cwd, fixture, result, account, credential, profile, interface, or
+socket. Only after irreversible drop does the ordinary controller resolve its
+own home to inspect the fixed production-session root; that value is never
+returned to root or public output.
 
 Caller authorization of the fixed repository entry is the trust decision.
 Implementation hashes prove that package/source and the authorized entry are
@@ -138,10 +141,10 @@ the provider leader and subordinate group converge. The controller may unlink
 only that exact expected socket after revalidating its type, target uid/gid,
 and mode. TERM residue, any extra entry, and every ownership/mode mismatch are
 terminal; this deterministic owned-name step is not fallback process cleanup.
-The ordinary controller snapshots the exact private production-session
-namespace before each signal case and requires that same name/inode/child
-baseline after convergence. Durable socket ownership records are never erased
-by the handoff.
+The ordinary controller requires an empty, descriptor-anchored private
+production-session namespace before the probe set, snapshots it before each
+signal case, and requires the same empty baseline after convergence. Durable
+socket ownership records are never erased by the handoff.
 
 ## Fixed probes and handoff
 

--- a/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
+++ b/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
@@ -112,11 +112,16 @@ drop-before-broad-parse contract.
 
 ## Lifecycle and cleanup
 
-Each process handle supports poll, bounded wait, exact process-group TERM/KILL,
-and close. Output pumps start immediately, retain only a bounded prefix, and
-make overflow, reader failure, or stuck EOF terminal. Partial pipe creation,
-partial spawn, response-transfer failure, timeout, protocol failure, controller
-loss, and normal close retire and reap every owned group.
+Each process handle supports poll, bounded wait, exact TERM/KILL, and close.
+TERM is directed to the exact owned process group. KILL first sends SIGKILL to
+the exact root provider leader; the still-live root supervisor keeps that child
+unreaped to pin its PGID while it permits authenticated parent-loss cleanup,
+then sends group TERM and finally group KILL only as bounded escalation. The
+provider is reaped only after no live subordinate remains, and the former group
+must then be absent. Output pumps start immediately, retain only a bounded
+prefix, and make overflow, reader failure, or stuck EOF terminal. Partial pipe
+creation, partial spawn, response-transfer failure, timeout, protocol failure,
+controller loss, and normal close retire and reap every owned group.
 
 On success the supervisor sends `complete` but stays alive. The guardian then
 proves the controller and every exact staged provider/launcher/worker image
@@ -129,10 +134,14 @@ administrator/kernel event and would require a persistent service, which this
 contract deliberately excludes.
 
 The requested KILL case may leave the ordinary private API socket name after
-the complete provider group is reaped. The controller may unlink only that
-exact expected socket after revalidating its type, target uid/gid, and mode.
-TERM residue, any extra entry, and every ownership/mode mismatch are terminal;
-this deterministic owned-name step is not fallback process cleanup.
+the provider leader and subordinate group converge. The controller may unlink
+only that exact expected socket after revalidating its type, target uid/gid,
+and mode. TERM residue, any extra entry, and every ownership/mode mismatch are
+terminal; this deterministic owned-name step is not fallback process cleanup.
+The ordinary controller snapshots the exact private production-session
+namespace before each signal case and requires that same name/inode/child
+baseline after convergence. Durable socket ownership records are never erased
+by the handoff.
 
 ## Fixed probes and handoff
 

--- a/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
+++ b/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
@@ -74,6 +74,10 @@ The supervisor independently attests the same dropped child before sending a
 welcome. Only the controller may later load private config, fixture, API/HVF,
 guest-matrix, or result code.
 
+Group attestation uses Darwin's bounded live-process `getgroups` ABI directly,
+not the system Python deployment-target account-directory variant that ignores
+`setgroups` changes.
+
 ## Fixed descriptor protocol
 
 The controller and supervisor use a connected `AF_UNIX/SOCK_DGRAM` socketpair.

--- a/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
+++ b/compat/firecracker/v1.16.0/elevated-certification-handoff-contract.md
@@ -64,8 +64,9 @@ controller loader or future private input is parsed, the child:
 1. redirects stdin/stdout/stderr to `/dev/null` and closes unrelated fds;
 2. clears supplementary groups;
 3. calls `setgid(target)` and then `setuid(target)`;
-4. attests real/effective/saved uid and gid, empty groups, parent, executable,
-   and process birth identity; and
+4. attests real/effective/saved uid and gid, Darwin's exact target-gid-only
+   `effective-only` group-access-list postcondition, parent, executable, and
+   process birth identity; and
 5. proves attempts to restore uid 0, gid 0, and a root group all fail without
    changing that identity.
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -252,6 +252,13 @@ fn run(
     if contained_shutdown_requested(contained)? {
         return Ok(());
     }
+    if let Some(readiness) = finite_contained_command_readiness(&args.command)
+        && let Some(session) = contained.as_mut()
+    {
+        session
+            .send_ready(readiness)
+            .map_err(|_| ProcessError::ContainedSession)?;
+    }
 
     match args.command {
         Command::Help => {
@@ -660,6 +667,10 @@ fn run(
             }
         }
     }
+}
+
+fn finite_contained_command_readiness(command: &Command) -> Option<bangbang_session::Readiness> {
+    matches!(command, Command::Version).then_some(bangbang_session::Readiness::NoApi)
 }
 
 fn finish_caught_runtime_panic<S>(
@@ -2989,7 +3000,7 @@ mod tests {
         ApiServerError, Args, CONFIG_FILE_MAX_BYTES, Command, DEFAULT_API_SOCK_PATH,
         DEFAULT_INSTANCE_ID, HTTP_MAX_PAYLOAD_SIZE, MAX_INSTANCE_ID_LEN, ProcessError,
         ProcessExitCode, SnapshotInspectionPath, StartupConfig, StartupTimeClock,
-        StartupTimeConfig, parse_process_args,
+        StartupTimeConfig, finite_contained_command_readiness, parse_process_args,
     };
 
     const CAUGHT_RUNTIME_PANIC_CHILD_ENV: &str = "BANGBANG_CAUGHT_RUNTIME_PANIC_CHILD";
@@ -4588,6 +4599,11 @@ mod tests {
         let args = parse(&["--version"]).expect("version arg should parse");
 
         assert_eq!(args.command, Command::Version);
+        assert_eq!(
+            finite_contained_command_readiness(&args.command),
+            Some(bangbang_session::Readiness::NoApi)
+        );
+        assert_eq!(finite_contained_command_readiness(&Command::Help), None);
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -5481,10 +5481,14 @@ TERM/KILL, close, and cleanup; exactly two stdout/stderr descriptors accompany
 spawn success. The configured target transport attests 8192-byte socket
 buffers before using a frame. Reciprocal guardian/supervisor liveness and a
 complete/cleanup/ack boundary cover either single root-actor loss without a
-persistent service. Fixed normal-product completion and live-signal probes use
-no Apple authorization and publish no canonical result. The inventory stays
-`383/0/2/33`; #1944 remains responsible for the private concurrent matrix and
-both retained network dispositions.
+persistent service. TERM targets the exact owned group; KILL targets the exact
+root provider first and preserves the ordinary cleanup actors through bounded
+parent-loss/TERM convergence before any group-KILL escalation. The former group
+must be absent and the exact production-session baseline restored. Fixed
+normal-product completion and live-signal probes use no Apple authorization and
+publish no canonical result. The inventory stays `383/0/2/33`; #1944 remains
+responsible for the private concurrent matrix and both retained network
+dispositions.
 
 ## Validation Expectations
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -5471,6 +5471,21 @@ ends with exact API and process cleanup. This evidence uses no Apple
 authorization and leaves both rows `missing-platform-feasible`; production
 provider handoff and the canonical matrix remain later slices.
 
+#1943 adds the nonfinal least-privileged production-provider handoff. A clean
+ordinary preparation builds and recursively manifests the normal ad-hoc
+networkless bundle. One externally authorized exact-root entry stages that
+fixed product, while an irreversibly dropped controller alone owns future
+private inputs. Root retains only an authenticated, sequence-correlated
+4096-byte datagram protocol for fixed-provider spawn, poll/bounded wait,
+TERM/KILL, close, and cleanup; exactly two stdout/stderr descriptors accompany
+spawn success. The configured target transport attests 8192-byte socket
+buffers before using a frame. Reciprocal guardian/supervisor liveness and a
+complete/cleanup/ack boundary cover either single root-actor loss without a
+persistent service. Fixed normal-product completion and live-signal probes use
+no Apple authorization and publish no canonical result. The inventory stays
+`383/0/2/33`; #1944 remains responsible for the private concurrent matrix and
+both retained network dispositions.
+
 ## Validation Expectations
 
 Every future compatibility change should choose validation appropriate to its

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -5484,7 +5484,8 @@ complete/cleanup/ack boundary cover either single root-actor loss without a
 persistent service. TERM targets the exact owned group; KILL targets the exact
 root provider first and preserves the ordinary cleanup actors through bounded
 parent-loss/TERM convergence before any group-KILL escalation. The former group
-must be absent and the exact production-session baseline restored. Fixed
+must be absent and the descriptor-anchored production-session namespace must be
+empty before and after the probe set. Fixed
 normal-product completion and live-signal probes use no Apple authorization and
 publish no canonical result. The inventory stays `383/0/2/33`; #1944 remains
 responsible for the private concurrent matrix and both retained network

--- a/docs/security.md
+++ b/docs/security.md
@@ -1467,10 +1467,14 @@ persistent service.
 
 The fixed #1943 probe carries no guest fixture or result. It proves repeat
 completion and live TERM/KILL using ordinary private API-grant material created
-only after drop. Public output is categorical and contains no path, id, PID,
-session, argument, interface, address, packet, nonce, raw process output, or
-private value. This foundation changes no capability disposition; #1944 alone
-may import it from the ordinary controller and publish the canonical verdict.
+only after drop. The contained worker's finite `--version` command publishes
+the existing `NoApi` readiness only after authenticated bootstrap and grant
+acceptance, allowing the existing topology to acknowledge a clean terminal;
+direct version behavior is unchanged. Public output is categorical and
+contains no path, id, PID, session, argument, interface, address, packet,
+nonce, raw process output, or private value. This foundation changes no
+capability disposition; #1944 alone may import it from the ordinary controller
+and publish the canonical verdict.
 
 The local vmnet worker path requires the host to satisfy macOS vmnet
 authorization, entitlement, and code-signing requirements. The split provider

--- a/docs/security.md
+++ b/docs/security.md
@@ -1439,6 +1439,10 @@ observes the same child identity before sending its session welcome. Only then
 does the child call the controller loader; private plan, API, HVF, fixture, and
 result parsing therefore remain outside root.
 
+The group attestation resolves Darwin's bounded live-process `getgroups` ABI
+directly. It does not use the system Python deployment-target variant, which
+reports the account-directory access list and does not reflect `setgroups`.
+
 Root retains a closed local lifecycle protocol, not general execution. Exact
 4096-byte Unix datagrams use explicitly attested 8192-byte socket buffers,
 monotonic per-role sequences, request correlation, a random 32-byte session,

--- a/docs/security.md
+++ b/docs/security.md
@@ -1410,6 +1410,63 @@ provider/launcher/worker/owner assembly, and foreground/daemon supervision.
 Guest-through-provider certification, the complete concurrent production
 matrix, and the optional Apple-authorized matrix remain undelivered.
 
+### Least-privileged elevated certification handoff boundary
+
+#1943 adds the one-shot privilege split required before the canonical
+certification may use the production provider. Ordinary preparation builds the
+normal ad-hoc/networkless bundle from a clean source and publishes a recursively
+manifested, nonwritable, no-link package to an absent destination. The manifest
+binds source and fixed implementation identity to every relative product node.
+It is a coherence and stale-package boundary. Trust still comes from the
+caller's explicit authorization of the fixed repository entry; code cannot
+authenticate itself against an already modified authorized checkout.
+
+The exact-root entry accepts only the package plus nonzero numeric target uid
+and gid. It never obtains authorization, discovers accounts or credentials, or
+accepts an executable, bundle override, environment, cwd, fixture, result,
+profile, interface, or socket. It validates the target-owned source package,
+copies into a fresh private root stage, root-owns and freezes the copy, repeats
+the manifest/layout/signature/entitlement checks, and opens traversal only
+after the normal networkless product is coherent. The entitlement-free staged
+provider is the only product image root may spawn.
+
+One controller child closes unrelated descriptors and stdio, clears
+supplementary groups, sets gid before uid, and attests ordinary real/effective/
+saved ids and empty groups. Attempts to restore uid 0, gid 0, or a root group
+must fail without changing birth identity. The supervisor independently
+observes the same child identity before sending its session welcome. Only then
+does the child call the controller loader; private plan, API, HVF, fixture, and
+result parsing therefore remain outside root.
+
+Root retains a closed local lifecycle protocol, not general execution. Exact
+4096-byte Unix datagrams use explicitly attested 8192-byte socket buffers,
+monotonic per-role sequences, request correlation, a random 32-byte session,
+SHA-256, zero reserved bytes/tail, closed message kinds, and bounded opaque
+argument encoding. Controller requests carry no descriptors. Successful spawn
+alone carries exactly two distinct read-only pipe descriptors. Root prepends
+the fixed provider bootstrap/target identity and fixes cwd, environment, stdin,
+descriptor closure, and process group; it neither semantically parses nor emits
+the launcher suffix. The provider continues to pin its sibling launcher/worker
+and drops the outer before broad argument parsing.
+
+Guardian and supervisor are reciprocal cleanup authorities. The supervisor
+does not exit successfully until the guardian has verified controller and exact
+staged product absence, removed the stage, and acknowledged cleanup. If either
+root actor is lost alone, the survivor terminates and reaps the controller and
+owned provider groups, scans only exact staged executable paths using
+`pid/ppid/state/comm`, verifies absence, and removes the stage. Forced cleanup,
+identity ambiguity, output overflow, protocol failure, or timeout is terminal.
+A simultaneous administrator/kernel destruction of both cleanup actors is
+outside a one-shot process contract and would require the deliberately rejected
+persistent service.
+
+The fixed #1943 probe carries no guest fixture or result. It proves repeat
+completion and live TERM/KILL using ordinary private API-grant material created
+only after drop. Public output is categorical and contains no path, id, PID,
+session, argument, interface, address, packet, nonce, raw process output, or
+private value. This foundation changes no capability disposition; #1944 alone
+may import it from the ordinary controller and publish the canonical verdict.
+
 The local vmnet worker path requires the host to satisfy macOS vmnet
 authorization, entitlement, and code-signing requirements. The split provider
 path instead relies on explicit operator-authorized root bootstrap followed by

--- a/docs/security.md
+++ b/docs/security.md
@@ -1465,12 +1465,17 @@ A simultaneous administrator/kernel destruction of both cleanup actors is
 outside a one-shot process contract and would require the deliberately rejected
 persistent service.
 
-After the requested KILL case has reaped the complete provider group, the
-kernel may retain the API socket name. The ordinary controller may unlink only
-that one expected name after revalidating socket type, target uid/gid, and
-mode. TERM residue, any extra entry, and every identity or mode mismatch remain
-terminal; this deterministic owned-name cleanup is distinct from a forced
-process cleanup.
+TERM targets the exact owned provider group. KILL instead sends SIGKILL only to
+the exact root provider leader, keeps that child unreaped to pin its PGID, and
+lets the ordinary launcher/worker perform authenticated parent-loss cleanup.
+The root supervisor then applies bounded group TERM and group KILL escalation
+only if live subordinates remain, reaps the provider, and requires the former
+group to be absent. The kernel may still retain the API socket name; the
+ordinary controller may unlink only that one expected name after revalidating
+socket type, target uid/gid, and mode. TERM residue, any extra entry, and every
+identity or mode mismatch remain terminal. The controller also requires the
+exact pre-probe production-session name/inode/child baseline afterward, so the
+handoff never erases or strands a durable product ownership record.
 
 The fixed #1943 probe carries no guest fixture or result. It proves repeat
 completion and live TERM/KILL using ordinary private API-grant material created

--- a/docs/security.md
+++ b/docs/security.md
@@ -1422,9 +1422,12 @@ caller's explicit authorization of the fixed repository entry; code cannot
 authenticate itself against an already modified authorized checkout.
 
 The exact-root entry accepts only the package plus nonzero numeric target uid
-and gid. It never obtains authorization, discovers accounts or credentials, or
-accepts an executable, bundle override, environment, cwd, fixture, result,
-profile, interface, or socket. It validates the target-owned source package,
+and gid. Its root actors never obtain authorization, discover accounts or
+credentials, or accept an executable, bundle override, environment, cwd,
+fixture, result, profile, interface, or socket. After irreversible drop, the
+ordinary controller resolves only its own home for the fixed production-session
+residue check; no account name or path is returned to root or public output. It
+validates the target-owned source package,
 copies into a fresh private root stage, root-owns and freezes the copy, repeats
 the manifest/layout/signature/entitlement checks, and opens traversal only
 after the normal networkless product is coherent. The entitlement-free staged
@@ -1473,9 +1476,10 @@ only if live subordinates remain, reaps the provider, and requires the former
 group to be absent. The kernel may still retain the API socket name; the
 ordinary controller may unlink only that one expected name after revalidating
 socket type, target uid/gid, and mode. TERM residue, any extra entry, and every
-identity or mode mismatch remain terminal. The controller also requires the
-exact pre-probe production-session name/inode/child baseline afterward, so the
-handoff never erases or strands a durable product ownership record.
+identity or mode mismatch remain terminal. The controller also requires an
+empty descriptor-anchored production-session namespace before the probe set and
+the same empty baseline afterward, so the handoff never accepts, erases, or
+strands a durable product ownership record.
 
 The fixed #1943 probe carries no guest fixture or result. It proves repeat
 completion and live TERM/KILL using ordinary private API-grant material created

--- a/docs/security.md
+++ b/docs/security.md
@@ -1432,8 +1432,9 @@ provider is the only product image root may spawn.
 
 One controller child closes unrelated descriptors and stdio, clears
 supplementary groups, sets gid before uid, and attests ordinary real/effective/
-saved ids and empty groups. Attempts to restore uid 0, gid 0, or a root group
-must fail without changing birth identity. The supervisor independently
+saved ids and Darwin's exact target-gid-only `effective-only` group-access-list
+postcondition. Attempts to restore uid 0, gid 0, or a root group must fail
+without changing birth identity. The supervisor independently
 observes the same child identity before sending its session welcome. Only then
 does the child call the controller loader; private plan, API, HVF, fixture, and
 result parsing therefore remain outside root.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1465,6 +1465,13 @@ A simultaneous administrator/kernel destruction of both cleanup actors is
 outside a one-shot process contract and would require the deliberately rejected
 persistent service.
 
+After the requested KILL case has reaped the complete provider group, the
+kernel may retain the API socket name. The ordinary controller may unlink only
+that one expected name after revalidating socket type, target uid/gid, and
+mode. TERM residue, any extra entry, and every identity or mode mismatch remain
+terminal; this deterministic owned-name cleanup is distinct from a forced
+process cleanup.
+
 The fixed #1943 probe carries no guest fixture or result. It proves repeat
 completion and live TERM/KILL using ordinary private API-grant material created
 only after drop. The contained worker's finite `--version` command publishes

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3155,17 +3155,20 @@ subordinates. The former group must be absent after the exact provider reap.
 The kernel may still retain the API socket name; the ordinary controller
 removes only that one expected socket after revalidating its type, target
 uid/gid, and mode. Any TERM residue, unexpected entry, identity/mode mismatch,
-or additional cleanup remains terminal. The test also snapshots the exact
-production-session namespace before each signal case and requires the same
-name/inode/child baseline after convergence; it never deletes a durable socket
-ownership record.
+or additional cleanup remains terminal. The test also requires an empty,
+descriptor-anchored production-session namespace before the probe set,
+snapshots it before each signal case, and requires the same empty baseline
+after convergence; it never deletes a durable socket ownership record.
 
 The focused product gate runs two clean version completions and live API-process
 TERM/KILL through the normal bundle. Private API grant material is created only
 after credential drop and is never emitted. After its authenticated contained
 bootstrap and grant acceptance, the finite worker `--version` path publishes
 the existing `NoApi` readiness before output and terminal completion; direct
-version behavior is unchanged. Exact success is:
+version behavior is unchanged. The ordinary controller alone resolves its own
+home after irreversible drop to require an empty production-session root before
+the probes and the same empty root afterward; root actors and public output
+receive no account name or path. Exact success is:
 
 ```text
 bangbang elevated vmnet handoff proof: ordinary=passed complete=passed repeat=passed term=passed kill=passed cleanup=passed

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3150,7 +3150,10 @@ Process observation is only `pid/ppid/state/comm`.
 
 The focused product gate runs two clean version completions and live API-process
 TERM/KILL through the normal bundle. Private API grant material is created only
-after credential drop and is never emitted. Exact success is:
+after credential drop and is never emitted. After its authenticated contained
+bootstrap and grant acceptance, the finite worker `--version` path publishes
+the existing `NoApi` readiness before output and terminal completion; direct
+version behavior is unchanged. Exact success is:
 
 ```text
 bangbang elevated vmnet handoff proof: ordinary=passed complete=passed repeat=passed term=passed kill=passed cleanup=passed

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3148,6 +3148,12 @@ identities and clean; guardian loss makes the supervisor do the same. Any
 forced or uncertain cleanup fails the gate even when absence is recovered.
 Process observation is only `pid/ppid/state/comm`.
 
+The requested KILL case may leave the kernel-owned API socket name after every
+process is reaped. The ordinary controller removes only that one expected
+socket after revalidating its type, target uid/gid, and mode. Any TERM residue,
+unexpected entry, identity/mode mismatch, or additional cleanup remains
+terminal; this exact owned-name removal is not a fallback process cleanup.
+
 The focused product gate runs two clean version completions and live API-process
 TERM/KILL through the normal bundle. Private API grant material is created only
 after credential drop and is never emitted. After its authenticated contained

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3148,11 +3148,17 @@ identities and clean; guardian loss makes the supervisor do the same. Any
 forced or uncertain cleanup fails the gate even when absence is recovered.
 Process observation is only `pid/ppid/state/comm`.
 
-The requested KILL case may leave the kernel-owned API socket name after every
-process is reaped. The ordinary controller removes only that one expected
-socket after revalidating its type, target uid/gid, and mode. Any TERM residue,
-unexpected entry, identity/mode mismatch, or additional cleanup remains
-terminal; this exact owned-name removal is not a fallback process cleanup.
+TERM targets the exact provider group. KILL sends SIGKILL only to the exact
+root provider leader, keeps that child unreaped while ordinary parent-loss
+cleanup runs, and then uses bounded group TERM/KILL escalation only for live
+subordinates. The former group must be absent after the exact provider reap.
+The kernel may still retain the API socket name; the ordinary controller
+removes only that one expected socket after revalidating its type, target
+uid/gid, and mode. Any TERM residue, unexpected entry, identity/mode mismatch,
+or additional cleanup remains terminal. The test also snapshots the exact
+production-session namespace before each signal case and requires the same
+name/inode/child baseline after convergence; it never deletes a durable socket
+ownership record.
 
 The focused product gate runs two clean version completions and live API-process
 TERM/KILL through the normal bundle. Private API grant material is created only

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3090,6 +3090,86 @@ or execute the final concurrency/death matrix, so the inventory remains exactly
 `383/0/2/33` and global final validation still fails only on the two retained
 network rows.
 
+### Least-privileged elevated certification handoff
+
+#1943 replaces the all-root topology driver as the process-control foundation
+for the later canonical certification. Preparation runs as the ordinary target
+user from a clean source and publishes one absent destination with a fixed
+name:
+
+```sh
+scripts/prepare-elevated-vmnet-handoff.sh \
+  --output /absolute/absent/bangbang-elevated-vmnet-handoff
+```
+
+The package contains the normal ad-hoc-signed networkless `Bangbang.app`, not a
+test-feature product. Its canonical manifest binds the source commit/tree,
+the fixed preparation/run/build implementation hashes, and every relative
+directory/file name, type, mode, size, and SHA-256. The preparer rejects dirty
+source, links, hard links, special or writable nodes, unexpected residue,
+replacement, and a pre-existing destination; it rechecks source and package
+identity before an exclusive `renamex_np(RENAME_EXCL)` publication.
+
+The caller separately authorizes the fixed root entry and supplies only the
+prepared package and its ordinary owner's numeric ids:
+
+```sh
+sudo -- scripts/run-elevated-vmnet-handoff.sh \
+  --prepared /absolute/absent/bangbang-elevated-vmnet-handoff \
+  --target-uid TARGET_UID \
+  --target-gid TARGET_GID
+```
+
+The wrapper closes stdin and never invokes an elevation frontend. Root stages
+and revalidates the exact product, then a protocol supervisor forks one
+controller, clears groups, sets gid before uid, and attests real/effective/saved
+ids plus failed root restoration before the controller loader runs. The root
+side can launch only its staged entitlement-free provider with the fixed
+bootstrap prefix, `/` cwd, `LANG/LC_ALL=C`, null stdin, fresh process group,
+and opaque bounded launcher arguments. Provider stdout/stderr arrive as exactly
+two read-only pipe descriptors; no arbitrary root executable or path is
+accepted.
+
+The local protocol uses exact 4096-byte authenticated Unix datagrams. Both
+endpoints first set and read back 8192-byte send/receive buffers because the
+target macOS default is too small for one atomic frame. Each record binds role,
+kind, descriptor count, monotonic sequence, request correlation, random
+session, handle/value, payload length, reserved-zero bytes, SHA-256, and a zero
+tail. The closed graph permits only welcome/ready, spawn, poll/bounded wait,
+TERM, KILL, close, and finish. Wrong, duplicate, excess, truncated, replayed,
+skipped, cross-session, post-terminal, or descriptor-confused traffic is
+terminal.
+
+A root guardian and supervisor hold reciprocal liveness. On normal completion
+the supervisor stays alive after `complete` until the guardian proves the
+controller and exact staged provider/launcher/worker images absent, removes
+the stage, and sends `ack`. Supervisor loss makes the guardian retire captured
+identities and clean; guardian loss makes the supervisor do the same. Any
+forced or uncertain cleanup fails the gate even when absence is recovered.
+Process observation is only `pid/ppid/state/comm`.
+
+The focused product gate runs two clean version completions and live API-process
+TERM/KILL through the normal bundle. Private API grant material is created only
+after credential drop and is never emitted. Exact success is:
+
+```text
+bangbang elevated vmnet handoff proof: ordinary=passed complete=passed repeat=passed term=passed kill=passed cleanup=passed
+```
+
+Portable manifest, protocol, descriptor, credential, loss, output, and cleanup
+coverage runs without root or Apple authorization:
+
+```sh
+python3 -m unittest scripts.tests.test_elevated_vmnet_handoff
+```
+
+The caller's explicit authorization of the fixed repository entry is the trust
+decision. Manifest implementation hashes prove source/package coherence and
+reject stale packages; they do not authenticate an otherwise modified entry.
+This child publishes neither the canonical private plan/result nor a capability
+claim. #1944 consumes its ordinary process factory, while the inventory remains
+exactly `383/0/2/33` and global final retains the same two network outcomes.
+
 The signed `hvf_lifecycle` native-v1 composite case builds the accepted one-
 vCPU/read-only-root session and gives the production generalized publisher two
 absent final paths. Its producer captures the complete non-memory state and

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -82,6 +82,28 @@ CLEANUP_TIMEOUT = 10.0
 POLL_SECONDS = 0.05
 MAX_CAPTURE_BYTES = 256 * 1024
 
+CONTROLLER_FAILURES = (
+    "internal",
+    "protocol",
+    "protocol-timeout",
+    "descriptor",
+    "arguments",
+    "output",
+    "timeout",
+    "cleanup",
+    "probe",
+    "controller",
+)
+SUPERVISOR_PHASES = (
+    "initial",
+    "fork",
+    "credentials",
+    "handshake",
+    "lifecycle",
+    "controller-exit",
+    "cleanup-ack",
+)
+
 PROC_PIDTBSDINFO = 3
 PROC_PIDPATHINFO_MAXSIZE = 4096
 
@@ -1667,6 +1689,15 @@ class ProviderSupervisor:
                         raise
                     finally:
                         _close_descriptors(outputs)
+                elif request.kind == Kind.FAILURE:
+                    if (
+                        request.handle
+                        or request.correlation
+                        or request.payload
+                        or not 1 <= request.value <= len(CONTROLLER_FAILURES)
+                    ):
+                        _fail("protocol")
+                    _fail(f"controller-{CONTROLLER_FAILURES[request.value - 1]}")
                 elif request.kind in (Kind.POLL, Kind.WAIT):
                     owned = self._require_handle(request)
                     if request.kind == Kind.POLL:
@@ -2322,6 +2353,8 @@ def _controller_child(
 ) -> NoReturn:
     exit_code = 1
     proxy: Optional[ControllerProxy] = None
+    session: Optional[SessionSocket] = None
+    failure_category = "internal"
     try:
         _redirect_stdio()
         _close_unrelated_descriptors({connection.fileno(), ready_descriptor})
@@ -2352,10 +2385,35 @@ def _controller_child(
         entry(proxy, layout, uid, gid)
         proxy.finish()
         exit_code = 0
+    except HandoffError as error:
+        failure_category = error.category
+        if proxy is not None:
+            try:
+                proxy.close()
+            except HandoffError:
+                pass
+        if session is not None and not session.terminal:
+            try:
+                category = (
+                    failure_category
+                    if failure_category in CONTROLLER_FAILURES
+                    else "internal"
+                )
+                session.send(
+                    Kind.FAILURE,
+                    value=CONTROLLER_FAILURES.index(category) + 1,
+                )
+            except HandoffError:
+                pass
     except BaseException:
         if proxy is not None:
             try:
                 proxy.close()
+            except HandoffError:
+                pass
+        if session is not None and not session.terminal:
+            try:
+                session.send(Kind.FAILURE, value=1)
             except HandoffError:
                 pass
     finally:
@@ -2396,10 +2454,20 @@ def _guardian_lease_alive(descriptor: int) -> bool:
         return False
 
 
+def _receive_completion(connection: socket.socket) -> bytes:
+    message = bytearray()
+    while len(message) < 2:
+        chunk = connection.recv(2 - len(message))
+        if not chunk:
+            raise OSError("completion peer closed")
+        message.extend(chunk)
+    return bytes(message)
+
+
 def _supervisor_complete(connection: socket.socket) -> None:
     try:
         connection.settimeout(CLEANUP_TIMEOUT)
-        if connection.send(b"C") != 1 or connection.recv(2) != b"A":
+        if connection.send(b"C\x00") != 2 or _receive_completion(connection) != b"A\x00":
             _fail("guardian")
     except HandoffError:
         raise
@@ -2410,8 +2478,16 @@ def _supervisor_complete(connection: socket.socket) -> None:
 def _wait_supervisor_complete(connection: socket.socket) -> None:
     try:
         connection.settimeout(SESSION_TIMEOUT + CLEANUP_TIMEOUT)
-        if connection.recv(2) != b"C":
-            _fail("supervisor")
+        message = _receive_completion(connection)
+        if message == b"C\x00":
+            return
+        if (
+            len(message) == 2
+            and message[0] == ord("F")
+            and 1 <= message[1] <= len(SUPERVISOR_PHASES)
+        ):
+            _fail(f"supervisor-{SUPERVISOR_PHASES[message[1] - 1]}")
+        _fail("supervisor")
     except HandoffError:
         raise
     except (OSError, socket.timeout) as error:
@@ -2421,7 +2497,7 @@ def _wait_supervisor_complete(connection: socket.socket) -> None:
 def _acknowledge_guardian_cleanup(connection: socket.socket) -> None:
     try:
         connection.settimeout(CLEANUP_TIMEOUT)
-        if connection.send(b"A") != 1:
+        if connection.send(b"A\x00") != 2:
             _fail("supervisor")
     except HandoffError:
         raise
@@ -2445,7 +2521,9 @@ def _supervisor_entry(
     controller_socket: Optional[socket.socket] = None
     ready_read = ready_write = -1
     guardian_lost = False
+    phase = 1
     try:
+        phase = 2
         supervisor_socket, controller_socket = socket.socketpair(
             socket.AF_UNIX, socket.SOCK_DGRAM
         )
@@ -2475,6 +2553,7 @@ def _supervisor_entry(
         os.close(ready_read)
         ready_read = -1
         controller_identity = capture_process(controller_pid)
+        phase = 3
         if (
             controller_identity.parent_pid != os.getpid()
             or (
@@ -2492,6 +2571,7 @@ def _supervisor_entry(
         ):
             _fail("credentials")
         session_id = secrets.token_bytes(32)
+        phase = 4
         session = SessionSocket(
             RecordSocket(supervisor_socket), Role.SUPERVISOR, session_id
         )
@@ -2518,16 +2598,23 @@ def _supervisor_entry(
             controller_identity,
             guardian_lease,
         )
+        phase = 5
         server.serve()
+        phase = 6
         status = _wait_child(controller_pid, PROTOCOL_TIMEOUT)
         controller_pid = -1
         if os.waitstatus_to_exitcode(status) != 0 or server.providers:
             _fail("controller")
+        phase = 7
         _supervisor_complete(completion)
         if os.path.lexists(stage.root):
             _fail("cleanup")
         return 0
     except BaseException:
+        try:
+            completion.send(bytes((ord("F"), phase)))
+        except OSError:
+            pass
         guardian_lost = not _guardian_lease_alive(guardian_lease)
         if server is not None:
             try:
@@ -2651,7 +2738,7 @@ def run_root(
             identity_read = -1
         try:
             _wait_supervisor_complete(guardian_completion)
-        except HandoffError:
+        except HandoffError as error:
             guardian_completion.close()
             guardian_completion = None
             _waited, status = os.waitpid(supervisor_pid, 0)
@@ -2660,7 +2747,7 @@ def run_root(
                 forced = _retire_pid(controller_identity) or forced
             forced = force_stage_process_cleanup(stage) or forced
             remove_stage(stage)
-            raise HandoffError("session")
+            raise error
         if controller_identity is not None:
             forced = _retire_pid(controller_identity) or forced
         forced = force_stage_process_cleanup(stage) or forced

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -84,6 +84,7 @@ MAX_CAPTURE_BYTES = 256 * 1024
 
 CONTROLLER_FAILURES = (
     "internal",
+    "credentials",
     "protocol",
     "protocol-timeout",
     "descriptor",
@@ -2355,11 +2356,13 @@ def _controller_child(
     proxy: Optional[ControllerProxy] = None
     session: Optional[SessionSocket] = None
     failure_category = "internal"
+    ready_published = False
     try:
         _redirect_stdio()
         _close_unrelated_descriptors({connection.fileno(), ready_descriptor})
         transition_controller_credentials(uid, gid, supervisor_pid)
-        _write_all(ready_descriptor, b"R")
+        _write_all(ready_descriptor, b"R\x00")
+        ready_published = True
         os.close(ready_descriptor)
         ready_descriptor = -1
         session = SessionSocket(RecordSocket(connection), Role.CONTROLLER)
@@ -2387,6 +2390,19 @@ def _controller_child(
         exit_code = 0
     except HandoffError as error:
         failure_category = error.category
+        if ready_descriptor >= 0 and not ready_published:
+            try:
+                category = (
+                    failure_category
+                    if failure_category in CONTROLLER_FAILURES
+                    else "internal"
+                )
+                _write_all(
+                    ready_descriptor,
+                    bytes((ord("F"), CONTROLLER_FAILURES.index(category) + 1)),
+                )
+            except HandoffError:
+                pass
         if proxy is not None:
             try:
                 proxy.close()
@@ -2406,6 +2422,11 @@ def _controller_child(
             except HandoffError:
                 pass
     except BaseException:
+        if ready_descriptor >= 0 and not ready_published:
+            try:
+                _write_all(ready_descriptor, b"F\x01")
+            except HandoffError:
+                pass
         if proxy is not None:
             try:
                 proxy.close()
@@ -2548,12 +2569,18 @@ def _supervisor_entry(
         _write_all(identity_descriptor, struct.pack("!I", controller_pid))
         os.close(identity_descriptor)
         identity_descriptor = -1
-        if _read_exact(ready_read, 1, PROTOCOL_TIMEOUT) != b"R":
+        phase = 3
+        ready_record = _read_exact(ready_read, 2, PROTOCOL_TIMEOUT)
+        if ready_record != b"R\x00":
+            if (
+                ready_record[0] == ord("F")
+                and 1 <= ready_record[1] <= len(CONTROLLER_FAILURES)
+            ):
+                _fail(f"controller-{CONTROLLER_FAILURES[ready_record[1] - 1]}")
             _fail("credentials")
         os.close(ready_read)
         ready_read = -1
         controller_identity = capture_process(controller_pid)
-        phase = 3
         if (
             controller_identity.parent_pid != os.getpid()
             or (

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -87,6 +87,7 @@ CREDENTIAL_FAILURES = (
     "credentials-initial-process",
     "credentials-initial-root",
     "credentials-clear-groups",
+    "credentials-cleared-groups",
     "credentials-set-gid",
     "credentials-set-uid",
     "credentials-dropped-observe",
@@ -1235,6 +1236,12 @@ def transition_controller_credentials(
     except OSError as error:
         raise HandoffError("credentials-clear-groups") from error
     try:
+        cleared_groups = operations.groups()
+    except OSError as error:
+        raise HandoffError("credentials-cleared-groups") from error
+    if cleared_groups != [0]:
+        _fail("credentials-cleared-groups")
+    try:
         operations.set_gid(target_gid)
     except OSError as error:
         raise HandoffError("credentials-set-gid") from error
@@ -1248,7 +1255,11 @@ def transition_controller_credentials(
         raise HandoffError("credentials-dropped-observe") from error
     if not initial.same_process(dropped) or dropped.parent_pid != supervisor_pid:
         _fail("credentials-dropped-process")
-    if operations.groups():
+    try:
+        dropped_groups = operations.groups()
+    except OSError as error:
+        raise HandoffError("credentials-dropped-groups") from error
+    if dropped_groups != [target_gid]:
         _fail("credentials-dropped-groups")
     if (
         dropped.uid,
@@ -1277,7 +1288,11 @@ def transition_controller_credentials(
             current = operations.identity()
         except HandoffError as error:
             raise HandoffError("credentials-restored-observe") from error
-        if current != dropped or operations.groups():
+        try:
+            current_groups = operations.groups()
+        except OSError as error:
+            raise HandoffError("credentials-restored-state") from error
+        if current != dropped or current_groups != [target_gid]:
             _fail("credentials-restored-state")
     return dropped
 

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -2312,6 +2312,7 @@ def _probe_session_entries(
     tuple[str, int, int, tuple[tuple[str, int, int, int, int, int], ...]], ...
 ]:
     root = _probe_session_root() if root is None else root
+    root_descriptor = -1
     try:
         metadata = os.lstat(root)
     except FileNotFoundError:
@@ -2327,62 +2328,117 @@ def _probe_session_entries(
     ):
         _fail("probe-session-root")
     try:
-        entries = sorted(os.scandir(root), key=lambda entry: entry.name)
-        if len(entries) > 128:
+        root_descriptor = os.open(
+            root,
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
+        opened_root = os.fstat(root_descriptor)
+        if (
+            opened_root.st_dev,
+            opened_root.st_ino,
+            opened_root.st_uid,
+            opened_root.st_gid,
+            stat.S_IMODE(opened_root.st_mode),
+        ) != (
+            metadata.st_dev,
+            metadata.st_ino,
+            os.getuid(),
+            os.getgid(),
+            0o700,
+        ):
+            _fail("probe-session-root")
+        names = sorted(os.listdir(root_descriptor))
+        if len(names) > 128:
             _fail("probe-session-root")
         result = []
-        for entry in entries:
-            if re.fullmatch(r"session-[0-9a-f]{64}", entry.name) is None:
+        for name in names:
+            if re.fullmatch(r"session-[0-9a-f]{64}", name) is None:
                 _fail("probe-session-root")
-            session = entry.stat(follow_symlinks=False)
-            if (
-                not stat.S_ISDIR(session.st_mode)
-                or stat.S_ISLNK(session.st_mode)
-                or session.st_uid != os.getuid()
-                or session.st_gid != os.getgid()
-                or stat.S_IMODE(session.st_mode) != 0o700
-            ):
-                _fail("probe-session-root")
-            children = sorted(os.scandir(entry.path), key=lambda child: child.name)
-            if len(children) > 8:
-                _fail("probe-session-root")
-            child_rows = []
-            for child in children:
-                child_metadata = child.stat(follow_symlinks=False)
+            session_descriptor = os.open(
+                name,
+                os.O_RDONLY
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=root_descriptor,
+            )
+            try:
+                session = os.fstat(session_descriptor)
                 if (
-                    stat.S_ISLNK(child_metadata.st_mode)
-                    or child_metadata.st_uid != os.getuid()
-                    or child_metadata.st_gid != os.getgid()
-                    or not (
-                        stat.S_ISREG(child_metadata.st_mode)
-                        or stat.S_ISSOCK(child_metadata.st_mode)
-                    )
+                    not stat.S_ISDIR(session.st_mode)
+                    or session.st_uid != os.getuid()
+                    or session.st_gid != os.getgid()
+                    or stat.S_IMODE(session.st_mode) != 0o700
                 ):
                     _fail("probe-session-root")
-                child_rows.append(
+                children = sorted(os.listdir(session_descriptor))
+                if len(children) > 8:
+                    _fail("probe-session-root")
+                child_rows = []
+                for child in children:
+                    child_metadata = os.stat(
+                        child,
+                        dir_fd=session_descriptor,
+                        follow_symlinks=False,
+                    )
+                    if (
+                        stat.S_ISLNK(child_metadata.st_mode)
+                        or child_metadata.st_uid != os.getuid()
+                        or child_metadata.st_gid != os.getgid()
+                        or not (
+                            stat.S_ISREG(child_metadata.st_mode)
+                            or stat.S_ISSOCK(child_metadata.st_mode)
+                        )
+                    ):
+                        _fail("probe-session-root")
+                    child_rows.append(
+                        (
+                            child,
+                            stat.S_IFMT(child_metadata.st_mode)
+                            | stat.S_IMODE(child_metadata.st_mode),
+                            child_metadata.st_dev,
+                            child_metadata.st_ino,
+                            child_metadata.st_size,
+                            child_metadata.st_mtime_ns,
+                        )
+                    )
+                linked_session = os.stat(
+                    name,
+                    dir_fd=root_descriptor,
+                    follow_symlinks=False,
+                )
+                if (
+                    linked_session.st_dev,
+                    linked_session.st_ino,
+                ) != (session.st_dev, session.st_ino):
+                    _fail("probe-session-root")
+                result.append(
                     (
-                        child.name,
-                        stat.S_IFMT(child_metadata.st_mode)
-                        | stat.S_IMODE(child_metadata.st_mode),
-                        child_metadata.st_dev,
-                        child_metadata.st_ino,
-                        child_metadata.st_size,
-                        child_metadata.st_mtime_ns,
+                        name,
+                        session.st_dev,
+                        session.st_ino,
+                        tuple(child_rows),
                     )
                 )
-            result.append(
-                (
-                    entry.name,
-                    session.st_dev,
-                    session.st_ino,
-                    tuple(child_rows),
-                )
-            )
+            finally:
+                os.close(session_descriptor)
+        visible_root = os.lstat(root)
+        if (
+            visible_root.st_dev,
+            visible_root.st_ino,
+        ) != (opened_root.st_dev, opened_root.st_ino):
+            _fail("probe-session-root")
         return tuple(result)
     except HandoffError:
         raise
     except OSError as error:
         raise HandoffError("probe-session-root") from error
+    finally:
+        if root_descriptor >= 0:
+            os.close(root_descriptor)
 
 
 def _create_private_probe_root(
@@ -2682,18 +2738,27 @@ def _fixed_signal_probe(
 
 
 def run_fixed_probes(proxy: ControllerProxy, layout: ProductLayout, uid: int, gid: int) -> None:
-    _fixed_completion_probe(proxy, layout, uid, gid, "handoff-complete-1")
-    _fixed_completion_probe(proxy, layout, uid, gid, "handoff-complete-2")
-    for instance, kind, category in (
-        ("handoff-term", Kind.TERM, "probe-term-cleanup"),
-        ("handoff-kill", Kind.KILL, "probe-kill-cleanup"),
-    ):
-        try:
-            _fixed_signal_probe(proxy, layout, uid, gid, instance, kind)
-        except HandoffError as error:
-            if error.category == "cleanup":
-                raise HandoffError(category) from error
-            raise
+    session_root = _probe_session_root()
+    if _probe_session_entries(session_root):
+        _fail("probe-session-root")
+    try:
+        _fixed_completion_probe(proxy, layout, uid, gid, "handoff-complete-1")
+        _fixed_completion_probe(proxy, layout, uid, gid, "handoff-complete-2")
+        for instance, kind, category in (
+            ("handoff-term", Kind.TERM, "probe-term-cleanup"),
+            ("handoff-kill", Kind.KILL, "probe-kill-cleanup"),
+        ):
+            try:
+                _fixed_signal_probe(proxy, layout, uid, gid, instance, kind)
+            except HandoffError as error:
+                if error.category == "cleanup":
+                    raise HandoffError(category) from error
+                raise
+    finally:
+        if not _wait_until(
+            lambda: _probe_session_entries(session_root) == (), CLEANUP_TIMEOUT
+        ):
+            _fail("cleanup")
 
 
 ControllerEntry = Callable[[ControllerProxy, ProductLayout, int, int], None]

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -83,6 +83,8 @@ CLEANUP_TIMEOUT = 10.0
 POLL_SECONDS = 0.05
 MAX_CAPTURE_BYTES = 256 * 1024
 MAX_CREDENTIAL_GROUPS = 1024
+PROVIDER_PARENT_LOSS_GRACE = 0.5
+PROVIDER_SIGNAL_GRACE = 2.0
 
 CREDENTIAL_FAILURES = (
     "credentials-initial-observe",
@@ -128,6 +130,7 @@ PROBE_FAILURES = (
     "probe-path",
     "probe-private-root",
     "probe-private-file",
+    "probe-session-root",
     "probe-term-cleanup",
     "probe-kill-cleanup",
 )
@@ -1593,33 +1596,138 @@ class OwnedProvider:
     handle: int
 
 
+def _provider_group_has_live_members(process_group: int) -> bool:
+    if process_group <= 1 or os.geteuid() != 0:
+        _fail("cleanup")
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # On Darwin an unreaped session leader with no other live members
+        # yields EPERM even to root. Keeping that exact child unreaped pins the
+        # PGID while this probe distinguishes live descendants from the
+        # provider zombie.
+        return False
+    except OSError as error:
+        raise HandoffError("cleanup") from error
+    return True
+
+
+def _wait_provider_group_quiescent(
+    process_group: int, timeout: float = PROVIDER_SIGNAL_GRACE
+) -> bool:
+    return _wait_until(
+        lambda: not _provider_group_has_live_members(process_group), timeout
+    )
+
+
+def _provider_group_absent(process_group: int) -> bool:
+    if process_group <= 1 or os.geteuid() != 0:
+        _fail("cleanup")
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return True
+    except OSError as error:
+        raise HandoffError("cleanup") from error
+    return False
+
+
+def _send_group_cleanup_signal(process_group: int, value: signal.Signals) -> None:
+    if not _provider_group_has_live_members(process_group):
+        return
+    try:
+        os.killpg(process_group, value)
+    except (ProcessLookupError, PermissionError):
+        if _provider_group_has_live_members(process_group):
+            _fail("cleanup")
+    except OSError as error:
+        raise HandoffError("cleanup") from error
+
+
+def _signal_provider(provider: OwnedProvider, kind: Kind) -> int:
+    process = provider.process
+    if process.returncode is not None or kind not in (Kind.TERM, Kind.KILL):
+        _fail("signal")
+    try:
+        if os.getpgid(process.pid) != process.pid:
+            _fail("signal")
+        if kind == Kind.TERM:
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            os.kill(process.pid, signal.SIGKILL)
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("signal") from error
+
+    quiescent = _wait_provider_group_quiescent(
+        process.pid,
+        PROVIDER_SIGNAL_GRACE
+        if kind == Kind.TERM
+        else PROVIDER_PARENT_LOSS_GRACE,
+    )
+    if not quiescent and kind == Kind.KILL:
+        _send_group_cleanup_signal(process.pid, signal.SIGTERM)
+        quiescent = _wait_provider_group_quiescent(process.pid)
+    if not quiescent:
+        _send_group_cleanup_signal(process.pid, signal.SIGKILL)
+        quiescent = _wait_provider_group_quiescent(process.pid)
+    if not quiescent:
+        _fail("cleanup")
+
+    try:
+        status = process.wait(timeout=PROVIDER_SIGNAL_GRACE)
+    except subprocess.TimeoutExpired as error:
+        raise HandoffError("cleanup") from error
+    if kind == Kind.KILL and status != -signal.SIGKILL:
+        _fail("signal")
+    if not _wait_until(
+        lambda: _provider_group_absent(process.pid), PROVIDER_SIGNAL_GRACE
+    ):
+        _fail("cleanup")
+    return status
+
+
 def _terminate_provider(provider: OwnedProvider) -> bool:
     process = provider.process
-    forced = False
-    if process.poll() is not None:
-        return forced
+    if process.returncode is not None:
+        if not _wait_until(
+            lambda: _provider_group_absent(process.pid), PROVIDER_SIGNAL_GRACE
+        ):
+            _fail("cleanup")
+        return False
     try:
         if os.getpgid(process.pid) != process.pid:
             _fail("cleanup")
     except ProcessLookupError:
-        process.poll()
-        return forced
+        status = process.poll()
+        if status is None or not _provider_group_absent(process.pid):
+            _fail("cleanup")
+        return False
     except OSError as error:
         raise HandoffError("cleanup") from error
-    for value in (signal.SIGTERM, signal.SIGKILL):
-        try:
-            os.killpg(process.pid, value)
-            forced = True
-        except ProcessLookupError:
-            pass
-        except OSError as error:
-            raise HandoffError("cleanup") from error
-        try:
-            process.wait(timeout=2.0)
-            return forced
-        except subprocess.TimeoutExpired:
-            continue
-    _fail("cleanup")
+    forced = False
+    if _provider_group_has_live_members(process.pid):
+        _send_group_cleanup_signal(process.pid, signal.SIGTERM)
+        forced = True
+    quiescent = _wait_provider_group_quiescent(process.pid)
+    if not quiescent:
+        _send_group_cleanup_signal(process.pid, signal.SIGKILL)
+        forced = True
+        quiescent = _wait_provider_group_quiescent(process.pid)
+    if not quiescent:
+        _fail("cleanup")
+    try:
+        process.wait(timeout=PROVIDER_SIGNAL_GRACE)
+    except subprocess.TimeoutExpired as error:
+        raise HandoffError("cleanup") from error
+    if not _wait_until(
+        lambda: _provider_group_absent(process.pid), PROVIDER_SIGNAL_GRACE
+    ):
+        _fail("cleanup")
+    return forced
 
 
 class ProviderSupervisor:
@@ -1742,7 +1850,13 @@ class ProviderSupervisor:
                 )
 
     def _status(self, owned: OwnedProvider) -> Optional[int]:
-        return owned.process.poll()
+        status = owned.process.poll()
+        if status is not None and not _wait_until(
+            lambda: _provider_group_absent(owned.process.pid),
+            PROVIDER_SIGNAL_GRACE,
+        ):
+            _fail("cleanup")
+        return status
 
     def _wait_status(self, owned: OwnedProvider, milliseconds: int) -> Optional[int]:
         if not 1 <= milliseconds <= 1000:
@@ -1838,17 +1952,8 @@ class ProviderSupervisor:
                     owned = self._require_handle(request)
                     if request.value != 0:
                         _fail("protocol")
-                    if owned.process.poll() is None:
-                        try:
-                            os.killpg(
-                                owned.process.pid,
-                                signal.SIGTERM if request.kind == Kind.TERM else signal.SIGKILL,
-                            )
-                        except ProcessLookupError:
-                            pass
-                        except OSError as error:
-                            raise HandoffError("signal") from error
-                    self._reply_status(request, owned, owned.process.poll())
+                    status = _signal_provider(owned, request.kind)
+                    self._reply_status(request, owned, status)
                 elif request.kind == Kind.CLOSE:
                     owned = self._require_handle(request)
                     if request.value != 0:
@@ -2185,6 +2290,101 @@ def _write_private_file(path: Path, data: bytes) -> None:
         _fail("probe-private-file")
 
 
+def _probe_session_root() -> Path:
+    # This lookup runs only in the irreversibly ordinary controller. The root
+    # guardian and protocol supervisor never receive or discover the account
+    # name or home path.
+    try:
+        import pwd
+
+        account = pwd.getpwuid(os.getuid())
+        home = Path(account.pw_dir)
+    except (ImportError, KeyError, OSError) as error:
+        raise HandoffError("probe-session-root") from error
+    if account.pw_uid != os.getuid() or not home.is_absolute() or "\x00" in os.fspath(home):
+        _fail("probe-session-root")
+    return home / "Library/Containers" / WORKER_IDENTIFIER / "Data/tmp/bangbang-sessions-v1"
+
+
+def _probe_session_entries(
+    root: Optional[Path] = None,
+) -> tuple[
+    tuple[str, int, int, tuple[tuple[str, int, int, int, int, int], ...]], ...
+]:
+    root = _probe_session_root() if root is None else root
+    try:
+        metadata = os.lstat(root)
+    except FileNotFoundError:
+        return ()
+    except OSError as error:
+        raise HandoffError("probe-session-root") from error
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or metadata.st_gid != os.getgid()
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        _fail("probe-session-root")
+    try:
+        entries = sorted(os.scandir(root), key=lambda entry: entry.name)
+        if len(entries) > 128:
+            _fail("probe-session-root")
+        result = []
+        for entry in entries:
+            if re.fullmatch(r"session-[0-9a-f]{64}", entry.name) is None:
+                _fail("probe-session-root")
+            session = entry.stat(follow_symlinks=False)
+            if (
+                not stat.S_ISDIR(session.st_mode)
+                or stat.S_ISLNK(session.st_mode)
+                or session.st_uid != os.getuid()
+                or session.st_gid != os.getgid()
+                or stat.S_IMODE(session.st_mode) != 0o700
+            ):
+                _fail("probe-session-root")
+            children = sorted(os.scandir(entry.path), key=lambda child: child.name)
+            if len(children) > 8:
+                _fail("probe-session-root")
+            child_rows = []
+            for child in children:
+                child_metadata = child.stat(follow_symlinks=False)
+                if (
+                    stat.S_ISLNK(child_metadata.st_mode)
+                    or child_metadata.st_uid != os.getuid()
+                    or child_metadata.st_gid != os.getgid()
+                    or not (
+                        stat.S_ISREG(child_metadata.st_mode)
+                        or stat.S_ISSOCK(child_metadata.st_mode)
+                    )
+                ):
+                    _fail("probe-session-root")
+                child_rows.append(
+                    (
+                        child.name,
+                        stat.S_IFMT(child_metadata.st_mode)
+                        | stat.S_IMODE(child_metadata.st_mode),
+                        child_metadata.st_dev,
+                        child_metadata.st_ino,
+                        child_metadata.st_size,
+                        child_metadata.st_mtime_ns,
+                    )
+                )
+            result.append(
+                (
+                    entry.name,
+                    session.st_dev,
+                    session.st_ino,
+                    tuple(child_rows),
+                )
+            )
+        return tuple(result)
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("probe-session-root") from error
+
+
 def _create_private_probe_root(
     parent: Path = Path("/private/var/tmp"),
 ) -> Path:
@@ -2309,7 +2509,7 @@ def _remove_killed_probe_socket(path: Path) -> None:
         raise HandoffError("cleanup") from error
 
 
-def _cleanup_probe_root(root: Path) -> bool:
+def _cleanup_probe_root(root: Path, *, require_material: bool = True) -> bool:
     forced = False
     try:
         metadata = os.lstat(root)
@@ -2364,7 +2564,10 @@ def _cleanup_probe_root(root: Path) -> bool:
                     _fail("cleanup")
                 actual[relative] = kind
         if (
-            not {"api", "grants.json"}.issubset(actual)
+            (
+                require_material
+                and not {"api", "grants.json"}.issubset(actual)
+            )
             or set(actual) - set(expected)
             or any(
                 expected[name] != kind for name, kind in actual.items()
@@ -2393,8 +2596,11 @@ def _fixed_signal_probe(
     instance: str,
     kind: Kind,
 ) -> None:
+    session_root = _probe_session_root()
+    session_baseline = _probe_session_entries(session_root)
     root = _create_private_probe_root()
     process: Optional[RemoteProviderProcess] = None
+    material_complete = False
     try:
         api = root / "api"
         api.mkdir(mode=0o700)
@@ -2415,6 +2621,7 @@ def _fixed_signal_probe(
                 }
             ),
         )
+        material_complete = True
         socket_path = api / "api.sock"
         if len(os.fsencode(socket_path)) >= 104:
             _fail("probe-path")
@@ -2449,10 +2656,29 @@ def _fixed_signal_probe(
                 _fail("cleanup")
             _remove_killed_probe_socket(socket_path)
     finally:
+        cleanup_failure: Optional[HandoffError] = None
         if process is not None:
-            process.close()
-        if _cleanup_probe_root(root):
-            _fail("cleanup")
+            try:
+                process.close()
+            except HandoffError as error:
+                cleanup_failure = error
+        try:
+            if _cleanup_probe_root(root, require_material=material_complete):
+                _fail("cleanup")
+        except HandoffError as error:
+            if cleanup_failure is None:
+                cleanup_failure = error
+        try:
+            if not _wait_until(
+                lambda: _probe_session_entries(session_root) == session_baseline,
+                CLEANUP_TIMEOUT,
+            ):
+                _fail("cleanup")
+        except HandoffError as error:
+            if cleanup_failure is None:
+                cleanup_failure = error
+        if cleanup_failure is not None:
+            raise cleanup_failure
 
 
 def run_fixed_probes(proxy: ControllerProxy, layout: ProductLayout, uid: int, gid: int) -> None:

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -128,6 +128,8 @@ PROBE_FAILURES = (
     "probe-path",
     "probe-private-root",
     "probe-private-file",
+    "probe-term-cleanup",
+    "probe-kill-cleanup",
 )
 CONTROLLER_FAILURES = (
     "internal",
@@ -2434,8 +2436,16 @@ def _fixed_signal_probe(
 def run_fixed_probes(proxy: ControllerProxy, layout: ProductLayout, uid: int, gid: int) -> None:
     _fixed_completion_probe(proxy, layout, uid, gid, "handoff-complete-1")
     _fixed_completion_probe(proxy, layout, uid, gid, "handoff-complete-2")
-    _fixed_signal_probe(proxy, layout, uid, gid, "handoff-term", Kind.TERM)
-    _fixed_signal_probe(proxy, layout, uid, gid, "handoff-kill", Kind.KILL)
+    for instance, kind, category in (
+        ("handoff-term", Kind.TERM, "probe-term-cleanup"),
+        ("handoff-kill", Kind.KILL, "probe-kill-cleanup"),
+    ):
+        try:
+            _fixed_signal_probe(proxy, layout, uid, gid, instance, kind)
+        except HandoffError as error:
+            if error.category == "cleanup":
+                raise HandoffError(category) from error
+            raise
 
 
 ControllerEntry = Callable[[ControllerProxy, ProductLayout, int, int], None]

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -1,0 +1,2747 @@
+#!/usr/bin/env python3
+"""Prepare and run the least-privileged elevated vmnet handoff foundation."""
+
+from __future__ import annotations
+
+import argparse
+import array
+import ctypes
+import dataclasses
+import enum
+import fcntl
+import hashlib
+import json
+import os
+import platform
+import plistlib
+import re
+import resource
+import secrets
+import select
+import shutil
+import signal
+import socket
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, NoReturn, Optional, Sequence
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+BUILD_BUNDLE = REPOSITORY_ROOT / "scripts/build-production-bundle.sh"
+PREPARE_WRAPPER = REPOSITORY_ROOT / "scripts/prepare-elevated-vmnet-handoff.sh"
+RUN_WRAPPER = REPOSITORY_ROOT / "scripts/run-elevated-vmnet-handoff.sh"
+IMPLEMENTATION_PATHS = (
+    Path("scripts/elevated_vmnet_handoff.py"),
+    Path("scripts/prepare-elevated-vmnet-handoff.sh"),
+    Path("scripts/run-elevated-vmnet-handoff.sh"),
+    Path("scripts/build-production-bundle.sh"),
+)
+
+SCHEMA_VERSION = 1
+PACKAGE_KIND = "bangbang-elevated-vmnet-handoff"
+MANIFEST_NAME = "manifest.json"
+BUNDLE_NAME = "Bangbang.app"
+LAUNCHER_NAME = "bangbang"
+PROVIDER_NAME = "bangbang-vmnet-provider"
+WORKER_BUNDLE_NAME = "BangbangWorker.app"
+WORKER_NAME = "bangbang-worker"
+LAUNCHER_IDENTIFIER = "dev.bangbang"
+PROVIDER_IDENTIFIER = "dev.bangbang.vmnet-provider"
+WORKER_IDENTIFIER = "dev.bangbang.worker"
+MAX_MANIFEST_BYTES = 512 * 1024
+MAX_PACKAGE_ENTRIES = 512
+MAX_PACKAGE_BYTES = 2 * 1024 * 1024 * 1024
+MAX_IMPLEMENTATION_BYTES = 2 * 1024 * 1024
+GIT_OBJECT_RE = re.compile(r"[0-9a-f]{40,64}\Z")
+FIXED_ENVIRONMENT = {"LANG": "C", "LC_ALL": "C"}
+RENAME_EXCL = 0x0000_0004
+
+RECORD_BYTES = 4096
+RECORD_MAGIC = b"BBEH0001"
+RECORD_VERSION = 1
+RECORD_PREFIX = struct.Struct("!8sHHHHQQ32sQqI12s")
+DIGEST_OFFSET = RECORD_PREFIX.size
+PAYLOAD_OFFSET = DIGEST_OFFSET + 32
+MAX_RECORD_PAYLOAD = RECORD_BYTES - PAYLOAD_OFFSET
+MAX_ARGUMENTS = 64
+MAX_ARGUMENT_BYTES = 1024
+MAX_ARGUMENT_PAYLOAD = 3072
+MAX_ANCILLARY_DESCRIPTORS = 4
+SOCKET_BUFFER_BYTES = 8192
+PROTOCOL_TIMEOUT = 5.0
+WAIT_SLICE_MILLISECONDS = 250
+PROCESS_TIMEOUT = 90.0
+SESSION_TIMEOUT = 30.0 * 60.0
+CLEANUP_TIMEOUT = 10.0
+POLL_SECONDS = 0.05
+MAX_CAPTURE_BYTES = 256 * 1024
+
+PROC_PIDTBSDINFO = 3
+PROC_PIDPATHINFO_MAXSIZE = 4096
+
+
+class HandoffError(RuntimeError):
+    """One value-free handoff failure."""
+
+    def __init__(self, category: str) -> None:
+        super().__init__(category)
+        self.category = category
+
+
+class ClosedArgumentParser(argparse.ArgumentParser):
+    def error(self, _message: str) -> NoReturn:
+        raise HandoffError("invocation")
+
+
+def _fail(category: str) -> NoReturn:
+    raise HandoffError(category)
+
+
+def _parse_id(value: str) -> int:
+    if (
+        not value
+        or not value.isascii()
+        or not value.isdecimal()
+        or value.startswith("0")
+        or len(value) > 10
+    ):
+        _fail("invocation")
+    parsed = int(value)
+    if not 0 < parsed <= 0xFFFF_FFFF:
+        _fail("invocation")
+    return parsed
+
+
+def _canonical(value: object) -> bytes:
+    try:
+        return (
+            json.dumps(
+                value,
+                allow_nan=False,
+                ensure_ascii=True,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode("ascii")
+    except (TypeError, ValueError) as error:
+        raise HandoffError("manifest") from error
+
+
+def _duplicate_safe_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            _fail("manifest")
+        result[key] = value
+    return result
+
+
+def _load_canonical_json(path: Path, maximum: int) -> dict[str, Any]:
+    descriptor = -1
+    try:
+        before = os.lstat(path)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or stat.S_ISLNK(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size <= 0
+            or before.st_size > maximum
+        ):
+            _fail("manifest")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+            or opened.st_size != before.st_size
+        ):
+            _fail("manifest")
+        raw = bytearray()
+        while len(raw) <= maximum:
+            chunk = os.read(descriptor, min(64 * 1024, maximum + 1 - len(raw)))
+            if not chunk:
+                break
+            raw.extend(chunk)
+        after = os.fstat(descriptor)
+        visible = os.lstat(path)
+        if (
+            len(raw) > maximum
+            or after.st_dev != opened.st_dev
+            or after.st_ino != opened.st_ino
+            or after.st_size != opened.st_size
+            or visible.st_dev != opened.st_dev
+            or visible.st_ino != opened.st_ino
+        ):
+            _fail("manifest")
+        value = json.loads(bytes(raw), object_pairs_hook=_duplicate_safe_object)
+    except HandoffError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise HandoffError("manifest") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if not isinstance(value, dict) or bytes(raw) != _canonical(value):
+        _fail("manifest")
+    return value
+
+
+def _sha256_file(path: Path, maximum: int) -> tuple[int, str]:
+    descriptor = -1
+    digest = hashlib.sha256()
+    try:
+        before = os.lstat(path)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or stat.S_ISLNK(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size < 0
+            or before.st_size > maximum
+        ):
+            _fail("artifact")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+            or opened.st_size != before.st_size
+        ):
+            _fail("artifact")
+        while chunk := os.read(descriptor, 1024 * 1024):
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+        visible = os.lstat(path)
+        if (
+            after.st_dev != opened.st_dev
+            or after.st_ino != opened.st_ino
+            or after.st_size != opened.st_size
+            or visible.st_dev != opened.st_dev
+            or visible.st_ino != opened.st_ino
+            or visible.st_size != opened.st_size
+        ):
+            _fail("artifact")
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("artifact") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return before.st_size, digest.hexdigest()
+
+
+def _run_tool(
+    arguments: Sequence[str],
+    category: str,
+    *,
+    timeout: float = 30.0,
+    cwd: Path = REPOSITORY_ROOT,
+    maximum: int = MAX_CAPTURE_BYTES,
+    environment: Optional[Mapping[str, str]] = None,
+) -> subprocess.CompletedProcess[bytes]:
+    if not arguments or any(not value or "\x00" in value for value in arguments):
+        _fail("internal")
+    try:
+        result = subprocess.run(
+            tuple(arguments),
+            cwd=cwd,
+            env=dict(environment) if environment is not None else FIXED_ENVIRONMENT,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise HandoffError(category) from error
+    if len(result.stdout) > maximum or len(result.stderr) > maximum:
+        _fail(category)
+    return result
+
+
+@dataclasses.dataclass(frozen=True)
+class SourceIdentity:
+    commit: str
+    tree: str
+
+
+def read_clean_source_identity() -> SourceIdentity:
+    for arguments in (
+        ("/usr/bin/git", "diff-index", "--quiet", "HEAD", "--"),
+        ("/usr/bin/git", "diff-files", "--quiet", "--"),
+        (
+            "/usr/bin/git",
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=normal",
+            "--ignore-submodules=all",
+        ),
+    ):
+        outcome = _run_tool(arguments, "source", timeout=10.0)
+        if outcome.returncode != 0 or outcome.stdout or outcome.stderr:
+            _fail("source")
+
+    values: list[str] = []
+    for arguments in (
+        ("/usr/bin/git", "rev-parse", "--verify", "HEAD"),
+        ("/usr/bin/git", "rev-parse", "--verify", "HEAD^{tree}"),
+    ):
+        outcome = _run_tool(arguments, "source", timeout=10.0)
+        try:
+            lines = outcome.stdout.decode("ascii").splitlines()
+        except UnicodeDecodeError as error:
+            raise HandoffError("source") from error
+        if outcome.returncode != 0 or outcome.stderr or len(lines) != 1:
+            _fail("source")
+        values.append(lines[0])
+    if any(GIT_OBJECT_RE.fullmatch(value) is None for value in values):
+        _fail("source")
+    return SourceIdentity(*values)
+
+
+@dataclasses.dataclass(frozen=True)
+class ProductLayout:
+    bundle: Path
+    launcher: Path
+    provider: Path
+    worker_bundle: Path
+    worker: Path
+
+    @classmethod
+    def from_package(cls, package: Path) -> "ProductLayout":
+        if not package.is_absolute():
+            _fail("package")
+        bundle = package / BUNDLE_NAME
+        helpers = bundle / "Contents/Helpers"
+        worker_bundle = helpers / WORKER_BUNDLE_NAME
+        return cls(
+            bundle=bundle,
+            launcher=bundle / "Contents/MacOS" / LAUNCHER_NAME,
+            provider=helpers / PROVIDER_NAME,
+            worker_bundle=worker_bundle,
+            worker=worker_bundle / "Contents/MacOS" / WORKER_NAME,
+        )
+
+    def executable_paths(self) -> tuple[Path, Path, Path]:
+        return (self.provider, self.launcher, self.worker)
+
+
+def _iter_plain_tree(root: Path) -> list[tuple[Path, os.stat_result]]:
+    result: list[tuple[Path, os.stat_result]] = []
+    pending = [root]
+    while pending:
+        directory = pending.pop()
+        try:
+            entries = sorted(os.scandir(directory), key=lambda entry: entry.name)
+        except OSError as error:
+            raise HandoffError("package") from error
+        for entry in entries:
+            path = Path(entry.path)
+            try:
+                metadata = entry.stat(follow_symlinks=False)
+            except OSError as error:
+                raise HandoffError("package") from error
+            result.append((path, metadata))
+            if len(result) > MAX_PACKAGE_ENTRIES:
+                _fail("package")
+            if stat.S_ISDIR(metadata.st_mode):
+                pending.append(path)
+            elif not stat.S_ISREG(metadata.st_mode):
+                _fail("package")
+    return sorted(result, key=lambda item: item[0].relative_to(root).as_posix())
+
+
+def _path_name(root: Path, path: Path) -> str:
+    try:
+        name = path.relative_to(root).as_posix()
+        encoded = name.encode("utf-8")
+    except (UnicodeEncodeError, ValueError) as error:
+        raise HandoffError("package") from error
+    if (
+        not name
+        or name.startswith("/")
+        or "//" in name
+        or any(part in ("", ".", "..") for part in name.split("/"))
+        or len(encoded) > 4096
+        or any(byte < 0x20 or byte == 0x7F for byte in encoded)
+    ):
+        _fail("package")
+    return name
+
+
+def _implementation_records() -> list[dict[str, object]]:
+    records = []
+    for relative in IMPLEMENTATION_PATHS:
+        size, digest = _sha256_file(REPOSITORY_ROOT / relative, MAX_IMPLEMENTATION_BYTES)
+        records.append(
+            {"name": relative.as_posix(), "sha256": digest, "size_bytes": size}
+        )
+    return records
+
+
+def _entry_records(root: Path, owner: int, group: int) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    total = 0
+    for path, metadata in _iter_plain_tree(root):
+        name = _path_name(root, path)
+        if name == MANIFEST_NAME:
+            continue
+        mode = stat.S_IMODE(metadata.st_mode)
+        if (
+            metadata.st_uid != owner
+            or metadata.st_gid != group
+            or mode & 0o222
+            or stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1
+        ):
+            _fail("package")
+        if stat.S_ISDIR(metadata.st_mode):
+            if mode != 0o555:
+                _fail("package")
+            records.append({"kind": "directory", "mode": mode, "name": name})
+            continue
+        if mode not in (0o444, 0o555):
+            _fail("package")
+        size, digest = _sha256_file(path, MAX_PACKAGE_BYTES)
+        total += size
+        if total > MAX_PACKAGE_BYTES:
+            _fail("package")
+        records.append(
+            {
+                "kind": "file",
+                "mode": mode,
+                "name": name,
+                "sha256": digest,
+                "size_bytes": size,
+            }
+        )
+    if not records or records[0].get("name") != BUNDLE_NAME:
+        _fail("package")
+    return records
+
+
+def _codesign(arguments: Sequence[str], category: str) -> subprocess.CompletedProcess[bytes]:
+    outcome = _run_tool(("/usr/bin/codesign", *arguments), category)
+    if outcome.returncode != 0:
+        _fail(category)
+    return outcome
+
+
+def _entitlements(path: Path) -> dict[str, object]:
+    raw = _codesign(("--display", "--entitlements", "-", "--xml", os.fspath(path)), "signature").stdout
+    if not raw.strip():
+        return {}
+    try:
+        value = plistlib.loads(raw)
+    except (plistlib.InvalidFileException, ValueError) as error:
+        raise HandoffError("signature") from error
+    if not isinstance(value, dict):
+        _fail("signature")
+    return value
+
+
+def validate_product(layout: ProductLayout) -> None:
+    required = (*layout.executable_paths(), layout.worker_bundle)
+    try:
+        for path in required:
+            metadata = os.lstat(path)
+            if stat.S_ISLNK(metadata.st_mode):
+                _fail("layout")
+        for executable in layout.executable_paths():
+            metadata = os.lstat(executable)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1 or not metadata.st_mode & 0o111:
+                _fail("layout")
+        if not stat.S_ISDIR(os.lstat(layout.worker_bundle).st_mode):
+            _fail("layout")
+        profile = layout.worker_bundle / "Contents/embedded.provisionprofile"
+        if os.path.lexists(profile):
+            _fail("entitlements")
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("layout") from error
+
+    _codesign(("--verify", "--deep", "--strict", "--verbose=4", os.fspath(layout.bundle)), "signature")
+    for path, identifier in (
+        (layout.bundle, LAUNCHER_IDENTIFIER),
+        (layout.provider, PROVIDER_IDENTIFIER),
+        (layout.worker_bundle, WORKER_IDENTIFIER),
+    ):
+        details = _codesign(("--display", "--verbose=4", os.fspath(path)), "signature").stderr.decode(
+            "utf-8", errors="strict"
+        )
+        if (
+            f"Identifier={identifier}" not in details
+            or "runtime" not in details.lower()
+            or "Signature=adhoc" not in details
+        ):
+            _fail("signature")
+    if _entitlements(layout.bundle) or _entitlements(layout.provider):
+        _fail("entitlements")
+    if _entitlements(layout.worker_bundle) != {
+        "com.apple.security.app-sandbox": True,
+        "com.apple.security.hypervisor": True,
+    }:
+        _fail("entitlements")
+
+
+def _write_exclusive(path: Path, data: bytes, mode: int) -> None:
+    descriptor = -1
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+        descriptor = os.open(path, flags, mode)
+        offset = 0
+        while offset < len(data):
+            count = os.write(descriptor, data[offset:])
+            if count <= 0:
+                _fail("publication")
+            offset += count
+        os.fsync(descriptor)
+        os.fchmod(descriptor, mode)
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("publication") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def create_manifest(root: Path, source: SourceIdentity, owner: int, group: int) -> None:
+    if not root.is_absolute() or not isinstance(source, SourceIdentity):
+        _fail("invocation")
+    try:
+        metadata = os.lstat(root)
+    except OSError as error:
+        raise HandoffError("package") from error
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != owner
+        or metadata.st_gid != group
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+        or os.path.lexists(root / MANIFEST_NAME)
+    ):
+        _fail("package")
+    layout = ProductLayout.from_package(root)
+    validate_product(layout)
+    for path, child in reversed(_iter_plain_tree(root)):
+        mode = 0o555 if stat.S_ISDIR(child.st_mode) or child.st_mode & 0o111 else 0o444
+        try:
+            os.chmod(path, mode, follow_symlinks=False)
+        except OSError as error:
+            raise HandoffError("package") from error
+    entries = _entry_records(root, owner, group)
+    document = {
+        "bundle_profile": "adhoc-networkless",
+        "entries": entries,
+        "implementation": _implementation_records(),
+        "kind": PACKAGE_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "source": dataclasses.asdict(source),
+    }
+    _write_exclusive(root / MANIFEST_NAME, _canonical(document), 0o444)
+    try:
+        os.chmod(root, 0o500)
+    except OSError as error:
+        raise HandoffError("package") from error
+
+
+def _parse_manifest(document: Mapping[str, object]) -> tuple[SourceIdentity, list[dict[str, object]]]:
+    if set(document) != {
+        "bundle_profile",
+        "entries",
+        "implementation",
+        "kind",
+        "schema_version",
+        "source",
+    }:
+        _fail("manifest")
+    if (
+        document.get("schema_version") != SCHEMA_VERSION
+        or document.get("kind") != PACKAGE_KIND
+        or document.get("bundle_profile") != "adhoc-networkless"
+    ):
+        _fail("manifest")
+    source_value = document.get("source")
+    if not isinstance(source_value, dict) or set(source_value) != {"commit", "tree"}:
+        _fail("manifest")
+    commit, tree = source_value.get("commit"), source_value.get("tree")
+    if not isinstance(commit, str) or not isinstance(tree, str) or GIT_OBJECT_RE.fullmatch(commit) is None or GIT_OBJECT_RE.fullmatch(tree) is None:
+        _fail("manifest")
+    entries = document.get("entries")
+    implementations = document.get("implementation")
+    if not isinstance(entries, list) or not isinstance(implementations, list):
+        _fail("manifest")
+    if implementations != _implementation_records():
+        _fail("implementation")
+    return SourceIdentity(commit, tree), entries
+
+
+def verify_package(root: Path, owner: int, group: int, *, root_mode: int = 0o500) -> SourceIdentity:
+    if not root.is_absolute():
+        _fail("invocation")
+    try:
+        metadata = os.lstat(root)
+        manifest_metadata = os.lstat(root / MANIFEST_NAME)
+    except OSError as error:
+        raise HandoffError("package") from error
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != owner
+        or metadata.st_gid != group
+        or stat.S_IMODE(metadata.st_mode) != root_mode
+        or not stat.S_ISREG(manifest_metadata.st_mode)
+        or stat.S_ISLNK(manifest_metadata.st_mode)
+        or manifest_metadata.st_nlink != 1
+        or manifest_metadata.st_uid != owner
+        or manifest_metadata.st_gid != group
+        or stat.S_IMODE(manifest_metadata.st_mode) != 0o444
+    ):
+        _fail("package")
+    document = _load_canonical_json(root / MANIFEST_NAME, MAX_MANIFEST_BYTES)
+    source, expected_entries = _parse_manifest(document)
+    actual_entries = _entry_records(root, owner, group)
+    if actual_entries != expected_entries:
+        _fail("manifest")
+    validate_product(ProductLayout.from_package(root))
+    return source
+
+
+def _publish_exclusive(source: Path, destination: Path) -> None:
+    if sys.platform != "darwin":
+        _fail("platform")
+    library = ctypes.CDLL(None, use_errno=True)
+    renamex = library.renamex_np
+    renamex.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint)
+    renamex.restype = ctypes.c_int
+    result = renamex(os.fsencode(source), os.fsencode(destination), RENAME_EXCL)
+    if result != 0:
+        _fail("publication")
+
+
+def _remove_tree(path: Path) -> None:
+    try:
+        if os.path.lexists(path):
+            metadata = os.lstat(path)
+            if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+                _fail("cleanup")
+            os.chmod(path, 0o700)
+            for child, child_metadata in _iter_plain_tree(path):
+                if stat.S_ISDIR(child_metadata.st_mode):
+                    os.chmod(child, 0o700, follow_symlinks=False)
+            shutil.rmtree(path)
+        if os.path.lexists(path):
+            _fail("cleanup")
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("cleanup") from error
+
+
+def prepare_package(output: Path) -> None:
+    if (
+        not output.is_absolute()
+        or output.name != PACKAGE_KIND
+        or os.path.lexists(output)
+        or sys.platform != "darwin"
+        or platform.machine() != "arm64"
+        or os.getuid() == 0
+        or os.geteuid() == 0
+    ):
+        _fail("invocation")
+    parent = output.parent
+    try:
+        parent_metadata = os.lstat(parent)
+    except OSError as error:
+        raise HandoffError("invocation") from error
+    if not stat.S_ISDIR(parent_metadata.st_mode) or stat.S_ISLNK(parent_metadata.st_mode):
+        _fail("invocation")
+    source = read_clean_source_identity()
+    stage = Path(tempfile.mkdtemp(prefix=f".{PACKAGE_KIND}.stage.", dir=parent))
+    published = False
+    try:
+        outcome = _run_tool(
+            (os.fspath(BUILD_BUNDLE), "--output", os.fspath(stage / BUNDLE_NAME)),
+            "build",
+            timeout=1800.0,
+            maximum=1024 * 1024,
+            environment=os.environ,
+        )
+        if outcome.returncode != 0:
+            _fail("build")
+        if read_clean_source_identity() != source:
+            _fail("source")
+        create_manifest(stage, source, os.getuid(), os.getgid())
+        verify_package(stage, os.getuid(), os.getgid())
+        if read_clean_source_identity() != source or os.path.lexists(output):
+            _fail("source")
+        _publish_exclusive(stage, output)
+        published = True
+    finally:
+        if not published and os.path.lexists(stage):
+            _remove_tree(stage)
+
+
+class Role(enum.IntEnum):
+    SUPERVISOR = 1
+    CONTROLLER = 2
+
+
+class Kind(enum.IntEnum):
+    WELCOME = 1
+    READY = 2
+    SPAWN = 10
+    SPAWNED = 11
+    POLL = 12
+    WAIT = 13
+    RUNNING = 14
+    EXITED = 15
+    TERM = 16
+    KILL = 17
+    CLOSE = 18
+    CLOSED = 19
+    FINISH = 20
+    FINISHED = 21
+    FAILURE = 22
+
+
+@dataclasses.dataclass(frozen=True)
+class Record:
+    role: Role
+    kind: Kind
+    sequence: int
+    correlation: int
+    session: bytes
+    handle: int = 0
+    value: int = 0
+    payload: bytes = b""
+    descriptor_count: int = 0
+
+    def encode(self) -> bytes:
+        if (
+            not isinstance(self.role, Role)
+            or not isinstance(self.kind, Kind)
+            or not 1 <= self.sequence <= 0xFFFF_FFFF_FFFF_FFFF
+            or not 0 <= self.correlation <= 0xFFFF_FFFF_FFFF_FFFF
+            or len(self.session) != 32
+            or not 0 <= self.handle <= 0xFFFF_FFFF_FFFF_FFFF
+            or not -(1 << 63) <= self.value < (1 << 63)
+            or not isinstance(self.payload, bytes)
+            or len(self.payload) > MAX_RECORD_PAYLOAD
+            or not 0 <= self.descriptor_count <= MAX_ANCILLARY_DESCRIPTORS
+        ):
+            _fail("protocol")
+        prefix = RECORD_PREFIX.pack(
+            RECORD_MAGIC,
+            RECORD_VERSION,
+            int(self.role),
+            int(self.kind),
+            self.descriptor_count,
+            self.sequence,
+            self.correlation,
+            self.session,
+            self.handle,
+            self.value,
+            len(self.payload),
+            bytes(12),
+        )
+        digest = hashlib.sha256(prefix + self.payload).digest()
+        return prefix + digest + self.payload + bytes(MAX_RECORD_PAYLOAD - len(self.payload))
+
+    @classmethod
+    def decode(cls, raw: bytes) -> "Record":
+        if len(raw) != RECORD_BYTES:
+            _fail("protocol")
+        try:
+            (
+                magic,
+                version,
+                role,
+                kind,
+                descriptor_count,
+                sequence,
+                correlation,
+                session,
+                handle,
+                value,
+                payload_length,
+                reserved,
+            ) = RECORD_PREFIX.unpack(raw[:DIGEST_OFFSET])
+            decoded_role = Role(role)
+            decoded_kind = Kind(kind)
+        except (ValueError, struct.error) as error:
+            raise HandoffError("protocol") from error
+        if (
+            magic != RECORD_MAGIC
+            or version != RECORD_VERSION
+            or reserved != bytes(12)
+            or sequence == 0
+            or payload_length > MAX_RECORD_PAYLOAD
+            or descriptor_count > MAX_ANCILLARY_DESCRIPTORS
+        ):
+            _fail("protocol")
+        payload = raw[PAYLOAD_OFFSET : PAYLOAD_OFFSET + payload_length]
+        if raw[PAYLOAD_OFFSET + payload_length :] != bytes(MAX_RECORD_PAYLOAD - payload_length):
+            _fail("protocol")
+        expected = hashlib.sha256(raw[:DIGEST_OFFSET] + payload).digest()
+        if not secrets.compare_digest(raw[DIGEST_OFFSET:PAYLOAD_OFFSET], expected):
+            _fail("protocol")
+        return cls(
+            decoded_role,
+            decoded_kind,
+            sequence,
+            correlation,
+            session,
+            handle,
+            value,
+            payload,
+            descriptor_count,
+        )
+
+
+def _close_descriptors(descriptors: Iterable[int]) -> None:
+    for descriptor in descriptors:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+
+
+class RecordSocket:
+    def __init__(self, connection: socket.socket) -> None:
+        if connection.family != socket.AF_UNIX or connection.type & 0xF != socket.SOCK_DGRAM:
+            _fail("descriptor")
+        self.connection = connection
+        try:
+            self.connection.setsockopt(
+                socket.SOL_SOCKET, socket.SO_SNDBUF, SOCKET_BUFFER_BYTES
+            )
+            self.connection.setsockopt(
+                socket.SOL_SOCKET, socket.SO_RCVBUF, SOCKET_BUFFER_BYTES
+            )
+            if (
+                self.connection.getsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF)
+                < SOCKET_BUFFER_BYTES
+                or self.connection.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+                < SOCKET_BUFFER_BYTES
+            ):
+                _fail("descriptor")
+            self.connection.settimeout(PROTOCOL_TIMEOUT)
+        except HandoffError:
+            raise
+        except OSError as error:
+            raise HandoffError("descriptor") from error
+
+    def close(self) -> None:
+        try:
+            self.connection.close()
+        except OSError:
+            pass
+
+    def send(self, record: Record, descriptors: Sequence[int] = ()) -> None:
+        if len(descriptors) != record.descriptor_count:
+            _fail("descriptor")
+        ancillary = []
+        if descriptors:
+            encoded = array.array("i", descriptors)
+            ancillary.append((socket.SOL_SOCKET, socket.SCM_RIGHTS, encoded))
+        try:
+            sent = self.connection.sendmsg((record.encode(),), ancillary)
+        except (OSError, socket.timeout) as error:
+            raise HandoffError("protocol-timeout" if isinstance(error, socket.timeout) else "protocol") from error
+        if sent != RECORD_BYTES:
+            _fail("protocol")
+
+    def receive(self) -> tuple[Record, list[int]]:
+        descriptors: list[int] = []
+        rights_messages = 0
+        try:
+            raw, ancillary, flags, _address = self.connection.recvmsg(
+                RECORD_BYTES + 1,
+                socket.CMSG_SPACE(MAX_ANCILLARY_DESCRIPTORS * array.array("i").itemsize),
+            )
+            for level, kind, data in ancillary:
+                if level != socket.SOL_SOCKET or kind != socket.SCM_RIGHTS:
+                    _fail("descriptor")
+                values = array.array("i")
+                if not data or len(data) % values.itemsize:
+                    _fail("descriptor")
+                rights_messages += 1
+                usable = len(data) - len(data) % values.itemsize
+                values.frombytes(data[:usable])
+                descriptors.extend(values)
+            if flags & (getattr(socket, "MSG_TRUNC", 0) | getattr(socket, "MSG_CTRUNC", 0)):
+                _fail("descriptor")
+            record = Record.decode(raw)
+            if (
+                record.descriptor_count != len(descriptors)
+                or rights_messages != (1 if descriptors else 0)
+            ):
+                _fail("descriptor")
+            return record, descriptors
+        except HandoffError:
+            _close_descriptors(descriptors)
+            raise
+        except socket.timeout as error:
+            _close_descriptors(descriptors)
+            raise HandoffError("protocol-timeout") from error
+        except OSError as error:
+            _close_descriptors(descriptors)
+            raise HandoffError("protocol") from error
+
+
+class SessionSocket:
+    def __init__(self, transport: RecordSocket, role: Role, session: Optional[bytes] = None) -> None:
+        self.transport = transport
+        self.role = role
+        self.peer = Role.CONTROLLER if role == Role.SUPERVISOR else Role.SUPERVISOR
+        self.session = session
+        self.send_sequence = 1
+        self.receive_sequence = 1
+        self.terminal = False
+
+    def send(
+        self,
+        kind: Kind,
+        *,
+        correlation: int = 0,
+        handle: int = 0,
+        value: int = 0,
+        payload: bytes = b"",
+        descriptors: Sequence[int] = (),
+    ) -> int:
+        if self.terminal or self.session is None:
+            _fail("protocol")
+        sequence = self.send_sequence
+        record = Record(
+            self.role,
+            kind,
+            sequence,
+            correlation,
+            self.session,
+            handle,
+            value,
+            payload,
+            len(descriptors),
+        )
+        self.transport.send(record, descriptors)
+        if sequence == 0xFFFF_FFFF_FFFF_FFFF:
+            self.terminal = True
+        else:
+            self.send_sequence += 1
+        return sequence
+
+    def receive(self, *, allow_unbound_welcome: bool = False) -> tuple[Record, list[int]]:
+        if self.terminal:
+            _fail("protocol")
+        record, descriptors = self.transport.receive()
+        if (
+            record.role != self.peer
+            or record.sequence != self.receive_sequence
+            or (
+                self.session is not None
+                and not secrets.compare_digest(record.session, self.session)
+            )
+        ):
+            _close_descriptors(descriptors)
+            _fail("protocol")
+        if self.session is None:
+            if not allow_unbound_welcome or record.kind != Kind.WELCOME:
+                _close_descriptors(descriptors)
+                _fail("protocol")
+            self.session = record.session
+        if record.sequence == 0xFFFF_FFFF_FFFF_FFFF:
+            self.terminal = True
+        else:
+            self.receive_sequence += 1
+        return record, descriptors
+
+
+def encode_arguments(arguments: Sequence[bytes]) -> bytes:
+    if not arguments or len(arguments) > MAX_ARGUMENTS:
+        _fail("arguments")
+    payload = bytearray(struct.pack("!H", len(arguments)))
+    for argument in arguments:
+        if (
+            not isinstance(argument, bytes)
+            or not argument
+            or len(argument) > MAX_ARGUMENT_BYTES
+            or b"\x00" in argument
+        ):
+            _fail("arguments")
+        payload.extend(struct.pack("!H", len(argument)))
+        payload.extend(argument)
+    if len(payload) > MAX_ARGUMENT_PAYLOAD:
+        _fail("arguments")
+    return bytes(payload)
+
+
+def decode_arguments(payload: bytes) -> tuple[bytes, ...]:
+    if not 2 <= len(payload) <= MAX_ARGUMENT_PAYLOAD:
+        _fail("arguments")
+    try:
+        count = struct.unpack_from("!H", payload)[0]
+    except struct.error as error:
+        raise HandoffError("arguments") from error
+    if not 1 <= count <= MAX_ARGUMENTS:
+        _fail("arguments")
+    result = []
+    offset = 2
+    for _index in range(count):
+        if offset + 2 > len(payload):
+            _fail("arguments")
+        length = struct.unpack_from("!H", payload, offset)[0]
+        offset += 2
+        if not 1 <= length <= MAX_ARGUMENT_BYTES or offset + length > len(payload):
+            _fail("arguments")
+        value = payload[offset : offset + length]
+        if b"\x00" in value:
+            _fail("arguments")
+        result.append(value)
+        offset += length
+    if offset != len(payload):
+        _fail("arguments")
+    return tuple(result)
+
+
+class ProcBsdInfo(ctypes.Structure):
+    _fields_ = [
+        ("flags", ctypes.c_uint32),
+        ("status", ctypes.c_uint32),
+        ("xstatus", ctypes.c_uint32),
+        ("pid", ctypes.c_uint32),
+        ("ppid", ctypes.c_uint32),
+        ("uid", ctypes.c_uint32),
+        ("gid", ctypes.c_uint32),
+        ("ruid", ctypes.c_uint32),
+        ("rgid", ctypes.c_uint32),
+        ("svuid", ctypes.c_uint32),
+        ("svgid", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint32),
+        ("command", ctypes.c_char * 16),
+        ("name", ctypes.c_char * 32),
+        ("nfiles", ctypes.c_uint32),
+        ("pgid", ctypes.c_uint32),
+        ("pjobc", ctypes.c_uint32),
+        ("terminal_device", ctypes.c_uint32),
+        ("terminal_pgid", ctypes.c_uint32),
+        ("nice", ctypes.c_int32),
+        ("start_seconds", ctypes.c_uint64),
+        ("start_microseconds", ctypes.c_uint64),
+    ]
+
+
+@dataclasses.dataclass(frozen=True)
+class ProcessIdentity:
+    pid: int
+    parent_pid: int
+    process_group: int
+    session: int
+    uid: int
+    gid: int
+    real_uid: int
+    real_gid: int
+    saved_uid: int
+    saved_gid: int
+    start_seconds: int
+    start_microseconds: int
+    executable: Path
+
+    def same_process(self, other: "ProcessIdentity") -> bool:
+        return (
+            self.pid,
+            self.start_seconds,
+            self.start_microseconds,
+            self.executable,
+        ) == (
+            other.pid,
+            other.start_seconds,
+            other.start_microseconds,
+            other.executable,
+        )
+
+
+def _libproc() -> ctypes.CDLL:
+    try:
+        library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+    except OSError as error:
+        raise HandoffError("identity") from error
+    library.proc_pidinfo.argtypes = (
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+        ctypes.c_int,
+    )
+    library.proc_pidinfo.restype = ctypes.c_int
+    library.proc_pidpath.argtypes = (
+        ctypes.c_int,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    )
+    library.proc_pidpath.restype = ctypes.c_int
+    return library
+
+
+def capture_process(pid: int) -> ProcessIdentity:
+    if sys.platform != "darwin" or not 1 < pid <= 0x7FFF_FFFF:
+        _fail("identity")
+    library = _libproc()
+    info = ProcBsdInfo()
+    size = ctypes.sizeof(info)
+    if library.proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, ctypes.byref(info), size) != size:
+        _fail("identity")
+    path_buffer = ctypes.create_string_buffer(PROC_PIDPATHINFO_MAXSIZE)
+    path_length = library.proc_pidpath(pid, path_buffer, PROC_PIDPATHINFO_MAXSIZE)
+    if path_length <= 0 or path_length >= PROC_PIDPATHINFO_MAXSIZE:
+        _fail("identity")
+    try:
+        executable = Path(path_buffer.raw[:path_length].decode("utf-8"))
+        session_id = os.getsid(pid)
+    except (OSError, UnicodeDecodeError) as error:
+        raise HandoffError("identity") from error
+    values = (
+        int(info.pid),
+        int(info.ppid),
+        int(info.pgid),
+        int(session_id),
+        int(info.uid),
+        int(info.gid),
+        int(info.ruid),
+        int(info.rgid),
+        int(info.svuid),
+        int(info.svgid),
+        int(info.start_seconds),
+        int(info.start_microseconds),
+    )
+    if values[0] != pid or any(value < 0 for value in values) or not executable.is_absolute():
+        _fail("identity")
+    return ProcessIdentity(*values, executable)
+
+
+class CredentialBackend:
+    """Injectable credential operations for the post-fork controller transition."""
+
+    def groups(self) -> list[int]:
+        return list(os.getgroups())
+
+    def clear_groups(self) -> None:
+        os.setgroups([])
+
+    def set_gid(self, value: int) -> None:
+        os.setgid(value)
+
+    def set_uid(self, value: int) -> None:
+        os.setuid(value)
+
+    def restore_groups(self) -> None:
+        os.setgroups([0])
+
+    def identity(self) -> ProcessIdentity:
+        return capture_process(os.getpid())
+
+
+def transition_controller_credentials(
+    target_uid: int,
+    target_gid: int,
+    supervisor_pid: int,
+    backend: Optional[CredentialBackend] = None,
+) -> ProcessIdentity:
+    if target_uid == 0 or target_gid == 0 or supervisor_pid <= 1:
+        _fail("credentials")
+    operations = backend if backend is not None else CredentialBackend()
+    initial = operations.identity()
+    if (
+        initial.pid != os.getpid()
+        or initial.parent_pid != supervisor_pid
+        or any(
+            value != 0
+            for value in (
+                initial.uid,
+                initial.gid,
+                initial.real_uid,
+                initial.real_gid,
+                initial.saved_uid,
+                initial.saved_gid,
+            )
+        )
+    ):
+        _fail("credentials")
+    try:
+        operations.clear_groups()
+        operations.set_gid(target_gid)
+        operations.set_uid(target_uid)
+    except OSError as error:
+        raise HandoffError("credentials") from error
+    dropped = operations.identity()
+    if (
+        not initial.same_process(dropped)
+        or dropped.parent_pid != supervisor_pid
+        or operations.groups()
+        or (
+            dropped.uid,
+            dropped.real_uid,
+            dropped.saved_uid,
+        )
+        != (target_uid, target_uid, target_uid)
+        or (
+            dropped.gid,
+            dropped.real_gid,
+            dropped.saved_gid,
+        )
+        != (target_gid, target_gid, target_gid)
+    ):
+        _fail("credentials")
+    for restore in (
+        lambda: operations.set_uid(0),
+        lambda: operations.set_gid(0),
+        operations.restore_groups,
+    ):
+        try:
+            restore()
+        except OSError:
+            pass
+        else:
+            _fail("credentials")
+        current = operations.identity()
+        if current != dropped or operations.groups():
+            _fail("credentials")
+    return dropped
+
+
+@dataclasses.dataclass(frozen=True)
+class ProcessRecord:
+    pid: int
+    parent_pid: int
+    state: str
+    command: str
+
+
+def _parse_process_table(raw: str) -> dict[int, ProcessRecord]:
+    records: dict[int, ProcessRecord] = {}
+    for line in raw.splitlines():
+        fields = line.strip().split(maxsplit=3)
+        if len(fields) != 4:
+            continue
+        try:
+            pid, parent = int(fields[0]), int(fields[1])
+        except ValueError:
+            continue
+        if pid <= 0 or parent < 0 or pid in records or not fields[2] or not fields[3]:
+            continue
+        records[pid] = ProcessRecord(pid, parent, fields[2], fields[3])
+    return records
+
+
+def _process_table() -> dict[int, ProcessRecord]:
+    outcome = _run_tool(
+        ("/bin/ps", "-axo", "pid=,ppid=,state=,comm="),
+        "process",
+        timeout=5.0,
+    )
+    if outcome.returncode != 0 or outcome.stderr:
+        _fail("process")
+    try:
+        return _parse_process_table(outcome.stdout.decode("utf-8", errors="strict"))
+    except UnicodeDecodeError as error:
+        raise HandoffError("process") from error
+
+
+@dataclasses.dataclass(frozen=True)
+class Stage:
+    root: Path
+    package: Path
+    layout: ProductLayout
+    device: int
+    inode: int
+
+
+def _normalize_root_copy(root: Path) -> None:
+    try:
+        for path, metadata in reversed(_iter_plain_tree(root)):
+            os.lchown(path, 0, 0)
+            mode = 0o555 if stat.S_ISDIR(metadata.st_mode) or metadata.st_mode & 0o111 else 0o444
+            os.chmod(path, mode, follow_symlinks=False)
+        os.lchown(root, 0, 0)
+        os.chmod(root, 0o555)
+    except OSError as error:
+        raise HandoffError("staging") from error
+
+
+def stage_package(prepared: Path, uid: int, gid: int) -> Stage:
+    expected_source = verify_package(prepared, uid, gid)
+    try:
+        root = Path(
+            tempfile.mkdtemp(
+                prefix="bangbang-elevated-handoff.", dir="/private/var/tmp"
+            )
+        )
+        package = root / "package"
+        shutil.copytree(prepared, package, symlinks=True, copy_function=shutil.copy2)
+        _normalize_root_copy(package)
+        if verify_package(prepared, uid, gid) != expected_source:
+            _fail("staging")
+        if verify_package(package, 0, 0, root_mode=0o555) != expected_source:
+            _fail("staging")
+        layout = ProductLayout.from_package(package)
+        validate_product(layout)
+        root_metadata = os.lstat(root)
+        if (
+            not stat.S_ISDIR(root_metadata.st_mode)
+            or stat.S_ISLNK(root_metadata.st_mode)
+            or root_metadata.st_uid != 0
+            or root_metadata.st_gid != 0
+            or stat.S_IMODE(root_metadata.st_mode) != 0o700
+        ):
+            _fail("staging")
+        os.chmod(root, 0o711)
+        return Stage(root, package, layout, root_metadata.st_dev, root_metadata.st_ino)
+    except HandoffError:
+        if "root" in locals() and os.path.lexists(root):
+            try:
+                _remove_tree(root)
+            except HandoffError:
+                pass
+        raise
+    except OSError as error:
+        if "root" in locals() and os.path.lexists(root):
+            try:
+                _remove_tree(root)
+            except HandoffError:
+                pass
+        raise HandoffError("staging") from error
+
+
+def _stage_process_ids(stage: Stage, records: Mapping[int, ProcessRecord]) -> set[int]:
+    exact = {os.fspath(path) for path in stage.layout.executable_paths()}
+    return {
+        record.pid
+        for record in records.values()
+        if record.command in exact
+    }
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = CLEANUP_TIMEOUT) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(POLL_SECONDS)
+    return predicate()
+
+
+def _retire_pid(identity: ProcessIdentity) -> bool:
+    forced = False
+    try:
+        current = capture_process(identity.pid)
+    except HandoffError:
+        if identity.pid not in _process_table():
+            return forced
+        _fail("cleanup")
+    if not current.same_process(identity):
+        _fail("cleanup")
+    for value in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.kill(identity.pid, value)
+            forced = True
+        except ProcessLookupError:
+            return forced
+        except OSError as error:
+            raise HandoffError("cleanup") from error
+        if _wait_until(
+            lambda: _process_identity_absent(identity),
+            timeout=2.0,
+        ):
+            return forced
+    _fail("cleanup")
+
+
+def _process_identity_absent(identity: ProcessIdentity) -> bool:
+    try:
+        current = capture_process(identity.pid)
+    except HandoffError:
+        if identity.pid not in _process_table():
+            return True
+        _fail("cleanup")
+    if not current.same_process(identity):
+        _fail("cleanup")
+    return False
+
+
+def force_stage_process_cleanup(stage: Stage) -> bool:
+    forced = False
+    for value in (signal.SIGTERM, signal.SIGKILL):
+        identifiers = _stage_process_ids(stage, _process_table())
+        if not identifiers:
+            return forced
+        for pid in sorted(identifiers, reverse=True):
+            try:
+                os.kill(pid, value)
+                forced = True
+            except ProcessLookupError:
+                pass
+            except OSError as error:
+                raise HandoffError("cleanup") from error
+        if _wait_until(lambda: not _stage_process_ids(stage, _process_table()), timeout=2.0):
+            return forced
+    _fail("cleanup")
+
+
+def remove_stage(stage: Stage) -> None:
+    try:
+        metadata = os.lstat(stage.root)
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_dev != stage.device
+            or metadata.st_ino != stage.inode
+            or metadata.st_uid != 0
+            or metadata.st_gid != 0
+            or stat.S_IMODE(metadata.st_mode) not in (0o700, 0o711)
+            or _stage_process_ids(stage, _process_table())
+        ):
+            _fail("cleanup")
+        os.chmod(stage.root, 0o700)
+        shutil.rmtree(stage.root)
+        if os.path.lexists(stage.root):
+            _fail("cleanup")
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("cleanup") from error
+
+
+def _validate_output_descriptor(descriptor: int) -> None:
+    try:
+        metadata = os.fstat(descriptor)
+        flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+        descriptor_flags = fcntl.fcntl(descriptor, fcntl.F_GETFD)
+        if not stat.S_ISFIFO(metadata.st_mode) or flags & os.O_ACCMODE != os.O_RDONLY:
+            _fail("descriptor")
+        if not descriptor_flags & fcntl.FD_CLOEXEC:
+            fcntl.fcntl(descriptor, fcntl.F_SETFD, descriptor_flags | fcntl.FD_CLOEXEC)
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("descriptor") from error
+
+
+@dataclasses.dataclass
+class OwnedProvider:
+    process: subprocess.Popen[bytes]
+    handle: int
+
+
+def _terminate_provider(provider: OwnedProvider) -> bool:
+    process = provider.process
+    forced = False
+    if process.poll() is not None:
+        return forced
+    try:
+        if os.getpgid(process.pid) != process.pid:
+            _fail("cleanup")
+    except ProcessLookupError:
+        process.poll()
+        return forced
+    except OSError as error:
+        raise HandoffError("cleanup") from error
+    for value in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(process.pid, value)
+            forced = True
+        except ProcessLookupError:
+            pass
+        except OSError as error:
+            raise HandoffError("cleanup") from error
+        try:
+            process.wait(timeout=2.0)
+            return forced
+        except subprocess.TimeoutExpired:
+            continue
+    _fail("cleanup")
+
+
+class ProviderSupervisor:
+    def __init__(
+        self,
+        session: SessionSocket,
+        layout: ProductLayout,
+        uid: int,
+        gid: int,
+        controller_pid: int,
+        controller_identity: ProcessIdentity,
+        guardian_lease: int,
+    ) -> None:
+        self.session = session
+        self.layout = layout
+        self.uid = uid
+        self.gid = gid
+        self.controller_pid = controller_pid
+        self.controller_identity = controller_identity
+        self.guardian_lease = guardian_lease
+        self.providers: dict[int, OwnedProvider] = {}
+        self.next_handle = 1
+        self.controller_status: Optional[int] = None
+
+    def _guardian_alive(self) -> bool:
+        try:
+            readable, _writable, _exceptional = select.select(
+                [self.guardian_lease], [], [], 0
+            )
+            if not readable:
+                return True
+            return bool(os.read(self.guardian_lease, 1))
+        except OSError as error:
+            raise HandoffError("guardian") from error
+
+    def _controller_alive(self) -> bool:
+        if self.controller_status is not None:
+            return False
+        try:
+            pid, status = os.waitpid(self.controller_pid, os.WNOHANG)
+        except ChildProcessError:
+            return False
+        except OSError as error:
+            raise HandoffError("controller") from error
+        if pid == 0:
+            try:
+                current = capture_process(self.controller_pid)
+            except HandoffError:
+                return False
+            return current.same_process(self.controller_identity)
+        self.controller_status = status
+        return False
+
+    def _spawn(self, arguments: tuple[bytes, ...]) -> tuple[OwnedProvider, list[int]]:
+        if self.next_handle > 0xFFFF_FFFF or len(self.providers) >= 8:
+            _fail("spawn")
+        stdout_read = stdout_write = stderr_read = stderr_write = -1
+        process: Optional[subprocess.Popen[bytes]] = None
+        transferred = False
+        try:
+            stdout_read, stdout_write = os.pipe()
+            stderr_read, stderr_write = os.pipe()
+            for descriptor in (stdout_read, stdout_write, stderr_read, stderr_write):
+                flags = fcntl.fcntl(descriptor, fcntl.F_GETFD)
+                fcntl.fcntl(descriptor, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
+            command = (
+                os.fsencode(self.layout.provider),
+                b"--bootstrap-v1",
+                b"--target-uid",
+                str(self.uid).encode("ascii"),
+                b"--target-gid",
+                str(self.gid).encode("ascii"),
+                b"--",
+                *arguments,
+            )
+            process = subprocess.Popen(
+                command,
+                cwd=b"/",
+                env=FIXED_ENVIRONMENT,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_write,
+                stderr=stderr_write,
+                start_new_session=True,
+                close_fds=True,
+            )
+            os.close(stdout_write)
+            stdout_write = -1
+            os.close(stderr_write)
+            stderr_write = -1
+            if process.pid <= 1 or os.getpgid(process.pid) != process.pid:
+                _fail("spawn")
+            handle = self.next_handle
+            self.next_handle += 1
+            owned = OwnedProvider(process, handle)
+            self.providers[handle] = owned
+            transferred = True
+            return owned, [stdout_read, stderr_read]
+        except HandoffError:
+            if process is not None:
+                _terminate_provider(OwnedProvider(process, 0))
+            raise
+        except OSError as error:
+            if process is not None:
+                try:
+                    _terminate_provider(OwnedProvider(process, 0))
+                except HandoffError:
+                    pass
+            raise HandoffError("spawn") from error
+        finally:
+            _close_descriptors(
+                descriptor
+                for descriptor in (stdout_write, stderr_write)
+                if descriptor >= 0
+            )
+            if not transferred:
+                _close_descriptors(
+                    descriptor
+                    for descriptor in (stdout_read, stderr_read)
+                    if descriptor >= 0
+                )
+
+    def _status(self, owned: OwnedProvider) -> Optional[int]:
+        return owned.process.poll()
+
+    def _wait_status(self, owned: OwnedProvider, milliseconds: int) -> Optional[int]:
+        if not 1 <= milliseconds <= 1000:
+            _fail("protocol")
+        deadline = time.monotonic() + milliseconds / 1000.0
+        while time.monotonic() < deadline:
+            status = owned.process.poll()
+            if status is not None:
+                return status
+            if not self._guardian_alive() or not self._controller_alive():
+                _fail("lease")
+            time.sleep(min(POLL_SECONDS, max(0.0, deadline - time.monotonic())))
+        return owned.process.poll()
+
+    def _reply_status(self, request: Record, owned: OwnedProvider, status: Optional[int]) -> None:
+        self.session.send(
+            Kind.RUNNING if status is None else Kind.EXITED,
+            correlation=request.sequence,
+            handle=owned.handle,
+            value=0 if status is None else status,
+        )
+
+    def _require_handle(self, request: Record) -> OwnedProvider:
+        if request.payload or request.descriptor_count or request.handle == 0:
+            _fail("protocol")
+        try:
+            return self.providers[request.handle]
+        except KeyError as error:
+            raise HandoffError("protocol") from error
+
+    def cleanup(self) -> bool:
+        forced = False
+        for handle in sorted(tuple(self.providers), reverse=True):
+            owned = self.providers.pop(handle)
+            forced = _terminate_provider(owned) or forced
+        return forced
+
+    def serve(self) -> None:
+        deadline = time.monotonic() + SESSION_TIMEOUT
+        try:
+            while True:
+                if not self._guardian_alive() or not self._controller_alive():
+                    _fail("lease")
+                if time.monotonic() >= deadline:
+                    _fail("session-timeout")
+                try:
+                    request, descriptors = self.session.receive()
+                except HandoffError as error:
+                    if error.category == "protocol-timeout":
+                        continue
+                    raise
+                if descriptors or request.correlation != 0:
+                    _close_descriptors(descriptors)
+                    _fail("protocol")
+                if request.kind == Kind.SPAWN:
+                    if request.handle or request.value:
+                        _fail("protocol")
+                    arguments = decode_arguments(request.payload)
+                    owned, outputs = self._spawn(arguments)
+                    try:
+                        self.session.send(
+                            Kind.SPAWNED,
+                            correlation=request.sequence,
+                            handle=owned.handle,
+                            value=owned.process.pid,
+                            descriptors=outputs,
+                        )
+                    except HandoffError:
+                        _terminate_provider(owned)
+                        self.providers.pop(owned.handle, None)
+                        raise
+                    finally:
+                        _close_descriptors(outputs)
+                elif request.kind in (Kind.POLL, Kind.WAIT):
+                    owned = self._require_handle(request)
+                    if request.kind == Kind.POLL:
+                        if request.value != 0:
+                            _fail("protocol")
+                        status = self._status(owned)
+                    else:
+                        status = self._wait_status(owned, request.value)
+                    self._reply_status(request, owned, status)
+                elif request.kind in (Kind.TERM, Kind.KILL):
+                    owned = self._require_handle(request)
+                    if request.value != 0:
+                        _fail("protocol")
+                    if owned.process.poll() is None:
+                        try:
+                            os.killpg(
+                                owned.process.pid,
+                                signal.SIGTERM if request.kind == Kind.TERM else signal.SIGKILL,
+                            )
+                        except ProcessLookupError:
+                            pass
+                        except OSError as error:
+                            raise HandoffError("signal") from error
+                    self._reply_status(request, owned, owned.process.poll())
+                elif request.kind == Kind.CLOSE:
+                    owned = self._require_handle(request)
+                    if request.value != 0:
+                        _fail("protocol")
+                    _terminate_provider(owned)
+                    status = owned.process.poll()
+                    if status is None:
+                        _fail("cleanup")
+                    self.providers.pop(owned.handle)
+                    self.session.send(
+                        Kind.CLOSED,
+                        correlation=request.sequence,
+                        handle=owned.handle,
+                        value=status,
+                    )
+                elif request.kind == Kind.FINISH:
+                    if request.handle or request.value or request.payload or self.providers:
+                        _fail("protocol")
+                    self.session.send(Kind.FINISHED, correlation=request.sequence)
+                    return
+                else:
+                    _fail("protocol")
+        except BaseException:
+            try:
+                self.cleanup()
+            except HandoffError:
+                pass
+            raise
+
+
+class _BoundedCapture:
+    def __init__(self, maximum: int) -> None:
+        self.maximum = maximum
+        self.data = bytearray()
+        self.overflow = False
+        self.failure = False
+        self.lock = threading.Lock()
+
+    def append(self, value: bytes) -> None:
+        with self.lock:
+            remaining = max(0, self.maximum - len(self.data))
+            self.data.extend(value[:remaining])
+            if len(value) > remaining:
+                self.overflow = True
+
+    def fail(self) -> None:
+        with self.lock:
+            self.failure = True
+
+    def result(self) -> tuple[bytes, bool, bool]:
+        with self.lock:
+            return bytes(self.data), self.overflow, self.failure
+
+
+def _pump_descriptor(descriptor: int, capture: _BoundedCapture) -> None:
+    try:
+        while True:
+            chunk = os.read(descriptor, 16 * 1024)
+            if not chunk:
+                return
+            capture.append(chunk)
+    except OSError:
+        capture.fail()
+
+
+class ControllerProxy:
+    def __init__(self, session: SessionSocket, layout: ProductLayout) -> None:
+        self.session = session
+        self.layout = layout
+        self.processes: set["RemoteProviderProcess"] = set()
+        self.finished = False
+
+    def _exchange(
+        self,
+        kind: Kind,
+        *,
+        handle: int = 0,
+        value: int = 0,
+        payload: bytes = b"",
+    ) -> tuple[Record, list[int]]:
+        if self.finished:
+            _fail("protocol")
+        sequence = self.session.send(
+            kind, handle=handle, value=value, payload=payload
+        )
+        response, descriptors = self.session.receive()
+        if response.correlation != sequence or response.kind == Kind.FAILURE:
+            _close_descriptors(descriptors)
+            _fail("protocol")
+        return response, descriptors
+
+    def spawn(self, arguments: Sequence[str]) -> "RemoteProviderProcess":
+        if (
+            not arguments
+            or any(not isinstance(value, str) or "\x00" in value for value in arguments)
+            or os.fsencode(arguments[0]) != os.fsencode(self.layout.launcher)
+        ):
+            _fail("arguments")
+        payload = encode_arguments(tuple(os.fsencode(value) for value in arguments[1:]))
+        response, descriptors = self._exchange(Kind.SPAWN, payload=payload)
+        try:
+            if (
+                response.kind != Kind.SPAWNED
+                or response.handle == 0
+                or not 1 < response.value <= 0x7FFF_FFFF
+                or response.payload
+                or len(descriptors) != 2
+                or descriptors[0] == descriptors[1]
+            ):
+                _fail("descriptor")
+            identities = []
+            for descriptor in descriptors:
+                _validate_output_descriptor(descriptor)
+                metadata = os.fstat(descriptor)
+                identities.append((metadata.st_dev, metadata.st_ino))
+            if len(set(identities)) != 2:
+                _fail("descriptor")
+            process = RemoteProviderProcess(
+                self,
+                response.handle,
+                response.value,
+                descriptors[0],
+                descriptors[1],
+            )
+            descriptors = []
+            self.processes.add(process)
+            return process
+        finally:
+            _close_descriptors(descriptors)
+
+    def _status_exchange(self, kind: Kind, handle: int, value: int = 0) -> Optional[int]:
+        response, descriptors = self._exchange(kind, handle=handle, value=value)
+        try:
+            if descriptors or response.handle != handle or response.payload:
+                _fail("protocol")
+            if response.kind == Kind.RUNNING and response.value == 0:
+                return None
+            if response.kind == Kind.EXITED and -255 <= response.value <= 255:
+                return response.value
+            _fail("protocol")
+        finally:
+            _close_descriptors(descriptors)
+
+    def _close_process(self, process: "RemoteProviderProcess") -> int:
+        response, descriptors = self._exchange(Kind.CLOSE, handle=process.handle)
+        try:
+            if (
+                descriptors
+                or response.kind != Kind.CLOSED
+                or response.handle != process.handle
+                or response.payload
+                or not -255 <= response.value <= 255
+            ):
+                _fail("protocol")
+            self.processes.discard(process)
+            return response.value
+        finally:
+            _close_descriptors(descriptors)
+
+    def finish(self) -> None:
+        if self.finished or self.processes:
+            _fail("cleanup")
+        response, descriptors = self._exchange(Kind.FINISH)
+        try:
+            if (
+                descriptors
+                or response.kind != Kind.FINISHED
+                or response.handle
+                or response.value
+                or response.payload
+            ):
+                _fail("protocol")
+            self.finished = True
+        finally:
+            _close_descriptors(descriptors)
+
+    def close(self) -> None:
+        failures = False
+        for process in tuple(self.processes):
+            try:
+                process.close()
+            except HandoffError:
+                failures = True
+        if failures:
+            _fail("cleanup")
+
+
+class RemoteProviderProcess:
+    def __init__(
+        self,
+        proxy: ControllerProxy,
+        handle: int,
+        pid: int,
+        stdout_descriptor: int,
+        stderr_descriptor: int,
+    ) -> None:
+        self.proxy = proxy
+        self.handle = handle
+        self.pid = pid
+        self.returncode: Optional[int] = None
+        self.stdout_descriptor = stdout_descriptor
+        self.stderr_descriptor = stderr_descriptor
+        self.stdout_capture = _BoundedCapture(MAX_CAPTURE_BYTES)
+        self.stderr_capture = _BoundedCapture(MAX_CAPTURE_BYTES)
+        self.closed = False
+        self.threads = (
+            threading.Thread(
+                target=_pump_descriptor,
+                args=(stdout_descriptor, self.stdout_capture),
+                name="bangbang-handoff-stdout",
+                daemon=True,
+            ),
+            threading.Thread(
+                target=_pump_descriptor,
+                args=(stderr_descriptor, self.stderr_capture),
+                name="bangbang-handoff-stderr",
+                daemon=True,
+            ),
+        )
+        for thread in self.threads:
+            thread.start()
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    def _output_failed(self) -> bool:
+        return any(capture.result()[1] or capture.result()[2] for capture in (self.stdout_capture, self.stderr_capture))
+
+    def poll(self) -> Optional[int]:
+        if self.closed:
+            return self.returncode
+        if self.returncode is None:
+            if self._output_failed():
+                self.kill()
+                _fail("output")
+            self.returncode = self.proxy._status_exchange(Kind.POLL, self.handle)
+        return self.returncode
+
+    def wait(self, timeout: float = PROCESS_TIMEOUT) -> int:
+        if timeout <= 0:
+            _fail("timeout")
+        deadline = time.monotonic() + timeout
+        while self.returncode is None:
+            if self._output_failed():
+                try:
+                    self.kill()
+                finally:
+                    _fail("output")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _fail("timeout")
+            milliseconds = max(
+                1,
+                min(WAIT_SLICE_MILLISECONDS, int(remaining * 1000)),
+            )
+            self.returncode = self.proxy._status_exchange(
+                Kind.WAIT, self.handle, milliseconds
+            )
+        return self.returncode
+
+    def terminate(self) -> None:
+        if self.returncode is None and not self.closed:
+            self.returncode = self.proxy._status_exchange(Kind.TERM, self.handle)
+
+    def kill(self) -> None:
+        if self.returncode is None and not self.closed:
+            self.returncode = self.proxy._status_exchange(Kind.KILL, self.handle)
+
+    def _finish_readers(self) -> tuple[bytes, bytes]:
+        for thread in self.threads:
+            thread.join(timeout=2.0)
+        if any(thread.is_alive() for thread in self.threads):
+            _fail("output")
+        stdout, stdout_overflow, stdout_failure = self.stdout_capture.result()
+        stderr, stderr_overflow, stderr_failure = self.stderr_capture.result()
+        if stdout_overflow or stderr_overflow or stdout_failure or stderr_failure:
+            _fail("output")
+        return stdout, stderr
+
+    def communicate(self, timeout: float = PROCESS_TIMEOUT) -> tuple[bytes, bytes]:
+        self.wait(timeout)
+        return self._finish_readers()
+
+    def close(self) -> None:
+        if self.closed and self not in self.proxy.processes:
+            return
+        if self.closed:
+            _fail("cleanup")
+        failure: Optional[HandoffError] = None
+        prior_status = self.returncode
+        try:
+            if self.returncode is None:
+                self.terminate()
+                try:
+                    self.wait(2.0)
+                except HandoffError:
+                    self.kill()
+                    self.wait(2.0)
+            closed_status = self.proxy._close_process(self)
+            if prior_status is not None and closed_status != prior_status:
+                _fail("protocol")
+            self.returncode = closed_status
+        except HandoffError as error:
+            failure = error
+        finally:
+            self.closed = True
+            _close_descriptors((self.stdout_descriptor, self.stderr_descriptor))
+            for thread in self.threads:
+                thread.join(timeout=0.25)
+        if failure is not None:
+            raise failure
+
+    def __enter__(self) -> "RemoteProviderProcess":
+        return self
+
+    def __exit__(self, _kind: object, _value: object, _traceback: object) -> None:
+        self.close()
+
+
+def _write_private_file(path: Path, data: bytes) -> None:
+    _write_exclusive(path, data, 0o600)
+    try:
+        metadata = os.lstat(path)
+    except OSError as error:
+        raise HandoffError("probe") from error
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_nlink != 1
+        or metadata.st_uid != os.getuid()
+        or metadata.st_gid != os.getgid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+    ):
+        _fail("probe")
+
+
+def _launcher_arguments(
+    layout: ProductLayout,
+    uid: int,
+    gid: int,
+    instance: str,
+    worker_arguments: Sequence[str],
+) -> tuple[str, ...]:
+    if re.fullmatch(r"[a-z0-9-]{1,64}", instance) is None:
+        _fail("probe")
+    return (
+        os.fspath(layout.launcher),
+        "--bangbang-jailer-v1",
+        "--id",
+        instance,
+        "--exec-file",
+        os.fspath(layout.worker),
+        "--uid",
+        str(uid),
+        "--gid",
+        str(gid),
+        "--vmnet-allow",
+        "shared",
+        "--vmnet-max-interfaces",
+        "1",
+        "--",
+        *worker_arguments,
+    )
+
+
+def _fixed_completion_probe(
+    proxy: ControllerProxy, layout: ProductLayout, uid: int, gid: int, instance: str
+) -> None:
+    process = proxy.spawn(
+        _launcher_arguments(layout, uid, gid, instance, ("--version",))
+    )
+    try:
+        stdout, stderr = process.communicate()
+        if process.returncode != 0 or stderr or not stdout.startswith(b"bangbang "):
+            _fail("probe")
+    finally:
+        process.close()
+
+
+def _probe_socket_present(path: Path, process: RemoteProviderProcess) -> bool:
+    if process.poll() is not None:
+        _fail("probe")
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise HandoffError("probe") from error
+    if (
+        not stat.S_ISSOCK(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+    ):
+        _fail("probe")
+    return True
+
+
+def _cleanup_probe_root(root: Path) -> bool:
+    forced = False
+    try:
+        metadata = os.lstat(root)
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o700
+        ):
+            _fail("cleanup")
+        expected = {
+            "api": "directory",
+            "api/api.sock": "socket",
+            "grants.json": "file",
+        }
+        actual: dict[str, str] = {}
+        for directory, names, files in os.walk(root):
+            base = Path(directory)
+            directory_metadata = os.lstat(base)
+            if (
+                not stat.S_ISDIR(directory_metadata.st_mode)
+                or stat.S_ISLNK(directory_metadata.st_mode)
+                or directory_metadata.st_uid != os.getuid()
+            ):
+                _fail("cleanup")
+            for name in (*names, *files):
+                path = base / name
+                child = os.lstat(path)
+                relative = path.relative_to(root).as_posix()
+                if stat.S_ISLNK(child.st_mode) or child.st_uid != os.getuid():
+                    _fail("cleanup")
+                if stat.S_ISDIR(child.st_mode):
+                    kind = "directory"
+                elif stat.S_ISREG(child.st_mode) and child.st_nlink == 1:
+                    kind = "file"
+                elif stat.S_ISSOCK(child.st_mode):
+                    kind = "socket"
+                else:
+                    _fail("cleanup")
+                expected_mode = {
+                    "api": 0o700,
+                    "api/api.sock": 0o600,
+                    "grants.json": 0o600,
+                }.get(relative)
+                if expected_mode is None or stat.S_IMODE(child.st_mode) != expected_mode:
+                    _fail("cleanup")
+                actual[relative] = kind
+        if (
+            not {"api", "grants.json"}.issubset(actual)
+            or set(actual) - set(expected)
+            or any(
+                expected[name] != kind for name, kind in actual.items()
+            )
+        ):
+            _fail("cleanup")
+        socket_path = root / "api/api.sock"
+        if actual.get("api/api.sock") == "socket":
+            socket_path.unlink()
+            forced = True
+        shutil.rmtree(root)
+        if os.path.lexists(root):
+            _fail("cleanup")
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("cleanup") from error
+    return forced
+
+
+def _fixed_signal_probe(
+    proxy: ControllerProxy,
+    layout: ProductLayout,
+    uid: int,
+    gid: int,
+    instance: str,
+    kind: Kind,
+) -> None:
+    root = Path(tempfile.mkdtemp(prefix="bbhandoff.", dir="/private/var/tmp"))
+    process: Optional[RemoteProviderProcess] = None
+    try:
+        os.chmod(root, 0o700)
+        api = root / "api"
+        api.mkdir(mode=0o700)
+        manifest = root / "grants.json"
+        _write_private_file(
+            manifest,
+            _canonical(
+                {
+                    "grants": [
+                        {
+                            "access": "create-children",
+                            "id": "handoff-api",
+                            "role": "api-socket-directory",
+                            "source": os.fspath(api),
+                        }
+                    ],
+                    "version": 1,
+                }
+            ),
+        )
+        socket_path = api / "api.sock"
+        if len(os.fsencode(socket_path)) >= 104:
+            _fail("probe")
+        arguments = _launcher_arguments(
+            layout,
+            uid,
+            gid,
+            instance,
+            (
+                "--bangbang-grant-manifest",
+                os.fspath(manifest),
+                "--",
+                "--api-sock",
+                "bangbang-grant:handoff-api/api.sock",
+            ),
+        )
+        process = proxy.spawn(arguments)
+        if not _wait_until(lambda: _probe_socket_present(socket_path, process), 20.0):
+            _fail("probe")
+        if kind == Kind.TERM:
+            process.terminate()
+        elif kind == Kind.KILL:
+            process.kill()
+        else:
+            _fail("internal")
+        process.wait(10.0)
+        process._finish_readers()
+        process.close()
+        process = None
+        if os.path.lexists(socket_path):
+            _fail("cleanup")
+    finally:
+        if process is not None:
+            process.close()
+        if _cleanup_probe_root(root):
+            _fail("cleanup")
+
+
+def run_fixed_probes(proxy: ControllerProxy, layout: ProductLayout, uid: int, gid: int) -> None:
+    _fixed_completion_probe(proxy, layout, uid, gid, "handoff-complete-1")
+    _fixed_completion_probe(proxy, layout, uid, gid, "handoff-complete-2")
+    _fixed_signal_probe(proxy, layout, uid, gid, "handoff-term", Kind.TERM)
+    _fixed_signal_probe(proxy, layout, uid, gid, "handoff-kill", Kind.KILL)
+
+
+ControllerEntry = Callable[[ControllerProxy, ProductLayout, int, int], None]
+ControllerLoader = Callable[[], ControllerEntry]
+
+
+def default_controller_loader() -> ControllerEntry:
+    return run_fixed_probes
+
+
+def _redirect_stdio() -> None:
+    descriptor = -1
+    try:
+        descriptor = os.open("/dev/null", os.O_RDWR | getattr(os, "O_CLOEXEC", 0))
+        for standard in (0, 1, 2):
+            os.dup2(descriptor, standard)
+    except OSError as error:
+        raise HandoffError("descriptor") from error
+    finally:
+        if descriptor > 2:
+            os.close(descriptor)
+
+
+def _close_unrelated_descriptors(preserved: set[int]) -> None:
+    try:
+        maximum = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+    except (OSError, ValueError) as error:
+        raise HandoffError("descriptor") from error
+    if maximum == resource.RLIM_INFINITY:
+        maximum = 65536
+    maximum = min(int(maximum), 65536)
+    for descriptor in range(3, maximum):
+        if descriptor in preserved:
+            continue
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+
+
+def _write_all(descriptor: int, data: bytes) -> None:
+    offset = 0
+    try:
+        while offset < len(data):
+            count = os.write(descriptor, data[offset:])
+            if count <= 0:
+                _fail("protocol")
+            offset += count
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("protocol") from error
+
+
+def _read_exact(descriptor: int, size: int, timeout: float) -> bytes:
+    deadline = time.monotonic() + timeout
+    data = bytearray()
+    try:
+        while len(data) < size:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _fail("protocol-timeout")
+            readable, _writable, _exceptional = select.select(
+                [descriptor], [], [], remaining
+            )
+            if not readable:
+                _fail("protocol-timeout")
+            chunk = os.read(descriptor, size - len(data))
+            if not chunk:
+                _fail("protocol")
+            data.extend(chunk)
+        return bytes(data)
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("protocol") from error
+
+
+def _controller_child(
+    connection: socket.socket,
+    ready_descriptor: int,
+    supervisor_pid: int,
+    layout: ProductLayout,
+    uid: int,
+    gid: int,
+    loader: ControllerLoader,
+) -> NoReturn:
+    exit_code = 1
+    proxy: Optional[ControllerProxy] = None
+    try:
+        _redirect_stdio()
+        _close_unrelated_descriptors({connection.fileno(), ready_descriptor})
+        transition_controller_credentials(uid, gid, supervisor_pid)
+        _write_all(ready_descriptor, b"R")
+        os.close(ready_descriptor)
+        ready_descriptor = -1
+        session = SessionSocket(RecordSocket(connection), Role.CONTROLLER)
+        welcome, descriptors = session.receive(allow_unbound_welcome=True)
+        try:
+            if (
+                descriptors
+                or welcome.kind != Kind.WELCOME
+                or welcome.correlation
+                or welcome.handle
+                or welcome.payload
+                or welcome.value != supervisor_pid
+                or os.getppid() != supervisor_pid
+            ):
+                _fail("protocol")
+        finally:
+            _close_descriptors(descriptors)
+        session.send(Kind.READY, correlation=welcome.sequence, value=os.getpid())
+        proxy = ControllerProxy(session, layout)
+        entry = loader()
+        if not callable(entry):
+            _fail("controller")
+        entry(proxy, layout, uid, gid)
+        proxy.finish()
+        exit_code = 0
+    except BaseException:
+        if proxy is not None:
+            try:
+                proxy.close()
+            except HandoffError:
+                pass
+    finally:
+        if ready_descriptor >= 0:
+            try:
+                os.close(ready_descriptor)
+            except OSError:
+                pass
+        try:
+            connection.close()
+        except OSError:
+            pass
+    os._exit(exit_code)
+
+
+def _wait_child(pid: int, timeout: float) -> int:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            waited, status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            _fail("controller")
+        except OSError as error:
+            raise HandoffError("controller") from error
+        if waited == pid:
+            return status
+        time.sleep(POLL_SECONDS)
+    _fail("controller-timeout")
+
+
+def _guardian_lease_alive(descriptor: int) -> bool:
+    try:
+        readable, _writable, _exceptional = select.select([descriptor], [], [], 0)
+        if not readable:
+            return True
+        return bool(os.read(descriptor, 1))
+    except OSError:
+        return False
+
+
+def _supervisor_complete(connection: socket.socket) -> None:
+    try:
+        connection.settimeout(CLEANUP_TIMEOUT)
+        if connection.send(b"C") != 1 or connection.recv(2) != b"A":
+            _fail("guardian")
+    except HandoffError:
+        raise
+    except (OSError, socket.timeout) as error:
+        raise HandoffError("guardian") from error
+
+
+def _wait_supervisor_complete(connection: socket.socket) -> None:
+    try:
+        connection.settimeout(SESSION_TIMEOUT + CLEANUP_TIMEOUT)
+        if connection.recv(2) != b"C":
+            _fail("supervisor")
+    except HandoffError:
+        raise
+    except (OSError, socket.timeout) as error:
+        raise HandoffError("supervisor") from error
+
+
+def _acknowledge_guardian_cleanup(connection: socket.socket) -> None:
+    try:
+        connection.settimeout(CLEANUP_TIMEOUT)
+        if connection.send(b"A") != 1:
+            _fail("supervisor")
+    except HandoffError:
+        raise
+    except (OSError, socket.timeout) as error:
+        raise HandoffError("supervisor") from error
+
+
+def _supervisor_entry(
+    stage: Stage,
+    uid: int,
+    gid: int,
+    guardian_lease: int,
+    identity_descriptor: int,
+    completion: socket.socket,
+    loader: ControllerLoader,
+) -> int:
+    controller_pid = -1
+    controller_identity: Optional[ProcessIdentity] = None
+    server: Optional[ProviderSupervisor] = None
+    supervisor_socket: Optional[socket.socket] = None
+    controller_socket: Optional[socket.socket] = None
+    ready_read = ready_write = -1
+    guardian_lost = False
+    try:
+        supervisor_socket, controller_socket = socket.socketpair(
+            socket.AF_UNIX, socket.SOCK_DGRAM
+        )
+        ready_read, ready_write = os.pipe()
+        controller_pid = os.fork()
+        if controller_pid == 0:
+            supervisor_socket.close()
+            os.close(ready_read)
+            _controller_child(
+                controller_socket,
+                ready_write,
+                os.getppid(),
+                stage.layout,
+                uid,
+                gid,
+                loader,
+            )
+        controller_socket.close()
+        controller_socket = None
+        os.close(ready_write)
+        ready_write = -1
+        _write_all(identity_descriptor, struct.pack("!I", controller_pid))
+        os.close(identity_descriptor)
+        identity_descriptor = -1
+        if _read_exact(ready_read, 1, PROTOCOL_TIMEOUT) != b"R":
+            _fail("credentials")
+        os.close(ready_read)
+        ready_read = -1
+        controller_identity = capture_process(controller_pid)
+        if (
+            controller_identity.parent_pid != os.getpid()
+            or (
+                controller_identity.uid,
+                controller_identity.real_uid,
+                controller_identity.saved_uid,
+            )
+            != (uid, uid, uid)
+            or (
+                controller_identity.gid,
+                controller_identity.real_gid,
+                controller_identity.saved_gid,
+            )
+            != (gid, gid, gid)
+        ):
+            _fail("credentials")
+        session_id = secrets.token_bytes(32)
+        session = SessionSocket(
+            RecordSocket(supervisor_socket), Role.SUPERVISOR, session_id
+        )
+        welcome_sequence = session.send(Kind.WELCOME, value=os.getpid())
+        ready, descriptors = session.receive()
+        try:
+            if (
+                descriptors
+                or ready.kind != Kind.READY
+                or ready.correlation != welcome_sequence
+                or ready.handle
+                or ready.payload
+                or ready.value != controller_pid
+            ):
+                _fail("protocol")
+        finally:
+            _close_descriptors(descriptors)
+        server = ProviderSupervisor(
+            session,
+            stage.layout,
+            uid,
+            gid,
+            controller_pid,
+            controller_identity,
+            guardian_lease,
+        )
+        server.serve()
+        status = _wait_child(controller_pid, PROTOCOL_TIMEOUT)
+        controller_pid = -1
+        if os.waitstatus_to_exitcode(status) != 0 or server.providers:
+            _fail("controller")
+        _supervisor_complete(completion)
+        if os.path.lexists(stage.root):
+            _fail("cleanup")
+        return 0
+    except BaseException:
+        guardian_lost = not _guardian_lease_alive(guardian_lease)
+        if server is not None:
+            try:
+                server.cleanup()
+            except HandoffError:
+                pass
+        if controller_pid > 1:
+            try:
+                if controller_identity is None:
+                    controller_identity = capture_process(controller_pid)
+                _retire_pid(controller_identity)
+            except HandoffError:
+                pass
+            try:
+                os.waitpid(controller_pid, 0)
+            except (ChildProcessError, OSError):
+                pass
+        try:
+            force_stage_process_cleanup(stage)
+        except HandoffError:
+            pass
+        if guardian_lost:
+            try:
+                remove_stage(stage)
+            except HandoffError:
+                pass
+        return 1
+    finally:
+        for descriptor in (
+            guardian_lease,
+            identity_descriptor,
+            ready_read,
+            ready_write,
+        ):
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+        for connection in (supervisor_socket, controller_socket):
+            if connection is not None:
+                try:
+                    connection.close()
+                except OSError:
+                    pass
+        try:
+            completion.close()
+        except OSError:
+            pass
+
+
+def _require_root_platform(uid: int, gid: int) -> None:
+    if (
+        sys.platform != "darwin"
+        or platform.machine() != "arm64"
+        or uid == 0
+        or gid == 0
+        or any(value != 0 for value in (os.getuid(), os.geteuid(), os.getgid(), os.getegid()))
+        or threading.active_count() != 1
+    ):
+        _fail("platform")
+    outcome = _run_tool(
+        ("/usr/sbin/sysctl", "-n", "kern.hv_support"),
+        "platform",
+        timeout=5.0,
+    )
+    if outcome.returncode != 0 or outcome.stderr or outcome.stdout.strip() != b"1":
+        _fail("platform")
+
+
+def run_root(
+    prepared: Path,
+    uid: int,
+    gid: int,
+    loader: ControllerLoader = default_controller_loader,
+) -> None:
+    _require_root_platform(uid, gid)
+    if not prepared.is_absolute() or prepared.name != PACKAGE_KIND:
+        _fail("invocation")
+    stage = stage_package(prepared, uid, gid)
+    lease_read = lease_write = identity_read = identity_write = -1
+    guardian_completion: Optional[socket.socket] = None
+    supervisor_completion: Optional[socket.socket] = None
+    supervisor_pid = -1
+    controller_identity: Optional[ProcessIdentity] = None
+    forced = False
+    completed = False
+    try:
+        lease_read, lease_write = os.pipe()
+        identity_read, identity_write = os.pipe()
+        guardian_completion, supervisor_completion = socket.socketpair(
+            socket.AF_UNIX, socket.SOCK_STREAM
+        )
+        supervisor_pid = os.fork()
+        if supervisor_pid == 0:
+            guardian_completion.close()
+            os.close(lease_write)
+            os.close(identity_read)
+            status = _supervisor_entry(
+                stage,
+                uid,
+                gid,
+                lease_read,
+                identity_write,
+                supervisor_completion,
+                loader,
+            )
+            os._exit(status)
+        supervisor_completion.close()
+        supervisor_completion = None
+        os.close(lease_read)
+        lease_read = -1
+        os.close(identity_write)
+        identity_write = -1
+        try:
+            raw_pid = _read_exact(identity_read, 4, PROTOCOL_TIMEOUT)
+            controller_pid = struct.unpack("!I", raw_pid)[0]
+            controller_identity = capture_process(controller_pid)
+        finally:
+            os.close(identity_read)
+            identity_read = -1
+        try:
+            _wait_supervisor_complete(guardian_completion)
+        except HandoffError:
+            guardian_completion.close()
+            guardian_completion = None
+            _waited, status = os.waitpid(supervisor_pid, 0)
+            supervisor_pid = -1
+            if controller_identity is not None:
+                forced = _retire_pid(controller_identity) or forced
+            forced = force_stage_process_cleanup(stage) or forced
+            remove_stage(stage)
+            raise HandoffError("session")
+        if controller_identity is not None:
+            forced = _retire_pid(controller_identity) or forced
+        forced = force_stage_process_cleanup(stage) or forced
+        remove_stage(stage)
+        _acknowledge_guardian_cleanup(guardian_completion)
+        guardian_completion.close()
+        guardian_completion = None
+        _waited, status = os.waitpid(supervisor_pid, 0)
+        supervisor_pid = -1
+        os.close(lease_write)
+        lease_write = -1
+        if os.waitstatus_to_exitcode(status) != 0 or forced:
+            _fail("session")
+        completed = True
+    finally:
+        for descriptor in (lease_read, lease_write, identity_read, identity_write):
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+        for connection in (guardian_completion, supervisor_completion):
+            if connection is not None:
+                try:
+                    connection.close()
+                except OSError:
+                    pass
+        if supervisor_pid > 1:
+            try:
+                os.kill(supervisor_pid, signal.SIGKILL)
+            except OSError:
+                pass
+            try:
+                os.waitpid(supervisor_pid, 0)
+            except OSError:
+                pass
+        if not completed and os.path.lexists(stage.root):
+            try:
+                force_stage_process_cleanup(stage)
+                remove_stage(stage)
+            except HandoffError:
+                pass
+
+
+def _parse_arguments(arguments: Optional[Sequence[str]]) -> argparse.Namespace:
+    parser = ClosedArgumentParser(allow_abbrev=False)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare", allow_abbrev=False)
+    prepare.add_argument("--output", required=True, type=Path)
+    root = subparsers.add_parser("run-root", allow_abbrev=False)
+    root.add_argument("--prepared", required=True, type=Path)
+    root.add_argument("--target-uid", required=True, type=_parse_id)
+    root.add_argument("--target-gid", required=True, type=_parse_id)
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Optional[Sequence[str]] = None) -> int:
+    try:
+        options = _parse_arguments(arguments)
+        if options.command == "prepare":
+            prepare_package(options.output)
+            print("bangbang elevated vmnet handoff prepare: ready")
+        elif options.command == "run-root":
+            run_root(options.prepared, options.target_uid, options.target_gid)
+            print(
+                "bangbang elevated vmnet handoff proof: "
+                "ordinary=passed complete=passed repeat=passed "
+                "term=passed kill=passed cleanup=passed"
+            )
+        else:  # pragma: no cover - argparse owns the closed command set
+            _fail("invocation")
+    except HandoffError as error:
+        print(f"bangbang elevated vmnet handoff: {error.category}", file=sys.stderr)
+        return 1
+    except SystemExit as error:
+        return int(error.code) if isinstance(error.code, int) else 1
+    except BaseException:
+        print("bangbang elevated vmnet handoff: internal", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -8,6 +8,7 @@ import array
 import ctypes
 import dataclasses
 import enum
+import errno
 import fcntl
 import hashlib
 import json
@@ -81,6 +82,7 @@ SESSION_TIMEOUT = 30.0 * 60.0
 CLEANUP_TIMEOUT = 10.0
 POLL_SECONDS = 0.05
 MAX_CAPTURE_BYTES = 256 * 1024
+MAX_CREDENTIAL_GROUPS = 1024
 
 CREDENTIAL_FAILURES = (
     "credentials-initial-observe",
@@ -1186,7 +1188,7 @@ class CredentialBackend:
     """Injectable credential operations for the post-fork controller transition."""
 
     def groups(self) -> list[int]:
-        return list(os.getgroups())
+        return _process_groups()
 
     def clear_groups(self) -> None:
         os.setgroups([])
@@ -1202,6 +1204,34 @@ class CredentialBackend:
 
     def identity(self) -> ProcessIdentity:
         return capture_process(os.getpid())
+
+
+def _read_process_groups(getgroups: Any) -> list[int]:
+    count = getgroups(0, None)
+    if count < 0:
+        raise OSError(ctypes.get_errno(), "getgroups")
+    if count > MAX_CREDENTIAL_GROUPS:
+        raise OSError(errno.EOVERFLOW, "getgroups")
+    if count == 0:
+        return []
+    groups = (ctypes.c_uint32 * count)()
+    actual = getgroups(count, groups)
+    if actual < 0:
+        raise OSError(ctypes.get_errno(), "getgroups")
+    if actual != count:
+        raise OSError(errno.EIO, "getgroups")
+    return [int(groups[index]) for index in range(actual)]
+
+
+def _process_groups() -> list[int]:
+    # Xcode's system Python is linked to getgroups$DARWIN_EXTSN, which reports
+    # the account-directory access list and ignores setgroups(2). Resolving the
+    # unversioned ABI explicitly observes the bounded live process group list.
+    library = ctypes.CDLL(None, use_errno=True)
+    getgroups = library.getgroups
+    getgroups.argtypes = (ctypes.c_int, ctypes.POINTER(ctypes.c_uint32))
+    getgroups.restype = ctypes.c_int
+    return _read_process_groups(getgroups)
 
 
 def transition_controller_credentials(

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -2289,6 +2289,26 @@ def _probe_socket_present(path: Path, process: RemoteProviderProcess) -> bool:
     return True
 
 
+def _remove_killed_probe_socket(path: Path) -> None:
+    try:
+        metadata = os.lstat(path)
+        if (
+            not stat.S_ISSOCK(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or metadata.st_gid != os.getgid()
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            _fail("cleanup")
+        path.unlink()
+        if os.path.lexists(path):
+            _fail("cleanup")
+    except HandoffError:
+        raise
+    except OSError as error:
+        raise HandoffError("cleanup") from error
+
+
 def _cleanup_probe_root(root: Path) -> bool:
     forced = False
     try:
@@ -2425,7 +2445,9 @@ def _fixed_signal_probe(
         process.close()
         process = None
         if os.path.lexists(socket_path):
-            _fail("cleanup")
+            if kind != Kind.KILL:
+                _fail("cleanup")
+            _remove_killed_probe_socket(socket_path)
     finally:
         if process is not None:
             process.close()

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -82,9 +82,28 @@ CLEANUP_TIMEOUT = 10.0
 POLL_SECONDS = 0.05
 MAX_CAPTURE_BYTES = 256 * 1024
 
+CREDENTIAL_FAILURES = (
+    "credentials-initial-observe",
+    "credentials-initial-process",
+    "credentials-initial-root",
+    "credentials-clear-groups",
+    "credentials-set-gid",
+    "credentials-set-uid",
+    "credentials-dropped-observe",
+    "credentials-dropped-process",
+    "credentials-dropped-groups",
+    "credentials-dropped-uid",
+    "credentials-dropped-gid",
+    "credentials-restore-uid",
+    "credentials-restore-gid",
+    "credentials-restore-groups",
+    "credentials-restored-observe",
+    "credentials-restored-state",
+)
 CONTROLLER_FAILURES = (
     "internal",
     "credentials",
+    *CREDENTIAL_FAILURES,
     "protocol",
     "protocol-timeout",
     "descriptor",
@@ -1193,11 +1212,13 @@ def transition_controller_credentials(
     if target_uid == 0 or target_gid == 0 or supervisor_pid <= 1:
         _fail("credentials")
     operations = backend if backend is not None else CredentialBackend()
-    initial = operations.identity()
-    if (
-        initial.pid != os.getpid()
-        or initial.parent_pid != supervisor_pid
-        or any(
+    try:
+        initial = operations.identity()
+    except HandoffError as error:
+        raise HandoffError("credentials-initial-observe") from error
+    if initial.pid != os.getpid() or initial.parent_pid != supervisor_pid:
+        _fail("credentials-initial-process")
+    if any(
             value != 0
             for value in (
                 initial.uid,
@@ -1207,48 +1228,57 @@ def transition_controller_credentials(
                 initial.saved_uid,
                 initial.saved_gid,
             )
-        )
-    ):
-        _fail("credentials")
+        ):
+        _fail("credentials-initial-root")
     try:
         operations.clear_groups()
+    except OSError as error:
+        raise HandoffError("credentials-clear-groups") from error
+    try:
         operations.set_gid(target_gid)
+    except OSError as error:
+        raise HandoffError("credentials-set-gid") from error
+    try:
         operations.set_uid(target_uid)
     except OSError as error:
-        raise HandoffError("credentials") from error
-    dropped = operations.identity()
+        raise HandoffError("credentials-set-uid") from error
+    try:
+        dropped = operations.identity()
+    except HandoffError as error:
+        raise HandoffError("credentials-dropped-observe") from error
+    if not initial.same_process(dropped) or dropped.parent_pid != supervisor_pid:
+        _fail("credentials-dropped-process")
+    if operations.groups():
+        _fail("credentials-dropped-groups")
     if (
-        not initial.same_process(dropped)
-        or dropped.parent_pid != supervisor_pid
-        or operations.groups()
-        or (
-            dropped.uid,
-            dropped.real_uid,
-            dropped.saved_uid,
-        )
-        != (target_uid, target_uid, target_uid)
-        or (
-            dropped.gid,
-            dropped.real_gid,
-            dropped.saved_gid,
-        )
-        != (target_gid, target_gid, target_gid)
-    ):
-        _fail("credentials")
-    for restore in (
-        lambda: operations.set_uid(0),
-        lambda: operations.set_gid(0),
-        operations.restore_groups,
+        dropped.uid,
+        dropped.real_uid,
+        dropped.saved_uid,
+    ) != (target_uid, target_uid, target_uid):
+        _fail("credentials-dropped-uid")
+    if (
+        dropped.gid,
+        dropped.real_gid,
+        dropped.saved_gid,
+    ) != (target_gid, target_gid, target_gid):
+        _fail("credentials-dropped-gid")
+    for label, restore in (
+        ("uid", lambda: operations.set_uid(0)),
+        ("gid", lambda: operations.set_gid(0)),
+        ("groups", operations.restore_groups),
     ):
         try:
             restore()
         except OSError:
             pass
         else:
-            _fail("credentials")
-        current = operations.identity()
+            _fail(f"credentials-restore-{label}")
+        try:
+            current = operations.identity()
+        except HandoffError as error:
+            raise HandoffError("credentials-restored-observe") from error
         if current != dropped or operations.groups():
-            _fail("credentials")
+            _fail("credentials-restored-state")
     return dropped
 
 

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -104,6 +104,14 @@ SUPERVISOR_PHASES = (
     "controller-exit",
     "cleanup-ack",
 )
+SUPERVISOR_FAILURES = (
+    *SUPERVISOR_PHASES,
+    "identity-capture",
+    "identity-parent",
+    "identity-uid",
+    "identity-gid",
+    *(f"controller-{category}" for category in CONTROLLER_FAILURES),
+)
 
 PROC_PIDTBSDINFO = 3
 PROC_PIDPATHINFO_MAXSIZE = 4096
@@ -2505,9 +2513,9 @@ def _wait_supervisor_complete(connection: socket.socket) -> None:
         if (
             len(message) == 2
             and message[0] == ord("F")
-            and 1 <= message[1] <= len(SUPERVISOR_PHASES)
+            and 1 <= message[1] <= len(SUPERVISOR_FAILURES)
         ):
-            _fail(f"supervisor-{SUPERVISOR_PHASES[message[1] - 1]}")
+            _fail(f"supervisor-{SUPERVISOR_FAILURES[message[1] - 1]}")
         _fail("supervisor")
     except HandoffError:
         raise
@@ -2580,23 +2588,24 @@ def _supervisor_entry(
             _fail("credentials")
         os.close(ready_read)
         ready_read = -1
-        controller_identity = capture_process(controller_pid)
+        try:
+            controller_identity = capture_process(controller_pid)
+        except HandoffError as error:
+            raise HandoffError("identity-capture") from error
+        if controller_identity.parent_pid != os.getpid():
+            _fail("identity-parent")
         if (
-            controller_identity.parent_pid != os.getpid()
-            or (
-                controller_identity.uid,
-                controller_identity.real_uid,
-                controller_identity.saved_uid,
-            )
-            != (uid, uid, uid)
-            or (
-                controller_identity.gid,
-                controller_identity.real_gid,
-                controller_identity.saved_gid,
-            )
-            != (gid, gid, gid)
-        ):
-            _fail("credentials")
+            controller_identity.uid,
+            controller_identity.real_uid,
+            controller_identity.saved_uid,
+        ) != (uid, uid, uid):
+            _fail("identity-uid")
+        if (
+            controller_identity.gid,
+            controller_identity.real_gid,
+            controller_identity.saved_gid,
+        ) != (gid, gid, gid):
+            _fail("identity-gid")
         session_id = secrets.token_bytes(32)
         phase = 4
         session = SessionSocket(
@@ -2637,9 +2646,17 @@ def _supervisor_entry(
         if os.path.lexists(stage.root):
             _fail("cleanup")
         return 0
-    except BaseException:
+    except BaseException as error:
         try:
-            completion.send(bytes((ord("F"), phase)))
+            category = (
+                error.category
+                if isinstance(error, HandoffError)
+                and error.category in SUPERVISOR_FAILURES
+                else SUPERVISOR_PHASES[phase - 1]
+            )
+            completion.send(
+                bytes((ord("F"), SUPERVISOR_FAILURES.index(category) + 1))
+            )
         except OSError:
             pass
         guardian_lost = not _guardian_lease_alive(guardian_lease)

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -103,8 +103,22 @@ CREDENTIAL_FAILURES = (
     "credentials-restored-observe",
     "credentials-restored-state",
 )
+PROVIDER_STATUS_FAILURES = {
+    10: "probe-completion-configuration",
+    11: "probe-completion-provider-protocol",
+    12: "probe-completion-provider-process",
+    13: "probe-completion-provider-timeout",
+    14: "probe-completion-provider-cleanup",
+    15: "probe-completion-provider-io",
+    16: "probe-completion-provider-authority",
+    17: "probe-completion-provider-descriptor",
+    18: "probe-completion-provider-bootstrap-descriptor",
+    19: "probe-completion-provider-stream",
+}
 PROBE_FAILURES = (
-    "probe-completion-status",
+    *PROVIDER_STATUS_FAILURES.values(),
+    "probe-completion-child-status",
+    "probe-completion-signal",
     "probe-completion-stderr",
     "probe-completion-stdout",
     "probe-signal-exited",
@@ -2206,7 +2220,13 @@ def _fixed_completion_probe(
     try:
         stdout, stderr = process.communicate()
         if process.returncode != 0:
-            _fail("probe-completion-status")
+            category = PROVIDER_STATUS_FAILURES.get(
+                process.returncode,
+                "probe-completion-signal"
+                if process.returncode is not None and process.returncode < 0
+                else "probe-completion-child-status",
+            )
+            _fail(category)
         if stderr:
             _fail("probe-completion-stderr")
         if not stdout.startswith(b"bangbang "):

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -103,6 +103,17 @@ CREDENTIAL_FAILURES = (
     "credentials-restored-observe",
     "credentials-restored-state",
 )
+PROBE_FAILURES = (
+    "probe-completion-status",
+    "probe-completion-stderr",
+    "probe-completion-stdout",
+    "probe-signal-exited",
+    "probe-socket-observe",
+    "probe-socket-shape",
+    "probe-socket-timeout",
+    "probe-path",
+    "probe-private-file",
+)
 CONTROLLER_FAILURES = (
     "internal",
     "credentials",
@@ -115,6 +126,7 @@ CONTROLLER_FAILURES = (
     "timeout",
     "cleanup",
     "probe",
+    *PROBE_FAILURES,
     "controller",
 )
 SUPERVISOR_PHASES = (
@@ -2144,7 +2156,7 @@ def _write_private_file(path: Path, data: bytes) -> None:
     try:
         metadata = os.lstat(path)
     except OSError as error:
-        raise HandoffError("probe") from error
+        raise HandoffError("probe-private-file") from error
     if (
         not stat.S_ISREG(metadata.st_mode)
         or stat.S_ISLNK(metadata.st_mode)
@@ -2153,7 +2165,7 @@ def _write_private_file(path: Path, data: bytes) -> None:
         or metadata.st_gid != os.getgid()
         or stat.S_IMODE(metadata.st_mode) != 0o600
     ):
-        _fail("probe")
+        _fail("probe-private-file")
 
 
 def _launcher_arguments(
@@ -2164,7 +2176,7 @@ def _launcher_arguments(
     worker_arguments: Sequence[str],
 ) -> tuple[str, ...]:
     if re.fullmatch(r"[a-z0-9-]{1,64}", instance) is None:
-        _fail("probe")
+        _fail("probe-path")
     return (
         os.fspath(layout.launcher),
         "--bangbang-jailer-v1",
@@ -2193,28 +2205,32 @@ def _fixed_completion_probe(
     )
     try:
         stdout, stderr = process.communicate()
-        if process.returncode != 0 or stderr or not stdout.startswith(b"bangbang "):
-            _fail("probe")
+        if process.returncode != 0:
+            _fail("probe-completion-status")
+        if stderr:
+            _fail("probe-completion-stderr")
+        if not stdout.startswith(b"bangbang "):
+            _fail("probe-completion-stdout")
     finally:
         process.close()
 
 
 def _probe_socket_present(path: Path, process: RemoteProviderProcess) -> bool:
     if process.poll() is not None:
-        _fail("probe")
+        _fail("probe-signal-exited")
     try:
         metadata = os.lstat(path)
     except FileNotFoundError:
         return False
     except OSError as error:
-        raise HandoffError("probe") from error
+        raise HandoffError("probe-socket-observe") from error
     if (
         not stat.S_ISSOCK(metadata.st_mode)
         or stat.S_ISLNK(metadata.st_mode)
         or metadata.st_uid != os.getuid()
         or stat.S_IMODE(metadata.st_mode) != 0o600
     ):
-        _fail("probe")
+        _fail("probe-socket-shape")
     return True
 
 
@@ -2321,7 +2337,7 @@ def _fixed_signal_probe(
         )
         socket_path = api / "api.sock"
         if len(os.fsencode(socket_path)) >= 104:
-            _fail("probe")
+            _fail("probe-path")
         arguments = _launcher_arguments(
             layout,
             uid,
@@ -2337,7 +2353,7 @@ def _fixed_signal_probe(
         )
         process = proxy.spawn(arguments)
         if not _wait_until(lambda: _probe_socket_present(socket_path, process), 20.0):
-            _fail("probe")
+            _fail("probe-socket-timeout")
         if kind == Kind.TERM:
             process.terminate()
         elif kind == Kind.KILL:

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -126,6 +126,7 @@ PROBE_FAILURES = (
     "probe-socket-shape",
     "probe-socket-timeout",
     "probe-path",
+    "probe-private-root",
     "probe-private-file",
 )
 CONTROLLER_FAILURES = (
@@ -2182,6 +2183,37 @@ def _write_private_file(path: Path, data: bytes) -> None:
         _fail("probe-private-file")
 
 
+def _create_private_probe_root(
+    parent: Path = Path("/private/var/tmp"),
+) -> Path:
+    root: Optional[Path] = None
+    try:
+        root = Path(tempfile.mkdtemp(prefix="bbhandoff.", dir=parent))
+        os.chown(root, os.getuid(), os.getgid())
+        os.chmod(root, 0o700)
+        metadata = os.lstat(root)
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or metadata.st_gid != os.getgid()
+            or stat.S_IMODE(metadata.st_mode) != 0o700
+        ):
+            _fail("probe-private-root")
+        return root
+    except BaseException as error:
+        if root is not None and os.path.lexists(root):
+            try:
+                shutil.rmtree(root)
+            except OSError as cleanup_error:
+                raise HandoffError("cleanup") from cleanup_error
+        if isinstance(error, HandoffError):
+            raise
+        if isinstance(error, OSError):
+            raise HandoffError("probe-private-root") from error
+        raise
+
+
 def _launcher_arguments(
     layout: ProductLayout,
     uid: int,
@@ -2248,6 +2280,7 @@ def _probe_socket_present(path: Path, process: RemoteProviderProcess) -> bool:
         not stat.S_ISSOCK(metadata.st_mode)
         or stat.S_ISLNK(metadata.st_mode)
         or metadata.st_uid != os.getuid()
+        or metadata.st_gid != os.getgid()
         or stat.S_IMODE(metadata.st_mode) != 0o600
     ):
         _fail("probe-socket-shape")
@@ -2262,6 +2295,7 @@ def _cleanup_probe_root(root: Path) -> bool:
             not stat.S_ISDIR(metadata.st_mode)
             or stat.S_ISLNK(metadata.st_mode)
             or metadata.st_uid != os.getuid()
+            or metadata.st_gid != os.getgid()
             or stat.S_IMODE(metadata.st_mode) != 0o700
         ):
             _fail("cleanup")
@@ -2278,13 +2312,18 @@ def _cleanup_probe_root(root: Path) -> bool:
                 not stat.S_ISDIR(directory_metadata.st_mode)
                 or stat.S_ISLNK(directory_metadata.st_mode)
                 or directory_metadata.st_uid != os.getuid()
+                or directory_metadata.st_gid != os.getgid()
             ):
                 _fail("cleanup")
             for name in (*names, *files):
                 path = base / name
                 child = os.lstat(path)
                 relative = path.relative_to(root).as_posix()
-                if stat.S_ISLNK(child.st_mode) or child.st_uid != os.getuid():
+                if (
+                    stat.S_ISLNK(child.st_mode)
+                    or child.st_uid != os.getuid()
+                    or child.st_gid != os.getgid()
+                ):
                     _fail("cleanup")
                 if stat.S_ISDIR(child.st_mode):
                     kind = "directory"
@@ -2332,10 +2371,9 @@ def _fixed_signal_probe(
     instance: str,
     kind: Kind,
 ) -> None:
-    root = Path(tempfile.mkdtemp(prefix="bbhandoff.", dir="/private/var/tmp"))
+    root = _create_private_probe_root()
     process: Optional[RemoteProviderProcess] = None
     try:
-        os.chmod(root, 0o700)
         api = root / "api"
         api.mkdir(mode=0o700)
         manifest = root / "grants.json"

--- a/scripts/elevated_vmnet_handoff.py
+++ b/scripts/elevated_vmnet_handoff.py
@@ -126,12 +126,26 @@ SUPERVISOR_PHASES = (
     "controller-exit",
     "cleanup-ack",
 )
+LIFECYCLE_FAILURES = (
+    "guardian",
+    "controller",
+    "spawn",
+    "cleanup",
+    "signal",
+    "lease",
+    "session-timeout",
+    "protocol",
+    "protocol-timeout",
+    "descriptor",
+    "arguments",
+)
 SUPERVISOR_FAILURES = (
     *SUPERVISOR_PHASES,
     "identity-capture",
     "identity-parent",
     "identity-uid",
     "identity-gid",
+    *(f"lifecycle-{category}" for category in LIFECYCLE_FAILURES),
     *(f"controller-{category}" for category in CONTROLLER_FAILURES),
 )
 
@@ -2609,6 +2623,17 @@ def _acknowledge_guardian_cleanup(connection: socket.socket) -> None:
         raise HandoffError("supervisor") from error
 
 
+def _supervisor_failure_category(error: BaseException, phase: int) -> str:
+    fallback = SUPERVISOR_PHASES[phase - 1]
+    if not isinstance(error, HandoffError):
+        return fallback
+    if error.category in SUPERVISOR_FAILURES:
+        return error.category
+    if phase == 5 and error.category in LIFECYCLE_FAILURES:
+        return f"lifecycle-{error.category}"
+    return fallback
+
+
 def _supervisor_entry(
     stage: Stage,
     uid: int,
@@ -2723,12 +2748,7 @@ def _supervisor_entry(
         return 0
     except BaseException as error:
         try:
-            category = (
-                error.category
-                if isinstance(error, HandoffError)
-                and error.category in SUPERVISOR_FAILURES
-                else SUPERVISOR_PHASES[phase - 1]
-            )
+            category = _supervisor_failure_category(error, phase)
             completion.send(
                 bytes((ord("F"), SUPERVISOR_FAILURES.index(category) + 1))
             )

--- a/scripts/prepare-elevated-vmnet-handoff.sh
+++ b/scripts/prepare-elevated-vmnet-handoff.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+LC_ALL=C
+export LC_ALL
+umask 077
+
+usage() {
+  /bin/cat <<'EOF'
+Usage: scripts/prepare-elevated-vmnet-handoff.sh --output ABSOLUTE_PATH
+
+Build and ad-hoc sign the normal networkless production bundle, bind it to the
+clean source and fixed handoff implementation, and exclusively publish an
+immutable package named bangbang-elevated-vmnet-handoff. Run as an ordinary
+user. No Apple developer identity or provisioning profile is used.
+EOF
+}
+
+output=""
+output_set=false
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --output)
+      if [[ "$output_set" == true ]]; then
+        echo "duplicate option" >&2
+        exit 2
+      fi
+      shift
+      if [[ "$#" -eq 0 || -z "$1" ]]; then
+        echo "--output requires a path" >&2
+        exit 2
+      fi
+      output="$1"
+      output_set=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "$output_set" != true || "$output" != /* \
+  || "$(/usr/bin/basename "$output")" != "bangbang-elevated-vmnet-handoff" ]]; then
+  echo "an absolute absent bangbang-elevated-vmnet-handoff output is required" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(/usr/bin/dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec /usr/bin/python3 "$repo_root/scripts/elevated_vmnet_handoff.py" \
+  prepare --output "$output" </dev/null

--- a/scripts/run-elevated-vmnet-handoff.sh
+++ b/scripts/run-elevated-vmnet-handoff.sh
@@ -11,8 +11,10 @@ Usage: scripts/run-elevated-vmnet-handoff.sh --prepared ABSOLUTE_PATH
 
 Run the fixed one-shot elevated vmnet handoff against one immutable prepared
 package. The caller must arrange exact-root execution externally. This entry
-does not discover identities or accept executable, environment, fixture,
-result, profile, account, credential, interface, or socket parameters.
+does not accept executable, environment, fixture, result, profile, account,
+credential, interface, or socket parameters. Root actors receive only the
+numeric target identity; the dropped controller resolves only its own fixed
+production-session root for residue validation.
 EOF
 }
 

--- a/scripts/run-elevated-vmnet-handoff.sh
+++ b/scripts/run-elevated-vmnet-handoff.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -euo pipefail
+LC_ALL=C
+export LC_ALL
+umask 077
+
+usage() {
+  /bin/cat <<'EOF'
+Usage: scripts/run-elevated-vmnet-handoff.sh --prepared ABSOLUTE_PATH
+       --target-uid NONZERO_U32 --target-gid NONZERO_U32
+
+Run the fixed one-shot elevated vmnet handoff against one immutable prepared
+package. The caller must arrange exact-root execution externally. This entry
+does not discover identities or accept executable, environment, fixture,
+result, profile, account, credential, interface, or socket parameters.
+EOF
+}
+
+prepared=""
+target_uid=""
+target_gid=""
+prepared_set=false
+uid_set=false
+gid_set=false
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --prepared)
+      if [[ "$prepared_set" == true ]]; then
+        echo "duplicate option" >&2
+        exit 2
+      fi
+      shift
+      if [[ "$#" -eq 0 || -z "$1" ]]; then
+        echo "--prepared requires a path" >&2
+        exit 2
+      fi
+      prepared="$1"
+      prepared_set=true
+      ;;
+    --target-uid)
+      if [[ "$uid_set" == true ]]; then
+        echo "duplicate option" >&2
+        exit 2
+      fi
+      shift
+      if [[ "$#" -eq 0 || -z "$1" ]]; then
+        echo "--target-uid requires a value" >&2
+        exit 2
+      fi
+      target_uid="$1"
+      uid_set=true
+      ;;
+    --target-gid)
+      if [[ "$gid_set" == true ]]; then
+        echo "duplicate option" >&2
+        exit 2
+      fi
+      shift
+      if [[ "$#" -eq 0 || -z "$1" ]]; then
+        echo "--target-gid requires a value" >&2
+        exit 2
+      fi
+      target_gid="$1"
+      gid_set=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "$prepared_set" != true || "$uid_set" != true || "$gid_set" != true \
+  || "$prepared" != /* \
+  || "$(/usr/bin/basename "$prepared")" != "bangbang-elevated-vmnet-handoff" \
+  || ! "$target_uid" =~ ^[1-9][0-9]{0,9}$ \
+  || ! "$target_gid" =~ ^[1-9][0-9]{0,9}$ ]]; then
+  echo "one prepared package and canonical nonzero target ids are required" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(/usr/bin/dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec /usr/bin/python3 "$repo_root/scripts/elevated_vmnet_handoff.py" \
+  run-root --prepared "$prepared" \
+  --target-uid "$target_uid" --target-gid "$target_gid" </dev/null

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -416,6 +416,28 @@ class FakeCredentialBackend(handoff.CredentialBackend):
 
 
 class CredentialTests(unittest.TestCase):
+    def test_process_group_reader_is_exact_bounded_and_two_phase(self) -> None:
+        expected = [20, 80]
+        calls = []
+
+        def getgroups(size, groups):
+            calls.append(size)
+            if size == 0:
+                return len(expected)
+            for index, value in enumerate(expected):
+                groups[index] = value
+            return len(expected)
+
+        self.assertEqual(handoff._read_process_groups(getgroups), expected)
+        self.assertEqual(calls, [0, len(expected)])
+
+        with self.assertRaises(OSError):
+            handoff._read_process_groups(
+                lambda size, _groups: handoff.MAX_CREDENTIAL_GROUPS + 1
+                if size == 0
+                else 0
+            )
+
     def test_transition_orders_drop_and_rejects_all_root_restoration(self) -> None:
         backend = FakeCredentialBackend(42, 501, 20)
         identity = handoff.transition_controller_credentials(501, 20, 42, backend)

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -545,6 +545,22 @@ class ProcessTests(unittest.TestCase):
             with self.assertRaisesRegex(handoff.HandoffError, "probe-session-root"):
                 handoff._probe_session_entries(root)
 
+    def test_fixed_probes_reject_preexisting_production_session_residue(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "bangbang-sessions-v1"
+            root.mkdir(mode=0o700)
+            session = root / ("session-" + "a" * 64)
+            session.mkdir(mode=0o700)
+            with mock.patch.object(
+                handoff, "_probe_session_root", return_value=root
+            ), self.assertRaisesRegex(handoff.HandoffError, "probe-session-root"):
+                handoff.run_fixed_probes(
+                    object(),
+                    handoff.ProductLayout.from_package(Path("/absolute/package")),
+                    os.getuid(),
+                    os.getgid(),
+                )
+
     def test_provider_kill_targets_leader_then_gracefully_converges_group(self) -> None:
         process = mock.Mock(pid=42, returncode=None)
         process.wait.return_value = -int(handoff.signal.SIGKILL)

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -498,6 +498,14 @@ class FakeProxy:
 class ProcessTests(unittest.TestCase):
     def test_probe_failures_are_closed_controller_categories(self) -> None:
         self.assertTrue(set(handoff.PROBE_FAILURES).issubset(handoff.CONTROLLER_FAILURES))
+        self.assertEqual(
+            set(handoff.PROVIDER_STATUS_FAILURES), set(range(10, 20))
+        )
+        self.assertTrue(
+            set(handoff.PROVIDER_STATUS_FAILURES.values()).issubset(
+                handoff.PROBE_FAILURES
+            )
+        )
 
     def test_remote_process_drains_both_descriptors_and_closes_once(self) -> None:
         stdout_read, stdout_write = os.pipe()

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -498,6 +498,8 @@ class FakeProxy:
 class ProcessTests(unittest.TestCase):
     def test_probe_failures_are_closed_controller_categories(self) -> None:
         self.assertTrue(set(handoff.PROBE_FAILURES).issubset(handoff.CONTROLLER_FAILURES))
+        self.assertLessEqual(len(handoff.CONTROLLER_FAILURES), 255)
+        self.assertLessEqual(len(handoff.SUPERVISOR_FAILURES), 255)
         self.assertEqual(
             set(handoff.PROVIDER_STATUS_FAILURES), set(range(10, 20))
         )
@@ -516,6 +518,85 @@ class ProcessTests(unittest.TestCase):
                 self.assertEqual(stat.S_IMODE(metadata.st_mode), 0o700)
             finally:
                 handoff._remove_tree(root)
+
+    def test_probe_session_baseline_binds_exact_owned_namespace_and_children(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "bangbang-sessions-v1"
+            root.mkdir(mode=0o700)
+            self.assertEqual(handoff._probe_session_entries(root), ())
+            session = root / ("session-" + "a" * 64)
+            session.mkdir(mode=0o700)
+            record = session / ".api-socket-owner"
+            record.write_bytes(bytes(96))
+            record.chmod(0o600)
+            baseline = handoff._probe_session_entries(root)
+            self.assertEqual(len(baseline), 1)
+            self.assertEqual(baseline[0][0], session.name)
+            record.write_bytes(b"x" * 96)
+            changed = record.stat().st_mtime_ns + 1_000_000_000
+            os.utime(record, ns=(changed, changed))
+            self.assertNotEqual(handoff._probe_session_entries(root), baseline)
+
+    def test_probe_session_baseline_rejects_unowned_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "bangbang-sessions-v1"
+            root.mkdir(mode=0o700)
+            (root / "unexpected").mkdir(mode=0o700)
+            with self.assertRaisesRegex(handoff.HandoffError, "probe-session-root"):
+                handoff._probe_session_entries(root)
+
+    def test_provider_kill_targets_leader_then_gracefully_converges_group(self) -> None:
+        process = mock.Mock(pid=42, returncode=None)
+        process.wait.return_value = -int(handoff.signal.SIGKILL)
+        provider = handoff.OwnedProvider(process, 1)
+        with mock.patch.object(handoff.os, "getpgid", return_value=42), mock.patch.object(
+            handoff.os, "kill"
+        ) as kill, mock.patch.object(handoff.os, "killpg") as killpg, mock.patch.object(
+            handoff, "_provider_group_has_live_members", return_value=True
+        ), mock.patch.object(
+            handoff,
+            "_wait_provider_group_quiescent",
+            side_effect=(False, True),
+        ), mock.patch.object(
+            handoff, "_provider_group_absent", return_value=True
+        ):
+            self.assertEqual(handoff._signal_provider(provider, handoff.Kind.KILL), -9)
+        kill.assert_called_once_with(42, handoff.signal.SIGKILL)
+        killpg.assert_called_once_with(42, handoff.signal.SIGTERM)
+
+    def test_provider_kill_escalates_only_after_bounded_parent_and_term_windows(self) -> None:
+        process = mock.Mock(pid=42, returncode=None)
+        process.wait.return_value = -int(handoff.signal.SIGKILL)
+        provider = handoff.OwnedProvider(process, 1)
+        with mock.patch.object(handoff.os, "getpgid", return_value=42), mock.patch.object(
+            handoff.os, "kill"
+        ), mock.patch.object(handoff.os, "killpg") as killpg, mock.patch.object(
+            handoff, "_provider_group_has_live_members", return_value=True
+        ), mock.patch.object(
+            handoff,
+            "_wait_provider_group_quiescent",
+            side_effect=(False, False, True),
+        ), mock.patch.object(
+            handoff, "_provider_group_absent", return_value=True
+        ):
+            self.assertEqual(handoff._signal_provider(provider, handoff.Kind.KILL), -9)
+        self.assertEqual(
+            killpg.call_args_list,
+            [mock.call(42, handoff.signal.SIGTERM), mock.call(42, handoff.signal.SIGKILL)],
+        )
+
+    def test_provider_signal_requires_group_absence_after_exact_reap(self) -> None:
+        process = mock.Mock(pid=42, returncode=None)
+        process.wait.return_value = -int(handoff.signal.SIGTERM)
+        provider = handoff.OwnedProvider(process, 1)
+        with mock.patch.object(handoff.os, "getpgid", return_value=42), mock.patch.object(
+            handoff.os, "killpg"
+        ), mock.patch.object(
+            handoff, "_wait_provider_group_quiescent", return_value=True
+        ), mock.patch.object(
+            handoff, "_wait_until", return_value=False
+        ), self.assertRaisesRegex(handoff.HandoffError, "cleanup"):
+            handoff._signal_provider(provider, handoff.Kind.TERM)
 
     def test_remote_process_drains_both_descriptors_and_closes_once(self) -> None:
         stdout_read, stdout_write = os.pipe()
@@ -753,6 +834,19 @@ class ProcessTests(unittest.TestCase):
                 self.assertFalse(os.path.lexists(root))
             finally:
                 listener.close()
+
+    def test_private_probe_cleanup_removes_valid_partial_material_after_early_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "probe"
+            root.mkdir(mode=0o700)
+            root.chmod(0o700)
+            api = root / "api"
+            api.mkdir(mode=0o700)
+            api.chmod(0o700)
+            self.assertFalse(
+                handoff._cleanup_probe_root(root, require_material=False)
+            )
+            self.assertFalse(os.path.lexists(root))
 
     def test_killed_probe_socket_has_exact_validated_cleanup(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -1,0 +1,837 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import socket
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPOSITORY_ROOT / "scripts/elevated_vmnet_handoff.py"
+PREPARE_PATH = REPOSITORY_ROOT / "scripts/prepare-elevated-vmnet-handoff.sh"
+RUN_PATH = REPOSITORY_ROOT / "scripts/run-elevated-vmnet-handoff.sh"
+SPEC = importlib.util.spec_from_file_location("elevated_vmnet_handoff", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+handoff = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = handoff
+SPEC.loader.exec_module(handoff)
+
+
+IMPLEMENTATION = [
+    {"name": "scripts/elevated_vmnet_handoff.py", "sha256": "1" * 64, "size_bytes": 1}
+]
+
+
+def make_product(root: Path) -> handoff.ProductLayout:
+    root.chmod(0o700)
+    layout = handoff.ProductLayout.from_package(root)
+    for directory in (
+        layout.bundle,
+        layout.bundle / "Contents",
+        layout.bundle / "Contents/MacOS",
+        layout.bundle / "Contents/Helpers",
+        layout.worker_bundle,
+        layout.worker_bundle / "Contents",
+        layout.worker_bundle / "Contents/MacOS",
+    ):
+        directory.mkdir(mode=0o755, exist_ok=True)
+        directory.chmod(0o755)
+    for index, executable in enumerate(layout.executable_paths(), 1):
+        executable.write_bytes(f"executable-{index}".encode("ascii"))
+        executable.chmod(0o755)
+    info = layout.worker_bundle / "Contents/Info.plist"
+    info.write_bytes(b"plist")
+    info.chmod(0o644)
+    return layout
+
+
+def thaw(root: Path) -> None:
+    if not os.path.lexists(root):
+        return
+    for directory, names, files in os.walk(root):
+        Path(directory).chmod(0o700)
+        for name in names:
+            path = Path(directory) / name
+            if not path.is_symlink():
+                path.chmod(0o700)
+        for name in files:
+            path = Path(directory) / name
+            if not path.is_symlink():
+                path.chmod(0o600)
+
+
+@contextlib.contextmanager
+def package_directory():
+    raw = tempfile.mkdtemp()
+    root = Path(raw)
+    try:
+        make_product(root)
+        yield root
+    finally:
+        thaw(root)
+        import shutil
+
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def create_package(root: Path) -> None:
+    source = handoff.SourceIdentity("a" * 40, "b" * 40)
+    with mock.patch.object(handoff, "validate_product"), mock.patch.object(
+        handoff, "_implementation_records", return_value=IMPLEMENTATION
+    ):
+        handoff.create_manifest(root, source, os.getuid(), os.getgid())
+
+
+def verify_package(root: Path) -> handoff.SourceIdentity:
+    with mock.patch.object(handoff, "validate_product"), mock.patch.object(
+        handoff, "_implementation_records", return_value=IMPLEMENTATION
+    ):
+        return handoff.verify_package(root, os.getuid(), os.getgid())
+
+
+class ManifestTests(unittest.TestCase):
+    def test_canonical_manifest_binds_every_plain_entry_and_source(self) -> None:
+        with package_directory() as root:
+            create_package(root)
+            self.assertEqual(stat.S_IMODE(root.stat().st_mode), 0o500)
+            self.assertEqual(
+                verify_package(root), handoff.SourceIdentity("a" * 40, "b" * 40)
+            )
+            document = json.loads((root / handoff.MANIFEST_NAME).read_bytes())
+            self.assertEqual(document["implementation"], IMPLEMENTATION)
+            self.assertEqual(document["bundle_profile"], "adhoc-networkless")
+            names = [entry["name"] for entry in document["entries"]]
+            self.assertEqual(names, sorted(names))
+            self.assertEqual(names[0], handoff.BUNDLE_NAME)
+            self.assertNotIn(handoff.MANIFEST_NAME, names)
+            for entry in document["entries"]:
+                self.assertFalse(entry["mode"] & 0o222)
+                if entry["kind"] == "file":
+                    self.assertRegex(entry["sha256"], r"^[0-9a-f]{64}$")
+
+    def test_verifier_rejects_extra_missing_content_mode_link_and_hardlink(self) -> None:
+        for mutation in ("extra", "missing", "content", "mode", "link", "hardlink"):
+            with self.subTest(mutation=mutation), package_directory() as root:
+                create_package(root)
+                root.chmod(0o700)
+                target = root / handoff.BUNDLE_NAME / "Contents/MacOS/bangbang"
+                target.parent.chmod(0o755)
+                if mutation == "extra":
+                    (root / "extra").write_bytes(b"extra")
+                    (root / "extra").chmod(0o444)
+                elif mutation == "missing":
+                    target.unlink()
+                elif mutation == "content":
+                    target.chmod(0o755)
+                    target.write_bytes(b"changed")
+                    target.chmod(0o555)
+                elif mutation == "mode":
+                    target.chmod(0o755)
+                elif mutation == "link":
+                    target.unlink()
+                    target.symlink_to(root / handoff.MANIFEST_NAME)
+                else:
+                    linked = root / "linked"
+                    os.link(target, linked)
+                    linked.chmod(0o555)
+                with self.assertRaises(handoff.HandoffError):
+                    verify_package(root)
+
+    def test_verifier_rejects_noncanonical_duplicate_unknown_and_stale_implementation(self) -> None:
+        for mutation in ("noncanonical", "duplicate", "unknown", "implementation"):
+            with self.subTest(mutation=mutation), package_directory() as root:
+                create_package(root)
+                root.chmod(0o700)
+                manifest = root / handoff.MANIFEST_NAME
+                document = json.loads(manifest.read_bytes())
+                manifest.chmod(0o600)
+                if mutation == "noncanonical":
+                    raw = json.dumps(document).encode("ascii")
+                elif mutation == "duplicate":
+                    raw = b'{"kind":"one","kind":"two"}\n'
+                else:
+                    if mutation == "unknown":
+                        document["unexpected"] = True
+                    else:
+                        document["implementation"][0]["sha256"] = "f" * 64
+                    raw = handoff._canonical(document)
+                manifest.write_bytes(raw)
+                manifest.chmod(0o444)
+                with self.assertRaises(handoff.HandoffError):
+                    verify_package(root)
+
+    def test_manifest_creation_rejects_collision_and_nonuniform_owner_contract(self) -> None:
+        with package_directory() as root:
+            (root / handoff.MANIFEST_NAME).write_bytes(b"occupied")
+            with mock.patch.object(handoff, "validate_product"), mock.patch.object(
+                handoff, "_implementation_records", return_value=IMPLEMENTATION
+            ), self.assertRaisesRegex(handoff.HandoffError, "package"):
+                handoff.create_manifest(
+                    root,
+                    handoff.SourceIdentity("a" * 40, "b" * 40),
+                    os.getuid(),
+                    os.getgid(),
+                )
+
+    def test_exclusive_publication_never_replaces_destination(self) -> None:
+        if sys.platform != "darwin":
+            self.skipTest("renamex_np is a Darwin contract")
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            source = parent / "source"
+            destination = parent / "destination"
+            source.mkdir()
+            handoff._publish_exclusive(source, destination)
+            self.assertTrue(destination.is_dir())
+            replacement = parent / "replacement"
+            replacement.mkdir()
+            with self.assertRaisesRegex(handoff.HandoffError, "publication"):
+                handoff._publish_exclusive(replacement, destination)
+            self.assertTrue(replacement.is_dir())
+
+
+class ProtocolTests(unittest.TestCase):
+    SESSION = bytes(range(32))
+
+    def record(self, **changes) -> handoff.Record:
+        values = {
+            "role": handoff.Role.CONTROLLER,
+            "kind": handoff.Kind.SPAWN,
+            "sequence": 7,
+            "correlation": 0,
+            "session": self.SESSION,
+            "handle": 0,
+            "value": 0,
+            "payload": handoff.encode_arguments((b"one", b"two")),
+            "descriptor_count": 0,
+        }
+        values.update(changes)
+        return handoff.Record(**values)
+
+    def test_record_round_trip_is_exact_fixed_authenticated_and_zero_tailed(self) -> None:
+        record = self.record()
+        encoded = record.encode()
+        self.assertEqual(len(encoded), handoff.RECORD_BYTES)
+        self.assertEqual(handoff.Record.decode(encoded), record)
+        payload_end = handoff.PAYLOAD_OFFSET + len(record.payload)
+        self.assertEqual(encoded[payload_end:], bytes(handoff.RECORD_BYTES - payload_end))
+        self.assertEqual(
+            encoded[handoff.DIGEST_OFFSET : handoff.PAYLOAD_OFFSET],
+            hashlib.sha256(encoded[: handoff.DIGEST_OFFSET] + record.payload).digest(),
+        )
+
+    def test_decoder_rejects_every_structural_region_and_length(self) -> None:
+        encoded = self.record().encode()
+        for offset in (0, 8, 10, 12, 14, 16, 24, 32, 64, 72, 80, 84, 96, 128, 4095):
+            with self.subTest(offset=offset):
+                changed = bytearray(encoded)
+                changed[offset] ^= 1
+                with self.assertRaisesRegex(handoff.HandoffError, "protocol"):
+                    handoff.Record.decode(bytes(changed))
+        for invalid in (b"", encoded[:-1], encoded + b"x"):
+            with self.assertRaisesRegex(handoff.HandoffError, "protocol"):
+                handoff.Record.decode(invalid)
+
+    def test_argument_vector_is_closed_bounded_and_byte_preserving(self) -> None:
+        arguments = (b"--opaque", b"private-\xff-value")
+        self.assertEqual(handoff.decode_arguments(handoff.encode_arguments(arguments)), arguments)
+        for invalid in ((), (b"",), (b"a\x00b",), (b"x" * 1025,)):
+            with self.assertRaisesRegex(handoff.HandoffError, "arguments"):
+                handoff.encode_arguments(invalid)
+        valid = handoff.encode_arguments((b"one",))
+        for invalid in (valid[:-1], valid + b"x", struct.pack("!H", 0)):
+            with self.assertRaisesRegex(handoff.HandoffError, "arguments"):
+                handoff.decode_arguments(invalid)
+
+    def test_datagram_transport_preserves_record_and_rights(self) -> None:
+        left, right = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+        read_descriptor, write_descriptor = os.pipe()
+        received = []
+        try:
+            sender = handoff.RecordSocket(left)
+            receiver = handoff.RecordSocket(right)
+            self.assertGreaterEqual(
+                left.getsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF),
+                handoff.SOCKET_BUFFER_BYTES,
+            )
+            self.assertGreaterEqual(
+                right.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF),
+                handoff.SOCKET_BUFFER_BYTES,
+            )
+            record = self.record(
+                role=handoff.Role.SUPERVISOR,
+                kind=handoff.Kind.SPAWNED,
+                descriptor_count=1,
+            )
+            sender.send(record, (read_descriptor,))
+            decoded, received = receiver.receive()
+            self.assertEqual(decoded, record)
+            self.assertEqual(len(received), 1)
+            handoff._validate_output_descriptor(received[0])
+        finally:
+            handoff._close_descriptors(received)
+            os.close(read_descriptor)
+            os.close(write_descriptor)
+            left.close()
+            right.close()
+
+    def test_transport_rejects_descriptor_count_confusion(self) -> None:
+        left, right = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+        try:
+            handoff.RecordSocket(left)
+            receiver = handoff.RecordSocket(right)
+            record = self.record(descriptor_count=1)
+            self.assertEqual(left.send(record.encode()), handoff.RECORD_BYTES)
+            with self.assertRaisesRegex(handoff.HandoffError, "descriptor"):
+                receiver.receive()
+        finally:
+            left.close()
+            right.close()
+
+    def test_output_descriptor_rejects_writable_pipe_and_non_pipe(self) -> None:
+        read_descriptor, write_descriptor = os.pipe()
+        with tempfile.TemporaryFile() as regular:
+            try:
+                handoff._validate_output_descriptor(read_descriptor)
+                with self.assertRaisesRegex(handoff.HandoffError, "descriptor"):
+                    handoff._validate_output_descriptor(write_descriptor)
+                with self.assertRaisesRegex(handoff.HandoffError, "descriptor"):
+                    handoff._validate_output_descriptor(regular.fileno())
+            finally:
+                os.close(read_descriptor)
+                os.close(write_descriptor)
+
+    def test_session_rejects_post_terminal_send_and_receive(self) -> None:
+        left, right = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+        try:
+            session = handoff.SessionSocket(
+                handoff.RecordSocket(left), handoff.Role.CONTROLLER, self.SESSION
+            )
+            session.terminal = True
+            with self.assertRaisesRegex(handoff.HandoffError, "protocol"):
+                session.send(handoff.Kind.FINISH)
+            with self.assertRaisesRegex(handoff.HandoffError, "protocol"):
+                session.receive()
+        finally:
+            left.close()
+            right.close()
+
+    def test_session_rejects_replay_skips_cross_session_and_wrong_role(self) -> None:
+        cases = ("replay", "skip", "cross-session", "wrong-role")
+        for case in cases:
+            with self.subTest(case=case):
+                left, right = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+                try:
+                    handoff.RecordSocket(left)
+                    receiver = handoff.SessionSocket(
+                        handoff.RecordSocket(right), handoff.Role.SUPERVISOR, self.SESSION
+                    )
+                    first = self.record(sequence=1)
+                    left.send(first.encode())
+                    receiver.receive()
+                    if case == "replay":
+                        invalid = first
+                    elif case == "skip":
+                        invalid = self.record(sequence=3)
+                    elif case == "cross-session":
+                        invalid = self.record(sequence=2, session=b"z" * 32)
+                    else:
+                        invalid = self.record(sequence=2, role=handoff.Role.SUPERVISOR)
+                    left.send(invalid.encode())
+                    with self.assertRaisesRegex(handoff.HandoffError, "protocol"):
+                        receiver.receive()
+                finally:
+                    left.close()
+                    right.close()
+
+
+class FakeCredentialBackend(handoff.CredentialBackend):
+    def __init__(self, supervisor_pid: int, uid: int, gid: int) -> None:
+        self.supervisor_pid = supervisor_pid
+        self.target_uid = uid
+        self.target_gid = gid
+        self.uid = 0
+        self.gid = 0
+        self.saved_uid = 0
+        self.saved_gid = 0
+        self.current_groups = [0, 80]
+        self.calls = []
+
+    def groups(self) -> list[int]:
+        return list(self.current_groups)
+
+    def clear_groups(self) -> None:
+        self.calls.append("clear-groups")
+        self.current_groups = []
+
+    def set_gid(self, value: int) -> None:
+        self.calls.append(f"set-gid-{value}")
+        if value == 0 and self.uid != 0:
+            raise PermissionError
+        self.gid = value
+        self.saved_gid = value
+
+    def set_uid(self, value: int) -> None:
+        self.calls.append(f"set-uid-{value}")
+        if value == 0 and self.uid != 0:
+            raise PermissionError
+        self.uid = value
+        self.saved_uid = value
+
+    def restore_groups(self) -> None:
+        self.calls.append("restore-groups")
+        raise PermissionError
+
+    def identity(self) -> handoff.ProcessIdentity:
+        return handoff.ProcessIdentity(
+            os.getpid(),
+            self.supervisor_pid,
+            os.getpgrp(),
+            os.getsid(0),
+            self.uid,
+            self.gid,
+            self.uid,
+            self.gid,
+            self.saved_uid,
+            self.saved_gid,
+            1,
+            2,
+            Path("/usr/bin/python3"),
+        )
+
+
+class CredentialTests(unittest.TestCase):
+    def test_transition_orders_drop_and_rejects_all_root_restoration(self) -> None:
+        backend = FakeCredentialBackend(42, 501, 20)
+        identity = handoff.transition_controller_credentials(501, 20, 42, backend)
+        self.assertEqual((identity.uid, identity.gid), (501, 20))
+        self.assertEqual(
+            backend.calls,
+            [
+                "clear-groups",
+                "set-gid-20",
+                "set-uid-501",
+                "set-uid-0",
+                "set-gid-0",
+                "restore-groups",
+            ],
+        )
+
+    def test_transition_rejects_wrong_order_effect_saved_or_groups(self) -> None:
+        backend = FakeCredentialBackend(42, 501, 20)
+        backend.saved_uid = 1
+        with self.assertRaisesRegex(handoff.HandoffError, "credentials"):
+            handoff.transition_controller_credentials(501, 20, 42, backend)
+        for uid, gid in ((0, 20), (501, 0)):
+            with self.assertRaisesRegex(handoff.HandoffError, "credentials"):
+                handoff.transition_controller_credentials(
+                    uid, gid, 42, FakeCredentialBackend(42, 501, 20)
+                )
+
+
+class FakeProxy:
+    def __init__(self) -> None:
+        self.statuses = [None, 0]
+        self.closed = 0
+        self.signals = []
+        self.processes = set()
+
+    def _status_exchange(self, kind, _handle, _value=0):
+        if kind in (handoff.Kind.TERM, handoff.Kind.KILL):
+            self.signals.append(kind)
+            return -int(kind == handoff.Kind.KILL) - 15
+        return self.statuses.pop(0) if self.statuses else 0
+
+    def _close_process(self, _process):
+        self.closed += 1
+        self.processes.discard(_process)
+        return _process.returncode if _process.returncode is not None else 0
+
+
+class ProcessTests(unittest.TestCase):
+    def test_remote_process_drains_both_descriptors_and_closes_once(self) -> None:
+        stdout_read, stdout_write = os.pipe()
+        stderr_read, stderr_write = os.pipe()
+        proxy = FakeProxy()
+        process = handoff.RemoteProviderProcess(
+            proxy, 1, 100, stdout_read, stderr_read
+        )
+        proxy.processes.add(process)
+        os.write(stdout_write, b"stdout")
+        os.write(stderr_write, b"stderr")
+        os.close(stdout_write)
+        os.close(stderr_write)
+        self.assertEqual(process.communicate(2.0), (b"stdout", b"stderr"))
+        process.close()
+        process.close()
+        self.assertEqual(proxy.closed, 1)
+
+    def test_remote_process_output_overflow_is_terminal_and_signals(self) -> None:
+        stdout_read, stdout_write = os.pipe()
+        stderr_read, stderr_write = os.pipe()
+        proxy = FakeProxy()
+        proxy.statuses = [None, 0]
+        process = handoff.RemoteProviderProcess(
+            proxy, 1, 100, stdout_read, stderr_read
+        )
+        proxy.processes.add(process)
+        process.stdout_capture.maximum = 4
+        os.write(stdout_write, b"overflow")
+        os.close(stdout_write)
+        os.close(stderr_write)
+        deadline = __import__("time").monotonic() + 2
+        while not process.stdout_capture.result()[1] and __import__("time").monotonic() < deadline:
+            __import__("time").sleep(0.01)
+        with self.assertRaisesRegex(handoff.HandoffError, "output"):
+            process.wait(1.0)
+        process.close()
+        self.assertIn(handoff.Kind.KILL, proxy.signals)
+
+    def test_remote_process_wait_timeout_keeps_handle_owned_for_explicit_cleanup(self) -> None:
+        stdout_read, stdout_write = os.pipe()
+        stderr_read, stderr_write = os.pipe()
+        os.close(stdout_write)
+        os.close(stderr_write)
+        proxy = FakeProxy()
+        process = handoff.RemoteProviderProcess(
+            proxy, 1, 100, stdout_read, stderr_read
+        )
+        proxy.processes.add(process)
+        with mock.patch.object(
+            proxy, "_status_exchange", return_value=None
+        ), self.assertRaisesRegex(handoff.HandoffError, "timeout"):
+            process.wait(0.01)
+        self.assertIn(process, proxy.processes)
+        process.close()
+        self.assertNotIn(process, proxy.processes)
+
+    def test_partial_spawn_closes_every_untransferred_pipe(self) -> None:
+        left, right = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+        lease_read, lease_write = os.pipe()
+        created = []
+        real_pipe = os.pipe
+
+        def tracked_pipe():
+            pair = real_pipe()
+            created.extend(pair)
+            return pair
+
+        supervisor = handoff.ProviderSupervisor(
+            handoff.SessionSocket(
+                handoff.RecordSocket(left), handoff.Role.SUPERVISOR, b"x" * 32
+            ),
+            handoff.ProductLayout.from_package(Path("/absolute/package")),
+            501,
+            20,
+            999,
+            object(),
+            lease_read,
+        )
+        try:
+            with mock.patch.object(handoff.os, "pipe", side_effect=tracked_pipe), mock.patch.object(
+                handoff.subprocess, "Popen", side_effect=OSError
+            ), self.assertRaisesRegex(handoff.HandoffError, "spawn"):
+                supervisor._spawn((b"--fixed",))
+            for descriptor in created:
+                with self.assertRaises(OSError):
+                    os.fstat(descriptor)
+        finally:
+            os.close(lease_read)
+            os.close(lease_write)
+            left.close()
+            right.close()
+
+    def test_guardian_lease_detects_exact_pipe_loss(self) -> None:
+        left, right = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+        lease_read, lease_write = os.pipe()
+        supervisor = handoff.ProviderSupervisor(
+            handoff.SessionSocket(
+                handoff.RecordSocket(left), handoff.Role.SUPERVISOR, b"x" * 32
+            ),
+            handoff.ProductLayout.from_package(Path("/absolute/package")),
+            501,
+            20,
+            999,
+            object(),
+            lease_read,
+        )
+        try:
+            self.assertTrue(supervisor._guardian_alive())
+            os.close(lease_write)
+            lease_write = -1
+            self.assertFalse(supervisor._guardian_alive())
+        finally:
+            os.close(lease_read)
+            if lease_write >= 0:
+                os.close(lease_write)
+            left.close()
+            right.close()
+
+    def test_server_cleans_owned_handles_on_controller_or_guardian_loss(self) -> None:
+        for lost in ("controller", "guardian"):
+            with self.subTest(lost=lost):
+                left, right = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+                lease_read, lease_write = os.pipe()
+                supervisor = handoff.ProviderSupervisor(
+                    handoff.SessionSocket(
+                        handoff.RecordSocket(left),
+                        handoff.Role.SUPERVISOR,
+                        b"x" * 32,
+                    ),
+                    handoff.ProductLayout.from_package(Path("/absolute/package")),
+                    501,
+                    20,
+                    999,
+                    object(),
+                    lease_read,
+                )
+                try:
+                    with mock.patch.object(
+                        supervisor,
+                        "_guardian_alive",
+                        return_value=lost != "guardian",
+                    ), mock.patch.object(
+                        supervisor,
+                        "_controller_alive",
+                        return_value=lost != "controller",
+                    ), mock.patch.object(
+                        supervisor, "cleanup", return_value=True
+                    ) as cleanup, self.assertRaisesRegex(
+                        handoff.HandoffError, "lease"
+                    ):
+                        supervisor.serve()
+                    cleanup.assert_called_once_with()
+                finally:
+                    os.close(lease_read)
+                    os.close(lease_write)
+                    left.close()
+                    right.close()
+
+    def test_protocol_pipe_timeout_is_categorical(self) -> None:
+        read_descriptor, write_descriptor = os.pipe()
+        try:
+            with self.assertRaisesRegex(handoff.HandoffError, "protocol-timeout"):
+                handoff._read_exact(read_descriptor, 1, 0.01)
+        finally:
+            os.close(read_descriptor)
+            os.close(write_descriptor)
+
+    def test_cleanup_completion_ack_keeps_supervisor_alive_until_stage_owner_finishes(self) -> None:
+        guardian, supervisor = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        failures = []
+
+        def complete():
+            try:
+                handoff._supervisor_complete(supervisor)
+            except BaseException as error:
+                failures.append(error)
+
+        thread = threading.Thread(target=complete)
+        thread.start()
+        handoff._wait_supervisor_complete(guardian)
+        self.assertTrue(thread.is_alive())
+        handoff._acknowledge_guardian_cleanup(guardian)
+        thread.join(timeout=2)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(failures, [])
+        guardian.close()
+        supervisor.close()
+
+    def test_cleanup_completion_detects_each_single_peer_loss(self) -> None:
+        guardian, supervisor = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        guardian.close()
+        with self.assertRaisesRegex(handoff.HandoffError, "guardian"):
+            handoff._supervisor_complete(supervisor)
+        supervisor.close()
+
+        guardian, supervisor = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        supervisor.close()
+        with self.assertRaisesRegex(handoff.HandoffError, "supervisor"):
+            handoff._wait_supervisor_complete(guardian)
+        guardian.close()
+
+    def test_private_probe_cleanup_removes_exact_socket_and_reports_forcing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "probe"
+            root.mkdir(mode=0o700)
+            root.chmod(0o700)
+            api = root / "api"
+            api.mkdir(mode=0o700)
+            api.chmod(0o700)
+            manifest = root / "grants.json"
+            manifest.write_bytes(b"manifest")
+            manifest.chmod(0o600)
+            listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            listener.bind(os.fspath(api / "api.sock"))
+            (api / "api.sock").chmod(0o600)
+            try:
+                self.assertTrue(handoff._cleanup_probe_root(root))
+                self.assertFalse(os.path.lexists(root))
+            finally:
+                listener.close()
+
+    def test_private_probe_cleanup_rejects_unknown_residue_without_deleting_it(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "probe"
+            root.mkdir(mode=0o700)
+            root.chmod(0o700)
+            api = root / "api"
+            api.mkdir(mode=0o700)
+            api.chmod(0o700)
+            manifest = root / "grants.json"
+            manifest.write_bytes(b"manifest")
+            manifest.chmod(0o600)
+            unexpected = root / "unexpected"
+            unexpected.write_bytes(b"private")
+            unexpected.chmod(0o600)
+            with self.assertRaisesRegex(handoff.HandoffError, "cleanup"):
+                handoff._cleanup_probe_root(root)
+            self.assertEqual(unexpected.read_bytes(), b"private")
+
+
+class SurfaceTests(unittest.TestCase):
+    def test_fixed_layout_and_ordinary_factory_strip_only_the_launcher(self) -> None:
+        layout = handoff.ProductLayout.from_package(
+            Path("/private/var/tmp/stage/package")
+        )
+        arguments = handoff._launcher_arguments(
+            layout, 501, 20, "fixed-case", ("--version",)
+        )
+        self.assertEqual(Path(arguments[0]), layout.launcher)
+        self.assertEqual(arguments.count("--bangbang-jailer-v1"), 1)
+        self.assertEqual(arguments[-1], "--version")
+        self.assertNotIn(os.fspath(layout.provider), arguments)
+
+    def test_controller_rejects_wrong_response_correlation(self) -> None:
+        class WrongCorrelationSession:
+            def send(self, *_arguments, **_keywords):
+                return 9
+
+            def receive(self):
+                return (
+                    handoff.Record(
+                        handoff.Role.SUPERVISOR,
+                        handoff.Kind.RUNNING,
+                        1,
+                        8,
+                        b"x" * 32,
+                    ),
+                    [],
+                )
+
+        proxy = handoff.ControllerProxy(
+            WrongCorrelationSession(),
+            handoff.ProductLayout.from_package(Path("/absolute/package")),
+        )
+        with self.assertRaisesRegex(handoff.HandoffError, "protocol"):
+            proxy._exchange(handoff.Kind.POLL, handle=1)
+
+    def test_controller_rejects_duplicate_pipe_identity_and_closes_both(self) -> None:
+        layout = handoff.ProductLayout.from_package(Path("/absolute/package"))
+        proxy = handoff.ControllerProxy(object(), layout)
+        read_descriptor, write_descriptor = os.pipe()
+        duplicate = os.dup(read_descriptor)
+        response = handoff.Record(
+            handoff.Role.SUPERVISOR,
+            handoff.Kind.SPAWNED,
+            1,
+            1,
+            b"x" * 32,
+            handle=1,
+            value=100,
+            descriptor_count=2,
+        )
+        try:
+            with mock.patch.object(
+                proxy, "_exchange", return_value=(response, [read_descriptor, duplicate])
+            ), self.assertRaisesRegex(handoff.HandoffError, "descriptor"):
+                proxy.spawn((os.fspath(layout.launcher), "--fixed"))
+            for descriptor in (read_descriptor, duplicate):
+                with self.assertRaises(OSError):
+                    os.fstat(descriptor)
+        finally:
+            os.close(write_descriptor)
+
+    def test_process_table_uses_only_pid_ppid_state_and_comm(self) -> None:
+        records = handoff._parse_process_table(
+            " 10 1 Ss /stage/provider\n"
+            " 11 10 S /stage/launcher\n"
+            "malformed\n"
+        )
+        self.assertEqual(records[10], handoff.ProcessRecord(10, 1, "Ss", "/stage/provider"))
+        self.assertEqual(records[11].parent_pid, 10)
+        self.assertNotIn(0, records)
+        source = MODULE_PATH.read_text(encoding="utf-8")
+        self.assertIn('(\"/bin/ps\", \"-axo\", \"pid=,ppid=,state=,comm=\")', source)
+        self.assertNotIn("pid=,ppid=,state=,command=", source)
+
+    def test_public_wrappers_have_closed_authority_and_no_internal_elevation(self) -> None:
+        prepare = PREPARE_PATH.read_text(encoding="utf-8")
+        runner = RUN_PATH.read_text(encoding="utf-8")
+        combined = (prepare + runner).lower()
+        self.assertNotIn("sudo", combined)
+        self.assertNotIn("password", combined)
+        self.assertNotIn("signing-identity", runner)
+        self.assertNotIn("provisioning-profile", runner)
+        self.assertNotIn("/bin/rm", combined)
+        self.assertIn("</dev/null", prepare)
+        self.assertIn("</dev/null", runner)
+        self.assertEqual(runner.count("--prepared"), 4)
+        self.assertIn("--target-uid", runner)
+        self.assertIn("--target-gid", runner)
+
+    def test_cli_rejects_root_zero_leading_zero_unknown_and_duplicate_authority(self) -> None:
+        valid = handoff._parse_arguments(
+            [
+                "run-root",
+                "--prepared",
+                "/tmp/bangbang-elevated-vmnet-handoff",
+                "--target-uid",
+                "501",
+                "--target-gid",
+                "20",
+            ]
+        )
+        self.assertEqual((valid.target_uid, valid.target_gid), (501, 20))
+        for value in ("0", "0501", "-1", "4294967296", " 501"):
+            with self.assertRaises(handoff.HandoffError):
+                handoff._parse_arguments(
+                    [
+                        "run-root",
+                        "--prepared",
+                        "/tmp/bangbang-elevated-vmnet-handoff",
+                        "--target-uid",
+                        value,
+                        "--target-gid",
+                        "20",
+                    ]
+                )
+
+    def test_public_failures_are_categorical_and_value_free(self) -> None:
+        stderr = io.StringIO()
+        with mock.patch.object(
+            handoff, "prepare_package", side_effect=handoff.HandoffError("source")
+        ), contextlib.redirect_stderr(stderr):
+            status = handoff.main(
+                ["prepare", "--output", "/private/SECRET/bangbang-elevated-vmnet-handoff"]
+            )
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr.getvalue(), "bangbang elevated vmnet handoff: source\n")
+        self.assertNotIn("SECRET", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -368,6 +368,7 @@ class FakeCredentialBackend(handoff.CredentialBackend):
         self.saved_uid = 0
         self.saved_gid = 0
         self.current_groups = [0, 80]
+        self.final_groups = [gid]
         self.calls = []
 
     def groups(self) -> list[int]:
@@ -375,7 +376,7 @@ class FakeCredentialBackend(handoff.CredentialBackend):
 
     def clear_groups(self) -> None:
         self.calls.append("clear-groups")
-        self.current_groups = []
+        self.current_groups = [self.gid]
 
     def set_gid(self, value: int) -> None:
         self.calls.append(f"set-gid-{value}")
@@ -383,6 +384,7 @@ class FakeCredentialBackend(handoff.CredentialBackend):
             raise PermissionError
         self.gid = value
         self.saved_gid = value
+        self.current_groups = list(self.final_groups)
 
     def set_uid(self, value: int) -> None:
         self.calls.append(f"set-uid-{value}")
@@ -440,6 +442,16 @@ class CredentialTests(unittest.TestCase):
                 handoff.transition_controller_credentials(
                     uid, gid, 42, FakeCredentialBackend(42, 501, 20)
                 )
+
+    def test_transition_requires_exact_effective_only_group_shape(self) -> None:
+        for groups in ([], [20, 80], [80]):
+            with self.subTest(groups=groups):
+                backend = FakeCredentialBackend(42, 501, 20)
+                backend.final_groups = groups
+                with self.assertRaisesRegex(
+                    handoff.HandoffError, "credentials-dropped-groups"
+                ):
+                    handoff.transition_controller_credentials(501, 20, 42, backend)
 
 
 class FakeProxy:

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -496,6 +496,9 @@ class FakeProxy:
 
 
 class ProcessTests(unittest.TestCase):
+    def test_probe_failures_are_closed_controller_categories(self) -> None:
+        self.assertTrue(set(handoff.PROBE_FAILURES).issubset(handoff.CONTROLLER_FAILURES))
+
     def test_remote_process_drains_both_descriptors_and_closes_once(self) -> None:
         stdout_read, stdout_write = os.pipe()
         stderr_read, stderr_write = os.pipe()

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -754,6 +754,18 @@ class ProcessTests(unittest.TestCase):
             finally:
                 listener.close()
 
+    def test_killed_probe_socket_has_exact_validated_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "api.sock"
+            listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            listener.bind(os.fspath(path))
+            path.chmod(0o600)
+            try:
+                handoff._remove_killed_probe_socket(path)
+                self.assertFalse(os.path.lexists(path))
+            finally:
+                listener.close()
+
     def test_private_probe_cleanup_rejects_unknown_residue_without_deleting_it(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory) / "probe"

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -507,6 +507,16 @@ class ProcessTests(unittest.TestCase):
             )
         )
 
+    def test_private_probe_root_has_exact_ordinary_identity_and_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = handoff._create_private_probe_root(Path(directory))
+            try:
+                metadata = os.lstat(root)
+                self.assertEqual((metadata.st_uid, metadata.st_gid), (os.getuid(), os.getgid()))
+                self.assertEqual(stat.S_IMODE(metadata.st_mode), 0o700)
+            finally:
+                handoff._remove_tree(root)
+
     def test_remote_process_drains_both_descriptors_and_closes_once(self) -> None:
         stdout_read, stdout_write = os.pipe()
         stderr_read, stderr_write = os.pipe()

--- a/scripts/tests/test_elevated_vmnet_handoff.py
+++ b/scripts/tests/test_elevated_vmnet_handoff.py
@@ -697,6 +697,22 @@ class ProcessTests(unittest.TestCase):
             handoff._wait_supervisor_complete(guardian)
         guardian.close()
 
+    def test_supervisor_lifecycle_failures_remain_fixed_and_categorical(self) -> None:
+        self.assertEqual(
+            handoff._supervisor_failure_category(handoff.HandoffError("spawn"), 5),
+            "lifecycle-spawn",
+        )
+        self.assertEqual(
+            handoff._supervisor_failure_category(
+                handoff.HandoffError("controller-probe"), 5
+            ),
+            "controller-probe",
+        )
+        self.assertEqual(
+            handoff._supervisor_failure_category(ValueError("private"), 5),
+            "lifecycle",
+        )
+
     def test_private_probe_cleanup_removes_exact_socket_and_reports_forcing(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory) / "probe"


### PR DESCRIPTION
## Summary

- add an immutable clean-source handoff package and fixed exact-root runner for an irreversibly ordinary certification controller
- add the closed provider lifecycle protocol, reciprocal cleanup ownership, bounded output transfer, and normal-product completion/TERM/KILL probes
- make contained `--version` publish the existing authenticated `NoApi` readiness and require an empty descriptor-anchored production-session namespace around the probe set
- document the no-Apple-authorization trust, signal, cleanup, and #1944 handoff boundaries while retaining `383/0/2/33`

## Verification

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (225 passed)
- `cargo fmt --all -- --check`
- workspace/all-target/cross-target checks and tests, HVF library tests, all documented Clippy targets, and rustdoc with warnings denied
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- caller-authorized exact-root prepared-package gate using only ad-hoc signing (all six public categories passed)
- `scripts/run-integration-tests.sh --test production_bundle` (81 passed)
- `scripts/run-integration-tests.sh` without `--allow-unsupported` (complete strict signed suite passed)

No Apple developer identity or provisioning profile was used.

Closes #1943
